### PR TITLE
Fixes to Ansible setup

### DIFF
--- a/deploy/code.yml
+++ b/deploy/code.yml
@@ -30,5 +30,6 @@
 
     - name: factory reset mongodb to empty with admin user
       shell: php FactoryReset.php run
+      become: true
       args:
         chdir: "{{lf_path}}/scripts/tools/"

--- a/deploy/code.yml
+++ b/deploy/code.yml
@@ -20,6 +20,14 @@
       when: inventory_hostname == "localhost"
       with_items: "{{site_src_paths}}"
 
+    - name: npm install
+      command: npm install
+      args:
+        chdir: "{{item}}"
+      changed_when: false
+      when: inventory_hostname == "localhost"
+      with_items: "{{site_src_paths}}"
+
     - name: factory reset mongodb to empty with admin user
       shell: php FactoryReset.php run
       args:

--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -33,7 +33,13 @@
         - unzip
         - p7zip-full
 
-    - file: src=/usr/bin/nodejs dest=/usr/local/bin/node state=link
+    - name: check for node binary
+      stat: path=/usr/local/bin/node
+      register: node_binary
+
+    - name: symlink node to nodejs
+      file: src=/usr/bin/nodejs dest=/usr/local/bin/node state=link
+      when: node_binary.stat.exists == False
 
     - name: install Composer
       shell: php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
This fixes some of the issues I ran into while setting up.

- `npm install` is now part of the Ansible script
- FactoryReset.php is now run as root as it requires
- Ansible doesn't throw a fit if `/usr/local/bin/node` is already a file (not a symlink).

I have no idea what I'm doing with Ansible, so some of this could be all wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/127)
<!-- Reviewable:end -->
