### PR TITLE
Add CSS cleanup script and fix audio dropdown menu

### DIFF
--- a/cleanup_css.sh
+++ b/cleanup_css.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# delete untracked CSS files in the given paths
+git ls-files --others src/{Site,angular-app}/**/*.css | xargs rm
+# Remove empty bootstrap4 directories
+find . -type d -empty -name bootstrap4 -delete

--- a/src/angular-app/languageforge/lexicon/directive/dc-audio.html
+++ b/src/angular-app/languageforge/lexicon/directive/dc-audio.html
@@ -7,21 +7,19 @@
     </div>
 
     <!-- more control -->
-    <div class="control-group" data-ng-hide="show.audioUpload" data-ng-class="dcControl.interfaceConfig.pullToSide">
+    <div data-ng-hide="show.audioUpload">
         <div data-ng-show="hasAudio()">
-            <div class="btn-group" uib-dropdown data-ng-show="$state.is('editor.entry') && dcControl.rights.canEditEntry()">
-                <a class="btn btn-secondary dropdown-toggle" uib-dropdown-toggle
-                    data-ng-class="dcControl.interfaceConfig.pullToSide">
-                    <span class="caret"></span></a>
-                <ul class="dropdown-menu" uib-dropdown-menu data-ng-class="dcControl.interfaceConfig.pullToSide">
-                    <li><a data-ng-href="{{audioDownloadUrl()}}">
-                        <i class="fa fa-download"></i>{{'Download' | translate}} '{{displayFilename()}}'</a></li>
-                    <li><a data-ng-click="deleteAudio()">
-                        <i class="fa fa-times"></i>{{'Delete' | translate}} '{{displayFilename()}}'</a></li>
-                    <li class="divider"></li>
-                    <li><a data-ng-click="show.audioUpload = true">
-                        <i class="fa fa-cloud-upload"></i>{{'Upload a replacement' | translate}}</a></li>
-                </ul>
+            <div class="dropdown" uib-dropdown data-ng-show="$state.is('editor.entry') && dcControl.rights.canEditEntry()">
+                <a class="btn btn-secondary dropdown-toggle" uib-dropdown-toggle><span class="caret"></span></a>
+                <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu data-ng-class="dcControl.interfaceConfig.pullToSide">
+                    <a class="dropdown-item" data-ng-href="{{audioDownloadUrl()}}">
+                        <i class="fa fa-download"></i> {{'Download' | translate}} '{{displayFilename()}}'</a>
+                    <a class="dropdown-item" data-ng-click="deleteAudio()">
+                        <i class="fa fa-times"></i> {{'Delete' | translate}} '{{displayFilename()}}'</a>
+                    <div class="divider"></div>
+                    <a class="dropdown-item" data-ng-click="show.audioUpload = true">
+                        <i class="fa fa-cloud-upload"></i> {{'Upload a replacement' | translate}}</a>
+                </div>
             </div>
             <div data-ng-hide="$state.is('editor.entry') && dcControl.rights.canEditEntry() || !$state.is('editor.entry')">
                 <a class="btn btn-secondary buttonAppend" data-ng-href="{{audioDownloadUrl()}}" title="Download audio">


### PR DESCRIPTION
Not sure what the best to add the cleanup script is. You can shell out from Gulp, but then you're basically writing a shell script in JavaScript.

Also fixed a dropdown menu on Language Forge that was overlooked during the move to Bootstrap 4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/96)
<!-- Reviewable:end -->
