### PR TITLE
Installer: Fix usage for clean install

### DIFF
--- a/installer/ubuntu1604Installer.sh
+++ b/installer/ubuntu1604Installer.sh
@@ -100,7 +100,7 @@ fi
 cd ..
 if [ ! -L web-scriptureforge ]; then
     echo "Fix scriptureforge.local symlink"
-    rm -r web-scriptureforge
+    sudo rm -r web-scriptureforge
     ln -s web-languageforge web-scriptureforge
 fi
 cd web-languageforge

--- a/refreshDeps.sh
+++ b/refreshDeps.sh
@@ -15,7 +15,7 @@ else
     APP_NAME="languageforge"
 fi
 
-rm -r node_modules
+rm -rf node_modules
 npm install
 cd src
 composer install


### PR DESCRIPTION
The folder `web-scriptureforge` was created via root.  `node_modules` does not exist on a clean install.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/179)
<!-- Reviewable:end -->
