### PR TITLE
Fix modals

### DIFF
--- a/src/Site/views/languageforge/theme/default/cssBootstrap4/languageforge_default.css
+++ b/src/Site/views/languageforge/theme/default/cssBootstrap4/languageforge_default.css
@@ -6797,7 +6797,7 @@ body {
 .newline {
   display: block; }
 
-.modal {
+.modal-select-language .modal {
   position: fixed;
   top: 0;
   right: 0;
@@ -6809,7 +6809,7 @@ body {
   overflow: hidden;
   outline: 0; }
 
-.modal-dialog {
+.modal-select-language .modal-dialog {
   width: 80%;
   height: 75%;
   background-color: white;
@@ -6822,10 +6822,23 @@ body {
   left: 0;
   right: 0; }
 
-.modal-content {
+.modal-select-language .modal-content {
+  height: 100%;
+  display: flex;
+  flex-flow: column; }
+  .modal-select-language .modal-content pui-select-language table tr {
+    cursor: pointer; }
+  .modal-select-language .modal-content pui-select-language td div {
+    height: 1.5rem;
+    overflow: hidden; }
+  .modal-select-language .modal-content .modal-body {
+    max-height: initial;
+    flex: 2; }
+
+.modal-select-language .modal-content {
   height: 100%; }
 
-.modal-body {
+.modal-select-language .modal-body {
   position: relative;
   max-height: 400px;
   padding: 15px;
@@ -6841,7 +6854,7 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 9999;
+  z-index: 1000;
   width: 100%;
   height: 50px;
   background-color: #104060; }
@@ -6906,19 +6919,6 @@ nav {
 @media (max-width: 500px) {
   .filter-list {
     float: left; } }
-
-.language-picker {
-  height: 100%;
-  display: flex;
-  flex-flow: column; }
-  .language-picker pui-select-language table tr {
-    cursor: pointer; }
-  .language-picker pui-select-language td div {
-    height: 1.5rem;
-    overflow: hidden; }
-  .language-picker .modal-body {
-    max-height: initial;
-    flex: 2; }
 
 /* Taken from Bootstrap4-alpha6. TODO Remove after Bootstrap upgrade to alpha6 or later */
 .no-gutters > .col,

--- a/src/Site/views/languageforge/theme/default/cssBootstrap4/languageforge_default.css
+++ b/src/Site/views/languageforge/theme/default/cssBootstrap4/languageforge_default.css
@@ -6805,12 +6805,25 @@ body {
   left: 0;
   z-index: 1050;
   display: block;
-  width: 80%;
-  height: 75%;
   margin: auto;
   overflow: hidden;
-  outline: 0;
-  background-color: white; }
+  outline: 0; }
+
+.modal-dialog {
+  width: 80%;
+  height: 75%;
+  background-color: white;
+  max-width: unset;
+  margin-top: auto;
+  margin-bottom: auto;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0; }
+
+.modal-content {
+  height: 100%; }
 
 .modal-body {
   position: relative;
@@ -6893,3 +6906,22 @@ nav {
 @media (max-width: 500px) {
   .filter-list {
     float: left; } }
+
+.language-picker {
+  height: 100%;
+  display: flex;
+  flex-flow: column; }
+  .language-picker pui-select-language table tr {
+    cursor: pointer; }
+  .language-picker pui-select-language td div {
+    height: 1.5rem;
+    overflow: hidden; }
+  .language-picker .modal-body {
+    max-height: initial;
+    flex: 2; }
+
+/* Taken from Bootstrap4-alpha6. TODO Remove after Bootstrap upgrade to alpha6 or later */
+.no-gutters > .col,
+.no-gutters > [class*="col-"] {
+  padding-right: 0;
+  padding-left: 0; }

--- a/src/Site/views/languageforge/theme/default/cssBootstrap4/sass/base/_global.scss
+++ b/src/Site/views/languageforge/theme/default/cssBootstrap4/sass/base/_global.scss
@@ -66,12 +66,27 @@ body{
   left: 0;
   z-index: 1050;
   display: block;
-  width: 80%;
-  height: 75%;
   margin: auto;
   overflow: hidden;
   outline: 0;
+}
+
+.modal-dialog {
+  width: 80%;
+  height: 75%;
   background-color: white;
+  max-width: unset;
+  margin-top: auto;
+  margin-bottom: auto;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.modal-content {
+  height: 100%;
 }
 
 .modal-body {
@@ -175,4 +190,40 @@ nav {
  .filter-list {
   float: left;
 }
+}
+
+.language-picker {
+
+  height: 100%;
+  display: flex;
+  flex-flow: column;
+
+  pui-select-language {
+    table tr {
+      cursor: pointer;
+    }
+
+    td div {
+      height: 1.5rem;
+      overflow: hidden;
+    }
+  }
+
+  .modal-body {
+    max-height: initial;
+    flex: 2;
+  }
+}
+
+/* Taken from Bootstrap4-alpha6. TODO Remove after Bootstrap upgrade to alpha6 or later */
+.no-gutters {
+  // disabled because they conflict with a preexisting fix that used negative margins
+  // margin-right: 0;
+  // margin-left: 0;
+
+  > .col,
+  > [class*="col-"] {
+    padding-right: 0;
+    padding-left: 0;
+  }
 }

--- a/src/Site/views/languageforge/theme/default/cssBootstrap4/sass/base/_global.scss
+++ b/src/Site/views/languageforge/theme/default/cssBootstrap4/sass/base/_global.scss
@@ -58,42 +58,69 @@ body{
     display: block;
 }
 // TODO: Remove hack for modal box issue as a result of ui.bootstrap
-.modal {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1050;
-  display: block;
-  margin: auto;
-  overflow: hidden;
-  outline: 0;
-}
+.modal-select-language {
 
-.modal-dialog {
-  width: 80%;
-  height: 75%;
-  background-color: white;
-  max-width: unset;
-  margin-top: auto;
-  margin-bottom: auto;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
+  .modal {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1050;
+    display: block;
+    margin: auto;
+    overflow: hidden;
+    outline: 0;
+  }
 
-.modal-content {
-  height: 100%;
-}
+  .modal-dialog {
+    width: 80%;
+    height: 75%;
+    background-color: white;
+    max-width: unset;
+    margin-top: auto;
+    margin-bottom: auto;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
 
-.modal-body {
-  position: relative;
-  max-height: 400px;
-  padding: 15px;
-  overflow-y: auto;
+  .modal-content {
+
+    height: 100%;
+    display: flex;
+    flex-flow: column;
+
+    pui-select-language {
+      table tr {
+        cursor: pointer;
+      }
+
+      td div {
+        height: 1.5rem;
+        overflow: hidden;
+      }
+    }
+
+    .modal-body {
+      max-height: initial;
+      flex: 2;
+    }
+  }
+
+
+  .modal-content {
+    height: 100%;
+  }
+
+  .modal-body {
+    position: relative;
+    max-height: 400px;
+    padding: 15px;
+    overflow-y: auto;
+  }
 }
 
 .breadcrumb {
@@ -107,7 +134,7 @@ body{
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 9999;
+  z-index: 1000;
   width: 100%;
   height: 50px;
   background-color: #104060;
@@ -190,29 +217,6 @@ nav {
  .filter-list {
   float: left;
 }
-}
-
-.language-picker {
-
-  height: 100%;
-  display: flex;
-  flex-flow: column;
-
-  pui-select-language {
-    table tr {
-      cursor: pointer;
-    }
-
-    td div {
-      height: 1.5rem;
-      overflow: hidden;
-    }
-  }
-
-  .modal-body {
-    max-height: initial;
-    flex: 2;
-  }
 }
 
 /* Taken from Bootstrap4-alpha6. TODO Remove after Bootstrap upgrade to alpha6 or later */

--- a/src/Site/views/languageforge/theme/default/cssBootstrap4/sass/new-project/languageforge_new-project.scss
+++ b/src/Site/views/languageforge/theme/default/cssBootstrap4/sass/new-project/languageforge_new-project.scss
@@ -61,38 +61,3 @@ a{
 .centerBlock {
   margin: auto;
 }
-
-/* Taken from Bootstrap4-alpha6. TODO Remove after Bootstrap upgrade to alpha6 or later */
-.no-gutters {
-  // disabled because they conflict with a preexisting fix that used negative margins
-  // margin-right: 0;
-  // margin-left: 0;
-
-  > .col,
-  > [class*="col-"] {
-    padding-right: 0;
-    padding-left: 0;
-  }
-}
-
-pui-select-language {
-
-  td div {
-    height: 1.5rem;
-    overflow: hidden;
-  }
-
-}
-
-.modal {
-  display: flex;
-  flex-flow: column;
-}
-
-.modal-body {
-  max-height: initial;
-}
-
-table.language-picker tr {
-  cursor: pointer;
-}

--- a/src/angular-app/bellows/directive/bootstrap4/modal.html
+++ b/src/angular-app/bellows/directive/bootstrap4/modal.html
@@ -1,18 +1,14 @@
-<div class="modal-dialog" role="document">
-    <div class="modal-content">
-        <div class="modal-header">
-            <h3>{{modalOptions.headerText}}</h3>
-        </div>
-        <div class="modal-body">
-            <p ng-bind-html="modalOptions.bodyText"></p>
-        </div>
-        <div class="modal-footer">
-            <button type="button" class="btn"
-                    data-ng-click="modalOptions.close()">{{modalOptions.closeButtonText}}
-            </button>
-            <button class="btn btn-primary"
-                    data-ng-click="modalOptions.ok();">{{modalOptions.actionButtonText}}
-            </button>
-        </div>
-    </div>
+<div class="modal-header">
+    <h3>{{modalOptions.headerText}}</h3>
+</div>
+<div class="modal-body">
+    <p ng-bind-html="modalOptions.bodyText"></p>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn"
+            data-ng-click="modalOptions.close()">{{modalOptions.closeButtonText}}
+    </button>
+    <button class="btn btn-primary"
+            data-ng-click="modalOptions.ok();">{{modalOptions.actionButtonText}}
+    </button>
 </div>

--- a/src/angular-app/bellows/directive/bootstrap4/pui-language.html
+++ b/src/angular-app/bellows/directive/bootstrap4/pui-language.html
@@ -31,7 +31,7 @@
     </div>
     <div class="row">
         <div class="table table-responsive table-hover table-sm">
-            <table class="table table-bordered language-picker">
+            <table class="table table-bordered">
                 <thead class="thead-inverse">
                 <tr>
                     <th>Name</th><th>Code</th><th>Country</th><th>Other Names</th>

--- a/src/angular-app/languageforge/lexicon/new-project/bootstrap4/languageforge_new-project.css
+++ b/src/angular-app/languageforge/lexicon/new-project/bootstrap4/languageforge_new-project.css
@@ -45,23 +45,3 @@ a {
 
 .centerBlock {
   margin: auto; }
-
-/* Taken from Bootstrap4-alpha6. TODO Remove after Bootstrap upgrade to alpha6 or later */
-.no-gutters > .col,
-.no-gutters > [class*="col-"] {
-  padding-right: 0;
-  padding-left: 0; }
-
-pui-select-language td div {
-  height: 1.5rem;
-  overflow: hidden; }
-
-.modal {
-  display: flex;
-  flex-flow: column; }
-
-.modal-body {
-  max-height: initial; }
-
-table.language-picker tr {
-  cursor: pointer; }

--- a/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.js
+++ b/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.js
@@ -674,7 +674,8 @@ angular.module('lexicon-new-project',
           $scope.add = function () {
             $modalInstance.close($scope.selected);
           };
-        }]
+        }],
+        windowTopClass: 'modal-select-language'
       });
       modalInstance.result.then(function (selected) {
         $scope.newProject.languageCode = selected.code;

--- a/src/angular-app/languageforge/lexicon/views/configuration.js
+++ b/src/angular-app/languageforge/lexicon/views/configuration.js
@@ -541,7 +541,8 @@ function ($scope, notice, lexProjectService, sessionService,
         };
 
         $scope.suggestedLanguageCodes = suggestedLanguageCodes;
-      }]
+      }],
+      windowTopClass: 'modal-select-language'
     });
 
     modalInstance.result.then(function (selected) {

--- a/src/angular-app/languageforge/lexicon/views/select-new-language.html
+++ b/src/angular-app/languageforge/lexicon/views/select-new-language.html
@@ -1,4 +1,3 @@
-<div class="language-picker">
 <div class="modal-header">
     <h3 translate="Select a New Input System Language"></h3>
 </div>
@@ -21,5 +20,4 @@
         <a href="http://www.sil.org/iso639-3/" target="_blank">
             <small><i class="fa fa-globe" aria-hidden="true"></i> {{'About Language 639-3 Codes' | translate}}</small></a>
     </div>
-</div>
 </div>

--- a/src/angular-app/languageforge/lexicon/views/select-new-language.html
+++ b/src/angular-app/languageforge/lexicon/views/select-new-language.html
@@ -1,3 +1,4 @@
+<div class="language-picker">
 <div class="modal-header">
     <h3 translate="Select a New Input System Language"></h3>
 </div>
@@ -20,4 +21,5 @@
         <a href="http://www.sil.org/iso639-3/" target="_blank">
             <small><i class="fa fa-globe" aria-hidden="true"></i> {{'About Language 639-3 Codes' | translate}}</small></a>
     </div>
+</div>
 </div>


### PR DESCRIPTION
The diff is far more noisy than the actual changes:
- In `_global.scss` mostly rules were moved around (with a few changes).
- `languageforge_new-project.scss` had some style rules moved to `_global.scss`.
- `modal.html` had two wrapping `div`s removed, and the indention adjusted accordingly.

Other than that the diff is mostly straightforward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/76)
<!-- Reviewable:end -->
