### PR TITLE
Improve notifications on mobile and header

### DIFF
--- a/src/Site/views/languageforge/theme/default/sass/_global.scss
+++ b/src/Site/views/languageforge/theme/default/sass/_global.scss
@@ -350,3 +350,15 @@ nav {
     width: 100%;
   }
 }
+
+nav.navbar {
+  transition: background-color 1s ease;
+
+  .nav-user.nav-item {
+    margin-left: 0;
+  }
+}
+
+.notices button.close {
+  margin-right: 0.5em;
+}

--- a/src/Site/views/languageforge/theme/default/sass/_global.scss
+++ b/src/Site/views/languageforge/theme/default/sass/_global.scss
@@ -332,3 +332,21 @@ nav {
 .typeahead-item {
   cursor: pointer;
 }
+
+.alert {
+  padding: 0.2em 1em;
+  text-align: center;
+}
+
+@include media-breakpoint-only(xs) {
+  .alert {
+    position: fixed;
+    z-index: 100;
+    bottom: 0;
+    left: 0;
+    right: 90;
+    margin-bottom: 0;
+    border-radius: 0;
+    width: 100%;
+  }
+}

--- a/src/Site/views/languageforge/theme/default/sass/_global.scss
+++ b/src/Site/views/languageforge/theme/default/sass/_global.scss
@@ -1,3 +1,5 @@
+$navbar-height: 50px;
+
 a {
   cursor: pointer;
 }
@@ -19,7 +21,7 @@ h1.mobile-title {
 }
 
 #app-container-for-bootstrap {
-  margin-top: 60px;
+  margin-top: $navbar-height + 10px;
   flex: 1;
 }
 .card .form-group-last {
@@ -225,7 +227,7 @@ dl.picklists dd {
   left: 0;
   z-index: 1000;
   width: 100%;
-  height: 50px;
+  height: $navbar-height;
   background-color: #104060;
 }
 
@@ -343,6 +345,10 @@ nav {
     position: initial;
   }
 
+  #app-container-for-bootstrap {
+    margin-top: 10px;
+  }
+
   .alert {
     position: fixed;
     z-index: 100;
@@ -365,4 +371,9 @@ nav.navbar {
 
 .notices button.close {
   margin-right: 0.5em;
+}
+
+footer.footer {
+  margin-top: 0.5em;
+  padding: 1em;
 }

--- a/src/Site/views/languageforge/theme/default/sass/_global.scss
+++ b/src/Site/views/languageforge/theme/default/sass/_global.scss
@@ -338,7 +338,11 @@ nav {
   text-align: center;
 }
 
-@include media-breakpoint-only(xs) {
+@include media-breakpoint-down(sm) {
+  nav.navbar {
+    position: initial;
+  }
+
   .alert {
     position: fixed;
     z-index: 100;

--- a/src/angular-app/bellows/cssBootstrap4/palaso-ui.scss
+++ b/src/angular-app/bellows/cssBootstrap4/palaso-ui.scss
@@ -188,6 +188,10 @@ div.notices {
     margin: auto;
 }
 
+.notices pre {
+  text-align: left;
+}
+
 /* overrides definitions in sf.css and bootstrap.css */
 div.notices .animate-repeat {
     line-height: inherit;

--- a/src/angular-app/bellows/directive/notice.js
+++ b/src/angular-app/bellows/directive/notice.js
@@ -18,11 +18,12 @@ angular.module('palaso.ui.notice', ['ui.bootstrap', 'bellows.services', 'ngAnima
     };
 
     return {
-      push: function (type, message, details, cannotClose) {
+      push: function (type, message, details, cannotClose, time) {
         var id = util.uuid();
-        if (type() == this.SUCCESS()) {
-          // success alert messages will auto-close after 10 seconds
-          timers[id] = $interval(function () {this.removeById(id);}.bind(this), 4 * 1000, 1);
+
+        if (!time && type() == this.SUCCESS()) time = 4 * 1000;
+        if (time) {
+          timers[id] = $interval(function () {this.removeById(id);}.bind(this), time, 1);
         }
 
         var obj = {

--- a/src/angular-app/languageforge/lexicon/lexicon.js
+++ b/src/angular-app/languageforge/lexicon/lexicon.js
@@ -135,8 +135,21 @@ angular.module('lexicon',
     Offline.options.checkOnLoad = true;
     Offline.options.checks = { xhr: { url: '/offlineCheck.txt' } };
 
+    // Set the page's Language Forge title, font size, and nav's background color
+    function setTitle(text, fontSize, backgroundColor) {
+      var title = document.querySelector('nav .mobile-title a');
+      title.textContent = text;
+      title.style.fontSize = fontSize;
+
+      document.querySelector('nav a.navbar-brand').textContent = text;
+
+      document.querySelector('nav.navbar').style.backgroundColor = backgroundColor;
+    }
+
     var offlineMessageId;
     Offline.on('up', function () {
+      setTitle('Language Forge', '', '');
+
       if ($scope.online == false) {
         notice.removeById(offlineMessageId);
         notice.push(notice.SUCCESS, 'You are back online!');
@@ -147,8 +160,10 @@ angular.module('lexicon',
     });
 
     Offline.on('down', function () {
+      setTitle('Language Forge Offline', '0.8em', '#555')
+
       offlineMessageId = notice.push(notice.ERROR,
-        'You are offline.  Some features are not available', null, true);
+        'You are offline. Some features are not available', null, true, 5 * 1000);
       $scope.online = false;
       if (!/^\/editor\//.test($location.path())) {
         // redirect to the editor


### PR DESCRIPTION
- Notifications are smaller and have text centered
- Header is nolonger sticky on mobile
- Notifications appear at the bottom of the screen on mobile
- Notification of offline mode only stays for 5 seconds
- Header changes to gray and text says "Language Forge Offline"
- Placement of close button on notifications has been fixed

Bug: With notifications shown at the bottom of the screen with absolute positioning, multiple notifications now stack instead of being displayed one above another. I'm unclear on the best approach to fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/108)
<!-- Reviewable:end -->
