### PR TITLE
Remove window.session from the the page template

### DIFF
--- a/src/Site/Controller/Base.php
+++ b/src/Site/Controller/Base.php
@@ -100,9 +100,6 @@ class Base
             array_unshift($this->data['cssFiles'], "Site/views/shared/cssBootstrap2/bootstrap.css");
         }
 
-        // Other session data
-        $this->data['jsonSession'] = json_encode(SessionCommands::getSessionData($this->_projectId, $this->_userId, $this->website, $this->_appName), JSON_UNESCAPED_SLASHES);
-
         // Add bellows JS for every page because top container menubar needs it for helps
         $bellowsFolder = NG_BASE_FOLDER . "bellows";
         $this->addJavascriptFiles($bellowsFolder . '/_js_module_definitions');

--- a/src/Site/views/shared/container/container.html.twig
+++ b/src/Site/views/shared/container/container.html.twig
@@ -54,7 +54,6 @@
     <script src="/Site/views/shared/container/xforge.navbarApp.js?v={{ version }}"></script>
 
     <script type="text/javascript">
-        window.session = {{ jsonSession|raw }};
         {% if isBootstrap4 %}
         var bootstrapVersion = "bootstrap4";
         {% else %}

--- a/src/angular-app/bellows/js/bellows.services.api.js
+++ b/src/angular-app/bellows/js/bellows.services.api.js
@@ -1,9 +1,10 @@
 angular.module('bellows.services')
-  .service('apiService', ['jsonRpc', '$q', function (jsonRpc, $q) {
+  .service('apiService', ['jsonRpc', '$q', '$window', function (jsonRpc, $q, $window) {
 
-    var projectId = window.location.pathname.match(/^\/app\/[a-z]+\/([a-z0-9]{24,})$/i);
+    var projectId = $window.location.pathname.match(/^\/app\/[a-z]+\/([a-z0-9]{24,})$/i);
     projectId = projectId == null ? undefined : projectId[1];
     this.projectId = projectId;
+    this.isProduction = !/\.local$/.test($window.location.hostname);
 
     this.call = function(method, args, callback) {
       var options = {

--- a/src/angular-app/languageforge/lexicon/lexicon.js
+++ b/src/angular-app/languageforge/lexicon/lexicon.js
@@ -20,9 +20,11 @@ angular.module('lexicon',
     'pascalprecht.translate'
   ])
   .config(['$stateProvider', '$urlRouterProvider', '$translateProvider', '$compileProvider',
-  function ($stateProvider, $urlRouterProvider, $translateProvider, $compileProvider) {
-    $compileProvider.debugInfoEnabled(!window.session.isProduction);
-    $compileProvider.commentDirectivesEnabled(!window.session.isProduction);
+    'apiServiceProvider',
+    function ($stateProvider, $urlRouterProvider, $translateProvider, $compileProvider,
+      apiService) {
+    $compileProvider.debugInfoEnabled(apiService.isProduction);
+    $compileProvider.commentDirectivesEnabled(apiService.isProduction);
 
     $urlRouterProvider.otherwise('/editor/list');
 


### PR DESCRIPTION
Removes window.session from the page template. On the client side it was still being used to determine whether the site is in production or not.

@megahirt We discussed a bit on Flowdock whether to make .org production and all else development, or .local development and all else production. This PR uses .local, but as I started to open this PR it occurred to me that when proxying with host rewriting, the client-side will see a non-.local hostname (for example, I've been accessing Language Forge on my phone as <ip address>:3000). This makes me think it might be better to fall back to development mode when the host ends in neither .org or .local.

Either way it's not a big deal at this time. All the isProduction variable is used for is turning on AngularJS optimizations, though it could be used for more in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/133)
<!-- Reviewable:end -->
