### PR TITLE
Fix wrong items being deleteable from option lists

### DIFF
--- a/src/angular-app/bellows/directive/bootstrap4/picklist-editor.html
+++ b/src/angular-app/bellows/directive/bootstrap4/picklist-editor.html
@@ -16,7 +16,7 @@
         </div>
     </div>
     <div class="row clearfix">
-        <div sv-root sv-part="items">
+        <div sv-root sv-part="items" sv-on-sort="onSort($indexFrom, $indexTo)">
             <div data-ng-repeat="item in items" class="picklist-group" sv-element>
                 <a data-ng-show="showRemove($index)" data-ng-click="pickRemoveItem($index)"><i class="fa fa-trash"></i></a>
                 <span data-ng-hide="showRemove($index)" style="padding-left: 17px"></span>


### PR DESCRIPTION
We now track the index of every item in the list, so that the delete buttons appear to "travel" alongside their corresponding items if items are rearranged.

This is a bugfix for #29.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/163)
<!-- Reviewable:end -->
