### PR TITLE
Fix navigation menus that caused a horizontal scrollbar	

### DIFF
--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -8,20 +8,20 @@
                 {% if app.website.domain == "languageforge.local" %} (Bootstrap 2){% endif %}
             </div>
             <div id="header-nav" class="pull-right">
-                <ul class="sf-menu">
+                <ul class="sf-menu sf-arrows">
                     <li><a href="/">Home</a></li>
                     {% if showHelpButton %}
                         <li ng-app="xforge.helpButton" ng-controller="helpButtonController" ng-show="showButton"><a ng-click="showHelpContent()">Help</a></li>
                     {% endif %}
                     {% if isLoggedIn %}
-                        <li id="myProjects"><a href="/app/projects">My Projects</a>
+                        <li id="myProjects"><a href="/app/projects" class="sf-with-ul">My Projects</a>
                             <ul>
                                 {% for project in projects %}
                                     <li><a href="{{ '/app/'~project.appName~'/'~project.id }}">{{ project.projectName }}</a></li>
                                 {% endfor %}
                             </ul>
                         </li>
-                        <li>
+                        <li class="sf-with-ul">
                             <a href="#"><img src="{{ smallAvatarUrl }}" style="width: 28px; height: 28px; float:left; position:relative; top:-5px; border:1px solid #39537c; margin-right:10px" id="smallAvatarURL" />Hi, {{ userName }}</a>
                             <ul>
                                 {% if isAdmin %}

--- a/src/Site/views/languageforge/theme/default/cssBootstrap2/superfish.css
+++ b/src/Site/views/languageforge/theme/default/cssBootstrap2/superfish.css
@@ -10,7 +10,11 @@
 .sf-menu ul {
     position:        absolute;
     top:            -999em;
-    width:            15em; /* left offset of submenus need to match (see below) */
+    width:            100%;
+}
+/* apply minimum width to projects and user menus */
+.sf-menu li:nth-child(n+3) {
+    min-width: 14em;
 }
 .sf-menu ul li {
     width:            100%;
@@ -28,7 +32,6 @@
 }
 .sf-menu li:hover ul,
 .sf-menu li.sfHover ul {
-    left:            -53px;
     top:            3.3em; /* match top ul list item height */
     z-index:        99;
 }


### PR DESCRIPTION
Fixes the horizontal scrollbar caused by the menu being hidden off screen and to the right.

The extent of the scrollbar was dependent on the length of the username in the menu. Longer usernames moved the menu farther left, sometimes making the scrollbar disappear.

Also re-adds the dropdown triangles on the menus:
![screenshot from 2016-12-16 10-29-27](https://cloud.githubusercontent.com/assets/6140710/21250805/99614cc4-c37a-11e6-863e-b4808b9e5e5b.png)
On the live branch they show up, and the menus fade. On master, as of commit 53ae518795cf2d4812b6b68385242b5bcd1e3365, the little arrows and fading of the menu nolonger happened (That commit is a squashed commit. The squashed commit where the changes of interest are from is 1174e29dafd04349a87512d2b9460cca17b53604).

That commit (1174e29dafd04349a87512d2b9460cca17b53604) also upgrades from jQuery 1.x to 3.x. I'm guessing that could be related, but I'm not going to investigate it more.