### PR TITLE
Make console warnings not be errors in e2e testing

### DIFF
--- a/test/app/allspecs/e2e/afterEach.spec.js
+++ b/test/app/allspecs/e2e/afterEach.spec.js
@@ -29,19 +29,20 @@ afterEach(function () {
   browser.manage().logs().get('browser').then(function (browserLog) {
     if (browserLog.length > 0) {
       for (var i = 0; i < browserLog.length; i++) {
-        var message = browserLog[i].message;
-        if (message.indexOf('\n') != -1) {
+        var message = browserLog[i];
+        var text = message.message;
+        if (text.indexOf('\n') != -1) {
 
           // place CR between lines
-          message = message.split('\n').join('\n');
+          text = text.split('\n').join('\n');
         }
 
-        if (util.isErrorToIgnore(message)) {
+        if (util.isMessageToIgnore(message)) {
           return;
         }
 
-        message = '\n\nBrowser Console JS Error: \n' + message + '\n\n';
-        expect(message).toEqual(''); // fail the test
+        text = '\n\nBrowser Console JS Error: \n' + text + '\n\n';
+        expect(text).toEqual(''); // fail the test
       }
     }
   });

--- a/test/app/bellows/pages/projectSettingsPage.js
+++ b/test/app/bellows/pages/projectSettingsPage.js
@@ -59,32 +59,5 @@ function BellowsProjectSettingsPage() {
     deleteButton: this.activePane.element(by.buttonText('Delete this project'))
   };
 
-  this.expectConsoleError = function () {
-    browser.manage().logs().get('browser').then(function (browserLog) {
-      if (browserLog.length > 1) {
-        for (var i = 0; i < browserLog.length; i++) {
-          var message = browserLog[i].message;
-          if (message.indexOf('\n') != -1) {
-
-            // place CR between lines
-            message = message.split('\n').join('\n');
-          }
-
-          if (util.isErrorToIgnore(message)) {
-            continue;
-          } else if (/You don't have sufficient privileges\./.test(message)) {
-            // this is the console error we expected
-            continue;
-          }
-
-          message = '\n\nBrowser Console JS Error: \n' + message + '\n\n';
-          expect(message).toEqual(''); // fail the test
-        }
-      } else {
-        expect(browserLog.length).toEqual(1);
-      }
-    });
-  };
-
 }
 

--- a/test/app/bellows/pages/util.js
+++ b/test/app/bellows/pages/util.js
@@ -155,13 +155,15 @@ function Utils() {
 
   // Errors we choose to ignore because they are typically not encountered by users, but only
   // in testing
-  this.isErrorToIgnore = function isErrorToIgnore(message) {
-    return /angular.*\.js .* TypeError: undefined is not a function/.test(message) ||
-      /angular.*\.js .* Error: \[\$compile:tpload]/.test(message) ||
-      /"level":"info"/.test(message) ||
-      /next_id/.test(message) ||
-      message.indexOf('password or credit card input in a non-secure context.') !== -1 ||
-      /ERR_INTERNET_DISCONNECTED/.test(message);
+  this.isMessageToIgnore = function isMessageToIgnore(message) {
+    if (message.level.name == 'WARNING') return true;
+
+    var text = message.message;
+
+    return /angular.*\.js .* TypeError: undefined is not a function/.test(text) ||
+      /angular.*\.js .* Error: \[\$compile:tpload]/.test(text) ||
+      text.includes('password or credit card input in a non-secure context.') ||
+      text.includes('ERR_INTERNET_DISCONNECTED');
   };
 
   this.scrollTop = function () {


### PR DESCRIPTION
Previously all messages in the console were matched by text to determine whether they are errors. Every time a warning is encountered that isn't explicitly ignored, it's considered an error. I've changed it to check the message's log level. I believe `INFO` level logging is [ignored by default.](https://github.com/webdriverio/webdriverio/issues/491#issuecomment-90496527)

Now if the log level is `WARNING` it will never be considered an error. I also remove some text ignoring rules that didn't seem to be necessary anymore, and confirmed the tests are still passing (though not always--they're rather unstable right now).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/105)
<!-- Reviewable:end -->
