### PR TITLE
Miscilaneous authentication and mobile fixes

### DIFF
--- a/src/Site/Controller/Auth.php
+++ b/src/Site/Controller/Auth.php
@@ -80,6 +80,7 @@ class Auth extends App
     {
         $this->data['last_username'] = $app['session']->get(Security::LAST_USERNAME);
         $errorMsg = $app['security.last_error']($request);
+        if($errorMsg == 'Bad credentials.') $errorMsg = 'Invalid username or password.';
         if ($errorMsg) {
             $app['session']->getFlashBag()->add('errorMessage', $errorMsg);
             if ($app['session']->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {

--- a/src/Site/views/languageforge/container/languageforgeBootstrap4.html.twig
+++ b/src/Site/views/languageforge/container/languageforgeBootstrap4.html.twig
@@ -90,7 +90,7 @@
                 {% if app.website.domain == "languageforge.local" %} (Bootstrap 4){% endif %}
             </a>
 
-            <h1 class="mobile-title pull-left"><a href="/">Language Forge</a></h1>
+            <h1 class="mobile-title pull-left hidden-md-up"><a href="/">Language Forge</a></h1>
 
             <ul class="nav navbar-nav pull-right">
                 <li class="nav-item header-button-rounded">


### PR DESCRIPTION
- Changes "Bad credentials" to "Invalid username or password." I'm not sure if there's a better way to do this, but I don't see one.

- Apparently I made the mobile logged-out header title show up even on large screens in c5bbcedf6e55f1e776d583221b4ccbb81270d8f7. This is now fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/85)
<!-- Reviewable:end -->
