### PR TITLE
Run AngularJS in production mode in the lexicon app

### DIFF
--- a/src/Api/Library/Shared/Website.php
+++ b/src/Api/Library/Shared/Website.php
@@ -28,6 +28,7 @@ class Website
         $this->base = $base;
         $this->theme = 'default';
         $this->ssl = false;
+        $this->isProduction = false;
         $this->defaultProjectCode = '';
         $this->userDefaultSiteRole = self::SITEROLE_USER; // must match SiteRoles::USER;
         $this->allowSignupFromOtherSites = true;
@@ -56,6 +57,9 @@ class Website
 
     /** @var boolean */
     public $allowSignupFromOtherSites;
+
+    /** @var boolean */
+    public $isProduction;
 
     /** @var array<Website> */
     private static $_sites;

--- a/src/Api/Library/Shared/WebsiteInstances.php
+++ b/src/Api/Library/Shared/WebsiteInstances.php
@@ -81,6 +81,7 @@ class WebsiteInstances
         $w->name = 'Scripture Forge';
         $w->ssl = true;
         $w->userDefaultSiteRole = Website::SITEROLE_PROJECT_CREATOR;
+        $w->isProduction = true;
         $sites['scriptureforge.org'] = $w;
 
         // jamaicanpsalms.com
@@ -89,6 +90,7 @@ class WebsiteInstances
         $w->ssl = true;
         $w->theme = 'jamaicanpsalms';
         $w->defaultProjectCode = 'jamaican_psalms';
+        $w->isProduction = true;
         $sites['jamaicanpsalms.scriptureforge.org'] = $w;
 
         // waaqwiinaagiwritings.org
@@ -97,6 +99,7 @@ class WebsiteInstances
         $w->ssl = true;
         $w->theme = 'simple';
         $w->defaultProjectCode = 'waaqwiinaagiwritings';
+        $w->isProduction = true;
         $sites['waaqwiinaagiwritings.org'] = $w;
 
         return $sites;
@@ -150,7 +153,9 @@ class WebsiteInstances
         $w->name = 'Language Forge';
         $w->userDefaultSiteRole = Website::SITEROLE_PROJECT_CREATOR;
         $w->ssl = true;
+        $w->isProduction = true;
         $sites['languageforge.org'] = $w;
+
 
         return $sites;
     }

--- a/src/Api/Model/Shared/Command/SessionCommands.php
+++ b/src/Api/Model/Shared/Command/SessionCommands.php
@@ -21,6 +21,8 @@ class SessionCommands
         $sessionData = array();
         $sessionData['baseSite'] = $website->base;
 
+        $sessionData['isProduction'] = $website->isProduction;
+
         if ($userId) {
             $sessionData['userId'] = (string) $userId;
             $user = new UserModel($userId);

--- a/src/angular-app/languageforge/lexicon/lexicon.js
+++ b/src/angular-app/languageforge/lexicon/lexicon.js
@@ -20,8 +20,11 @@ angular.module('lexicon',
     'lexicon.services',
     'pascalprecht.translate'
   ])
-  .config(['$stateProvider', '$urlRouterProvider', '$translateProvider',
-  function ($stateProvider, $urlRouterProvider, $translateProvider) {
+  .config(['$stateProvider', '$urlRouterProvider', '$translateProvider', '$compileProvider',
+  function ($stateProvider, $urlRouterProvider, $translateProvider, $compileProvider) {
+    $compileProvider.debugInfoEnabled(!window.session.isProduction);
+    $compileProvider.commentDirectivesEnabled(!window.session.isProduction);
+
     $urlRouterProvider.otherwise('/editor/list');
 
     // State machine from ui.router


### PR DESCRIPTION
This only applies to the lexicon app. It could be added to others, but they haven't been experiencing the same performance issues. I can't tell any significant change in performance, but the [AngularJS production guide](https://docs.angularjs.org/guide/production) says it gives "a significant performance boost."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/106)
<!-- Reviewable:end -->
