### PR TITLE
Fix warnings in e2e tests

### DIFF
--- a/test/app/bellows/pages/appFrame.js
+++ b/test/app/bellows/pages/appFrame.js
@@ -7,7 +7,7 @@ var SfAppFrame = function() {
     success: element(by.css('.alert-success')),
     info:    element(by.css('.alert-info')),
     warn:    element(by.css('.alert-warn')),
-    error:   element(by.css('.alert-danger')),
+    error:   element.all(by.css('.alert-danger')).first(),
   };
   // Alternate names for the above
   this.successMessage = this.message.success;

--- a/test/app/languageforge/lexicon/pages/lexModals.js
+++ b/test/app/languageforge/lexicon/pages/lexModals.js
@@ -23,7 +23,7 @@ function LexModals() {
     levelDropdown: element(by.model('newCustomData.level')),
     typeDropdown: element(by.model('newCustomData.type')),
     listCodeDropdown: element(by.model('newCustomData.listCode')),
-    addButton: element(by.partialButtonText('Add'))
+    addButton: element(by.css('.modal-footer')).element(by.partialButtonText('Add'))
   };
 
 }


### PR DESCRIPTION
Fixes warnings in the e2e tests about multiple elements being found for a selector. I was hoping to make the tests fail when multiple elements are found, but it doesn't look like Protractor supports this. It is possible to work around (see angular/protractor#2417) but probably not worth the extra work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/90)
<!-- Reviewable:end -->
