### PR TITLE
Comments view integrated into the main entry view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -339,6 +339,12 @@
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.4.tgz",
       "integrity": "sha1-A7exXAGggC1+LPWTJA5gQFTcd/s="
     },
+    "angular-inview": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/angular-inview/-/angular-inview-2.1.0.tgz",
+      "integrity": "sha1-noYVuJ8m+AVlqu9wagSpxmfH14U=",
+      "dev": true
+    },
     "angular-mocks": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.6.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -339,12 +339,6 @@
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.4.tgz",
       "integrity": "sha1-A7exXAGggC1+LPWTJA5gQFTcd/s="
     },
-    "angular-inview": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/angular-inview/-/angular-inview-2.1.0.tgz",
-      "integrity": "sha1-noYVuJ8m+AVlqu9wagSpxmfH14U=",
-      "dev": true
-    },
     "angular-mocks": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.6.6.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/offline-js": "^0.7.28",
     "@types/quill": "1.3.2",
     "@types/rangy": "0.0.30",
+    "angular-inview": "^2.1.0",
     "angular-mocks": "^1.6.5",
     "awesome-typescript-loader": "^3.2.2",
     "copy-webpack-plugin": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@types/offline-js": "^0.7.28",
     "@types/quill": "1.3.2",
     "@types/rangy": "0.0.30",
-    "angular-inview": "^2.1.0",
     "angular-mocks": "^1.6.5",
     "awesome-typescript-loader": "^3.2.2",
     "copy-webpack-plugin": "^4.0.1",

--- a/src/Api/Model/Languageforge/Lexicon/LexCommentModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexCommentModel.php
@@ -53,6 +53,10 @@ class LexCommentModel extends MapperModel
     /** @var LexCommentFieldReference */
     public $regarding;
 
+    /** @var string
+     *  This is either a sense, example or pronunciation guid that references the location of this comment */
+    public $contextGuid;
+
     /** @var int */
     public $score;
 

--- a/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
+++ b/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
@@ -72,18 +72,18 @@ export class LexiconCommentService {
     this.comments.counts.currentEntry.fields = {};
     this.comments.items.currentEntry.length = 0;
     for (const comment of this.comments.items.all) {
-      const fieldName = comment.regarding.field  + '_' + comment.regarding.inputSystemAbbreviation;
+      const contextId = comment.regarding.field  + '_' + comment.regarding.inputSystemAbbreviation;
       if (comment.entryRef === entryId) {
-        if (fieldName && angular.isUndefined(this.comments.counts.currentEntry.fields[fieldName])) {
-          this.comments.counts.currentEntry.fields[fieldName] = 0;
+        if (contextId && angular.isUndefined(this.comments.counts.currentEntry.fields[contextId])) {
+          this.comments.counts.currentEntry.fields[contextId] = 0;
         }
 
         this.comments.items.currentEntry.push(comment);
 
         // update the appropriate count for this field and update the total count
         if (comment.status !== 'resolved') {
-          if (fieldName) {
-            this.comments.counts.currentEntry.fields[fieldName]++;
+          if (contextId) {
+            this.comments.counts.currentEntry.fields[contextId]++;
           }
 
           this.comments.counts.currentEntry.total++;

--- a/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
+++ b/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
@@ -72,7 +72,7 @@ export class LexiconCommentService {
     this.comments.counts.currentEntry.fields = {};
     this.comments.items.currentEntry.length = 0;
     for (const comment of this.comments.items.all) {
-      const fieldName = comment.regarding.field;
+      const fieldName = comment.regarding.field  + '_' + comment.regarding.inputSystemAbbreviation;
       if (comment.entryRef === entryId) {
         if (fieldName && angular.isUndefined(this.comments.counts.currentEntry.fields[fieldName])) {
           this.comments.counts.currentEntry.fields[fieldName] = 0;
@@ -108,9 +108,9 @@ export class LexiconCommentService {
     }
   }
 
-  getFieldCommentCount(fieldName: string): number {
-    if (angular.isDefined(this.comments.counts.currentEntry.fields[fieldName])) {
-      return this.comments.counts.currentEntry.fields[fieldName];
+  getFieldCommentCount(contextId: string): number {
+    if (angular.isDefined(this.comments.counts.currentEntry.fields[contextId])) {
+      return this.comments.counts.currentEntry.fields[contextId];
     }
 
     return 0;
@@ -144,9 +144,11 @@ export class LexiconCommentService {
 
   refreshFilteredComments(filter: any): void {
     this.comments.items.currentEntryFiltered.length = 0;
-    const comments = this.$filter('filter')(this.comments.items.currentEntry, filter.byText);
+    let comments = this.$filter('filter')(this.comments.items.currentEntry, filter.byText);
     const arr = this.comments.items.currentEntryFiltered;
-    arr.push.apply(arr, this.$filter('filter')(comments, filter.byStatus));
+    comments = this.$filter('filter')(comments, filter.byStatus);
+    comments = this.$filter('filter')(comments, filter.byContext);
+    arr.push.apply(arr, comments);
   }
 
   update(commentData: any, callback: JsonRpcCallback): angular.IPromise<JsonRpcResult> {

--- a/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
+++ b/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
@@ -69,11 +69,10 @@ export class LexiconCommentService {
   /**
    * This should be called whenever the entry context changes (to update the comments and comment counts)
    */
-  loadEntryComments(entryId: string): angular.IPromise<any> {
+  loadEntryComments(entryId: string): Promise<any> {
     this.comments.counts.currentEntry.total = 0;
     this.comments.counts.currentEntry.fields = {};
     this.comments.items.currentEntry.length = 0;
-    const defer = this.$q.defer();
     const promises = [];
     for (const comment of this.comments.items.all) {
       if (comment.entryRef === entryId) {
@@ -105,10 +104,7 @@ export class LexiconCommentService {
         }));
       }
     }
-    this.$q.all(promises).then(response => {
-      defer.resolve();
-    });
-    return defer.promise;
+    return Promise.all(promises);
   }
 
   /**

--- a/src/angular-app/bellows/directive/_palaso.ui.comments.dc-comment.scss
+++ b/src/angular-app/bellows/directive/_palaso.ui.comments.dc-comment.scss
@@ -107,9 +107,6 @@ $small-text-size: 0.8em;
     font-size: 0.95em;
   }
 }
-.commentContent {
-  margin-bottom: 0.5em;
-}
 .commentContentContainer i.fa-times:hover, .commentRepliesContainer i.fa-times:hover {
     color: #ed364f;
 }

--- a/src/angular-app/bellows/directive/_palaso.ui.comments.dc-comment.scss
+++ b/src/angular-app/bellows/directive/_palaso.ui.comments.dc-comment.scss
@@ -14,25 +14,6 @@ $small-text-size: 0.8em;
   padding: 6px 0;
 }
 
-.comments-search-container {
-    position: relative;
-    input {
-      padding-right: 174px;
-    }
-    select {
-      position: absolute;
-      right: 0;
-      top: 0;
-      width: 150px;
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-    }
-    span {
-        position: absolute;
-        right: 156px;
-        top: 7px
-    }
-}
 .regardingFieldName {
     font-weight: bold;
 }
@@ -49,11 +30,6 @@ $small-text-size: 0.8em;
 
 .regardingFieldValue.uneditable-input {
     height: 15px;
-}
-
-.commentContainer {
-    margin: 5px 0 14px 0;
-    position: relative;
 }
 
 .comment-footer {

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
@@ -1,4 +1,4 @@
-<div class="commentBubbleContainer" in-view="inview = !inview" ng-class="(inview) ? 'inview' : ''" in-view-options="{viewportOffset: [-130, 0]}">
+<div class="commentBubbleContainer">
     <a ng-click="getComments()" title="Show Comments" class="commentBubble" ng-class="(getCountForDisplay() < 1 ? 'noCount' : '')">
         <i class="fa fa-comments"></i><span class="commentCount" style="">{{getCountForDisplay()}}</span>
         <span class="commentLabel">Comment{{(getCountForDisplay() !== 1) ? 's' : ''}}</span>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
@@ -1,5 +1,6 @@
 <div class="commentBubbleContainer">
     <a ng-click="getComments()" title="Show Comments" class="commentBubble" ng-class="(getCountForDisplay() < 1 ? 'noCount' : '')">
         <i class="fa fa-comments"></i><span class="commentCount" style="">{{getCountForDisplay()}}</span>
+        <span class="commentLabel">Comment{{(getCountForDisplay() !== 1) ? 's' : ''}}</span>
     </a>
 </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
@@ -1,4 +1,4 @@
-<div class="commentBubbleContainer">
+<div class="commentBubbleContainer" in-view="inview = !inview" ng-class="(inview) ? 'inview' : ''" in-view-options="{viewportOffset: [-130, 0]}">
     <a ng-click="getComments()" title="Show Comments" class="commentBubble" ng-class="(getCountForDisplay() < 1 ? 'noCount' : '')">
         <i class="fa fa-comments"></i><span class="commentCount" style="">{{getCountForDisplay()}}</span>
         <span class="commentLabel">Comment{{(getCountForDisplay() !== 1) ? 's' : ''}}</span>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
@@ -1,5 +1,5 @@
-<div ng-show="getCount() > 0 && $state.is('editor.entry')">
-    <a ng-click="control.showComments()" title="Show Comments" class="commentBubble">
-        <i class="fa fa-comment fa-2x"></i><span class="commentCount" style="">{{getCountForDisplay()}}</span>
+<div class="commentBubbleContainer">
+    <a ng-click="getComments()" title="Show Comments" class="commentBubble" ng-class="(getCountForDisplay() < 1 ? 'noCount' : '')">
+        <i class="fa fa-comments"></i><span class="commentCount" style="">{{getCountForDisplay()}}</span>
     </a>
 </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
@@ -1,6 +1,7 @@
-<div class="commentBubbleContainer">
-    <a ng-click="getComments()" title="Show Comments" class="commentBubble" ng-class="(getCountForDisplay() < 1 ? 'noCount' : '')">
-        <i class="fa fa-comments"></i><span class="commentCount" style="">{{getCountForDisplay()}}</span>
+<div class="commentBubbleContainer" ng-class="(!active ? 'comment-inactivate' : '')">
+    <a ng-click="getComments()" title="{{(active) ? 'Show Comments' : 'Please wait while comments are setup'}}" class="commentBubble" ng-class="(getCountForDisplay() < 1 ? 'noCount' : '')">
+        <i class="fa fa-spinner fa-spin" ng-hide="active"></i>
+        <i class="fa fa-comments" ng-show="active"></i><span class="commentCount" style="">{{getCountForDisplay()}}</span>
         <span class="commentLabel">Comment{{(getCountForDisplay() !== 1) ? 's' : ''}}</span>
     </a>
 </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -9,14 +9,25 @@ angular.module('palaso.ui.comments')
         field: '=',
         control: '=',
         inputSystem: '<',
-        model: '='
+        model: '=',
+        configType: '<',
+        multiOptionValue: '<',
+        picture: '<'
       },
-      controller: ['$scope', 'lexCommentService', 'sessionService', '$element', function ($scope, commentService, ss, $element) {
+      controller: ['$scope', 'lexCommentService', 'sessionService', '$element',
+        function ($scope, commentService, ss, $element) {
         if (!angular.isDefined($scope.inputSystem)) {
           $scope.inputSystem = '';
         }
 
-        $scope.contextId = $scope.field + '_' + $scope.inputSystem;
+        $scope.pictureSrc = '';
+        if (angular.isDefined($scope.configType) && $scope.configType === 'picture') {
+          $scope.contextId = $scope.field + '_' + $scope.picture.guid;
+          $scope.pictureSrc = $scope.picture.filename;
+        } else {
+          $scope.contextId = $scope.field + '_' + $scope.inputSystem;
+        }
+
         $scope.element = $element;
 
         ss.getSession().then(function (session) {
@@ -45,7 +56,11 @@ angular.module('palaso.ui.comments')
               $scope.control.hideCommentsPanel();
             } else {
               $scope.control.setCommentContext($scope.field, $scope.inputSystem);
-              $scope.control.selectFieldForComment($scope.field, $scope.model, $scope.inputSystem);
+              $scope.control.selectFieldForComment($scope.field,
+                $scope.model,
+                $scope.inputSystem,
+                $scope.multiOptionValue,
+                $scope.pictureSrc);
               var bubbleOffset = $scope.element.offset().top;
               var rightPanel = angular.element('.comments-right-panel');
               var rightPanelOffset = rightPanel.offset().top;

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -17,12 +17,15 @@ angular.module('palaso.ui.comments', ['angular-inview'])
       controller: ['$scope', 'lexCommentService', 'sessionService', '$element', 'lexConfigService',
         function ($scope, commentService, ss, $element, lexConfig, inview) {
         if (!angular.isDefined($scope.inputSystem)) {
-          $scope.inputSystem = '';
+          $scope.inputSystem = {
+            abbreviation: '',
+            tag: ''
+          };
         }
 
         $scope.pictureSrc = '';
         $scope.inview = false;
-        $scope.contextId = $scope.field + '_' + $scope.inputSystem;
+        $scope.contextId = $scope.field + '_' + $scope.inputSystem.abbreviation;
         lexConfig.getFieldConfig($scope.field).then(function (fieldConfig) {
           if (fieldConfig.type === 'pictures' && angular.isDefined($scope.picture)) {
             $scope.pictureSrc = $scope.$parent.getPictureUrl($scope.picture);
@@ -52,22 +55,25 @@ angular.module('palaso.ui.comments', ['angular-inview'])
 
           $scope.getComments = function getComments() {
             if (!angular.isDefined($scope.inputSystem)) {
-              $scope.inputSystem = '';
+              $scope.inputSystem = {
+                abbreviation: '',
+                tag: ''
+              };
             }
 
             if ($scope.control.commentContext.field === $scope.field &&
-              $scope.control.commentContext.abbreviation === $scope.inputSystem &&
+              $scope.control.commentContext.abbreviation === $scope.inputSystem.abbreviation &&
               $scope.control.commentContext.multiOptionValue === $scope.multiOptionValue &&
               $scope.control.commentContext.pictureSrc === $scope.pictureSrc) {
               $scope.control.hideCommentsPanel();
             } else {
               $scope.control.setCommentContext($scope.field,
-                $scope.inputSystem,
+                $scope.inputSystem.abbreviation,
                 $scope.multiOptionValue,
                 $scope.pictureSrc);
               $scope.control.selectFieldForComment($scope.field,
                 $scope.model,
-                $scope.inputSystem,
+                $scope.inputSystem.tag,
                 $scope.multiOptionValue,
                 $scope.pictureSrc);
               if ($scope.multiOptionValue) {
@@ -75,6 +81,7 @@ angular.module('palaso.ui.comments', ['angular-inview'])
               } else {
                 var bubbleOffset = $scope.element.offset().top;
               }
+
               var rightPanel = angular.element('.comments-right-panel');
               var rightPanelOffset = rightPanel.offset().top;
               var offsetAuthor = 40;

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('palaso.ui.comments', ['angular-inview'])
+angular.module('palaso.ui.comments')
   .directive('commentBubble', [function () {
     return {
       restrict: 'E',
@@ -15,7 +15,7 @@ angular.module('palaso.ui.comments', ['angular-inview'])
         picture: '<'
       },
       controller: ['$scope', 'lexCommentService', 'sessionService', '$element', 'lexConfigService',
-        function ($scope, commentService, ss, $element, lexConfig, inview) {
+        function ($scope, commentService, ss, $element, lexConfig) {
         if (!angular.isDefined($scope.inputSystem)) {
           $scope.inputSystem = {
             abbreviation: '',
@@ -24,7 +24,6 @@ angular.module('palaso.ui.comments', ['angular-inview'])
         }
 
         $scope.pictureSrc = '';
-        $scope.inview = false;
         $scope.contextId = $scope.field + '_' + $scope.inputSystem.abbreviation;
         lexConfig.getFieldConfig($scope.field).then(function (fieldConfig) {
           if (fieldConfig.type === 'pictures' && angular.isDefined($scope.picture)) {

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -8,11 +8,16 @@ angular.module('palaso.ui.comments')
       scope: {
         field: '=',
         control: '=',
-        inputSystem: '='
+        inputSystem: '<',
+        model: '='
       },
-      controller: ['$scope', 'lexCommentService', 'sessionService', function ($scope, commentService, ss) {
+      controller: ['$scope', 'lexCommentService', 'sessionService', '$element', function ($scope, commentService, ss, $element) {
+        if (!angular.isDefined($scope.inputSystem)) {
+          $scope.inputSystem = '';
+        }
 
         $scope.contextId = $scope.field + '_' + $scope.inputSystem;
+        $scope.element = $element;
 
         ss.getSession().then(function (session) {
           $scope.getCount = function getCount() {
@@ -31,7 +36,23 @@ angular.module('palaso.ui.comments')
           };
 
           $scope.getComments = function getComments() {
-            $scope.control.setCommentContext($scope.field, $scope.inputSystem);
+            if (!angular.isDefined($scope.inputSystem)) {
+              $scope.inputSystem = '';
+            }
+
+            if ($scope.control.commentContext.field === $scope.field &&
+              $scope.control.commentContext.abbreviation === $scope.inputSystem) {
+              $scope.control.hideCommentsPanel();
+            } else {
+              $scope.control.setCommentContext($scope.field, $scope.inputSystem);
+              $scope.control.selectFieldForComment($scope.field, $scope.model, $scope.inputSystem);
+              var bubbleOffset = $scope.element.offset().top;
+              var rightPanel = angular.element('.comments-right-panel');
+              var rightPanelOffset = rightPanel.offset().top;
+              var offsetAuthor = 40;
+              rightPanel.css({ paddingTop: (bubbleOffset - rightPanelOffset - offsetAuthor) });
+              $scope.control.showCommentsPanel();
+            }
           };
         });
 

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -7,28 +7,31 @@ angular.module('palaso.ui.comments')
       templateUrl: '/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html',
       scope: {
         field: '=',
-        control: '='
+        control: '=',
+        inputSystem: '='
       },
       controller: ['$scope', 'lexCommentService', 'sessionService', function ($scope, commentService, ss) {
+
+        $scope.contextId = $scope.field + '_' + $scope.inputSystem;
 
         ss.getSession().then(function (session) {
           $scope.getCount = function getCount() {
             if (session.hasProjectRight(ss.domain.COMMENTS, ss.operation.CREATE)) {
-              return commentService.getFieldCommentCount($scope.field);
+              return commentService.getFieldCommentCount($scope.contextId);
             }
           };
 
           $scope.getCountForDisplay = function getCountForDisplay() {
             var count = $scope.getCount();
             if (count) {
-              if (count < 10) {
-                return ' ' + count;
-              } else {
-                return count;
-              }
+              return count;
             } else {
               return '';
             }
+          };
+
+          $scope.getComments = function getComments() {
+            $scope.control.setCommentContext($scope.field, $scope.inputSystem);
           };
         });
 

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('palaso.ui.comments')
+angular.module('palaso.ui.comments', ['angular-inview'])
   .directive('commentBubble', [function () {
     return {
       restrict: 'E',
@@ -15,12 +15,13 @@ angular.module('palaso.ui.comments')
         picture: '<'
       },
       controller: ['$scope', 'lexCommentService', 'sessionService', '$element', 'lexConfigService',
-        function ($scope, commentService, ss, $element, lexConfig) {
+        function ($scope, commentService, ss, $element, lexConfig, inview) {
         if (!angular.isDefined($scope.inputSystem)) {
           $scope.inputSystem = '';
         }
 
         $scope.pictureSrc = '';
+        $scope.inview = false;
         $scope.contextId = $scope.field + '_' + $scope.inputSystem;
         lexConfig.getFieldConfig($scope.field).then(function (fieldConfig) {
           if (fieldConfig.type === 'pictures' && angular.isDefined($scope.picture)) {

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
@@ -41,5 +41,8 @@
       font-weight: normal;
       padding: 0;
     }
+    .commentLabel {
+      display: none;
+    }
   }
 }

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
@@ -1,16 +1,45 @@
-a.commentBubble:hover {
-    text-decoration: none;
-}
-a.commentBubble {
-    color: #faa732;
-    padding: 0 20px 0 20px;
-    position:relative;
-    top: -3px;
-}
-
-a.commentBubble .commentCount {
-    color: white;
+.commentBubbleContainer {
+  position: absolute;
+  right: -20px;
+  z-index: 20;
+  top: 4px;
+  a.commentBubble {
+    background: #104060;
+    border-radius: 50%;
     position: relative;
-    right: 32px;
-    bottom: 5px;
+    width: 31px;
+    height: 31px;
+    line-height: 28px;
+    display: block;
+    text-align: center;
+    &.noCount {
+      background: #ebebeb;
+      .commentCount {
+        display: none;
+      }
+    }
+    i {
+      color: #fff;
+      font-size: 12px;
+    }
+    &:hover {
+      text-decoration: none;
+    }
+    .commentCount {
+      color: #fff;
+      position: absolute;
+      top: -8px;
+      right: -2px;
+      background: #1d64f0;
+      border-radius: 50%;
+      width: 18px;
+      height: 18px;
+      font-size: 10px;
+      display: block;
+      line-height: 18px;
+      text-align: center;
+      font-weight: normal;
+      padding: 0;
+    }
+  }
 }

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
@@ -3,11 +3,6 @@
   right: -20px;
   z-index: 20;
   top: 4px;
-  opacity: 0;
-  transition: opacity 0.5s;
-  &.inview {
-    opacity: 1;
-  }
   a.commentBubble {
     background: #104060;
     border-radius: 50%;

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
@@ -3,6 +3,11 @@
   right: -20px;
   z-index: 20;
   top: 4px;
+  opacity: 0;
+  transition: opacity 0.5s;
+  &.inview {
+    opacity: 1;
+  }
   a.commentBubble {
     background: #104060;
     border-radius: 50%;

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.scss
@@ -3,6 +3,14 @@
   right: -20px;
   z-index: 20;
   top: 4px;
+  &.comment-inactivate {
+    a.commentBubble {
+      cursor: not-allowed;
+      i {
+        color: #1d64f0;
+      }
+    }
+  }
   a.commentBubble {
     background: #104060;
     border-radius: 50%;

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
@@ -1,21 +1,31 @@
-<div>
-    <div class="comments-search-container">
-        <input dir="auto" class="form-control" placeholder="Filter Comments" ng-model="commentFilter.text" type="text">&nbsp;
-        <span ng-show="commentFilter.text != ''" title="Clear Filter" ng-click="commentFilter.text = ''">
-            <i class="fa fa-times"></i>
-        </span>
-        <!--suppress HtmlFormInputWithoutLabel -->
-        <select ng-show="rights.canUpdateCommentStatus()" class="form-control custom-select" data-ng-model="commentFilter.status">
-            <option value="all">Show All</option>
-            <option value="unresolved">Unresolved</option>
-            <option ng-if="rights.canUpdateCommentStatus()" value="todo">Todo</option>
-        </select>
+<div class="comments-right-panel-container" ng-class="{'context-mode': commentFilter.regardingField, 'panel-visible': control.commentPanelVisible > 0, 'panel-closing': control.commentPanelVisible === -1}">
+    <div ng-hide="commentFilter.regardingField">
+        <div class="comments-search-container">
+            <input dir="auto" class="form-control" placeholder="Filter Comments" ng-model="commentFilter.text" type="text">
+            <span ng-show="commentFilter.text != ''" title="Clear Filter" ng-click="commentFilter.text = ''">
+                <i class="fa fa-times"></i>
+            </span>
+            <!--suppress HtmlFormInputWithoutLabel -->
+            <select ng-show="rights.canUpdateCommentStatus()" class="form-control custom-select" data-ng-model="commentFilter.status">
+                <option value="all">Show All</option>
+                <option value="unresolved">Unresolved</option>
+                <option ng-if="rights.canUpdateCommentStatus()" value="todo">Todo</option>
+            </select>
+        </div>
     </div>
-</div>
-<div class="commentListView">
-    <div ng-show="rights.canComment()" class="newCommentForm">
+    <div class="commentListView">
+        <div class="commentListContainer">
+            <div ng-repeat="comment in currentEntryCommentsFiltered">
+                <dc-comment></dc-comment>
+            </div>
+        </div>
+    </div>
+    <div ng-show="rights.canComment() && newComment.regarding.field && showNewComment" class="newCommentForm" ng-class="(showNewComment) ? 'show' : 'nope'">
         <div class="card card-default">
-            <div class="card-body">
+            <div class="card-title" ng-show="currentEntryCommentsFiltered.length === 0">
+                <span class="sense-label">{{getSenseLabel(newComment.regarding.field)}}</span> {{newComment.regarding.fieldNameForDisplay}}{{(newComment.regarding.inputSystemAbbreviation) ? ' - ' + newComment.regarding.inputSystemAbbreviation : ''}}
+            </div>
+            <div class="card-block">
                 <form ng-submit="postNewComment()">
                     <div class="commentRegarding">
                         <i class="fa fa-times" style="float:right; color:#808080; cursor: pointer" ng-click="newComment.regarding.field = ''" ng-show="newComment.regarding.field"></i>
@@ -42,16 +52,11 @@
                         <div ng-hide="newComment.regarding.field" class="alert alert-warning"><span data-translate="Click on a field in the editor to give context to your comment"></span></div>
                     </div>
                     <textarea required data-ng-model="newComment.content" class="form-control" placeholder="{{getNewCommentPlaceholderText()}}"  ></textarea>
-                    <div class="text-xs-right">
+                    <div class="d-flex justify-content-end">
                         <button type="submit" class="btn btn-sm btn-primary">Post</button>
                     </div>
                 </form>
             </div>
-        </div>
-    </div>
-    <div class="commentListContainer">
-        <div ng-repeat="comment in currentEntryCommentsFiltered">
-            <dc-comment></dc-comment>
         </div>
     </div>
 </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
@@ -13,49 +13,27 @@
             </select>
         </div>
     </div>
-    <div class="commentListView">
-        <div class="commentListContainer">
-            <div ng-repeat="comment in currentEntryCommentsFiltered">
-                <dc-comment></dc-comment>
+    <div class="commentsListMainContainer">
+        <div class="commentListView">
+            <div class="commentListContainer">
+                <div ng-repeat="comment in currentEntryCommentsFiltered">
+                    <dc-comment></dc-comment>
+                </div>
             </div>
         </div>
-    </div>
-    <div ng-show="rights.canComment() && newComment.regarding.field && showNewComment" class="newCommentForm" ng-class="(showNewComment) ? 'show' : 'nope'">
-        <div class="card card-default">
-            <div class="card-title" ng-show="currentEntryCommentsFiltered.length === 0">
-                <span class="sense-label">{{getSenseLabel(newComment.regarding.field)}}</span> {{newComment.regarding.fieldNameForDisplay}}{{(newComment.regarding.inputSystemAbbreviation) ? ' - ' + newComment.regarding.inputSystemAbbreviation : ''}}
-            </div>
-            <div class="card-block">
-                <form ng-submit="postNewComment()">
-                    <div class="commentRegarding">
-                        <i class="fa fa-times" style="float:right; color:#808080; cursor: pointer" ng-click="newComment.regarding.field = ''" ng-show="newComment.regarding.field"></i>
-                        <div class="text-muted">This comment is regarding</div>
-                        <div ng-show="newComment.regarding.field">
-                            <div class="form-group">
-                                <span class="regardingContext">{{newComment.regarding.word}}</span>
-                                <em>{{newComment.regarding.meaning}}</em>
-                            </div>
-                            <div class="form-group row">
-                                <label class="regardingFieldName col-md-3 text-md-right">{{newComment.regarding.fieldNameForDisplay}}</label>
-                                <div class="col-md-9">
-                                    <div data-ng-class="(newComment.regarding.inputSystem) ? 'input-group' : ''"
-                                         data-ng-hide="newComment.isRegardingPicture">
-                                        <span data-ng-show="newComment.regarding.inputSystem" class="input-group-addon wsid regardingInputSystem" title="{{newComment.regarding.inputSystem}}">{{newComment.regarding.inputSystemAbbreviation}}</span>
-                                        <regarding-field class="form-control" content="newComment.regarding.fieldValue" field-config="newComment.regardingFieldConfig"> </regarding-field>
-                                    </div>
-                                    <div data-ng-if="newComment.isRegardingPicture">
-                                        <img data-ng-src="{{newComment.regarding.fieldValue}}">
-                                    </div>
-                                </div>
-                            </div>
+        <div ng-show="rights.canComment() && newComment.regarding.field && showNewComment" class="newCommentForm" ng-class="{'show': showNewComment, 'regard': newComment.regarding.field}">
+            <div class="card card-default">
+                <div class="card-title" ng-show="currentEntryCommentsFiltered.length === 0">
+                    <span class="sense-label">{{getSenseLabel(newComment.regarding.field)}}</span> {{newComment.regarding.fieldNameForDisplay}}{{(newComment.regarding.inputSystemAbbreviation) ? ' - ' + newComment.regarding.inputSystemAbbreviation : ''}}
+                </div>
+                <div class="card-block">
+                    <form ng-submit="postNewComment()">
+                        <textarea required data-ng-model="newComment.content" class="form-control" placeholder="{{getNewCommentPlaceholderText()}}"  ></textarea>
+                        <div class="d-flex justify-content-end">
+                            <button type="submit" class="btn btn-sm btn-primary">Post</button>
                         </div>
-                        <div ng-hide="newComment.regarding.field" class="alert alert-warning"><span data-translate="Click on a field in the editor to give context to your comment"></span></div>
-                    </div>
-                    <textarea required data-ng-model="newComment.content" class="form-control" placeholder="{{getNewCommentPlaceholderText()}}"  ></textarea>
-                    <div class="d-flex justify-content-end">
-                        <button type="submit" class="btn btn-sm btn-primary">Post</button>
-                    </div>
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
@@ -1,5 +1,5 @@
-<div class="comments-right-panel-container" ng-class="{'context-mode': commentFilter.regardingField, 'panel-visible': control.commentPanelVisible > 0, 'panel-closing': control.commentPanelVisible === -1}">
-    <div ng-hide="commentFilter.regardingField">
+<div class="comments-right-panel-container" ng-class="{'context-mode': commentFilter.contextGuid, 'panel-visible': control.commentPanelVisible > 0, 'panel-closing': control.commentPanelVisible === -1}">
+    <div ng-hide="commentFilter.contextGuid">
         <div class="comments-search-container">
             <input dir="auto" class="form-control" placeholder="Filter Comments" ng-model="commentFilter.text" type="text">
             <span ng-show="commentFilter.text != ''" title="Clear Filter" ng-click="commentFilter.text = ''">
@@ -24,7 +24,7 @@
         <div ng-show="rights.canComment() && newComment.regarding.field && showNewComment" class="newCommentForm" ng-class="{'show': showNewComment, 'regard': newComment.regarding.field}">
             <div class="card card-default">
                 <div class="card-title" ng-show="currentEntryCommentsFiltered.length === 0">
-                    <span class="sense-label">{{getSenseLabel(newComment.regarding.field)}}</span> {{newComment.regarding.fieldNameForDisplay}}{{(newComment.regarding.inputSystemAbbreviation) ? ' - ' + newComment.regarding.inputSystemAbbreviation : ''}}
+                    <span class="sense-label">{{getNewCommentSenseLabel(newComment.regarding.field)}}</span> {{newComment.regarding.fieldNameForDisplay}}{{(newComment.regarding.inputSystemAbbreviation) ? ' - ' + newComment.regarding.inputSystemAbbreviation : ''}}
                 </div>
                 <div class="card-block">
                     <form ng-submit="postNewComment()">

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
@@ -29,7 +29,7 @@ angular.module('palaso.ui.comments')
         };
 
         $scope.initializeNewComment = function initializeNewComment() {
-          if($scope.showNewComment) {
+          if ($scope.showNewComment) {
             $scope.newComment.content = '';
           } else {
             $scope.newComment = {
@@ -55,6 +55,8 @@ angular.module('palaso.ui.comments')
           status: 'all',
           regardingField: '',
           regardingInputSystemAbbreviation: '',
+          multiOptionValue: '',
+          pictureSrc: '',
           byText: function byText(comment) {
             // Convert entire comment object to a big string and search for filter.
             // Note: This has a slight side effect of ID and avatar information
@@ -89,7 +91,21 @@ angular.module('palaso.ui.comments')
               return true;
             } else if (comment.regarding.field === $scope.commentFilter.regardingField &&
               comment.regarding.inputSystemAbbreviation === $scope.commentFilter.regardingInputSystemAbbreviation) {
-              return true;
+              if ($scope.commentFilter.multiOptionValue) {
+                if (comment.regarding.fieldValue === $scope.commentFilter.multiOptionValue) {
+                  return true;
+                } else {
+                  return false;
+                }
+              } else if ($scope.commentFilter.pictureSrc) {
+                if (comment.regarding.fieldValue === $scope.commentFilter.pictureSrc) {
+                  return true;
+                } else {
+                  return false;
+                }
+              } else {
+                return true;
+              }
             }
 
             return false;
@@ -136,15 +152,16 @@ angular.module('palaso.ui.comments')
         commentService.refreshFilteredComments($scope.commentFilter);
 
         $scope.loadComments = function loadComments() {
-          commentService.loadEntryComments($scope.entry.id);
-          commentService.refreshFilteredComments($scope.commentFilter);
-          if ($scope.commentInteractiveStatus.id) {
-            angular.forEach($scope.currentEntryCommentsFiltered, function (comment) {
-              if (comment.id === $scope.commentInteractiveStatus.id) {
-                comment.showRepliesContainer = $scope.commentInteractiveStatus.visible;
-              }
-            });
-          }
+          commentService.loadEntryComments($scope.entry.id).then(function () {
+            commentService.refreshFilteredComments($scope.commentFilter);
+            if ($scope.commentInteractiveStatus.id) {
+              angular.forEach($scope.currentEntryCommentsFiltered, function (comment) {
+                if (comment.id === $scope.commentInteractiveStatus.id) {
+                  comment.showRepliesContainer = $scope.commentInteractiveStatus.visible;
+                }
+              });
+            }
+          });
         };
 
         $scope.setCommentInteractiveStatus = function setCommentInteractiveStatus(id, visible) {
@@ -181,9 +198,14 @@ angular.module('palaso.ui.comments')
           return label;
         };
 
-        $scope.showCommentsInContext = function showCommentsInContext(field, abbreviation) {
+        $scope.showCommentsInContext = function showCommentsInContext(field,
+                                                                      abbreviation,
+                                                                      multiOptionValue,
+                                                                      pictureUrl) {
           $scope.commentFilter.regardingField = field;
           $scope.commentFilter.regardingInputSystemAbbreviation = abbreviation;
+          $scope.commentFilter.multiOptionValue = multiOptionValue;
+          $scope.commentFilter.pictureSrc = pictureUrl;
           if (field !== '') {
             $scope.showNewComment = true;
           } else {
@@ -255,7 +277,10 @@ angular.module('palaso.ui.comments')
 
         $scope.$watch('control.commentContext', function (newVal, oldVal) {
           if (newVal !== oldVal) {
-            $scope.showCommentsInContext(newVal.field, newVal.abbreviation);
+            $scope.showCommentsInContext(newVal.field,
+              newVal.abbreviation,
+              newVal.multiOptionValue,
+              newVal.pictureSrc);
           }
 
         }, true);

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
@@ -42,6 +42,8 @@ angular.module('palaso.ui.comments')
         $scope.commentFilter = {
           text: '',
           status: 'all',
+          regardingField: '',
+          regardingInputSystemAbbreviation: '',
           byText: function byText(comment) {
             // Convert entire comment object to a big string and search for filter.
             // Note: This has a slight side effect of ID and avatar information
@@ -63,6 +65,24 @@ angular.module('palaso.ui.comments')
                   return true;
                 }
               }
+            }
+
+            return false;
+          },
+
+          byContext: function byContext(comment) {
+            console.log('reached');
+            if (!angular.isDefined(comment)) {
+              return false;
+            } else if (!$scope.commentFilter.regardingField ||
+              !$scope.commentFilter.regardingInputSystemAbbreviation) {
+              // Return true as we're most likely not running a valid context search so return all
+              console.log('nope');
+              return true;
+            } else if (comment.regarding.field === $scope.commentFilter.regardingField &&
+              comment.regarding.inputSystemAbbreviation === $scope.commentFilter.regardingInputSystemAbbreviation) {
+              console.log('boom!');
+              return true;
             }
 
             return false;
@@ -154,6 +174,13 @@ angular.module('palaso.ui.comments')
           return label;
         };
 
+        $scope.showCommentsInContext = function showCommentsInContext(field, abbreviation) {
+          console.log('go go go: ');
+          $scope.commentFilter.regardingField = field;
+          $scope.commentFilter.regardingInputSystemAbbreviation = abbreviation;
+          commentService.refreshFilteredComments($scope.commentFilter);
+        };
+
         $scope.$watch('entry', function (newVal) {
           if (newVal && !angular.equals(newVal, {})) {
             $scope.loadComments();
@@ -174,6 +201,15 @@ angular.module('palaso.ui.comments')
           }
 
         });
+
+        $scope.$watch('control.commentContext', function (newVal, oldVal) {
+          console.log('here');
+          if (newVal !== oldVal) {
+            console.log('change');
+            $scope.showCommentsInContext(newVal.field, newVal.abbreviation);
+          }
+
+        }, true);
 
       }],
 

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
@@ -21,23 +21,27 @@ angular.module('palaso.ui.comments')
          regarding: {}
          };
          */
-        $scope.panelVisible = false;
-        $scope.showNewComment = true;
+        $scope.showNewComment = false;
+        $scope.senseLabel = '';
         $scope.commentInteractiveStatus = {
           id: '',
           visible: false
         };
 
         $scope.initializeNewComment = function initializeNewComment() {
-          $scope.newComment =  {
-            id: '',
-            content: '',
-            entryRef: $scope.entry.id,
-            regarding: {
-              meaning: $scope.control.getMeaningForDisplay($scope.entry),
-              word: $scope.control.getWordForDisplay($scope.entry)
-            }
-          };
+          if($scope.showNewComment) {
+            $scope.newComment.content = '';
+          } else {
+            $scope.newComment = {
+              id: '',
+              content: '',
+              entryRef: $scope.entry.id,
+              regarding: {
+                meaning: $scope.control.getMeaningForDisplay($scope.entry),
+                word: $scope.control.getWordForDisplay($scope.entry)
+              }
+            };
+          }
         };
 
         $scope.currentEntryCommentsFiltered = commentService.comments.items.currentEntryFiltered;
@@ -168,7 +172,8 @@ angular.module('palaso.ui.comments')
           if ($scope.currentEntryCommentsFiltered.length === 0) {
             label = $filter('translate')('Your comment goes here.  Be the first to share!');
           } else if ($scope.currentEntryCommentsFiltered.length > 0) {
-            label = $filter('translate')('Start a new conversation thread.  Enter your comment here.');
+            label = $filter('translate')('Start a new conversation thread. ' +
+              'Enter your comment here.');
           } else {
             label = $filter('translate')('Join the discussion and type your comment here.');
           }
@@ -179,6 +184,12 @@ angular.module('palaso.ui.comments')
         $scope.showCommentsInContext = function showCommentsInContext(field, abbreviation) {
           $scope.commentFilter.regardingField = field;
           $scope.commentFilter.regardingInputSystemAbbreviation = abbreviation;
+          if (field !== '') {
+            $scope.showNewComment = true;
+          } else {
+            $scope.showNewComment = false;
+          }
+
           commentService.refreshFilteredComments($scope.commentFilter);
         };
 
@@ -198,23 +209,28 @@ angular.module('palaso.ui.comments')
         };
 
         $scope.getSenseLabel = function getSenseLabel(regardingField) {
-            var configField = null;
-            if ($scope.control.config.entry.fields.hasOwnProperty(regardingField)) {
-              configField = $scope.control.config.entry.fields[regardingField];
-            } else if ($scope.control.config.entry.fields.senses.fields.hasOwnProperty(regardingField)) {
-              configField = $scope.control.config.entry.fields.senses.fields[regardingField];
-            } else if ($scope.control.config.entry.fields.senses.fields.examples.fields.hasOwnProperty(regardingField)) {
-              configField = $scope.control.config.entry.fields.senses.fields.examples.fields[regardingField];
-            }
-
-            if (configField !== null) {
-              if (configField.hasOwnProperty('senseLabel')) {
-                return configField.senseLabel;
-              }
-            }
-
+          if (!angular.isDefined(regardingField)) {
             return '';
-          };
+          }
+
+          var configField = null;
+          var fields = $scope.control.config.entry.fields;
+          if (fields.hasOwnProperty(regardingField)) {
+            configField = fields[regardingField];
+          } else if (fields.senses.fields.hasOwnProperty(regardingField)) {
+            configField = fields.senses.fields[regardingField];
+          } else if (fields.senses.fields.examples.fields.hasOwnProperty(regardingField)) {
+            configField = fields.senses.fields.examples.fields[regardingField];
+          }
+
+          if (configField !== null) {
+            if (configField.hasOwnProperty('senseLabel')) {
+              return configField.senseLabel;
+            }
+          }
+
+          return '';
+        };
 
         $scope.$watch('entry', function (newVal) {
           if (newVal && !angular.equals(newVal, {})) {

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -42,7 +42,7 @@
                     (<span ng-show="!comment.regarding.visible">view</span><span ng-show="comment.regarding.visible">hide</span> original meaning)</button>
                 <div class="commentRegarding" data-ng-show="comment.regarding.field && comment.regarding.visible === true && !comment.editing">
                     <regarding-field class="form-control" content="comment.regarding.fieldValue"
-                         field-config="commentRegardingFieldConfig"></regarding-field>
+                         field-config="commentRegardingFieldConfig" ng-hide="isCommentRegardingPicture"></regarding-field>
                     <div data-ng-if="isCommentRegardingPicture">
                         <img data-ng-src="{{comment.regarding.fieldValue}}">
                     </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -1,12 +1,49 @@
 <div class="commentContainer card">
-    <div class="card-body" data-ng-class="{resolvedComment: comment.status == 'resolved'}">
+    <div class="card-title">
+        {{comment.regarding.fieldNameForDisplay}} - {{comment.regarding.inputSystemAbbreviation}}
+    </div>
+    <div class="card-block" data-ng-class="{resolvedComment: comment.status == 'resolved'}">
         <div class="commentContentContainer">
+            <div class="comment-meta">
+                <div>
+                    <img class="rounded-circle"
+                         data-ng-src="{{getAvatarUrl(comment.authorInfo.createdByUserRef.avatar_ref)}}">
+                    <div class="data-and-author">
+                        <div class="comment-author">{{comment.authorInfo.createdByUserRef.name}}</div>
+                        <div class="comment-date">{{comment.authorInfo.createdDate | relativetime}}</div>
+                    </div>
+                </div>
+                <div class="dropdown" uib-dropdown>
+                    <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle type="button"><i
+                            class="fa fa-ellipsis-v"></i></button>
+                    <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
+                        <a href class="dropdown-item" data-ng-show="comment.status != 'open'"
+                           data-ng-click="updateCommentStatus(comment.id, 'open')"><i
+                                class="fa fa-chevron-circle-up"></i> Reopen comment</a>
+                        <a href class="dropdown-item" data-ng-show="comment.status != 'resolved'"
+                           data-ng-click="updateCommentStatus(comment.id, 'resolved')"><i class="fa fa-check"></i> Mark
+                            as resolved</a>
+                        <a href class="dropdown-item" data-ng-show="comment.status != 'todo'"
+                           data-ng-click="updateCommentStatus(comment.id, 'todo')"><i class="fa fa-edit"></i> Mark as
+                            to-do</a>
+                        <div class="dropdown-divider"></div>
+                        <a href class="dropdown-item"
+                           data-ng-show="rights.canEditComment(comment.authorInfo.createdByUserRef.id)"
+                           data-ng-click="editComment()"><i class="fa fa-pencil"></i> Edit</a>
+                        <a href class="dropdown-item"
+                           data-ng-show="rights.canDeleteComment(comment.authorInfo.createdByUserRef.id) && !comment.editing"
+                           data-ng-click="deleteComment(comment)"><i class="fa fa-trash"></i> Delete</a>
+                    </div>
+                </div>
+            </div>
             <div class="comment-body">
                 <div class="comment-status">
-                    <div data-ng-show="comment.status == 'resolved'" class="comment-status-resolved" title="This comment is marked as resolved">
+                    <div data-ng-show="comment.status == 'resolved'" class="comment-status-resolved"
+                         title="This comment is marked as resolved">
                         <i style="color: #8be25c;" class="fa fa-check"></i> Resolved
                     </div>
-                    <div data-ng-show="comment.status == 'todo'" class="comment-status-todo" title="This comment is marked as todo">
+                    <div data-ng-show="comment.status == 'todo'" class="comment-status-todo"
+                         title="This comment is marked as todo">
                         <i class="fa fa-edit"></i> Todo
                     </div>
                 </div>
@@ -20,8 +57,11 @@
                             <label class="regardingFieldName col-md-3 text-md-right">{{comment.regarding.fieldNameForDisplay}}</label>
                             <div class="col-md-9" data-ng-if="!isCommentRegardingPicture">
                                 <div data-ng-class="(comment.regarding.inputSystem) ? 'input-group' : ''">
-                                    <span data-ng-show="comment.regarding.inputSystem" class="input-group-addon wsid regardingInputSystem" title="{{comment.regarding.inputSystem}}">{{comment.regarding.inputSystemAbbreviation}}</span>
-                                    <regarding-field class="form-control" content="comment.regarding.fieldValue" field-config="commentRegardingFieldConfig">
+                                    <span data-ng-show="comment.regarding.inputSystem"
+                                          class="input-group-addon wsid regardingInputSystem"
+                                          title="{{comment.regarding.inputSystem}}">{{comment.regarding.inputSystemAbbreviation}}</span>
+                                    <regarding-field class="form-control" content="comment.regarding.fieldValue"
+                                                     field-config="commentRegardingFieldConfig">
                                     </regarding-field>
                                 </div>
                             </div>
@@ -36,74 +76,78 @@
                     <!--suppress HtmlFormInputWithoutLabel -->
                     <textarea class="form-control" data-ng-model="editingCommentContent"></textarea>
                     <div>
-                        <button data-ng-disabled="!comment.content" class="btn btn-sm btn-primary float-right" data-ng-click="updateComment(comment)">Update</button>
+                        <button data-ng-disabled="!comment.content" class="btn btn-sm btn-primary float-right"
+                                data-ng-click="updateComment(comment)">Update
+                        </button>
                         <a class="btn btn-sm btn-std float-left" data-ng-click="comment.editing = false">Cancel</a>
                     </div>
                 </div>
             </div>
-            <div class="comment-footer">
-                <div>
-                    <img class="rounded-circle" data-ng-src="{{getAvatarUrl(comment.authorInfo.createdByUserRef.avatar_ref)}}">
-                </div>
-                <div class="data-and-author">
-                    <div class="commentAuthor">{{comment.authorInfo.createdByUserRef.name}}</div>
-                    <div class="commentDate">{{comment.authorInfo.createdDate | relativetime}}</div>
-                </div>
-                <div class="commentPlusOne">{{comment.score}}
-                    <i data-ng-show="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'" style="cursor: pointer"
-                        data-ng-click="plusOneComment(comment.id)" title="Like comment" class="fa fa-thumbs-o-up"></i>
-                    <i data-ng-hide="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'" style="opacity: 0.5" class="fa fa-thumbs-o-up"></i>
-                </div>
-                <div class="dropdown float-right" uib-dropdown>
-                    <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle type="button"><i class="fa fa-ellipsis-v"></i></button>
-                    <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
-                        <a href class="dropdown-item" data-ng-show="comment.status != 'open'" data-ng-click="updateCommentStatus(comment.id, 'open')"><i class="fa fa-chevron-circle-up"></i> Reopen comment</a>
-                        <a href class="dropdown-item" data-ng-show="comment.status != 'resolved'" data-ng-click="updateCommentStatus(comment.id, 'resolved')"><i class="fa fa-check"></i> Mark as resolved</a>
-                        <a href class="dropdown-item" data-ng-show="comment.status != 'todo'" data-ng-click="updateCommentStatus(comment.id, 'todo')"><i class="fa fa-edit"></i> Mark as to-do</a>
-                        <div class="dropdown-divider"></div>
-                        <a href class="dropdown-item" data-ng-show="rights.canEditComment(comment.authorInfo.createdByUserRef.id)" data-ng-click="editComment()"><i class="fa fa-pencil"></i> Edit</a>
-                        <a href class="dropdown-item" data-ng-show="rights.canDeleteComment(comment.authorInfo.createdByUserRef.id) && !comment.editing"
-                            data-ng-click="deleteComment(comment)"><i class="fa fa-trash" ></i> Delete</a>
-                    </div>
-                </div>
+        </div>
+        <div class="comment-interaction">
+            <span class="likes">{{comment.score}} Like{{(comment.score != 1 ? 's' : '')}}</span>
+            <span class="replies">{{comment.replies.length || '0'}} Comment{{(comment.replies.length != 1 ? 's' : '')}}</span>
+        </div>
+        <div class="comment-actions">
+            <div class="btn-like">
+                <i data-ng-show="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'"
+                   style="cursor: pointer"
+                   data-ng-click="plusOneComment(comment.id)" title="Like comment" class="fa fa-thumbs-o-up"></i>
+                <i data-ng-hide="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'"
+                   style="opacity: 0.5" class="fa fa-thumbs-o-up"></i>
+                <span>Like</span>
+            </div>
+            <div class="btn-comments" ng-click="showCommentReplies()">
+                <i class="fa fa-comment-o"></i>
+                <span>Comments</span>
             </div>
         </div>
-        <div class="commentRepliesContainer">
-            <div data-ng-repeat="reply in comment.replies" data-ng-mouseenter="reply.hover = true" data-ng-mouseleave="reply.hover = false" class="reply">
-                <div data-ng-hide="reply.editing" class="comment-replies">
-                    <div class="reply-body">
-                        <span class="replyContent">{{reply.content}}</span><span class="commentAuthor"> - {{reply.authorInfo.createdByUserRef.name}}</span>
-                        <span class="commentDate">{{reply.authorInfo.createdDate | relativetime}}</span>
-                    </div>
-                    <div data-ng-show="comment.status != 'resolved'" class="reply-actions">
-                        <div class="dropdown float-right" uib-dropdown>
-                            <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle type="button"><i class="fa fa-ellipsis-v"></i></button>
-                            <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
-                                <a href class="btn btn-sm btn-std dropdown-item editReplyLink"
-                                   data-ng-show="rights.canEditComment(reply.authorInfo.createdByUserRef.id)"
-                                   data-ng-click="editReply(reply)">
-                                    <i class="fa fa-pencil"></i> Edit</a>
-                                <a href class="btn btn-sm btn-std dropdown-item deleteReplyLink"
-                                   data-ng-show="rights.canDeleteComment(reply.authorInfo.createdByUserRef.id)"
-                                   data-ng-click="deleteCommentReply(comment.id, reply)">
-                                    <i class="fa fa-trash"></i> Delete</a>
+        <div class="commentRepliesContainer" data-ng-show="showRepliesContainer">
+            <div class="comment-replies">
+                <div data-ng-repeat="reply in comment.replies" data-ng-mouseenter="reply.hover = true"
+                     data-ng-mouseleave="reply.hover = false">
+                    <div data-ng-hide="reply.editing">
+                        <div class="reply-body">
+                            <div class="reply-meta">
+                                <div class="comment-author">{{reply.authorInfo.createdByUserRef.name}}</div>
+                                <div class="comment-date">{{reply.authorInfo.createdDate | relativetime}}</div>
+                            </div>
+                            <span class="reply-content">{{reply.content}}</span>
+                        </div>
+                        <div data-ng-show="comment.status != 'resolved'" class="reply-actions">
+                            <div class="dropdown float-right" uib-dropdown>
+                                <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle
+                                        type="button"><i class="fa fa-ellipsis-v"></i></button>
+                                <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
+                                    <a href class="btn btn-sm btn-std dropdown-item editReplyLink"
+                                       data-ng-show="rights.canEditComment(reply.authorInfo.createdByUserRef.id)"
+                                       data-ng-click="editReply(reply)">
+                                        <i class="fa fa-pencil"></i> Edit</a>
+                                    <a href class="btn btn-sm btn-std dropdown-item deleteReplyLink"
+                                       data-ng-show="rights.canDeleteComment(reply.authorInfo.createdByUserRef.id)"
+                                       data-ng-click="deleteCommentReply(comment.id, reply)">
+                                        <i class="fa fa-trash"></i> Delete</a>
+                                </div>
                             </div>
                         </div>
                     </div>
+                    <form data-ng-show="showReplies" data-ng-submit="submitReply(reply)">
+                        <!--suppress HtmlFormInputWithoutLabel -->
+                        <textarea class="form-control" data-ng-model="reply.editingContent"
+                                  pui-auto-focus="reply.isAutoFocusEditing"></textarea>
+                        <button type="submit" class="btn btn-sm btn-primary">Update</button>
+                        <a href data-ng-click="reply.editing = false">Cancel</a>
+                    </form>
                 </div>
-                <form data-ng-show="reply.editing" data-ng-submit="submitReply(reply)">
-                    <!--suppress HtmlFormInputWithoutLabel -->
-                    <textarea class="form-control" data-ng-model="reply.editingContent" pui-auto-focus="reply.isAutoFocusEditing"></textarea>
-                    <button type="submit" class="btn btn-sm btn-primary">Update</button>
-                    <a href data-ng-click="reply.editing = false">Cancel</a>
-                </form>
             </div>
             <form class="commentNewReplyForm" data-ng-show="showNewReplyForm" data-ng-submit="submitReply(newReply)">
-                <textarea class="form-control" placeholder="Reply here.  Press Enter when done." data-ng-model="newReply.editingContent" pui-auto-focus="isAutoFocusNewReply"></textarea>
+                <textarea class="form-control" placeholder="Reply here.  Press Enter when done."
+                          data-ng-model="newReply.editingContent" pui-auto-focus="isAutoFocusNewReply"></textarea>
                 <button type="submit" class="btn btn-sm btn-primary">Post</button>
                 <a href data-ng-click="showNewReplyForm = false">Cancel</a>
             </form>
         </div>
-        <a href class="btn btn-sm btn-std float-right" data-ng-show="rights.canComment() && !showNewReplyForm" data-ng-click="doReply()"><i class="fa fa-reply"></i> Reply</a>
+        <a href class="btn btn-sm btn-std float-right" data-ng-show="rights.canComment() && !showNewReplyForm"
+           data-ng-click="doReply()"><i class="fa fa-reply"></i> Reply</a>
     </div>
 </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -13,20 +13,10 @@
                         <div class="comment-date">{{comment.authorInfo.createdDate | relativetime}}</div>
                     </div>
                 </div>
-                <div class="dropdown" uib-dropdown>
+                <div class="dropdown" uib-dropdown data-ng-show="rights.canEditComment(comment.authorInfo.createdByUserRef.id) || rights.canDeleteComment(comment.authorInfo.createdByUserRef.id) && !comment.editing">
                     <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle type="button"><i
                             class="fa fa-ellipsis-v"></i></button>
                     <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
-                        <a href class="dropdown-item" data-ng-show="comment.status != 'open'"
-                           data-ng-click="updateCommentStatus(comment.id, 'open')"><i
-                                class="fa fa-chevron-circle-up"></i> Reopen comment</a>
-                        <a href class="dropdown-item" data-ng-show="comment.status != 'resolved'"
-                           data-ng-click="updateCommentStatus(comment.id, 'resolved')"><i class="fa fa-check"></i> Mark
-                            as resolved</a>
-                        <a href class="dropdown-item" data-ng-show="comment.status != 'todo'"
-                           data-ng-click="updateCommentStatus(comment.id, 'todo')"><i class="fa fa-edit"></i> Mark as
-                            to-do</a>
-                        <div class="dropdown-divider"></div>
                         <a href class="dropdown-item"
                            data-ng-show="rights.canEditComment(comment.authorInfo.createdByUserRef.id)"
                            data-ng-click="editComment()"><i class="fa fa-pencil"></i> Edit</a>
@@ -37,40 +27,6 @@
                 </div>
             </div>
             <div class="comment-body">
-                <div class="comment-status">
-                    <div data-ng-show="comment.status == 'resolved'" class="comment-status-resolved"
-                         title="This comment is marked as resolved">
-                        <i style="color: #8be25c;" class="fa fa-check"></i> Resolved
-                    </div>
-                    <div data-ng-show="comment.status == 'todo'" class="comment-status-todo"
-                         title="This comment is marked as todo">
-                        <i class="fa fa-edit"></i> Todo
-                    </div>
-                </div>
-                <div class="commentRegarding card card-default" data-ng-show="comment.regarding.field">
-                    <div class="card-body">
-                        <div class="form-group">
-                            <span class="regardingContext">{{comment.regarding.word}}</span>
-                            <em>{{comment.regarding.meaning}}</em>
-                        </div>
-                        <div class="form-group row">
-                            <label class="regardingFieldName col-md-3 text-md-right">{{comment.regarding.fieldNameForDisplay}}</label>
-                            <div class="col-md-9" data-ng-if="!isCommentRegardingPicture">
-                                <div data-ng-class="(comment.regarding.inputSystem) ? 'input-group' : ''">
-                                    <span data-ng-show="comment.regarding.inputSystem"
-                                          class="input-group-addon wsid regardingInputSystem"
-                                          title="{{comment.regarding.inputSystem}}">{{comment.regarding.inputSystemAbbreviation}}</span>
-                                    <regarding-field class="form-control" content="comment.regarding.fieldValue"
-                                                     field-config="commentRegardingFieldConfig">
-                                    </regarding-field>
-                                </div>
-                            </div>
-                        </div>
-                        <div data-ng-if="isCommentRegardingPicture">
-                            <img data-ng-src="{{comment.regarding.fieldValue}}">
-                        </div>
-                    </div>
-                </div>
                 <div class="commentContent" data-ng-hide="comment.editing" data-ng-bind="comment.content"></div>
                 <div data-ng-show="comment.editing" class="commentEditing">
                     <!--suppress HtmlFormInputWithoutLabel -->
@@ -82,6 +38,15 @@
                         </button>
                     </div>
                 </div>
+                <button ng-show="!comment.editing" class="btn btn-std btn-sm" ng-click="comment.regarding.visible = !comment.regarding.visible">
+                    (<span ng-show="!comment.regarding.visible">view</span><span ng-show="comment.regarding.visible">hide</span> original meaning)</button>
+                <div class="commentRegarding" data-ng-show="comment.regarding.field && comment.regarding.visible === true && !comment.editing">
+                    <regarding-field class="form-control" content="comment.regarding.fieldValue"
+                         field-config="commentRegardingFieldConfig"></regarding-field>
+                    <div data-ng-if="isCommentRegardingPicture">
+                        <img data-ng-src="{{comment.regarding.fieldValue}}">
+                    </div>
+                </div>
             </div>
         </div>
         <div class="comment-interaction">
@@ -90,14 +55,31 @@
         </div>
         <div class="comment-actions">
             <div class="btn-like">
-                <i data-ng-show="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'"
-                   style="cursor: pointer"
-                   data-ng-click="plusOneComment(comment.id)" title="Like comment" class="fa fa-thumbs-o-up"></i>
-                <i data-ng-hide="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'"
-                   style="opacity: 0.5" class="fa fa-thumbs-o-up"></i>
-                <span>Like</span>
+                <div class="can-like btn-action-icon" data-ng-show="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'" data-ng-click="plusOneComment(comment.id)">
+                    <i title="Like comment" class="fa fa-thumbs-o-up"></i>
+                    <span>Like</span>
+                </div>
+                <div class="liked btn-action-icon" data-ng-hide="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'">
+                    <i class="fa fa-thumbs-o-up"></i>
+                    <span>Like</span>
+                </div>
             </div>
-            <div class="btn-comments" ng-click="showCommentReplies()">
+            <div class="btn-todo">
+                <div ng-show="rights.canUpdateCommentStatus()">
+                    <div class="open-todo btn-action-icon" data-ng-show="comment.status == 'resolved'"
+                       data-ng-click="updateCommentStatus(comment.id, 'open')"><i class="fa fa-pencil-square-o"></i><span>Resolved</span></div>
+                    <div class="resolve-todo btn-action-icon" data-ng-show="comment.status == 'todo'"
+                       data-ng-click="updateCommentStatus(comment.id, 'resolved')"><i class="fa fa-pencil-square-o"></i><span>To do</span></div>
+                    <div class="mark-todo btn-action-icon" data-ng-show="comment.status != 'resolved' && comment.status != 'todo'"
+                       data-ng-click="updateCommentStatus(comment.id, 'todo')"><i class="fa fa-pencil-square-o"></i><span>To do</span></div>
+                </div>
+                <div ng-hide="rights.canUpdateCommentStatus()">
+                    <div class="open-todo open-todo-readonly btn-action-icon" data-ng-show="comment.status == 'resolved'">
+                        <i class="fa fa-pencil-square-o"></i><span>Resolved</span>
+                    </div>
+                </div>
+            </div>
+            <div class="btn-comments btn-action-icon" ng-click="showCommentReplies()">
                 <i class="fa fa-comment-o"></i>
                 <span>Comments</span>
             </div>
@@ -114,16 +96,16 @@
                             </div>
                             <span class="reply-content">{{reply.content}}</span>
                         </div>
-                        <div data-ng-show="comment.status != 'resolved'" class="reply-actions">
+                        <div data-ng-show="comment.status != 'resolved' && rights.canEditComment(reply.authorInfo.createdByUserRef.id)" class="reply-actions">
                             <div class="dropdown float-right" uib-dropdown>
                                 <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle
                                         type="button"><i class="fa fa-ellipsis-v"></i></button>
                                 <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
-                                    <a href class="btn btn-sm btn-std dropdown-item editReplyLink"
+                                    <a href class="dropdown-item editReplyLink"
                                        data-ng-show="rights.canEditComment(reply.authorInfo.createdByUserRef.id)"
                                        data-ng-click="editReply(reply)">
                                         <i class="fa fa-pencil"></i> Edit</a>
-                                    <a href class="btn btn-sm btn-std dropdown-item deleteReplyLink"
+                                    <a href class="dropdown-item deleteReplyLink"
                                        data-ng-show="rights.canDeleteComment(reply.authorInfo.createdByUserRef.id)"
                                        data-ng-click="deleteCommentReply(comment.id, reply)">
                                         <i class="fa fa-trash"></i> Delete</a>
@@ -142,7 +124,7 @@
                     </form>
                 </div>
             </div>
-            <form ng-show="showNewReplyForm" class="commentNewReplyForm" data-ng-submit="submitReply(newReply)">
+            <form ng-show="showNewReplyForm && comment.status != 'resolved'" class="commentNewReplyForm" data-ng-submit="submitReply(newReply)">
                 <textarea class="form-control" placeholder="Reply here.  Press Enter when done."
                           data-ng-model="newReply.editingContent" pui-auto-focus="isAutoFocusNewReply"></textarea>
                 <div class="d-flex justify-content-end">

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -1,6 +1,6 @@
 <div class="commentContainer card">
     <div class="card-title">
-        {{comment.regarding.fieldNameForDisplay}} - {{comment.regarding.inputSystemAbbreviation}}
+        <span class="sense-label">{{getSenseLabel()}}</span> {{comment.regarding.fieldNameForDisplay}}{{(comment.regarding.inputSystemAbbreviation) ? ' - ' + comment.regarding.inputSystemAbbreviation : ''}}
     </div>
     <div class="card-block" data-ng-class="{resolvedComment: comment.status == 'resolved'}">
         <div class="commentContentContainer">
@@ -75,11 +75,11 @@
                 <div data-ng-show="comment.editing" class="commentEditing">
                     <!--suppress HtmlFormInputWithoutLabel -->
                     <textarea class="form-control" data-ng-model="editingCommentContent"></textarea>
-                    <div>
-                        <button data-ng-disabled="!comment.content" class="btn btn-sm btn-primary float-right"
+                    <div class="d-flex justify-content-end">
+                        <a class="btn btn-sm btn-std" data-ng-click="comment.editing = false">Cancel</a>
+                        <button data-ng-disabled="!comment.content" class="btn btn-sm btn-primary"
                                 data-ng-click="updateComment(comment)">Update
                         </button>
-                        <a class="btn btn-sm btn-std float-left" data-ng-click="comment.editing = false">Cancel</a>
                     </div>
                 </div>
             </div>
@@ -102,11 +102,11 @@
                 <span>Comments</span>
             </div>
         </div>
-        <div class="commentRepliesContainer" data-ng-show="showRepliesContainer">
-            <div class="comment-replies">
+        <div class="commentRepliesContainer" data-ng-show="comment.showRepliesContainer" ng-class="(comment.showRepliesContainer) ? 'on' : 'off'">
+            <div class="comment-replies" ng-show="comment.replies.length">
                 <div data-ng-repeat="reply in comment.replies" data-ng-mouseenter="reply.hover = true"
                      data-ng-mouseleave="reply.hover = false">
-                    <div data-ng-hide="reply.editing">
+                    <div data-ng-hide="reply.editing" class="comment-reply">
                         <div class="reply-body">
                             <div class="reply-meta">
                                 <div class="comment-author">{{reply.authorInfo.createdByUserRef.name}}</div>
@@ -131,23 +131,25 @@
                             </div>
                         </div>
                     </div>
-                    <form data-ng-show="showReplies" data-ng-submit="submitReply(reply)">
+                    <form data-ng-show="reply.editing" data-ng-submit="submitReply(reply)" class="reply-edit-form">
                         <!--suppress HtmlFormInputWithoutLabel -->
                         <textarea class="form-control" data-ng-model="reply.editingContent"
                                   pui-auto-focus="reply.isAutoFocusEditing"></textarea>
-                        <button type="submit" class="btn btn-sm btn-primary">Update</button>
-                        <a href data-ng-click="reply.editing = false">Cancel</a>
+                        <div class="d-flex justify-content-end">
+                            <a href class="btn btn-sm btn-std" data-ng-click="cancelReply(reply)">Cancel</a>
+                            <button type="submit" class="btn btn-sm btn-primary">Update</button>
+                        </div>
                     </form>
                 </div>
             </div>
-            <form class="commentNewReplyForm" data-ng-show="showNewReplyForm" data-ng-submit="submitReply(newReply)">
+            <form ng-show="showNewReplyForm" class="commentNewReplyForm" data-ng-submit="submitReply(newReply)">
                 <textarea class="form-control" placeholder="Reply here.  Press Enter when done."
                           data-ng-model="newReply.editingContent" pui-auto-focus="isAutoFocusNewReply"></textarea>
-                <button type="submit" class="btn btn-sm btn-primary">Post</button>
-                <a href data-ng-click="showNewReplyForm = false">Cancel</a>
+                <div class="d-flex justify-content-end">
+                    <a href class="btn btn-sm btn-std" data-ng-click="showCommentReplies()">Hide</a>
+                    <button type="submit" class="btn btn-sm btn-primary"><i class="fa fa-reply"></i> Reply</button>
+                </div>
             </form>
         </div>
-        <a href class="btn btn-sm btn-std float-right" data-ng-show="rights.canComment() && !showNewReplyForm"
-           data-ng-click="doReply()"><i class="fa fa-reply"></i> Reply</a>
     </div>
 </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
@@ -11,11 +11,9 @@ angular.module('palaso.ui.comments')
         function ($scope, commentService, sessionService, util, modal) {
           $scope.getAvatarUrl = util.constructor.getAvatarUrl;
 
-          $scope.showNewReplyForm = false;
+          $scope.showNewReplyForm = true;
 
           $scope.newReply = { id: '', editingContent: '' };
-
-          $scope.showRepliesContainer = false;
 
           $scope.editingCommentContent = '';
 
@@ -30,7 +28,10 @@ angular.module('palaso.ui.comments')
           }
 
           $scope.showCommentReplies = function showCommentReplies() {
-            $scope.showRepliesContainer = !$scope.showRepliesContainer;
+            $scope.$parent.showNewComment = !$scope.$parent.showNewComment;
+            $scope.comment.showRepliesContainer = !$scope.comment.showRepliesContainer;
+            $scope.setCommentInteractiveStatus($scope.comment.id, $scope.comment.showRepliesContainer);
+            $scope.getSenseLabel();
           };
 
           $scope.doReply = function doReply() {
@@ -44,6 +45,12 @@ angular.module('palaso.ui.comments')
             reply.editing = true;
             reply.editingContent = angular.copy(reply.content);
             reply.isAutoFocusEditing = true;
+            $scope.showNewReplyForm = false;
+          };
+
+          $scope.cancelReply = function cancelReply(reply) {
+            reply.editing = false;
+            $scope.showNewReplyForm = true;
           };
 
           $scope.submitReply = function submitReply(reply) {
@@ -51,13 +58,14 @@ angular.module('palaso.ui.comments')
             reply.content = angular.copy(reply.editingContent);
             delete reply.editingContent;
             updateReply($scope.comment.id, reply);
-            $scope.newReply = {id: '', editingContent: ''};
+            $scope.newReply = { id: '', editingContent: '' };
           };
 
           function updateReply(commentId, reply) {
             commentService.updateReply(commentId, reply, function (result) {
               if (result.ok) {
                 $scope.control.editorService.refreshEditorData().then($scope.loadComments);
+                $scope.showNewReplyForm = true;
               }
             });
           }
@@ -134,9 +142,12 @@ angular.module('palaso.ui.comments')
               $scope.comment.replies[i].editing = false;
             }
 
-            $scope.showNewReplyForm = false;
             $scope.comment.editing = false;
           }
+
+          $scope.getSenseLabel = function getSenseLabel() {
+            return $scope.$parent.getSenseLabel($scope.comment.regarding.field);
+          };
 
         }],
 

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
@@ -146,7 +146,7 @@ angular.module('palaso.ui.comments')
           }
 
           $scope.getSenseLabel = function getSenseLabel() {
-            return $scope.$parent.getSenseLabel($scope.comment.regarding.field);
+            return $scope.$parent.getSenseLabel($scope.comment.regarding.field, $scope.comment.contextGuid);
           };
 
         }],

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
@@ -2,137 +2,143 @@
 
 angular.module('palaso.ui.comments')
 
-  // Palaso UI Dictionary Control: Comments
+// Palaso UI Dictionary Control: Comments
   .directive('dcComment', [function () {
     return {
       restrict: 'E',
       templateUrl: '/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html',
       controller: ['$scope', 'lexCommentService', 'sessionService', 'utilService', 'modalService',
-      function ($scope, commentService, sessionService, util, modal) {
-        $scope.getAvatarUrl = util.constructor.getAvatarUrl;
-
-        $scope.showNewReplyForm = false;
-
-        $scope.newReply = { id: '', editingContent: '' };
-
-        $scope.editingCommentContent = '';
-
-        if ($scope.comment.regarding.field && angular.isDefined($scope.control.configService)) {
-          $scope.control.configService.getFieldConfig($scope.comment.regarding.field)
-            .then(function (config) {
-            $scope.commentRegardingFieldConfig = config;
-            $scope.isCommentRegardingPicture =
-              (($scope.commentRegardingFieldConfig.type === 'pictures') &&
-              !($scope.comment.regarding.inputSystem));
-          });
-        }
-
-        $scope.doReply = function doReply() {
-          hideInputFields();
-          $scope.showNewReplyForm = true;
-          $scope.isAutoFocusNewReply = true;
-        };
-
-        $scope.editReply = function editReply(reply) {
-          hideInputFields();
-          reply.editing = true;
-          reply.editingContent = angular.copy(reply.content);
-          reply.isAutoFocusEditing = true;
-        };
-
-        $scope.submitReply = function submitReply(reply) {
-          hideInputFields();
-          reply.content = angular.copy(reply.editingContent);
-          delete reply.editingContent;
-          updateReply($scope.comment.id, reply);
-          $scope.newReply = { id: '', editingContent: '' };
-        };
-
-        function updateReply(commentId, reply) {
-          commentService.updateReply(commentId, reply, function (result) {
-            if (result.ok) {
-              $scope.control.editorService.refreshEditorData().then($scope.loadComments);
-            }
-          });
-        }
-
-        $scope.updateCommentStatus = function updateCommentStatus(commentId, status) {
-          commentService.updateStatus(commentId, status, function (result) {
-            if (result.ok) {
-              $scope.control.editorService.refreshEditorData().then($scope.loadComments);
-            }
-          });
-        };
-
-        $scope.deleteComment = function deleteComment(comment) {
-          var deletemsg;
-          sessionService.getSession().then(function (session) {
-            if (session.userId() === comment.authorInfo.createdByUserRef.id) {
-              deletemsg = 'Are you sure you want to delete your own comment?';
-            } else {
-              deletemsg = 'Are you sure you want to delete ' +
-                comment.authorInfo.createdByUserRef.name + '\'s comment?';
-            }
-
-            modal.showModalSimple('Delete Comment', deletemsg, 'Cancel', 'Delete Comment')
-              .then(function () {
-                commentService.remove(comment.id).then(function () {
-                  $scope.control.editorService.refreshEditorData().then($scope.loadComments);
-                });
-
-                commentService.removeCommentFromLists(comment.id);
-              }, angular.noop);
-          });
-        };
-
-        $scope.deleteCommentReply = function deleteCommentReply(commentId, reply) {
-          var deletemsg;
-          sessionService.getSession().then(function (session) {
-            if (session.userId() === reply.authorInfo.createdByUserRef.id) {
-              deletemsg = 'Are you sure you want to delete your own comment reply?';
-            } else {
-              deletemsg = 'Are you sure you want to delete ' +
-                reply.authorInfo.createdByUserRef.name + '\'s comment reply?';
-            }
-
-            modal.showModalSimple('Delete Reply', deletemsg, 'Cancel', 'Delete Reply')
-              .then(function () {
-                commentService.deleteReply(commentId, reply.id).then(function () {
-                  $scope.control.editorService.refreshEditorData().then($scope.loadComments);
-                });
-
-                commentService.removeCommentFromLists(commentId, reply.id);
-              }, angular.noop);
-          });
-        };
-
-        $scope.editComment = function editComment() {
-          hideInputFields();
-          $scope.comment.editing = true;
-          $scope.editingCommentContent = angular.copy($scope.comment.content);
-        };
-
-        $scope.updateComment = function updateComment() {
-          hideInputFields();
-          $scope.comment.content = angular.copy($scope.editingCommentContent);
-
-          commentService.update($scope.comment).then(function () {
-            $scope.control.editorService.refreshEditorData().then($scope.loadComments);
-          });
-
-          $scope.editingCommentContent = '';
-        };
-
-        function hideInputFields() {
-          for (var i = 0; i < $scope.comment.replies.length; i++) {
-            $scope.comment.replies[i].editing = false;
-          }
+        function ($scope, commentService, sessionService, util, modal) {
+          $scope.getAvatarUrl = util.constructor.getAvatarUrl;
 
           $scope.showNewReplyForm = false;
-          $scope.comment.editing = false;
-        }
 
-      }],
+          $scope.newReply = { id: '', editingContent: '' };
+
+          $scope.showRepliesContainer = false;
+
+          $scope.editingCommentContent = '';
+
+          if ($scope.comment.regarding.field && angular.isDefined($scope.control.configService)) {
+            $scope.control.configService.getFieldConfig($scope.comment.regarding.field)
+              .then(function (config) {
+                $scope.commentRegardingFieldConfig = config;
+                $scope.isCommentRegardingPicture =
+                  (($scope.commentRegardingFieldConfig.type === 'pictures') &&
+                    !($scope.comment.regarding.inputSystem));
+              });
+          }
+
+          $scope.showCommentReplies = function showCommentReplies() {
+            $scope.showRepliesContainer = !$scope.showRepliesContainer;
+          };
+
+          $scope.doReply = function doReply() {
+            hideInputFields();
+            $scope.showNewReplyForm = true;
+            $scope.isAutoFocusNewReply = true;
+          };
+
+          $scope.editReply = function editReply(reply) {
+            hideInputFields();
+            reply.editing = true;
+            reply.editingContent = angular.copy(reply.content);
+            reply.isAutoFocusEditing = true;
+          };
+
+          $scope.submitReply = function submitReply(reply) {
+            hideInputFields();
+            reply.content = angular.copy(reply.editingContent);
+            delete reply.editingContent;
+            updateReply($scope.comment.id, reply);
+            $scope.newReply = {id: '', editingContent: ''};
+          };
+
+          function updateReply(commentId, reply) {
+            commentService.updateReply(commentId, reply, function (result) {
+              if (result.ok) {
+                $scope.control.editorService.refreshEditorData().then($scope.loadComments);
+              }
+            });
+          }
+
+          $scope.updateCommentStatus = function updateCommentStatus(commentId, status) {
+            commentService.updateStatus(commentId, status, function (result) {
+              if (result.ok) {
+                $scope.control.editorService.refreshEditorData().then($scope.loadComments);
+              }
+            });
+          };
+
+          $scope.deleteComment = function deleteComment(comment) {
+            var deletemsg;
+            sessionService.getSession().then(function (session) {
+              if (session.userId() === comment.authorInfo.createdByUserRef.id) {
+                deletemsg = 'Are you sure you want to delete your own comment?';
+              } else {
+                deletemsg = 'Are you sure you want to delete ' +
+                  comment.authorInfo.createdByUserRef.name + '\'s comment?';
+              }
+
+              modal.showModalSimple('Delete Comment', deletemsg, 'Cancel', 'Delete Comment')
+                .then(function () {
+                  commentService.remove(comment.id).then(function () {
+                    $scope.control.editorService.refreshEditorData().then($scope.loadComments);
+                  });
+
+                  commentService.removeCommentFromLists(comment.id);
+                }, angular.noop);
+            });
+          };
+
+          $scope.deleteCommentReply = function deleteCommentReply(commentId, reply) {
+            var deletemsg;
+            sessionService.getSession().then(function (session) {
+              if (session.userId() === reply.authorInfo.createdByUserRef.id) {
+                deletemsg = 'Are you sure you want to delete your own comment reply?';
+              } else {
+                deletemsg = 'Are you sure you want to delete ' +
+                  reply.authorInfo.createdByUserRef.name + '\'s comment reply?';
+              }
+
+              modal.showModalSimple('Delete Reply', deletemsg, 'Cancel', 'Delete Reply')
+                .then(function () {
+                  commentService.deleteReply(commentId, reply.id).then(function () {
+                    $scope.control.editorService.refreshEditorData().then($scope.loadComments);
+                  });
+
+                  commentService.removeCommentFromLists(commentId, reply.id);
+                }, angular.noop);
+            });
+          };
+
+          $scope.editComment = function editComment() {
+            hideInputFields();
+            $scope.comment.editing = true;
+            $scope.editingCommentContent = angular.copy($scope.comment.content);
+          };
+
+          $scope.updateComment = function updateComment() {
+            hideInputFields();
+            $scope.comment.content = angular.copy($scope.editingCommentContent);
+
+            commentService.update($scope.comment).then(function () {
+              $scope.control.editorService.refreshEditorData().then($scope.loadComments);
+            });
+
+            $scope.editingCommentContent = '';
+          };
+
+          function hideInputFields() {
+            for (var i = 0; i < $scope.comment.replies.length; i++) {
+              $scope.comment.replies[i].editing = false;
+            }
+
+            $scope.showNewReplyForm = false;
+            $scope.comment.editing = false;
+          }
+
+        }],
 
       link: function (scope, element, attrs, controller) {
       }

--- a/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.html
@@ -1,15 +1,1 @@
-<div class="row">
-    <div class="col-md-6">
-        <div>
-            <dc-rendered config="entryConfig" model="entry"></dc-rendered>
-        </div>
-        <div>
-            <div class="entryItemView">
-                <dc-entry config="entryConfig" model="entry" control="control"></dc-entry>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-6">
-        <comments-right-panel entry="entry" control="control" new-comment="newComment"></comments-right-panel>
-    </div>
-</div>
+<comments-right-panel entry="entry" control="control" new-comment="newComment" class="comments-right-panel"></comments-right-panel>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.html
@@ -1,1 +1,4 @@
 <comments-right-panel entry="entry" control="control" new-comment="newComment" class="comments-right-panel"></comments-right-panel>
+<div class="comments-right-panel-backdrop" ng-click="control.hideCommentsPanel()">
+    <i class="fa fa-times"></i>
+</div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.js
@@ -26,7 +26,7 @@ angular.module('palaso.ui.comments')
           $scope.config = config;
           $scope.control.selectFieldForComment =
           function selectFieldForComment(fieldName, model, inputSystem, multioptionValue,
-                                         pictureFilePath) {
+                                         pictureFilePath, contextGuid) {
             var canComment = session.hasProjectRight(ss.domain.COMMENTS, ss.operation.CREATE);
             if (!canComment) return;
 
@@ -38,6 +38,7 @@ angular.module('palaso.ui.comments')
               delete $scope.newComment.regarding.inputSystem;
               delete $scope.newComment.regarding.inputSystemAbbreviation;
               $scope.newComment.isRegardingPicture = false;
+              $scope.newComment.contextGuid = contextGuid;
               if (inputSystem) {
                 $scope.newComment.regarding.fieldValue = getFieldValue(model, inputSystem);
                 $scope.newComment.regarding.inputSystem =

--- a/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
@@ -14,7 +14,7 @@
     font-size: 14px;
     display: block;
     .newCommentForm {
-        /* TODO: Enable again */
+        /* TODO: Enable  */
         display: none;
     }
 

--- a/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
@@ -1,0 +1,125 @@
+#lexAppEditView {
+    display: flex;
+    justify-content: center;
+    .container {
+        margin: 0;
+    }
+}
+
+.comments-right-panel {
+    width: 280px;
+    transition: width 0.5s;
+    overflow: hidden;
+    color: #104060;
+    font-size: 14px;
+    display: block;
+    .newCommentForm {
+        /* TODO: Enable again */
+        display: none;
+    }
+
+    .commentContainer {
+        border-radius: 0;
+        border: 0;
+        .card-title {
+            background: #cddeeb;
+            display: block;
+            font-weight: bold;
+            padding: 4px 14px;
+            margin: 0;
+        }
+
+        .card-block {
+            background: #e6eff5;
+            padding: 7px 14px;
+            .comment-meta {
+                display: flex;
+                justify-content: space-between;
+                > div {
+                    display: flex;
+                }
+
+                img {
+                    width: 40px !important;
+                    height: 40px;
+                    margin-right: 5px;
+                }
+
+                .data-and-author {
+                    line-height: 18px;
+                    .comment-author {
+                        font-weight: bold;
+                    }
+                }
+            }
+            .comment-body {
+                color: #373a3d;
+                margin: 10px 0 14px;
+            }
+
+            .comment-interaction {
+                display: flex;
+                justify-content: space-between;
+                font-size: 12px;
+                opacity: 0.75;
+            }
+
+            .comment-actions {
+                margin: 4px -14px;
+                padding: 4px 14px;
+                display: flex;
+                justify-content: space-between;
+                border: 1px solid #cddeeb;
+                border-left: 0;
+                border-right: 0;
+                > div {
+                    cursor: pointer;
+                    display: flex;
+                    align-items: center;
+                    i {
+                        font-size: 16px;
+                        margin-right: 4px;
+                    }
+
+                    span {
+                        font-size: 12px;
+                        opacity: 0.75;
+                    }
+                }
+            }
+            .commentRegarding {
+                /* TODO: Enable again */
+                display: none;
+            }
+
+            .commentRepliesContainer {
+                .comment-replies {
+                }
+                margin-left: 10px;
+                padding-left: 5px;
+                border-left: 1px solid #cddeeb;
+                > div {
+                    margin-bottom: 10px;
+                    &:last-child {
+                        margin-bottom: 0;
+                    }
+                }
+                .reply-meta {
+                    line-height: 18px;
+
+                    .comment-author {
+                        font-weight: bold;
+                        display: block;
+                    }
+
+                    .comment-date {
+                        display: block;
+                    }
+                }
+                .reply-content {
+                    color: #373a3d;
+                }
+            }
+        }
+    }
+}

--- a/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
@@ -1,7 +1,10 @@
 /* Colours as defined in UxPin */
 $BlackSqueeze: #e6eff5;
+$BlueRibbon: #1d64f0;
 $Botticelli: #cddeeb;
 $Eden: #104060;
+$PastelGreen: #6edc6c;
+$Silver: #c0c0c0;
 $WildSand: #f6f6f6;
 
 #lexAppEditView {
@@ -130,6 +133,25 @@ $WildSand: #f6f6f6;
         .comment-body {
           color: #373a3d;
           margin: 10px 0 14px;
+          .btn {
+            padding: 0;
+            margin: 5px 0;
+            font-style: italic;
+          }
+          .commentRegarding {
+            .form-control {
+              border-radius: 0;
+              background: $WildSand;
+              border: 1px solid $Silver;
+              padding: 2px 6px;
+              font-size: 14px;
+              span {
+                background: transparent;
+                border: 0;
+                padding: 0;
+              }
+            }
+          }
         }
 
         .comment-interaction {
@@ -141,13 +163,14 @@ $WildSand: #f6f6f6;
 
         .comment-actions {
           margin: 4px -14px;
-          padding: 4px 14px;
+          padding: 0 14px;
           display: flex;
           justify-content: space-between;
           border: 1px solid $Botticelli;
           border-left: 0;
           border-right: 0;
-          > div {
+          .btn-action-icon {
+            padding: 4px 0;
             cursor: pointer;
             display: flex;
             align-items: center;
@@ -161,12 +184,40 @@ $WildSand: #f6f6f6;
               opacity: 0.75;
             }
           }
+          .btn-like {
+            .liked {
+              opacity: 0.5;
+              cursor: default;
+            }
+          }
+          .btn-todo {
+            .btn-action-icon {
+              width: 100px;
+              justify-content: center;
+            }
+            .resolve-todo,
+            .open-todo {
+              color: #fff;
+              span {
+                opacity: 1;
+              }
+            }
+            .resolve-todo {
+              background-color: $BlueRibbon;
+            }
+            .open-todo {
+              background-color: $PastelGreen;
+              &.open-todo-readonly {
+                cursor: default;
+              }
+            }
+            .mark-todo {
+              border: 1px solid $Botticelli;
+              border-top: 0;
+              border-bottom: 0;
+            }
+          }
         }
-        .commentRegarding {
-          /* TODO: Enable again */
-          display: none;
-        }
-
         .commentRepliesContainer {
           .comment-replies {
             margin: 13px 0;
@@ -174,6 +225,7 @@ $WildSand: #f6f6f6;
             border-left: 1px solid $Botticelli;
             .comment-reply {
               position: relative;
+              margin-bottom: 10px;
             }
             .reply-edit-form {
               margin: 5px;
@@ -223,11 +275,28 @@ $WildSand: #f6f6f6;
           border: 0;
           color: $Eden;
         }
-        .btn.ellipsis-menu {
-          min-width: 14px;
+        .dropdown[uib-dropdown] {
           height: 20px;
-          background: $Botticelli;
-          padding: 0;
+          .btn.ellipsis-menu {
+            min-width: 14px;
+            background: $Botticelli;
+            padding: 0;
+          }
+          .dropdown-menu {
+            background: $WildSand;
+            border: 1px solid $Silver;
+            border-radius: 0;
+            min-width: auto;
+            padding: 0;
+            a {
+              font-size: 12px;
+              color: $Eden;
+              padding: 6px 10px;
+              &:hover {
+                background: darken($WildSand, 10%);
+              }
+            }
+          }
         }
       }
     }

--- a/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
@@ -1,125 +1,235 @@
+/* Colours as defined in UxPin */
+$BlackSqueeze: #e6eff5;
+$Botticelli: #cddeeb;
+$Eden: #104060;
+$WildSand: #f6f6f6;
+
 #lexAppEditView {
-    display: flex;
-    justify-content: center;
-    .container {
-        margin: 0;
-    }
+  display: flex;
+  justify-content: center;
+  .container {
+    margin: 0;
+  }
 }
 
 .comments-right-panel {
+  color: $Eden;
+  font-size: 14px;
+  display: block;
+  .comments-right-panel-container {
+    position: relative;
     width: 280px;
-    transition: width 0.5s;
-    overflow: hidden;
-    color: #104060;
-    font-size: 14px;
-    display: block;
-    .newCommentForm {
-        /* TODO: Enable  */
-        display: none;
+    transition: width 0.5s ease-in-out, margin-left 0.5s ease-in-out, opacity 0.5s linear 0.5s;
+    margin-left: 15px;
+    opacity: 1;
+    &.panel-closing {
+      transition: width 0.5s ease-in-out 0.5s, margin-left 0.5s ease-in-out 0.5s, opacity 0.5s;
+      overflow: visible;
+      height: auto !important;
     }
-
-    .commentContainer {
+    &.panel-opening {
+      overflow: hidden;
+    }
+    &:not(.panel-visible) {
+      width: 0;
+      margin-left: 0;
+      opacity: 0;
+      height: 0;
+      overflow: hidden;
+    }
+    &.context-mode {
+      &:before {
+        position: absolute;
+        content: "";
+        width: 0;
+        height: 0;
+        border-style: solid;
+        border-width: 12px 12px 12px 0;
+        border-color: transparent $BlackSqueeze transparent transparent;
+        top: 46px;
+        left: -12px;
+      }
+      .commentListContainer {
+        > div:nth-child(n+2) {
+          .card-title {
+            display: none;
+          }
+        }
+      }
+    }
+    .comments-search-container {
+      position: relative;
+      input, select {
+        background-color: $WildSand;
         border-radius: 0;
+        color: $Eden;
+        font-size: 14px;
         border: 0;
-        .card-title {
-            background: #cddeeb;
-            display: block;
-            font-weight: bold;
-            padding: 4px 14px;
-            margin: 0;
+      }
+      input {
+        padding-right: 140px;
+      }
+      select {
+        border-left: 1px solid $Eden;
+        max-width: 112px;
+        height: auto;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+      span {
+        position: absolute;
+        right: 123px;
+        top: 7px;
+        i {
+          cursor: pointer;
         }
-
-        .card-block {
-            background: #e6eff5;
-            padding: 7px 14px;
-            .comment-meta {
-                display: flex;
-                justify-content: space-between;
-                > div {
-                    display: flex;
-                }
-
-                img {
-                    width: 40px !important;
-                    height: 40px;
-                    margin-right: 5px;
-                }
-
-                .data-and-author {
-                    line-height: 18px;
-                    .comment-author {
-                        font-weight: bold;
-                    }
-                }
-            }
-            .comment-body {
-                color: #373a3d;
-                margin: 10px 0 14px;
-            }
-
-            .comment-interaction {
-                display: flex;
-                justify-content: space-between;
-                font-size: 12px;
-                opacity: 0.75;
-            }
-
-            .comment-actions {
-                margin: 4px -14px;
-                padding: 4px 14px;
-                display: flex;
-                justify-content: space-between;
-                border: 1px solid #cddeeb;
-                border-left: 0;
-                border-right: 0;
-                > div {
-                    cursor: pointer;
-                    display: flex;
-                    align-items: center;
-                    i {
-                        font-size: 16px;
-                        margin-right: 4px;
-                    }
-
-                    span {
-                        font-size: 12px;
-                        opacity: 0.75;
-                    }
-                }
-            }
-            .commentRegarding {
-                /* TODO: Enable again */
-                display: none;
-            }
-
-            .commentRepliesContainer {
-                .comment-replies {
-                }
-                margin-left: 10px;
-                padding-left: 5px;
-                border-left: 1px solid #cddeeb;
-                > div {
-                    margin-bottom: 10px;
-                    &:last-child {
-                        margin-bottom: 0;
-                    }
-                }
-                .reply-meta {
-                    line-height: 18px;
-
-                    .comment-author {
-                        font-weight: bold;
-                        display: block;
-                    }
-
-                    .comment-date {
-                        display: block;
-                    }
-                }
-                .reply-content {
-                    color: #373a3d;
-                }
-            }
-        }
+      }
     }
+    .commentContainer,
+    .newCommentForm .card {
+      border-radius: 0;
+      border: 0;
+      .card-title {
+        background: $Botticelli;
+        display: block;
+        font-weight: bold;
+        padding: 4px 14px;
+        margin: 0;
+        .sense-label {
+          font-weight: normal;
+          opacity: 0.75;
+          display: inline-block;
+          padding-right: 10px;
+        }
+      }
+
+      .card-block {
+        background: $BlackSqueeze;
+        padding: 7px 14px;
+        .comment-meta {
+          display: flex;
+          justify-content: space-between;
+          > div {
+            display: flex;
+          }
+
+          img {
+            width: 40px !important;
+            height: 40px;
+            margin-right: 5px;
+          }
+
+          .data-and-author {
+            line-height: 18px;
+            .comment-author {
+              font-weight: bold;
+            }
+          }
+        }
+        .comment-body {
+          color: #373a3d;
+          margin: 10px 0 14px;
+        }
+
+        .comment-interaction {
+          display: flex;
+          justify-content: space-between;
+          font-size: 12px;
+          opacity: 0.75;
+        }
+
+        .comment-actions {
+          margin: 4px -14px;
+          padding: 4px 14px;
+          display: flex;
+          justify-content: space-between;
+          border: 1px solid $Botticelli;
+          border-left: 0;
+          border-right: 0;
+          > div {
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            i {
+              font-size: 16px;
+              margin-right: 4px;
+            }
+
+            span {
+              font-size: 12px;
+              opacity: 0.75;
+            }
+          }
+        }
+        .commentRegarding {
+          /* TODO: Enable again */
+          display: none;
+        }
+
+        .commentRepliesContainer {
+          .comment-replies {
+            margin: 13px 0;
+            padding-left: 8px;
+            border-left: 1px solid $Botticelli;
+            .comment-reply {
+              position: relative;
+            }
+            .reply-edit-form {
+              margin: 5px;
+              textarea {
+                margin-bottom: 5px;
+              }
+            }
+          }
+          > div {
+            margin-bottom: 10px;
+            &:last-child {
+              margin-bottom: 0;
+            }
+          }
+          .reply-meta {
+            line-height: 18px;
+
+            .comment-author {
+              font-weight: bold;
+              display: block;
+            }
+
+            .comment-date {
+              display: block;
+            }
+          }
+          .reply-content {
+            color: #373a3d;
+          }
+        }
+        textarea {
+          border-radius: 2px;
+          border: 0;
+          font-size: 14px;
+          color: rgba(16, 64, 96, 0.5);
+        }
+        .btn-sm {
+          border-radius: 2px;
+          font-size: 12px;
+          padding: 0.15rem 0.5rem;
+          min-width: 60px;
+          cursor: pointer;
+          box-shadow: none;
+        }
+        .btn-std {
+          background: transparent;
+          border: 0;
+          color: $Eden;
+        }
+        .btn.ellipsis-menu {
+          min-width: 14px;
+          height: 20px;
+          background: $Botticelli;
+          padding: 0;
+        }
+      }
+    }
+  }
 }

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -530,6 +530,16 @@ dc-entry .card {
       right: -41px;
     }
   }
+  .dc-pictures {
+    .commentBubbleContainer {
+      right: -35px;
+    }
+    .dc-multitext {
+      .commentBubbleContainer {
+        right: -20px;
+      }
+    }
+  }
 }
 
 .entryItemView {

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -326,43 +326,161 @@ dc-entry .card {
 }
 
 #lexAppEditView {
-    .lexiconItemListContainer {
-        max-height: 460px;
-        overflow: auto;
+  .lexiconItemListContainer {
+    max-height: 460px;
+    overflow: auto;
+  }
+  .word-definition-title {
+    margin-bottom: 5px;
+    padding: 8px 0 24px;
+  }
+  .card-body .addItem {
+    margin-right: 0;
+  }
+  .topAddMeaning {
+    margin-bottom: 14px;
+  }
+  .list-group-item:not(.list-group-item-action) {
+    cursor: pointer;
+  }
+  .listItemPrimary {
+    z-index: 2;
+    font-size: 1.0em;
+  }
+  .listItemSecondary {
+    z-index: 2;
+    font-size: 0.8em;
+    overflow: hidden;
+  }
+  .deleteX {
+    i {
+      cursor: pointer;
     }
-    .word-definition-title {
-        margin-bottom: 5px;
-        padding: 8px 0 24px;
+    i:hover {
+      color: map-get($theme-colors, danger);
     }
-    .card-body .addItem {
-        margin-right: 0;
-    }
-    .topAddMeaning {
-        margin-bottom: 14px;
-    }
-    .list-group-item:not(.list-group-item-action) {
-        cursor: pointer;
-    }
-    .listItemPrimary {
-        z-index: 2;
-        font-size: 1.0em;
-    }
-    .listItemSecondary {
-        z-index: 2;
-        font-size: 0.8em;
+  }
+  h5 {
+    margin: 0;
+  }
+  .entry-words-minimized {
+    position: absolute;
+    z-index: 1;
+    opacity: 0;
+    transition: all 0.5s;
+    transform: rotate(90deg);
+    transform-origin: left;
+    margin-left: 5px;
+  }
+  .entry-words-container {
+    opacity: 1;
+    display: block;
+  }
+  > .container,
+  .entries-list-container,
+  .entry-primary-container {
+    transition: all 0.5s;
+  }
+  .comments-right-panel-backdrop {
+    display: none;
+  }
+  @include media-breakpoint-between(md, lg) {
+    &.comments-panel-visible {
+      > .container {
+        max-width: 634px;
+      }
+      .entries-list-container {
+        flex: 0 0 50px;
         overflow: hidden;
-    }
-    .deleteX {
-        i {
-            cursor: pointer;
+        .entry-words-minimized {
+          opacity: 1;
         }
-        i:hover {
-            color: map-get($theme-colors, danger);
+        .entry-words-container {
+          opacity: 0;
+          overflow: hidden;
+          width: 0;
+          height: 0;
         }
+      }
+      .entry-primary-container {
+        flex: 0 0 calc(100% - 50px);
+        max-width: 100%;
+      }
     }
-    h5 {
-        margin: 0;
+    &.panel-closing {
+      > .container,
+      .entries-list-container,
+      .entry-primary-container {
+        transition-delay: 0.5s;
+      }
+      .entry-words-minimized {
+        margin-left: -50px;
+      }
+      .entry-words-container {
+        transition: opacity 0.5s ease-in-out 1s;
+      }
+      .entries-list-container {
+        overflow: hidden;
+      }
     }
+  }
+  @include media-breakpoint-down(sm) {
+    .comments-right-panel {
+      position: absolute;
+      top: 0;
+      right: 0;
+      z-index: 1001;
+      padding-top: 0 !important;
+      .comments-right-panel-container {
+        width: 280px !important;
+        transition: opacity 0.5s;
+        background: #e6eff5;
+        &:before {
+          display: none;
+        }
+        .commentsListMainContainer {
+          height: calc(100% - 33px);
+          overflow: auto;
+        }
+      }
+      .context-mode {
+        .commentsListMainContainer {
+          height: 100%;
+        }
+      }
+    }
+    .comments-right-panel-backdrop {
+      display: block;
+      opacity: 0;
+      transition: opacity 0.5s;
+      position: absolute;
+      z-index: 1000;
+      height: 0;
+      width: 0;
+      left: 0;
+      top: 0;
+      background: rgba(192, 192, 192, 0.9);
+      content: "";
+      i {
+        cursor: pointer;
+        margin: 12px;
+        font-size: 24px;
+      }
+    }
+    &.comments-panel-visible {
+      .comments-right-panel {
+        height: 100%;
+        .comments-right-panel-container {
+          height: 100%;
+        }
+      }
+      .comments-right-panel-backdrop {
+        opacity: 1;
+        height: 100%;
+        width: 100%;
+      }
+    }
+  }
 }
 
 .lexiconListItemCompact {
@@ -392,6 +510,19 @@ dc-entry .card {
     position: relative;
     .comment-bubble-group {
       position: relative;
+    }
+  }
+  @include media-breakpoint-down(md) {
+    .dc-multitext,
+    .dc-multioptionlist,
+    .dc-pictures,
+    .dc-optionlist,
+    .dc-semanticdomain {
+      .comment-bubble-group:first-child {
+        .commentBubbleContainer {
+          top: 44px;
+        }
+      }
     }
   }
   .dc-example {

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -390,8 +390,13 @@ dc-entry .card {
     min-height: 580px;
   .field-container {
     position: relative;
-    .dc-multitext-tag {
+    .comment-bubble-group {
       position: relative;
+    }
+  }
+  .dc-example {
+    .commentBubbleContainer {
+      right: -41px;
     }
   }
 }

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -387,9 +387,13 @@ dc-entry .card {
     /*  TODO: review this in light of animation and the footer staying at the bottom. IJH 2014-09
         The view is used in edit and comment view */
 
-    overflow-y: auto;
-    overflow-x: hidden;
     min-height: 580px;
+  .field-container {
+    position: relative;
+    .dc-multitext-tag {
+      position: relative;
+    }
+  }
 }
 
 .entryItemView {

--- a/src/angular-app/languageforge/lexicon/editor/editor-abstract.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-abstract.html
@@ -1,49 +1,51 @@
 <div data-ng-cloak id="lexAppContainer">
-    <div class="row">
-        <div class="col-12">
-            <div class="lexAppToolbar" data-ng-show="!$state.is('editor.list')">
-                <div class="float-left">
-                    <a id="toListLink" data-ng-show="$state.is('editor.entry')" class="btn btn-std"
-                       data-ng-click="returnToList()"
-                       title="Back to List">
-                        <i class="fa fa-arrow-circle-left"></i>
-                        <span class="d-none d-md-inline-block">List</span></a>
+    <div class="container">
+        <div class="row">
+            <div class="col">
+                <div class="lexAppToolbar" data-ng-show="!$state.is('editor.list')">
+                    <div class="float-left">
+                        <a id="toListLink" data-ng-show="$state.is('editor.entry')" class="btn btn-std"
+                           data-ng-click="returnToList()"
+                           title="Back to List">
+                            <i class="fa fa-arrow-circle-left"></i>
+                            <span class="d-none d-md-inline-block">List</span></a>
 
-                    <button id="editorNewWordBtn" class="btn btn-primary"
-                            data-ng-show="$state.is('editor.entry')" data-ng-if="rights.canEditEntry()"
-                            data-ng-click="newEntry()">
-                        <i class="fa fa-plus"></i><span class="hidden-md-down"> New Word</span></button>
+                        <button id="editorNewWordBtn" class="btn btn-primary"
+                                data-ng-show="$state.is('editor.entry')" data-ng-if="rights.canEditEntry()"
+                                data-ng-click="newEntry()">
+                            <i class="fa fa-plus"></i><span class="hidden-md-down"> New Word</span></button>
 
-                    <a id="toEditLink" data-ng-show="$state.is('editor.comments')" class="btn btn-std"
-                       data-ng-click="editEntry(currentEntry.id)" title="Return to Edit Entry">
-                        <i class="fa fa-arrow-circle-left"></i>
-                        Edit </a>
-                </div>
-                <div class="float-right" data-ng-show="$state.is('editor.entry')">
-                    <span data-ng-if="rights.canEditEntry()">
-                        <span class="text-muted">{{saveNotice()}}</span>
-                        <button id="saveEntryBtn" class="btn btn-primary" data-ng-click="saveCurrentEntry(true)"
-                                data-ng-disabled="!currentEntryIsDirty()">
-                            <i class="fa fa-save"></i> <span class="d-none d-md-inline-block">{{saveButtonTitle()}}</span>
+                        <a id="toEditLink" data-ng-show="$state.is('editor.comments')" class="btn btn-std"
+                           data-ng-click="editEntry(currentEntry.id)" title="Return to Edit Entry">
+                            <i class="fa fa-arrow-circle-left"></i>
+                            Edit </a>
+                    </div>
+                    <div class="float-right" data-ng-show="$state.is('editor.entry')">
+                        <span data-ng-if="rights.canEditEntry()">
+                            <span class="text-muted">{{saveNotice()}}</span>
+                            <button id="saveEntryBtn" class="btn btn-primary" data-ng-click="saveCurrentEntry(true)"
+                                    data-ng-disabled="!currentEntryIsDirty()">
+                                <i class="fa fa-save"></i> <span class="d-none d-md-inline-block">{{saveButtonTitle()}}</span>
+                            </button>
+                        </span>
+                        <span data-ng-if="entryLoaded()">
+                            <button id="toggleHiddenFieldsBtn" class="btn btn-std"
+                                    data-ng-click="show.emptyFields = !show.emptyFields">
+                                <i class="fa" data-ng-class="show.emptyFields ? 'fa-minus-square-o' : 'fa-plus-square-o'"></i>
+                                <span class="d-none d-md-inline-block">{{show.emptyFields ? 'Hide Extra Fields' : 'Show Extra Fields'}}</span>
+                            </button>
+                        </span>
+                        <button id="toCommentsLink"
+                           class="btn btn-primary" data-ng-click="showComments()" title="Show Comments">
+                            <current-entry-comment-count></current-entry-comment-count>
+                            <i class="fa fa-comments commentColor"></i>
                         </button>
-                    </span>
-                    <span data-ng-if="entryLoaded()">
-                        <button id="toggleHiddenFieldsBtn" class="btn btn-std"
-                                data-ng-click="show.emptyFields = !show.emptyFields">
-                            <i class="fa" data-ng-class="show.emptyFields ? 'fa-minus-square-o' : 'fa-plus-square-o'"></i>
-                            <span class="d-none d-md-inline-block">{{show.emptyFields ? 'Hide Extra Fields' : 'Show Extra Fields'}}</span>
-                        </button>
-                    </span>
-                    <button id="toCommentsLink"
-                       class="btn btn-primary" data-ng-click="showComments()" title="Show Comments">
-                        <current-entry-comment-count></current-entry-comment-count>
-                        <i class="fa fa-comments commentColor"></i>
-                    </button>
-                </div>
-                <div class="float-right" data-ng-show="$state.is('editor.comments')">
-                    <div id="commentsCount" class="btn btn-std">
-                        <current-entry-comment-count></current-entry-comment-count>
-                        <i class="fa fa-comments commentColor"></i>
+                    </div>
+                    <div class="float-right" data-ng-show="$state.is('editor.comments')">
+                        <div id="commentsCount" class="btn btn-std">
+                            <current-entry-comment-count></current-entry-comment-count>
+                            <i class="fa fa-comments commentColor"></i>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.html
@@ -1,93 +1,97 @@
-<div id="lexAppEditView" class="animate-switch row">
-    <div class="col-md-4">
+<div id="lexAppEditView" class="animate-switch">
+    <div class="container">
         <div class="row">
-            <div class="col-md-12 col-lg-8">
-                <pui-typeahead class="typeahead" placeholder="'Search Entries'"
-                               items="typeahead.searchResults" term="typeahead.searchItemSelected"
-                               search="typeahead.searchEntries" select="typeahead.searchSelect">
-                    <ul data-ng-if="typeahead.searchResults.length > 0" class="list-group">
-                        <li data-typeahead-item="e" class="typeahead-item list-group-item"
-                            data-ng-repeat="e in typeahead.searchResults | limitTo: typeahead.limit">
-                            <div class="listItemPrimary" data-ng-bind-html="getPrimaryListItemForDisplay(config, e)"></div>
-                            <small class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(e)"></small>
-                        </li>
-                    </ul>
-                    <div style="text-align:center; background-color: #d3d3d3; color:black;"
-                         data-ng-if="typeahead.searchResults.length > 0">
-                        <small><i>{{typeahead.matchCountCaption}}</i></small>
+            <div class="col-md-4">
+                <div class="row">
+                    <div class="col-md-12 col-lg-8">
+                        <pui-typeahead class="typeahead" placeholder="'Search Entries'"
+                                       items="typeahead.searchResults" term="typeahead.searchItemSelected"
+                                       search="typeahead.searchEntries" select="typeahead.searchSelect">
+                            <ul data-ng-if="typeahead.searchResults.length > 0" class="list-group">
+                                <li data-typeahead-item="e" class="typeahead-item list-group-item"
+                                    data-ng-repeat="e in typeahead.searchResults | limitTo: typeahead.limit">
+                                    <div class="listItemPrimary" data-ng-bind-html="getPrimaryListItemForDisplay(config, e)"></div>
+                                    <small class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(e)"></small>
+                                </li>
+                            </ul>
+                            <div style="text-align:center; background-color: #d3d3d3; color:black;"
+                                 data-ng-if="typeahead.searchResults.length > 0">
+                                <small><i>{{typeahead.matchCountCaption}}</i></small>
+                            </div>
+                        </pui-typeahead>
                     </div>
-                </pui-typeahead>
-            </div>
-            <div class="col-md-12 col-lg-4 d-none d-md-block">
-                <button ng-click="show.entryListModifiers = !show.entryListModifiers" class="btn btn-sm float-right">
-                    <span class="fa" data-ng-class="show.entryListModifiers ? 'fa-minus-square-o': 'fa-plus-square-o'"></span>
-                    Options</button>
-            </div>
-        </div>
-        <br class="d-none d-md-block d-lg-none">
-        <div class="row">
-            <div class="d-none d-md-block" ng-show="show.entryListModifiers">
-                <div class="form-group sortfilter-form">
-                    <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
-                    <div class="form-inline">
-                        <select id="sortEntriesBy" class="custom-select sortfilter-control"
-                                ng-change="sortEntries(true)" ng-model="entryListModifiers.sortBy"
-                                ng-options="item as item.label for item in entryListModifiers.sortOptions track by item.value">
-                        </select>
-                        <label style="margin: 7px">
-                            <input type="checkbox" ng-change="sortEntries(true)" ng-model="entryListModifiers.sortReverse"> Reverse
-                        </label>
+                    <div class="col-md-12 col-lg-4 d-none d-md-block">
+                        <button ng-click="show.entryListModifiers = !show.entryListModifiers" class="btn btn-sm float-right">
+                            <span class="fa" data-ng-class="show.entryListModifiers ? 'fa-minus-square-o': 'fa-plus-square-o'"></span>
+                            Options</button>
                     </div>
                 </div>
-                <div class="form-group sortfilter-form">
-                    <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
-                    <div class="form-inline">
-                        <select class="custom-select sortfilter-control" ng-show="entryListModifiers.filterBy"
-                                ng-change="filterEntries(true)" ng-model="entryListModifiers.filterType">
-                            <option value="isEmpty">Doesn't have</option>
-                            <option value="isNotEmpty">Has</option>
-                        </select>
-                        <select class="custom-select sortfilter-control" id="filterEntriesFor"
-                                ng-change="filterEntries(true)" ng-model="entryListModifiers.filterBy"
-                                ng-options="item as item.label for item in entryListModifiers.filterOptions track by item.key">
-                            <option value="">Show All</option>
-                        </select>
-                        <button ng-click="resetEntryListFilter()" ng-show="entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
-                    </div>
-                </div>
+                <br class="d-none d-md-block d-lg-none">
+                <div class="row">
+                    <div class="d-none d-md-block" ng-show="show.entryListModifiers">
+                        <div class="form-group sortfilter-form">
+                            <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
+                            <div class="form-inline">
+                                <select id="sortEntriesBy" class="custom-select sortfilter-control"
+                                        ng-change="sortEntries(true)" ng-model="entryListModifiers.sortBy"
+                                        ng-options="item as item.label for item in entryListModifiers.sortOptions track by item.value">
+                                </select>
+                                <label style="margin: 7px">
+                                    <input type="checkbox" ng-change="sortEntries(true)" ng-model="entryListModifiers.sortReverse"> Reverse
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group sortfilter-form">
+                            <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
+                            <div class="form-inline">
+                                <select class="custom-select sortfilter-control" ng-show="entryListModifiers.filterBy"
+                                        ng-change="filterEntries(true)" ng-model="entryListModifiers.filterType">
+                                    <option value="isEmpty">Doesn't have</option>
+                                    <option value="isNotEmpty">Has</option>
+                                </select>
+                                <select class="custom-select sortfilter-control" id="filterEntriesFor"
+                                        ng-change="filterEntries(true)" ng-model="entryListModifiers.filterBy"
+                                        ng-options="item as item.label for item in entryListModifiers.filterOptions track by item.key">
+                                    <option value="">Show All</option>
+                                </select>
+                                <button ng-click="resetEntryListFilter()" ng-show="entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
+                            </div>
+                        </div>
 
-                <br>
-            </div>
-        </div>
-
-        <div class="row">
-            <div class="col d-none d-md-block list-group">
-                <div class="list-group-item list-group-item-action active">
-                    <small ng-hide="entryListModifiers.filterBy" id="totalNumberOfEntries" class="float-right"><span class="notranslate">{{entries.length}}</span> {{'entries' | translate}}</small>
-                    <small ng-show="entryListModifiers.filterBy" class="float-right notranslate">{{filteredEntries.length}} / {{entries.length}}</small>
-                    <h5>{{ 'Words in dictionary' | translate }}</h5>
+                        <br>
+                    </div>
                 </div>
-                <div id="compactEntryListContainer" class="lexiconItemListContainer" data-pui-when-scrolled="show.more()">
-                    <div id="entryId_{{entry.id}}" class="list-group-item lexiconListItemCompact"
-                         data-ng-class="{selected: entry.id == currentEntry.id, listItemHasComment: commentService.getEntryCommentCount(entry.id) > 0}"
-                         title="{{getCompactItemListOverlay(entry)}}"
-                         data-ng-repeat="entry in visibleEntries track by entry.id" data-ng-click="editEntry(entry.id)">
-                        <div dir="auto" class="listItemPrimary" data-ng-bind-html="getPrimaryListItemForDisplay(config, entry)"></div>
-                        <div dir="auto" class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(entry)"></div>
+                <div class="row">
+                    <div class="col d-none d-md-block list-group">
+                        <div class="list-group-item list-group-item-action active">
+                            <small ng-hide="entryListModifiers.filterBy" id="totalNumberOfEntries" class="float-right"><span class="notranslate">{{entries.length}}</span> {{'entries' | translate}}</small>
+                            <small ng-show="entryListModifiers.filterBy" class="float-right notranslate">{{filteredEntries.length}} / {{entries.length}}</small>
+                            <h5>{{ 'Words in dictionary' | translate }}</h5>
+                        </div>
+                        <div id="compactEntryListContainer" class="lexiconItemListContainer" data-pui-when-scrolled="show.more()">
+                            <div id="entryId_{{entry.id}}" class="list-group-item lexiconListItemCompact"
+                                 data-ng-class="{selected: entry.id == currentEntry.id, listItemHasComment: commentService.getEntryCommentCount(entry.id) > 0}"
+                                 title="{{getCompactItemListOverlay(entry)}}"
+                                 data-ng-repeat="entry in visibleEntries track by entry.id" data-ng-click="editEntry(entry.id)">
+                                <div dir="auto" class="listItemPrimary" data-ng-bind-html="getPrimaryListItemForDisplay(config, entry)"></div>
+                                <div dir="auto" class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(entry)"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-8">
+                <div class="word-definition-title">
+                    <dc-rendered config="config.entry" model="currentEntry"></dc-rendered>
+                </div>
+                <div>
+                    <div class="entryItemView" data-ng-if="entryLoaded()">
+                        <dc-entry config="config.entry" model="currentEntry" control="control"></dc-entry>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-
-    <div class="col-md-8">
-        <div class="word-definition-title">
-            <dc-rendered config="config.entry" model="currentEntry"></dc-rendered>
-        </div>
-        <div>
-            <div class="entryItemView" data-ng-if="entryLoaded()">
-                <dc-entry config="config.entry" model="currentEntry" control="control"></dc-entry>
-            </div>
-        </div>
-    </div>
+    <lex-comments-view id="lexAppCommentView" class="animate-switch" entry-config="config.entry" entry="currentEntry"
+                       control="control"></lex-comments-view>
 </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.html
@@ -1,86 +1,91 @@
-<div id="lexAppEditView" class="animate-switch">
+<div id="lexAppEditView" class="animate-switch" ng-class="{'panel-closing': control.commentPanelVisible === -1, 'comments-panel-visible': commentPanelVisible === true}">
     <div class="container">
         <div class="row">
-            <div class="col-md-4">
-                <div class="row">
-                    <div class="col-md-12 col-lg-8">
-                        <pui-typeahead class="typeahead" placeholder="'Search Entries'"
-                                       items="typeahead.searchResults" term="typeahead.searchItemSelected"
-                                       search="typeahead.searchEntries" select="typeahead.searchSelect">
-                            <ul data-ng-if="typeahead.searchResults.length > 0" class="list-group">
-                                <li data-typeahead-item="e" class="typeahead-item list-group-item"
-                                    data-ng-repeat="e in typeahead.searchResults | limitTo: typeahead.limit">
-                                    <div class="listItemPrimary" data-ng-bind-html="getPrimaryListItemForDisplay(config, e)"></div>
-                                    <small class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(e)"></small>
-                                </li>
-                            </ul>
-                            <div style="text-align:center; background-color: #d3d3d3; color:black;"
-                                 data-ng-if="typeahead.searchResults.length > 0">
-                                <small><i>{{typeahead.matchCountCaption}}</i></small>
-                            </div>
-                        </pui-typeahead>
-                    </div>
-                    <div class="col-md-12 col-lg-4 d-none d-md-block">
-                        <button ng-click="show.entryListModifiers = !show.entryListModifiers" class="btn btn-sm float-right">
-                            <span class="fa" data-ng-class="show.entryListModifiers ? 'fa-minus-square-o': 'fa-plus-square-o'"></span>
-                            Options</button>
-                    </div>
-                </div>
-                <br class="d-none d-md-block d-lg-none">
-                <div class="row">
-                    <div class="d-none d-md-block" ng-show="show.entryListModifiers">
-                        <div class="form-group sortfilter-form">
-                            <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
-                            <div class="form-inline">
-                                <select id="sortEntriesBy" class="custom-select sortfilter-control"
-                                        ng-change="sortEntries(true)" ng-model="entryListModifiers.sortBy"
-                                        ng-options="item as item.label for item in entryListModifiers.sortOptions track by item.value">
-                                </select>
-                                <label style="margin: 7px">
-                                    <input type="checkbox" ng-change="sortEntries(true)" ng-model="entryListModifiers.sortReverse"> Reverse
-                                </label>
-                            </div>
+            <div class="col-md-5 col-lg-4 entries-list-container">
+                <div class="entry-words-minimized"><button class="btn btn-primary" ng-click="control.hideCommentsPanel()">Show words in dictionary</button></div>
+                <div class="entry-words-container">
+                    <div class="row">
+                        <div class="col-md-12 col-lg-8">
+                            <pui-typeahead class="typeahead" placeholder="'Search Entries'"
+                                           items="typeahead.searchResults" term="typeahead.searchItemSelected"
+                                           search="typeahead.searchEntries" select="typeahead.searchSelect">
+                                <ul data-ng-if="typeahead.searchResults.length > 0" class="list-group">
+                                    <li data-typeahead-item="e" class="typeahead-item list-group-item"
+                                        data-ng-repeat="e in typeahead.searchResults | limitTo: typeahead.limit">
+                                        <div class="listItemPrimary" data-ng-bind-html="getPrimaryListItemForDisplay(config, e)"></div>
+                                        <small class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(e)"></small>
+                                    </li>
+                                </ul>
+                                <div style="text-align:center; background-color: #d3d3d3; color:black;"
+                                     data-ng-if="typeahead.searchResults.length > 0">
+                                    <small><i>{{typeahead.matchCountCaption}}</i></small>
+                                </div>
+                            </pui-typeahead>
                         </div>
-                        <div class="form-group sortfilter-form">
-                            <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
-                            <div class="form-inline">
-                                <select class="custom-select sortfilter-control" ng-show="entryListModifiers.filterBy"
-                                        ng-change="filterEntries(true)" ng-model="entryListModifiers.filterType">
-                                    <option value="isEmpty">Doesn't have</option>
-                                    <option value="isNotEmpty">Has</option>
-                                </select>
-                                <select class="custom-select sortfilter-control" id="filterEntriesFor"
-                                        ng-change="filterEntries(true)" ng-model="entryListModifiers.filterBy"
-                                        ng-options="item as item.label for item in entryListModifiers.filterOptions track by item.key">
-                                    <option value="">Show All</option>
-                                </select>
-                                <button ng-click="resetEntryListFilter()" ng-show="entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
-                            </div>
+                        <div class="col-md-12 col-lg-4 d-none d-md-block">
+                            <button ng-click="show.entryListModifiers = !show.entryListModifiers" class="btn btn-sm float-right">
+                                <span class="fa" data-ng-class="show.entryListModifiers ? 'fa-minus-square-o': 'fa-plus-square-o'"></span>
+                                Options</button>
                         </div>
+                    </div>
+                    <br class="d-none d-md-block d-lg-none">
+                    <div class="row">
+                        <div class="d-none d-md-block" ng-show="show.entryListModifiers">
+                            <div class="form-group sortfilter-form">
+                                <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
+                                <div class="form-inline">
+                                    <select id="sortEntriesBy" class="custom-select sortfilter-control"
+                                            ng-change="sortEntries(true)" ng-model="entryListModifiers.sortBy"
+                                            ng-options="item as item.label for item in entryListModifiers.sortOptions track by item.value">
+                                    </select>
+                                    <label style="margin: 7px">
+                                        <input type="checkbox" ng-change="sortEntries(true)" ng-model="entryListModifiers.sortReverse"> Reverse
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="form-group sortfilter-form">
+                                <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
+                                <div class="form-inline">
+                                    <select class="custom-select sortfilter-control" ng-show="entryListModifiers.filterBy"
+                                            ng-change="filterEntries(true)" ng-model="entryListModifiers.filterType">
+                                        <option value="isEmpty">Doesn't have</option>
+                                        <option value="isNotEmpty">Has</option>
+                                    </select>
+                                    <select class="custom-select sortfilter-control" id="filterEntriesFor"
+                                            ng-change="filterEntries(true)" ng-model="entryListModifiers.filterBy"
+                                            ng-options="item as item.label for item in entryListModifiers.filterOptions track by item.key">
+                                        <option value="">Show All</option>
+                                    </select>
+                                    <button ng-click="resetEntryListFilter()" ng-show="entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
+                                </div>
+                            </div>
 
-                        <br>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col d-none d-md-block list-group">
-                        <div class="list-group-item list-group-item-action active">
-                            <small ng-hide="entryListModifiers.filterBy" id="totalNumberOfEntries" class="float-right"><span class="notranslate">{{entries.length}}</span> {{'entries' | translate}}</small>
-                            <small ng-show="entryListModifiers.filterBy" class="float-right notranslate">{{filteredEntries.length}} / {{entries.length}}</small>
-                            <h5>{{ 'Words in dictionary' | translate }}</h5>
+                            <br>
                         </div>
-                        <div id="compactEntryListContainer" class="lexiconItemListContainer" data-pui-when-scrolled="show.more()">
-                            <div id="entryId_{{entry.id}}" class="list-group-item lexiconListItemCompact"
-                                 data-ng-class="{selected: entry.id == currentEntry.id, listItemHasComment: commentService.getEntryCommentCount(entry.id) > 0}"
-                                 title="{{getCompactItemListOverlay(entry)}}"
-                                 data-ng-repeat="entry in visibleEntries track by entry.id" data-ng-click="editEntry(entry.id)">
-                                <div dir="auto" class="listItemPrimary" data-ng-bind-html="getPrimaryListItemForDisplay(config, entry)"></div>
-                                <div dir="auto" class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(entry)"></div>
+                    </div>
+                    <div class="row">
+                        <div class="col d-none d-md-block">
+                            <div class="list-group">
+                                <div class="list-group-item list-group-item-action active">
+                                    <small ng-hide="entryListModifiers.filterBy" id="totalNumberOfEntries" class="float-right"><span class="notranslate">{{entries.length}}</span> {{'entries' | translate}}</small>
+                                    <small ng-show="entryListModifiers.filterBy" class="float-right notranslate">{{filteredEntries.length}} / {{entries.length}}</small>
+                                    <h5>{{ 'Words in dictionary' | translate }}</h5>
+                                </div>
+                                <div id="compactEntryListContainer" class="lexiconItemListContainer" data-pui-when-scrolled="show.more()">
+                                    <div id="entryId_{{entry.id}}" class="list-group-item lexiconListItemCompact"
+                                         data-ng-class="{selected: entry.id == currentEntry.id, listItemHasComment: commentService.getEntryCommentCount(entry.id) > 0}"
+                                         title="{{getCompactItemListOverlay(entry)}}"
+                                         data-ng-repeat="entry in visibleEntries track by entry.id" data-ng-click="editEntry(entry.id)">
+                                        <div dir="auto" class="listItemPrimary" data-ng-bind-html="getPrimaryListItemForDisplay(config, entry)"></div>
+                                        <div dir="auto" class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(entry)"></div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-            <div class="col-md-8">
+            <div class="col-md-7 col-lg-8 entry-primary-container">
                 <div class="word-definition-title">
                     <dc-rendered config="config.entry" model="currentEntry"></dc-rendered>
                 </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.html
@@ -1,93 +1,99 @@
 <div id="lexAppListView" class="animate-switch">
-    <div data-ng-hide="visibleEntries.length === 0" class="row">
-        <pui-typeahead class="typeahead col-xs-12 col-sm-8" placeholder="'Search Entries'"
-                   items="typeahead.searchResults" term="typeahead.searchItemSelected"
-                   search="typeahead.searchEntries" select="typeahead.searchSelect">
-            <ul data-ng-if="typeahead.searchResults.length > 0" class="list-group">
-                <li data-typeahead-item="e" class="typeahead-item list-group-item"
-                    data-ng-repeat="e in typeahead.searchResults | limitTo: typeahead.limit">
-                    <div class="listItemPrimary" data-ng-bind-html="getWordForDisplay(e)"></div>
-                    <small class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(e)"></small>
-                </li>
-            </ul>
-            <div style="text-align:center; background-color: #d3d3d3; color:black;"
-                 data-ng-if="typeahead.searchResults.length > 0">
-                <small><i>{{typeahead.matchCountCaption}}</i></small></div>
-        </pui-typeahead>
-        <div class="col-xs-6 col-sm-2">
-            <button class="btn btn-sm" type="button" data-ng-click="show.entryListModifiers = !show.entryListModifiers">
-                <i class="fa" data-ng-class="{ 'fa-minus-square-o': show.entryListModifiers, 'fa-plus-square-o': !show.entryListModifiers }"></i>
-                <span class="d-none d-md-inline-block">&nbsp;Options</span>
-            </button>
-        </div>
-        <div class="col-xs-6 col-sm-2">
-            <button class="btn btn-primary float-right" type="button" id="newWord" data-ng-if="rights.canEditEntry()"
-                    data-ng-click="newEntry()">
-                <i class="fa fa-plus"></i><span class="d-none d-md-inline-block">&nbsp;New Word</span>
-            </button>
-        </div>
-    </div>
-    <div class="row" data-ng-show="show.entryListModifiers">
-        <div class="col-md-12 col-lg-6">
-            <div class="form-group sortfilter-form">
-                <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
-                <div class="form-inline">
-                    <select id="sortEntriesBy" class="custom-select sortfilter-control"
-                            data-ng-change="sortEntries(true)" data-ng-model="entryListModifiers.sortBy"
-                            data-ng-options="item as item.label for item in entryListModifiers.sortOptions track by item.value">
-                    </select>
-                    <label style="margin: 7px">
-                        <input type="checkbox" data-ng-change="sortEntries(true)" data-ng-model="entryListModifiers.sortReverse"> Reverse
-                    </label>
+    <div class="container">
+        <div class="row">
+            <div class="col">
+                <div data-ng-hide="visibleEntries.length === 0" class="row">
+                    <pui-typeahead class="typeahead col-xs-12 col-sm-8" placeholder="'Search Entries'"
+                               items="typeahead.searchResults" term="typeahead.searchItemSelected"
+                               search="typeahead.searchEntries" select="typeahead.searchSelect">
+                        <ul data-ng-if="typeahead.searchResults.length > 0" class="list-group">
+                            <li data-typeahead-item="e" class="typeahead-item list-group-item"
+                                data-ng-repeat="e in typeahead.searchResults | limitTo: typeahead.limit">
+                                <div class="listItemPrimary" data-ng-bind-html="getWordForDisplay(e)"></div>
+                                <small class="listItemSecondary" data-ng-bind-html="getMeaningForDisplay(e)"></small>
+                            </li>
+                        </ul>
+                        <div style="text-align:center; background-color: #d3d3d3; color:black;"
+                             data-ng-if="typeahead.searchResults.length > 0">
+                            <small><i>{{typeahead.matchCountCaption}}</i></small></div>
+                    </pui-typeahead>
+                    <div class="col-xs-6 col-sm-2">
+                        <button class="btn btn-sm" type="button" data-ng-click="show.entryListModifiers = !show.entryListModifiers">
+                            <i class="fa" data-ng-class="{ 'fa-minus-square-o': show.entryListModifiers, 'fa-plus-square-o': !show.entryListModifiers }"></i>
+                            <span class="d-none d-md-inline-block">&nbsp;Options</span>
+                        </button>
+                    </div>
+                    <div class="col-xs-6 col-sm-2">
+                        <button class="btn btn-primary float-right" type="button" id="newWord" data-ng-if="rights.canEditEntry()"
+                                data-ng-click="newEntry()">
+                            <i class="fa fa-plus"></i><span class="d-none d-md-inline-block">&nbsp;New Word</span>
+                        </button>
+                    </div>
                 </div>
-            </div>
-        </div>
-        <div class="col-md-12 col-lg-6">
-            <div class="form-group sortfilter-form">
-                <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
-                <div class="form-inline">
-                    <select class="custom-select sortfilter-control" data-ng-show="entryListModifiers.filterBy"
-                            data-ng-change="filterEntries(true)" data-ng-model="entryListModifiers.filterType">
-                        <option value="isEmpty">Doesn't have</option>
-                        <option value="isNotEmpty">Has</option>
-                    </select>
-                    <select class="custom-select sortfilter-control" id="filterEntriesFor"
-                            data-ng-change="filterEntries(true)" data-ng-model="entryListModifiers.filterBy"
-                            data-ng-options="item as item.label for item in entryListModifiers.filterOptions track by item.key">
-                        <option value="">Show All</option>
-                    </select>
-                    <button data-ng-click="resetEntryListFilter()" data-ng-show="entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
-                </div>
-            </div>
-        </div>
+                <div class="row" data-ng-show="show.entryListModifiers">
+                    <div class="col-md-12 col-lg-6">
+                        <div class="form-group sortfilter-form">
+                            <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
+                            <div class="form-inline">
+                                <select id="sortEntriesBy" class="custom-select sortfilter-control"
+                                        data-ng-change="sortEntries(true)" data-ng-model="entryListModifiers.sortBy"
+                                        data-ng-options="item as item.label for item in entryListModifiers.sortOptions track by item.value">
+                                </select>
+                                <label style="margin: 7px">
+                                    <input type="checkbox" data-ng-change="sortEntries(true)" data-ng-model="entryListModifiers.sortReverse"> Reverse
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-12 col-lg-6">
+                        <div class="form-group sortfilter-form">
+                            <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
+                            <div class="form-inline">
+                                <select class="custom-select sortfilter-control" data-ng-show="entryListModifiers.filterBy"
+                                        data-ng-change="filterEntries(true)" data-ng-model="entryListModifiers.filterType">
+                                    <option value="isEmpty">Doesn't have</option>
+                                    <option value="isNotEmpty">Has</option>
+                                </select>
+                                <select class="custom-select sortfilter-control" id="filterEntriesFor"
+                                        data-ng-change="filterEntries(true)" data-ng-model="entryListModifiers.filterBy"
+                                        data-ng-options="item as item.label for item in entryListModifiers.filterOptions track by item.key">
+                                    <option value="">Show All</option>
+                                </select>
+                                <button data-ng-click="resetEntryListFilter()" data-ng-show="entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
+                            </div>
+                        </div>
+                    </div>
 
-        <br>
-    </div>
-    <div class="lexiconItemListContainer" data-pui-when-scrolled="show.more()">
-        <div class="text-center no-entries" data-ng-show="entries.length == 0 && rights.canEditProject() && finishedLoading">
-            <h4>Looks like there are no entries yet.</h4>
-            <button class="btn btn-primary" data-ng-click="navigateToLiftImport()"
-                    data-ng-hide="projectSettings.hasSendReceive">
-                <i class="fa fa-upload"></i> Import entries from LIFT</button>
-            <button class="btn btn-primary" data-ng-click="syncProject()" data-ng-show="projectSettings.hasSendReceive">
-                <i class="fa fa-refresh"></i> Synchronize project with LanguageDepot.org</button>
-            <button class="btn btn-primary" id="noEntriesNewWord" data-ng-if="rights.canEditEntry()"
-                    data-ng-click="newEntry()"><i class="fa fa-plus"></i> New Word
-            </button>
-        </div>
-        <div class="list-group" data-ng-show="entries.length > 0 && finishedLoading">
-            <div class="lexiconListItem list-group-item list-group-item-action active">
-                <small data-ng-hide="entryListModifiers.filterBy" id="totalNumberOfEntries" class="float-right">
-                    <span class="notranslate">{{entries.length}}</span> entries</small>
-                <small data-ng-show="entryListModifiers.filterBy" class="float-right notranslate">{{filteredEntries.length}} / {{entries.length}}</small>
-                <h5>Words in dictionary</h5>
-            </div>
-            <div class="lexiconListItem list-group-item list-group-item-action" data-ng-repeat="entry in visibleEntries track by entry.id"
-                 data-ng-click="editEntryAndScroll(entry.id)">
-                <dc-rendered config="config.entry" model="entry"></dc-rendered>
-                <div data-ng-show="commentService.getEntryCommentCount(entry.id) > 0"
-                     style="position:absolute; right:5px;top:3px">
-                    <i class="fa fa-comment commentColor"></i>
+                    <br>
+                </div>
+                <div class="lexiconItemListContainer" data-pui-when-scrolled="show.more()">
+                    <div class="text-center no-entries" data-ng-show="entries.length == 0 && rights.canEditProject() && finishedLoading">
+                        <h4>Looks like there are no entries yet.</h4>
+                        <button class="btn btn-primary" data-ng-click="navigateToLiftImport()"
+                                data-ng-hide="projectSettings.hasSendReceive">
+                            <i class="fa fa-upload"></i> Import entries from LIFT</button>
+                        <button class="btn btn-primary" data-ng-click="syncProject()" data-ng-show="projectSettings.hasSendReceive">
+                            <i class="fa fa-refresh"></i> Synchronize project with LanguageDepot.org</button>
+                        <button class="btn btn-primary" id="noEntriesNewWord" data-ng-if="rights.canEditEntry()"
+                                data-ng-click="newEntry()"><i class="fa fa-plus"></i> New Word
+                        </button>
+                    </div>
+                    <div class="list-group" data-ng-show="entries.length > 0 && finishedLoading">
+                        <div class="lexiconListItem list-group-item list-group-item-action active">
+                            <small data-ng-hide="entryListModifiers.filterBy" id="totalNumberOfEntries" class="float-right">
+                                <span class="notranslate">{{entries.length}}</span> entries</small>
+                            <small data-ng-show="entryListModifiers.filterBy" class="float-right notranslate">{{filteredEntries.length}} / {{entries.length}}</small>
+                            <h5>Words in dictionary</h5>
+                        </div>
+                        <div class="lexiconListItem list-group-item list-group-item-action" data-ng-repeat="entry in visibleEntries track by entry.id"
+                             data-ng-click="editEntryAndScroll(entry.id)">
+                            <dc-rendered config="config.entry" model="entry"></dc-rendered>
+                            <div data-ng-show="commentService.getEntryCommentCount(entry.id) > 0"
+                                 style="position:absolute; right:5px;top:3px">
+                                <i class="fa fa-comment commentColor"></i>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -33,11 +33,11 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
   .controller('EditorCtrl', ['$scope', 'userService', 'sessionService', 'lexEntryApiService', '$q',
     '$state', '$window', '$interval', '$filter', 'lexLinkService', 'lexUtils', 'lexRightsService',
     'silNoticeService', '$rootScope', '$location', 'lexConfigService', 'lexCommentService',
-    'lexEditorDataService', 'lexProjectService', 'lexSendReceive', 'modalService',
+    'lexEditorDataService', 'lexProjectService', 'lexSendReceive', 'modalService', '$timeout',
   function ($scope, userService, sessionService, lexService, $q,
             $state, $window, $interval, $filter, linkService, utils, rightsService,
             notice, $rootScope, $location, lexConfig, commentService,
-            editorService, lexProjectService, sendReceive, modal) {
+            editorService, lexProjectService, sendReceive, modal, $timeout) {
 
     var pristineEntry = {};
     var warnOfUnsavedEditsId;
@@ -695,19 +695,24 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
       };
 
       $scope.showCommentsPanel = function showCommentsPanel() {
-        $scope.commentPanelVisible = true;
-        angular.element('.comments-right-panel-container').addClass('panel-opening');
-        setTimeout(function () {
-          angular.element('.comments-right-panel-container').removeClass('panel-opening');
-        }, 500);
+        if ($scope.commentPanelVisible !== true) {
+          $scope.commentPanelVisible = true;
+          angular.element('.comments-right-panel-container').addClass('panel-opening');
+          $timeout(function () {
+            angular.element('.comments-right-panel-container').removeClass('panel-opening');
+          }, 500);
+        }
       };
 
       $scope.hideCommentsPanel = function hideCommentsPanel() {
         $scope.commentPanelVisible = -1;
-        setTimeout(function () {
+
+        // Delay relates to the CSS timer for mobile vs > tablet
+        var delay = (angular.element('#compactEntryListContainer').is(':visible')) ? 1500 : 500;
+        $timeout(function () {
           $scope.commentPanelVisible = false;
           $scope.setCommentContext('', '');
-        }, 500); // Delay relates to the CSS timer
+        }, delay);
       };
 
       sendReceive.setPollUpdateSuccessCallback(pollUpdateSuccess);

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -52,7 +52,11 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
     $scope.visibleEntries = editorService.visibleEntries;
     $scope.filteredEntries = editorService.filteredEntries;
     $scope.entryListModifiers = editorService.entryListModifiers;
-    $scope.commentContext = {};
+    $scope.commentContext = {
+      field: '',
+      abbreviation: ''
+    };
+    $scope.commentPanelVisible = false;
     $scope.sortEntries = function (args) {
       editorService.sortEntries.apply(this, arguments).then(function () {
         $scope.typeahead.searchEntries($scope.typeahead.searchItemSelected);
@@ -680,8 +684,30 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
 
       // Comments View
       $scope.showComments = function showComments() {
-        $scope.saveCurrentEntry(true);
-        $state.go('editor.comments', { entryId: $scope.currentEntry.id });
+        if ($scope.commentPanelVisible === true && $scope.commentContext.field === '') {
+          $scope.hideCommentsPanel();
+          $scope.setCommentContext('', '');
+        } else {
+          $scope.setCommentContext('', '');
+          angular.element('.comments-right-panel').css({ paddingTop: 0 });
+          $scope.showCommentsPanel();
+        }
+      };
+
+      $scope.showCommentsPanel = function showCommentsPanel() {
+        $scope.commentPanelVisible = true;
+        angular.element('.comments-right-panel-container').addClass('panel-opening');
+        setTimeout(function () {
+          angular.element('.comments-right-panel-container').removeClass('panel-opening');
+        }, 500);
+      };
+
+      $scope.hideCommentsPanel = function hideCommentsPanel() {
+        $scope.commentPanelVisible = -1;
+        setTimeout(function () {
+          $scope.commentPanelVisible = false;
+          $scope.setCommentContext('', '');
+        }, 500); // Delay relates to the CSS timer
       };
 
       sendReceive.setPollUpdateSuccessCallback(pollUpdateSuccess);
@@ -906,7 +932,18 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
       $scope.setCommentContext = function setCommentContext(field, abbreviation) {
         $scope.commentContext.field = field;
         $scope.commentContext.abbreviation = abbreviation;
-        console.log('all set - watch kick in place. ' + field + ', ' + abbreviation);
+      };
+
+      $scope.setCommentSenseLabel = function setCommentSenseLabel(fieldName, senseLabel) {
+        var field = null;
+        if ($scope.config.entry.fields.hasOwnProperty(fieldName)) {
+          field = $scope.config.entry.fields[fieldName];
+        }
+
+        if (field !== null) {
+          console.log(fieldName + ' - ' + senseLabel);
+          field.senseLabel = senseLabel;
+        }
       };
     });
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -54,7 +54,9 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
     $scope.entryListModifiers = editorService.entryListModifiers;
     $scope.commentContext = {
       field: '',
-      abbreviation: ''
+      abbreviation: '',
+      multiOptionValue: '',
+      pictureSrc: ''
     };
     $scope.commentPanelVisible = false;
     $scope.sortEntries = function (args) {
@@ -934,9 +936,14 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
         }
       };
 
-      $scope.setCommentContext = function setCommentContext(field, abbreviation) {
+      $scope.setCommentContext = function setCommentContext(field,
+                                                            abbreviation,
+                                                            multiOptionValue,
+                                                            pictureSrc) {
         $scope.commentContext.field = field;
         $scope.commentContext.abbreviation = abbreviation;
+        $scope.commentContext.multiOptionValue = multiOptionValue;
+        $scope.commentContext.pictureSrc = pictureSrc;
       };
 
       $scope.setCommentSenseLabel = function setCommentSenseLabel(fieldName, senseLabel) {

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -52,6 +52,7 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
     $scope.visibleEntries = editorService.visibleEntries;
     $scope.filteredEntries = editorService.filteredEntries;
     $scope.entryListModifiers = editorService.entryListModifiers;
+    $scope.commentContext = {};
     $scope.sortEntries = function (args) {
       editorService.sortEntries.apply(this, arguments).then(function () {
         $scope.typeahead.searchEntries($scope.typeahead.searchItemSelected);
@@ -900,6 +901,12 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
         if (entry.id) {
           $scope.editEntryAndScroll(entry.id);
         }
+      };
+
+      $scope.setCommentContext = function setCommentContext(field, abbreviation) {
+        $scope.commentContext.field = field;
+        $scope.commentContext.abbreviation = abbreviation;
+        console.log('all set - watch kick in place. ' + field + ', ' + abbreviation);
       };
     });
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -53,10 +53,7 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
     $scope.filteredEntries = editorService.filteredEntries;
     $scope.entryListModifiers = editorService.entryListModifiers;
     $scope.commentContext = {
-      field: '',
-      abbreviation: '',
-      multiOptionValue: '',
-      pictureSrc: ''
+      contextGuid: ''
     };
     $scope.commentPanelVisible = false;
     $scope.sortEntries = function (args) {
@@ -463,6 +460,8 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
         } else {
           $state.go('editor.entry', { entryId: id });
         }
+
+        $scope.hideCommentsPanel();
       };
 
       $scope.newEntry = function newEntry() {
@@ -484,6 +483,8 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
           } else {
             $state.go('editor.entry', { entryId: newEntry.id });
           }
+
+          $scope.hideCommentsPanel();
         });
       };
 
@@ -634,6 +635,8 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
                 editorService.refreshEditorData();
               });
             }
+
+            $scope.hideCommentsPanel();
           }, angular.noop);
       };
 
@@ -688,9 +691,12 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
       $scope.showComments = function showComments() {
         if ($scope.commentPanelVisible === true && $scope.commentContext.field === '') {
           $scope.hideCommentsPanel();
-          $scope.setCommentContext('', '');
+
+          // Reset the comment context AFTER the panel starts hiding
+          $scope.setCommentContext('', '', '', '', '');
         } else {
-          $scope.setCommentContext('', '');
+          // Reset the comment context BEFORE we start showing the panel
+          $scope.setCommentContext('', '', '', '', '');
           angular.element('.comments-right-panel').css({ paddingTop: 0 });
           $scope.showCommentsPanel();
         }
@@ -936,27 +942,10 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
         }
       };
 
-      $scope.setCommentContext = function setCommentContext(field,
-                                                            abbreviation,
-                                                            multiOptionValue,
-                                                            pictureSrc) {
-        $scope.commentContext.field = field;
-        $scope.commentContext.abbreviation = abbreviation;
-        $scope.commentContext.multiOptionValue = multiOptionValue;
-        $scope.commentContext.pictureSrc = pictureSrc;
+      $scope.setCommentContext = function setCommentContext(contextGuid) {
+        $scope.commentContext.contextGuid = contextGuid;
       };
 
-      $scope.setCommentSenseLabel = function setCommentSenseLabel(fieldName, senseLabel) {
-        var field = null;
-        if ($scope.config.entry.fields.hasOwnProperty(fieldName)) {
-          field = $scope.config.entry.fields[fieldName];
-        }
-
-        if (field !== null) {
-          console.log(fieldName + ' - ' + senseLabel);
-          field.senseLabel = senseLabel;
-        }
-      };
     });
 
   }])

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-multioptionlist.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-multioptionlist.scss
@@ -33,6 +33,12 @@ dc-multioptionlist {
                 height: auto;
                 display: flex;
                 align-items: center;
+                &.noCount {
+                  .commentCount {
+                    display: inline-block;
+                    width: 5px;
+                  }
+                }
                 i {
                   color: inherit;
                   font-size: 16px;
@@ -44,6 +50,8 @@ dc-multioptionlist {
                   position: relative;
                   top: 0;
                   left: 0;
+                  width: auto;
+                  padding: 0 2px;
                 }
                 .commentLabel {
                   display: inline-block;
@@ -54,6 +62,11 @@ dc-multioptionlist {
               .commentBubbleContainer {
                 position: absolute;
                 a.commentBubble {
+                  &.noCount {
+                    .commentCount {
+                      display: none;
+                    }
+                  }
                   .commentCount {
                     color: #fff;
                     position: absolute;
@@ -61,6 +74,7 @@ dc-multioptionlist {
                     left: -9px;
                     background: #1d64f0;
                     font-size: 10px;
+                    width: 18px;
                   }
                   i,
                   .commentLabel {

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-multioptionlist.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-multioptionlist.scss
@@ -1,55 +1,93 @@
-form.dc-multioptionlist {
+dc-multioptionlist {
+  form.dc-multioptionlist {
     margin: 0;
-}
+    .controls {
+      .dc-multioptionlist-values {
+        position: relative;
+        margin-bottom: 10px;
+        padding-right: 15px;
+        display: inline-flex;
+        > div {
+          display: flex;
+          .dc-multioptionlist-value {
+            border-right: 0;
+            border-radius: 3px 0 0 3px;
+            select {
+              margin-bottom: 20px;
+            }
+          }
+          .dropdown {
+            .btn {
+              border-radius: 0 3px 3px 0;
+              height: 100%;
+              padding: 0 7px;
+            }
+            .commentBubbleContainer {
+              position: relative;
+              top: 0;
+              right: 0;
+              a.commentBubble {
+                background: inherit;
+                color: inherit;
+                width: auto;
+                height: auto;
+                display: flex;
+                align-items: center;
+                i {
+                  color: inherit;
+                  font-size: 16px;
+                }
+                .commentCount {
+                  background: inherit;
+                  color: inherit;
+                  font-size: inherit;
+                  position: relative;
+                  top: 0;
+                  left: 0;
+                }
+                .commentLabel {
+                  display: inline-block;
+                }
+              }
+            }
+            .dropdown-comment-count {
+              .commentBubbleContainer {
+                position: absolute;
+                a.commentBubble {
+                  .commentCount {
+                    color: #fff;
+                    position: absolute;
+                    top: -9px;
+                    left: -9px;
+                    background: #1d64f0;
+                    font-size: 10px;
+                  }
+                  i,
+                  .commentLabel {
+                    display: none;
+                  }
+                }
+              }
+            }
+          }
+        }
 
-form.dc-multioptionlist .controls div {
-    display: inline-block;
-  &.dc-multioptionlist-values-list {
-    display: block;
+        .dc-multioptionlist-value {
+          border: 1px solid $lf-lines;
+          padding: $input-btn-padding-y $input-btn-padding-x;
+          border-radius: $border-radius;
+        }
+      }
+      .dc-multioptionlist-values-list {
+        display: block;
+      }
+    }
   }
-}
-
-form.dc-multioptionlist .controls > div {
-    margin-bottom: 10px;
-}
-
-.dc-multioptionlist-values {
-    position: relative;
-}
-
-.dc-multioptionlist-values > div {
-    padding-right: 9px;
-}
-
-.dc-multioptionlist-value {
-    border: 1px solid $lf-lines;
-    padding: $input-btn-padding-y $input-btn-padding-x;
-    border-radius: $border-radius;
-}
-
-form.dc-multioptionlist i.closeicon {
-  position: absolute;
-  top: -6px;
-  right: 0;
-  padding: 5px;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid $lf-lines;
-  border-radius: 50%;
-  cursor: pointer;
-  width: 28px;
-  height: 28px;
-  text-align: center;
-}
-form.dc-multioptionlist i.closeicon:hover {
-  background: map-get($theme-colors, danger);
-  color: #fff;
-}
-
-.dc-multioptionlist-value select, dc-multioptionlist .addItem {
+  .addItem {
     margin-bottom: 20px;
-}
-
-dc-multioptionlist .spacing-after {
+  }
+  .spacing-after {
     line-height: 0;
     margin-bottom: 10px;
+  }
 }

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-multioptionlist.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-multioptionlist.scss
@@ -4,6 +4,9 @@ form.dc-multioptionlist {
 
 form.dc-multioptionlist .controls div {
     display: inline-block;
+  &.dc-multioptionlist-values-list {
+    display: block;
+  }
 }
 
 form.dc-multioptionlist .controls > div {

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-multioptionlist.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-multioptionlist.scss
@@ -1,6 +1,5 @@
 form.dc-multioptionlist {
     margin: 0;
-    margin-right: -4px;
 }
 
 form.dc-multioptionlist .controls div {

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-picture.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-picture.scss
@@ -38,6 +38,7 @@
     right: 0;
     line-height: 28px;
     text-align: center;
+    z-index: 1;
     i {
       vertical-align: top;
     }

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-semanticdomain.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-semanticdomain.scss
@@ -1,50 +1,97 @@
-form.dc-semanticdomain {
+dc-semanticdomain {
+  form.dc-semanticdomain {
     margin: 0;
-}
+    .controls {
+      .dc-semanticdomain-values {
+        position: relative;
+        margin-bottom: 10px;
+        padding-right: 15px;
+        display: inline-flex;
+        > div {
+          display: flex;
+          .dc-semanticdomain-value {
+            border-right: 0;
+            border-radius: 3px 0 0 3px;
+            select {
+              margin-bottom: 20px;
+            }
+          }
+          .dropdown {
+            .btn {
+              border-radius: 0 3px 3px 0;
+              height: 100%;
+              padding: 0 7px;
+            }
+            .commentBubbleContainer {
+              position: relative;
+              top: 0;
+              right: 0;
+              a.commentBubble {
+                background: inherit;
+                color: inherit;
+                width: auto;
+                height: auto;
+                display: flex;
+                align-items: center;
+                i {
+                  color: inherit;
+                  font-size: 16px;
+                }
+                .commentCount {
+                  background: inherit;
+                  color: inherit;
+                  font-size: inherit;
+                  position: relative;
+                  top: 0;
+                  left: 0;
+                }
+                .commentLabel {
+                  display: inline-block;
+                }
+              }
+            }
+            .dropdown-comment-count {
+              .commentBubbleContainer {
+                position: absolute;
+                a.commentBubble {
+                  .commentCount {
+                    color: #fff;
+                    position: absolute;
+                    top: -9px;
+                    left: -9px;
+                    background: #1d64f0;
+                    font-size: 10px;
+                  }
+                  i,
+                  .commentLabel {
+                    display: none;
+                  }
+                }
+              }
+            }
+          }
+        }
 
-form.dc-semanticdomain .controls div {
-    display: inline-block;
-}
-
-form.dc-semanticdomain .controls > div {
+        .dc-semanticdomain-value {
+          border: 1px solid $lf-lines;
+          padding: $input-btn-padding-y $input-btn-padding-x;
+          border-radius: $border-radius;
+        }
+      }
+      .dc-semanticdomain-values-list {
+        display: block;
+      }
+    }
+  }
+  .addItem {
+    margin-bottom: 20px;
+  }
+  .spacing-after {
+    line-height: 0;
     margin-bottom: 10px;
+  }
 }
 
-.dc-semanticdomain-values {
-    position: relative;
-}
-
-.dc-semanticdomain-values > div {
-    padding-right: 9px;
-}
-
-.dc-semanticdomain-value {
-    border: 1px solid $lf-lines;
-    padding: $input-btn-padding-y $input-btn-padding-x;
-    border-radius: $border-radius;
-}
-
-form.dc-semanticdomain i.closeicon {
-    position: absolute;
-    top: -6px;
-    right: 0;
-    padding: 5px;
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid $lf-lines;
-    border-radius: 50%;
-    cursor: pointer;
-    width: 28px;
-    height: 28px;
-    text-align: center;
-}
-form.dc-semanticdomain i.closeicon:hover {
-  background: map-get($theme-colors, danger);
-  color: #fff;
-}
-
-.dc-semanticdomain-value select, dc-semanticdomain .addItem {
-    margin: 0 0 20px;
-}
 
 dc-semanticdomain .spacing-after {
     line-height: 0;

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-semanticdomain.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-semanticdomain.scss
@@ -33,6 +33,12 @@ dc-semanticdomain {
                 height: auto;
                 display: flex;
                 align-items: center;
+                &.noCount {
+                  .commentCount {
+                    display: inline-block;
+                    width: 5px;
+                  }
+                }
                 i {
                   color: inherit;
                   font-size: 16px;
@@ -44,6 +50,8 @@ dc-semanticdomain {
                   position: relative;
                   top: 0;
                   left: 0;
+                  width: auto;
+                  padding: 0 2px;
                 }
                 .commentLabel {
                   display: inline-block;
@@ -54,6 +62,11 @@ dc-semanticdomain {
               .commentBubbleContainer {
                 position: absolute;
                 a.commentBubble {
+                  &.noCount {
+                    .commentCount {
+                      display: none;
+                    }
+                  }
                   .commentCount {
                     color: #fff;
                     position: absolute;
@@ -61,6 +74,7 @@ dc-semanticdomain {
                     left: -9px;
                     background: #1d64f0;
                     font-size: 10px;
+                    width: 18px;
                   }
                   i,
                   .commentLabel {
@@ -92,8 +106,7 @@ dc-semanticdomain {
   }
 }
 
-
 dc-semanticdomain .spacing-after {
-    line-height: 0;
-    margin-bottom: 10px;
+  line-height: 0;
+  margin-bottom: 10px;
 }

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-semanticdomain.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-semanticdomain.scss
@@ -1,6 +1,5 @@
 form.dc-semanticdomain {
     margin: 0;
-    margin-right: -4px;
 }
 
 form.dc-semanticdomain .controls div {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.js
@@ -43,6 +43,9 @@ angular.module('palaso.ui.dc.entry', ['palaso.ui.dc.fieldrepeat', 'palaso.ui.dc.
           $scope.control.deleteEntry($scope.control.currentEntry);
         };
 
+        angular.forEach($scope.control.config.entry.fields, function (field) {
+          field.senseLabel = 'Entry';
+        });
       }]
     };
   }])

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.js
@@ -13,6 +13,7 @@ angular.module('palaso.ui.dc.entry', ['palaso.ui.dc.fieldrepeat', 'palaso.ui.dc.
       controller: ['$scope', '$state', 'lexRightsService',
       function ($scope, $state, rightsService) {
         $scope.$state = $state;
+        $scope.contextGuid = '';
 
         rightsService.getRights().then(function (rights) {
           $scope.rights = rights;
@@ -26,6 +27,8 @@ angular.module('palaso.ui.dc.entry', ['palaso.ui.dc.fieldrepeat', 'palaso.ui.dc.
           } else {
             $scope.model.senses.push(newSense);
           }
+
+          $scope.control.hideCommentsPanel();
         };
 
         $scope.deleteSense = function (index) {
@@ -36,6 +39,7 @@ angular.module('palaso.ui.dc.entry', ['palaso.ui.dc.fieldrepeat', 'palaso.ui.dc.
             .then(function () {
               $scope.model.senses.splice(index, 1);
               $scope.control.saveCurrentEntry();
+              $scope.control.hideCommentsPanel();
             }, angular.noop);
         };
 

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.js
@@ -14,10 +14,17 @@ angular.module('palaso.ui.dc.example', ['palaso.ui.dc.fieldrepeat'])
     },
     controller: ['$scope', '$state', function ($scope, $state) {
       $scope.$state = $state;
+      $scope.contextGuid = $scope.$parent.contextGuid + ' example#' + $scope.model.guid;
 
-      angular.forEach($scope.control.config.entry.fields.senses.fields.examples.fields, function (field) {
-        field.senseLabel = 'Example ' + ($scope.index + 1);
-      });
+      angular.forEach($scope.control.config.entry.fields.senses.fields.examples.fields,
+        function (field) {
+          if (!angular.isDefined(field.senseLabel)) {
+            field.senseLabel = [];
+            field.senseLabel[-1] = 'Example';
+          }
+
+          field.senseLabel[$scope.index] = 'Example ' + ($scope.index + 1);
+        });
     }],
 
     link: function (scope, element, attrs, controller) {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.js
@@ -14,6 +14,10 @@ angular.module('palaso.ui.dc.example', ['palaso.ui.dc.fieldrepeat'])
     },
     controller: ['$scope', '$state', function ($scope, $state) {
       $scope.$state = $state;
+
+      angular.forEach($scope.control.config.entry.fields.senses.fields.examples.fields, function (field) {
+        field.senseLabel = 'Example ' + ($scope.index + 1);
+      });
     }],
 
     link: function (scope, element, attrs, controller) {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
@@ -8,18 +8,17 @@
                     data-ng-click="control.selectFieldForComment(fieldName, model[fieldName])"
                     config="config.fields[fieldName]"
                     model="model[fieldName]"
-                    items="optionlists[config.fields[fieldName].listCode].items"></dc-optionlist>
-                <comment-bubble control="control" field="fieldName"></comment-bubble>
+                    items="optionlists[config.fields[fieldName].listCode].items"
+                    field-name="fieldName"></dc-optionlist>
             </div>
             <div data-ng-switch-when="multioptionlist">
                 <dc-multioptionlist data-ng-if="fieldName != 'semanticDomain'" class="dc-item"
-                    config="config.fields[fieldName]" model="model[fieldName]"
+                    control="control" config="config.fields[fieldName]" model="model[fieldName]"
                     items="optionlists[config.fields[fieldName].listCode].items"
-                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem, multioptionValue)"></dc-multioptionlist>
+                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem, multioptionValue)" field-name="fieldName"></dc-multioptionlist>
                 <dc-semanticdomain data-ng-if="fieldName == 'semanticDomain'" class="dc-item"
-                    config="config.fields[fieldName]" model="model[fieldName]"
-                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem, multioptionValue)"></dc-semanticdomain>
-                <comment-bubble control="control" field="fieldName"></comment-bubble>
+                    control="control" config="config.fields[fieldName]" model="model[fieldName]"
+                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem, multioptionValue)" field-name="fieldName"></dc-semanticdomain>
             </div>
             <div data-ng-switch-when="multitext">
                 <dc-multitext class="dc-item" control="control"
@@ -32,13 +31,11 @@
                 <dc-multiparagraph class="dc-item" control="control"
                     config="config.fields[fieldName]" model="model[fieldName]"
                     select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem)"></dc-multiparagraph>
-                <comment-bubble control="control" field="fieldName"></comment-bubble>
             </div>
             <div data-ng-switch-when="pictures">
                 <dc-picture class="dc-item" control="control"
                     config="config.fields[fieldName]"
-                    pictures="model[fieldName]"></dc-picture>
-                <comment-bubble control="control" field="fieldName"></comment-bubble>
+                    pictures="model[fieldName]" field-name="fieldName"></dc-picture>
             </div>
             <div data-ng-switch-when="fields"></div>
             <div data-ng-switch-default>unsupported type

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
@@ -32,7 +32,7 @@
             </div>
             <div data-ng-switch-when="pictures">
                 <dc-picture class="dc-item" control="control"
-                    config="config.fields[fieldName]"
+                    config="config.fields[fieldName]" model="model[fieldName]"
                     pictures="model[fieldName]" field-name="fieldName"></dc-picture>
             </div>
             <div data-ng-switch-when="fields"></div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
@@ -5,7 +5,6 @@
         <div data-ng-switch data-on="config.fields[fieldName].type" class="field-container">
             <div data-ng-switch-when="optionlist">
                 <dc-optionlist class="dc-item" control="control"
-                    data-ng-click="control.selectFieldForComment(fieldName, model[fieldName])"
                     config="config.fields[fieldName]"
                     model="model[fieldName]"
                     items="optionlists[config.fields[fieldName].listCode].items"
@@ -15,22 +14,21 @@
                 <dc-multioptionlist data-ng-if="fieldName != 'semanticDomain'" class="dc-item"
                     control="control" config="config.fields[fieldName]" model="model[fieldName]"
                     items="optionlists[config.fields[fieldName].listCode].items"
-                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem, multioptionValue)" field-name="fieldName"></dc-multioptionlist>
+                    field-name="fieldName"></dc-multioptionlist>
                 <dc-semanticdomain data-ng-if="fieldName == 'semanticDomain'" class="dc-item"
                     control="control" config="config.fields[fieldName]" model="model[fieldName]"
-                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem, multioptionValue)" field-name="fieldName"></dc-semanticdomain>
+                    field-name="fieldName"></dc-semanticdomain>
             </div>
             <div data-ng-switch-when="multitext">
                 <dc-multitext class="dc-item" control="control"
                     config="config.fields[fieldName]"
                     model="model[fieldName]"
-                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem)"
                     field-name="fieldName"></dc-multitext>
             </div>
             <div data-ng-switch-when="multiparagraph">
                 <dc-multiparagraph class="dc-item" control="control"
                     config="config.fields[fieldName]" model="model[fieldName]"
-                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem)"></dc-multiparagraph>
+                    field-name="fieldName"></dc-multiparagraph>
             </div>
             <div data-ng-switch-when="pictures">
                 <dc-picture class="dc-item" control="control"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
@@ -2,7 +2,7 @@
     <div data-ng-if="!config.fields[fieldName].hideIfEmpty || control.show.emptyFields ||
         (config.fields[fieldName].hideIfEmpty && fieldContainsData(config.fields[fieldName].type, model[fieldName]))"
         data-ng-class="{selectableFieldForComment: $state.is('editor.comments') && control.rights.canComment()}">
-        <div data-ng-switch data-on="config.fields[fieldName].type">
+        <div data-ng-switch data-on="config.fields[fieldName].type" class="field-container">
             <div data-ng-switch-when="optionlist">
                 <dc-optionlist class="dc-item" control="control"
                     data-ng-click="control.selectFieldForComment(fieldName, model[fieldName])"
@@ -25,8 +25,8 @@
                 <dc-multitext class="dc-item" control="control"
                     config="config.fields[fieldName]"
                     model="model[fieldName]"
-                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem)"></dc-multitext>
-                <comment-bubble control="control" field="fieldName"></comment-bubble>
+                    select-field="control.selectFieldForComment(fieldName, model[fieldName], inputSystem)"
+                    field-name="fieldName"></dc-multitext>
             </div>
             <div data-ng-switch-when="multiparagraph">
                 <dc-multiparagraph class="dc-item" control="control"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.js
@@ -18,6 +18,7 @@ angular.module('palaso.ui.dc.fieldrepeat', ['palaso.ui.dc.multitext', 'palaso.ui
     function ($scope, $state, lexConfigService) {
       $scope.$state = $state;
       $scope.fieldContainsData = lexConfigService.fieldContainsData;
+      $scope.contextGuid = $scope.$parent.contextGuid;
 
       var unregister = $scope.$watch($scope.control.config, function () {
         if (angular.isDefined($scope.control.config)) {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.html
@@ -1,7 +1,7 @@
 <form class="form-horizontal dc-multioptionlist">
     <div class="form-group row comment-bubble-group">
-        <label class="col-form-label col-md-4 text-md-right">{{config.label}}</label>
-        <div class="controls col-md-8">
+        <label class="col-form-label col-lg-4 text-lg-right">{{config.label}}</label>
+        <div class="controls col-lg-8">
             <div class="dc-multioptionlist-values"
                  data-ng-repeat="value in model.values | orderBy: orderItemsByListOrder">
                 <div data-ng-mouseover="valueToBeDeleted = value" data-ng-mouseleave="valueToBeDeleted = ''">
@@ -13,7 +13,7 @@
                        data-ng-show="showDeleteButton(valueToBeDeleted, value)" data-ng-click="deleteValue(value)"></i>
                 </div>
             </div>
-            <div class="dc-multioptionlist-values"
+            <div class="dc-multioptionlist-values-list"
                  data-ng-show="$state.is('editor.entry') && rights.canEditEntry() && isAdding">
                 <!--suppress HtmlFormInputWithoutLabel -->
                 <select class="form-control custom-select" data-ng-change="addValue()" data-ng-model="newValue"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.html
@@ -2,15 +2,25 @@
     <div class="form-group row comment-bubble-group">
         <label class="col-form-label col-lg-4 text-lg-right">{{config.label}}</label>
         <div class="controls col-lg-8">
-            <div class="dc-multioptionlist-values"
+            <div class="dc-multioptionlist-values list-repeater"
                  data-ng-repeat="value in model.values | orderBy: orderItemsByListOrder">
-                <div data-ng-mouseover="valueToBeDeleted = value" data-ng-mouseleave="valueToBeDeleted = ''">
+                <div>
                     <div class="dc-multioptionlist-value"
                          data-ng-click="selectValue(value)">
                         {{getDisplayName(value)}}
                     </div>
-                    <i class="closeicon fa fa-trash" title="Delete {{config.label}}"
-                       data-ng-show="showDeleteButton(valueToBeDeleted, value)" data-ng-click="deleteValue(value)"></i>
+                    <div class="dropdown" uib-dropdown>
+                        <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle type="button">
+                            <i class="fa fa-ellipsis-v"></i>
+                        </button>
+                        <div class="dropdown-comment-count">
+                            <comment-bubble control="control" field="fieldName" multi-option-value="getDisplayName(value)" model="model"></comment-bubble>
+                        </div>
+                        <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
+                            <a href class="dropdown-item" data-ng-click="deleteValue(value)"><i class="fa fa-trash"></i> Delete</a>
+                            <comment-bubble class="dropdown-item" control="control" field="fieldName" multi-option-value="getDisplayName(value)" model="model"></comment-bubble>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="dc-multioptionlist-values-list"
@@ -25,7 +35,6 @@
                 </div>
             </div>
         </div>
-        <comment-bubble control="control" field="fieldName" input-system="" model="model"></comment-bubble>
     </div>
 </form>
 <div class="addItem"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.html
@@ -1,5 +1,5 @@
 <form class="form-horizontal dc-multioptionlist">
-    <div class="form-group row">
+    <div class="form-group row comment-bubble-group">
         <label class="col-form-label col-md-4 text-md-right">{{config.label}}</label>
         <div class="controls col-md-8">
             <div class="dc-multioptionlist-values"
@@ -25,6 +25,7 @@
                 </div>
             </div>
         </div>
+        <comment-bubble control="control" field="fieldName" input-system="" model="model"></comment-bubble>
     </div>
 </form>
 <div class="addItem"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.js
@@ -10,8 +10,10 @@ angular.module('palaso.ui.dc.multioptionlist', [])
     scope: {
       config: '=',
       model: '=',
+      control: '=',
       items: '=',
-      selectField: '&'
+      selectField: '&',
+      fieldName: '='
     },
     controller: ['$scope', '$state', 'lexRightsService', function ($scope, $state, rightsService) {
       $scope.$state = $state;

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.js
@@ -19,6 +19,7 @@ angular.module('palaso.ui.dc.multioptionlist', [])
       $scope.$state = $state;
       $scope.isAdding = false;
       $scope.valueToBeDeleted = '';
+      $scope.contextGuid = $scope.$parent.contextGuid;
 
       rightsService.getRights().then(function(rights) {
         $scope.rights = rights;

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.html
@@ -1,7 +1,7 @@
 <form class="form-horizontal dc-multiparagraph">
-    <div class="form-group row">
-        <label class="col-form-label col-md-4 text-md-right">{{config.label}}</label>
-        <div class="controls col-md-8">
+    <div class="form-group row comment-bubble-group">
+        <label class="col-form-label col-lg-4 text-lg-right">{{config.label}}</label>
+        <div class="controls col-lg-8">
             <div class="input-group" data-ng-click="selectInputSystem(model.inputSystem)"
                 data-ng-class="{selectableInputSystemFieldForComment: $state.is('editor.comments') && control.rights.canComment()}">
                 <span class="wsid input-group-addon notranslate"
@@ -20,5 +20,6 @@
                     fte-dir="inputSystemDirection(model.inputSystem)"></dc-formattedtext>
             </div>
         </div>
+        <comment-bubble control="control" field="fieldName" input-system="" model="model"></comment-bubble>
     </div>
 </form>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.js
@@ -12,12 +12,13 @@ angular.module('palaso.ui.dc.multiparagraph', ['coreModule', 'palaso.ui.showOver
       config: '=',
       model: '=',
       control: '=',
-      selectField: '&'
+      selectField: '&',
+      fieldName: '='
     },
     controller: ['$scope', '$state', 'sessionService', function ($scope, $state, sessionService) {
       $scope.$state = $state;
 
-      sessionService.getSession().then(function(session) {
+      sessionService.getSession().then(function (session) {
         $scope.inputSystems = session.projectSettings().config.inputSystems;
 
         $scope.inputSystemDirection = function inputSystemDirection(tag) {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.js
@@ -17,6 +17,7 @@ angular.module('palaso.ui.dc.multiparagraph', ['coreModule', 'palaso.ui.showOver
     },
     controller: ['$scope', '$state', 'sessionService', function ($scope, $state, sessionService) {
       $scope.$state = $state;
+      $scope.contextGuid = $scope.$parent.contextGuid;
 
       sessionService.getSession().then(function (session) {
         $scope.inputSystems = session.projectSettings().config.inputSystems;

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
@@ -1,5 +1,5 @@
 <form class="form-horizontal dc-multitext">
-    <div class="form-group row dc-multitext-tag" data-ng-repeat="tag in config.inputSystems">
+    <div class="form-group row comment-bubble-group" data-ng-repeat="tag in config.inputSystems">
         <label class="col-form-label col-md-4 text-md-right" data-ng-show="config.type != 'pictures'"
                data-ng-class="$first ? '' : 'd-none d-md-inline-block'">
             <span data-ng-show="$first">{{config.label}}</span></label>
@@ -18,6 +18,6 @@
                 </dc-audio>
             </div>
         </div>
-        <comment-bubble control="control" field="fieldName" input-system="tag"></comment-bubble>
+        <comment-bubble control="control" field="fieldName" input-system="inputSystems[tag].abbreviation" model="model"></comment-bubble>
     </div>
 </form>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
@@ -18,6 +18,6 @@
                 </dc-audio>
             </div>
         </div>
-        <comment-bubble control="control" field="fieldName" input-system="inputSystems[tag].abbreviation" model="model"></comment-bubble>
+        <comment-bubble control="control" field="fieldName" input-system="inputSystems[tag]" model="model"></comment-bubble>
     </div>
 </form>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
@@ -1,9 +1,9 @@
 <form class="form-horizontal dc-multitext">
     <div class="form-group row comment-bubble-group" data-ng-repeat="tag in config.inputSystems">
-        <label class="col-form-label col-md-4 text-md-right" data-ng-show="config.type != 'pictures'"
-               data-ng-class="$first ? '' : 'd-none d-md-inline-block'">
+        <label class="col-form-label col-lg-4 text-lg-right" data-ng-show="config.type != 'pictures'"
+               data-ng-class="$first ? '' : 'd-none d-lg-inline-block'">
             <span data-ng-show="$first">{{config.label}}</span></label>
-        <div class="controls" data-ng-class="config.type == 'pictures' ? 'col-md-12' : 'col-md-8'">
+        <div class="controls" data-ng-class="config.type == 'pictures' ? 'col' : 'col-lg-8'">
             <div class="input-group" data-ng-click="selectInputSystem(tag)"
                  data-ng-class="{selectableInputSystemFieldForComment: $state.is('editor.comments') && control.rights.canComment()}">
                 <span class="wsid input-group-addon notranslate" tabindex="-1"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
@@ -1,5 +1,5 @@
 <form class="form-horizontal dc-multitext">
-    <div class="form-group row" data-ng-repeat="tag in config.inputSystems">
+    <div class="form-group row dc-multitext-tag" data-ng-repeat="tag in config.inputSystems">
         <label class="col-form-label col-md-4 text-md-right" data-ng-show="config.type != 'pictures'"
                data-ng-class="$first ? '' : 'd-none d-md-inline-block'">
             <span data-ng-show="$first">{{config.label}}</span></label>
@@ -18,5 +18,6 @@
                 </dc-audio>
             </div>
         </div>
+        <comment-bubble control="control" field="fieldName" input-system="tag"></comment-bubble>
     </div>
 </form>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('palaso.ui.dc.multitext', ['palaso.ui.showOverflow', 'palaso.ui.dc.formattedtext',
-  'palaso.ui.dc.audio'])
+  'palaso.ui.dc.audio', 'palaso.ui.comments'])
 
 // Dictionary Control Multitext
 .directive('dcMultitext', [function () {
@@ -12,7 +12,8 @@ angular.module('palaso.ui.dc.multitext', ['palaso.ui.showOverflow', 'palaso.ui.d
       config: '=',
       model: '=',
       control: '=',
-      selectField: '&'
+      selectField: '&',
+      fieldName: '='
     },
     controller: ['$scope', '$state', 'sessionService', 'lexUtils',
     function ($scope, $state, sessionService, lexUtils) {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.js
@@ -13,12 +13,18 @@ angular.module('palaso.ui.dc.multitext', ['palaso.ui.showOverflow', 'palaso.ui.d
       model: '=',
       control: '=',
       selectField: '&',
-      fieldName: '='
+      fieldName: '=',
+      picture: '<'
     },
     controller: ['$scope', '$state', 'sessionService', 'lexUtils',
     function ($scope, $state, sessionService, lexUtils) {
       $scope.$state = $state;
       $scope.isAudio = lexUtils.constructor.isAudio;
+      $scope.contextGuid = $scope.$parent.contextGuid;
+
+      if (angular.isDefined($scope.picture)) {
+        $scope.contextGuid += ' pictures#' + $scope.picture.guid;
+      }
 
       sessionService.getSession().then(function (session) {
         $scope.inputSystems = session.projectSettings().config.inputSystems;

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-optionlist.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-optionlist.html
@@ -1,5 +1,5 @@
 <form class="form-horizontal dc-optionlist">
-    <div class="form-group row">
+    <div class="form-group row comment-bubble-group">
         <label class="col-form-label col-md-4 text-md-right">{{config.label}}</label>
         <div class="controls col-md-8">
             <!--suppress HtmlFormInputWithoutLabel -->
@@ -10,5 +10,6 @@
             <span class="uneditable-input" data-ng-hide="$state.is('editor.entry') && control.rights.canEditEntry()"
                   data-ng-bind="getDisplayName(model.value)"></span>
         </div>
+        <comment-bubble control="control" field="fieldName" input-system="" model="model"></comment-bubble>
     </div>
 </form>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-optionlist.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-optionlist.html
@@ -1,7 +1,7 @@
 <form class="form-horizontal dc-optionlist">
     <div class="form-group row comment-bubble-group">
-        <label class="col-form-label col-md-4 text-md-right">{{config.label}}</label>
-        <div class="controls col-md-8">
+        <label class="col-form-label col-lg-4 text-lg-right">{{config.label}}</label>
+        <div class="controls col-lg-8">
             <!--suppress HtmlFormInputWithoutLabel -->
             <select class="form-control custom-select" data-ng-show="$state.is('editor.entry') && control.rights.canEditEntry()"
                     data-ng-model="model.value" data-ng-options="item.key as item.value for item in items">

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-optionlist.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-optionlist.js
@@ -14,6 +14,7 @@ angular.module('palaso.ui.dc.optionlist', [])
       },
       controller: ['$scope', '$state', function ($scope, $state) {
         $scope.$state = $state;
+        $scope.contextGuid = $scope.$parent.contextGuid;
         $scope.getDisplayName = function getDisplayName(value) {
           var displayName = value;
           if (angular.isDefined($scope.items)) {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-optionlist.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-optionlist.js
@@ -9,7 +9,8 @@ angular.module('palaso.ui.dc.optionlist', [])
         config: '=',
         model: '=',
         control: '=',
-        items: '='
+        items: '=',
+        fieldName: '='
       },
       controller: ['$scope', '$state', function ($scope, $state) {
         $scope.$state = $state;

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.html
@@ -8,8 +8,10 @@
                     <i data-ng-click="deletePicture($index)" title="Delete Picture"
                        class="fa fa-trash"></i>
                 </div>
-                <img class="img-fluid" data-ng-src="{{getPictureUrl(picture)}}" data-ng-attr-title="{{getPictureDescription(picture)}}"
-                     data-ng-click="control.selectFieldForComment('pictures', picture, '', '', getPictureUrl(picture))">
+                <div class="comment-bubble-group">
+                    <img class="img-fluid" data-ng-src="{{getPictureUrl(picture)}}" data-ng-attr-title="{{getPictureDescription(picture)}}">
+                    <comment-bubble control="control" field="fieldName" model="picture" picture="picture" config-type="config.type"></comment-bubble>
+                </div>
                 <div data-ng-if="!config.captionHideIfEmpty || control.show.emptyFields ||
                  (config.captionHideIfEmpty && fieldContainsData('multitext', picture.caption))">
                     <dc-multitext control="control"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.html
@@ -17,7 +17,8 @@
                     <dc-multitext control="control"
                                   config="config"
                                   model="picture.caption"
-                                  field-name="fieldName">
+                                  field-name="fieldName"
+                                  picture="picture">
                     </dc-multitext>
                 </div>
             </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.html
@@ -1,5 +1,5 @@
 <form class="form-horizontal dc-pictures">
-    <div class="form-group row">
+    <div class="form-group row comment-bubble-group">
         <label class="col-form-label col-md-4 text-md-right">{{config.label}}</label>
         <div class="col-md-8">
             <div class="dc-picture" data-ng-repeat="picture in pictures">
@@ -39,6 +39,7 @@
                 </div>
             </div>
         </div>
+        <comment-bubble control="control" field="fieldName" input-system="" model="model"></comment-bubble>
     </div>
 </form>
 <div data-ng-show="control.rights.canEditEntry() && $state.is('editor.entry') && ! upload.showAddPicture"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.html
@@ -1,7 +1,7 @@
 <form class="form-horizontal dc-pictures">
-    <div class="form-group row comment-bubble-group">
-        <label class="col-form-label col-md-4 text-md-right">{{config.label}}</label>
-        <div class="col-md-8">
+    <div class="form-group row">
+        <label class="col-form-label col-lg-4 text-lg-right">{{config.label}}</label>
+        <div class="col-lg-8">
             <div class="dc-picture" data-ng-repeat="picture in pictures">
                 <div data-ng-if="control.rights.canEditEntry() && $state.is('editor.entry')"
                      class="deleteX pictureX float-right">
@@ -15,7 +15,7 @@
                     <dc-multitext control="control"
                                   config="config"
                                   model="picture.caption"
-                                  select-field="control.selectFieldForComment('pictures', picture.caption, inputSystem)">
+                                  field-name="fieldName">
                     </dc-multitext>
                 </div>
             </div>
@@ -39,7 +39,6 @@
                 </div>
             </div>
         </div>
-        <comment-bubble control="control" field="fieldName" input-system="" model="model"></comment-bubble>
     </div>
 </form>
 <div data-ng-show="control.rights.canEditEntry() && $state.is('editor.entry') && ! upload.showAddPicture"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.js
@@ -10,6 +10,7 @@ angular.module('palaso.ui.dc.picture', ['palaso.ui.dc.multitext', 'palaso.ui.not
     templateUrl: '/angular-app/languageforge/lexicon/editor/field/dc-picture.html',
     scope: {
       config: '=',
+      model: '=',
       pictures: '=',
       control: '=',
       fieldName: '='

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.js
@@ -23,6 +23,7 @@ angular.module('palaso.ui.dc.picture', ['palaso.ui.dc.multitext', 'palaso.ui.not
       $scope.upload = {};
       $scope.upload.progress = 0;
       $scope.upload.file = null;
+      $scope.contextGuid = $scope.$parent.contextGuid;
 
       $scope.fieldContainsData = lexConfigService.fieldContainsData;
 

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.js
@@ -11,7 +11,8 @@ angular.module('palaso.ui.dc.picture', ['palaso.ui.dc.multitext', 'palaso.ui.not
     scope: {
       config: '=',
       pictures: '=',
-      control: '='
+      control: '=',
+      fieldName: '='
     },
     controller: ['$scope', '$state', 'Upload', '$filter', 'sessionService', 'lexProjectService',
       'lexConfigService', 'silNoticeService', 'modalService',

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.html
@@ -1,7 +1,7 @@
 <form class="form-horizontal dc-semanticdomain">
     <div class="form-group row comment-bubble-group">
-        <label class="col-form-label col-md-4 text-md-right">{{config.label}}</label>
-        <div class="controls col-md-8">
+        <label class="col-form-label col-lg-4 text-lg-right">{{config.label}}</label>
+        <div class="controls col-lg-8">
             <div class="notranslate dc-semanticdomain-values"
                  data-ng-repeat="value in model.values | orderBy: orderItemsByListOrder">
                 <div data-ng-mouseover="valueToBeDeleted = value" data-ng-mouseleave="valueToBeDeleted = ''">

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.html
@@ -1,5 +1,5 @@
 <form class="form-horizontal dc-semanticdomain">
-    <div class="form-group row">
+    <div class="form-group row comment-bubble-group">
         <label class="col-form-label col-md-4 text-md-right">{{config.label}}</label>
         <div class="controls col-md-8">
             <div class="notranslate dc-semanticdomain-values"
@@ -25,6 +25,7 @@
                 </div>
             </div>
         </div>
+        <comment-bubble control="control" field="fieldName" input-system="" model="model"></comment-bubble>
     </div>
 </form>
 <div class="addItem"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.html
@@ -2,18 +2,28 @@
     <div class="form-group row comment-bubble-group">
         <label class="col-form-label col-lg-4 text-lg-right">{{config.label}}</label>
         <div class="controls col-lg-8">
-            <div class="notranslate dc-semanticdomain-values"
+            <div class="notranslate dc-semanticdomain-values list-repeater"
                  data-ng-repeat="value in model.values | orderBy: orderItemsByListOrder">
                 <div data-ng-mouseover="valueToBeDeleted = value" data-ng-mouseleave="valueToBeDeleted = ''">
                     <div class="dc-semanticdomain-value"
                          data-ng-click="selectValue(value)">
                         {{getDisplayName(value)}}
                     </div>
-                    <i class="fa fa-trash closeicon" title="Delete {{config.label}}"
-                       data-ng-show="showDeleteButton(valueToBeDeleted, value)" data-ng-click="deleteValue(value)"></i>
+                    <div class="dropdown" uib-dropdown>
+                        <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle type="button">
+                            <i class="fa fa-ellipsis-v"></i>
+                        </button>
+                        <div class="dropdown-comment-count">
+                            <comment-bubble control="control" field="fieldName" multi-option-value="getDisplayName(value)" model="model"></comment-bubble>
+                        </div>
+                        <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
+                            <a href class="dropdown-item" data-ng-click="deleteValue(value)"><i class="fa fa-trash"></i> Delete</a>
+                            <comment-bubble class="dropdown-item" control="control" field="fieldName" multi-option-value="getDisplayName(value)" model="model"></comment-bubble>
+                        </div>
+                    </div>
                 </div>
             </div>
-            <div class="notranslate dc-semanticdomain-values"
+            <div class="notranslate dc-semanticdomain-values-list"
                  data-ng-show="$state.is('editor.entry') && rights.canEditEntry() && isAdding">
                 <!--suppress HtmlFormInputWithoutLabel -->
                 <select class="form-control custom-select" data-ng-change="addValue()" data-ng-model="newValue"
@@ -25,7 +35,6 @@
                 </div>
             </div>
         </div>
-        <comment-bubble control="control" field="fieldName" input-system="" model="model"></comment-bubble>
     </div>
 </form>
 <div class="addItem"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.js
@@ -10,7 +10,9 @@ angular.module('palaso.ui.dc.semanticdomain', [])
     scope: {
       config: '=',
       model: '=',
-      selectField: '&'
+      control: '=',
+      selectField: '&',
+      fieldName: '='
     },
     controller: ['$scope', '$state', 'lexRightsService', function ($scope, $state, rightsService) {
       $scope.$state = $state;

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.js
@@ -18,6 +18,7 @@ angular.module('palaso.ui.dc.semanticdomain', [])
       $scope.$state = $state;
       $scope.isAdding = false;
       $scope.valueToBeDeleted = '';
+      $scope.contextGuid = $scope.$parent.contextGuid;
 
       function createOptions() {
         var options = [];

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.js
@@ -16,11 +16,13 @@ angular.module('palaso.ui.dc.sense', ['palaso.ui.dc.fieldrepeat', 'palaso.ui.dc.
     },
     controller: ['$scope', '$state', function ($scope, $state) {
       $scope.$state = $state;
+      $scope.contextGuid = 'sense#' + $scope.model.guid;
 
       $scope.addExample = function addExample() {
         var newExample = {};
         $scope.control.makeValidModelRecursive($scope.config.fields.examples, newExample);
         $scope.model.examples.push(newExample);
+        $scope.control.hideCommentsPanel();
       };
 
       $scope.deleteExample = function deleteExample(index) {
@@ -30,12 +32,17 @@ angular.module('palaso.ui.dc.sense', ['palaso.ui.dc.fieldrepeat', 'palaso.ui.dc.
         modal.showModalSimple('Delete Example', deletemsg, 'Cancel', 'Delete Example')
           .then(function () {
             $scope.model.examples.splice(index, 1);
-            $scope.control.saveCurrentEntry();
+            $scope.control.hideCommentsPanel();
           }, angular.noop);
       };
 
       angular.forEach($scope.control.config.entry.fields.senses.fields, function (field) {
-        field.senseLabel = 'Meaning ' + ($scope.index + 1);
+        if (!angular.isDefined(field.senseLabel)) {
+          field.senseLabel = [];
+          field.senseLabel[-1] = 'Meaning';
+        }
+
+        field.senseLabel[$scope.index] = 'Meaning ' + ($scope.index + 1);
       });
     }]
   };

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.js
@@ -33,6 +33,10 @@ angular.module('palaso.ui.dc.sense', ['palaso.ui.dc.fieldrepeat', 'palaso.ui.dc.
             $scope.control.saveCurrentEntry();
           }, angular.noop);
       };
+
+      angular.forEach($scope.control.config.entry.fields.senses.fields, function (field) {
+        field.senseLabel = 'Meaning ' + ($scope.index + 1);
+      });
     }]
   };
 }]);

--- a/src/angular-app/languageforge/lexicon/lexicon.html
+++ b/src/angular-app/languageforge/lexicon/lexicon.html
@@ -1,38 +1,40 @@
 {% verbatim %}
-<div class="content container"
+<div class="content container-fluid"
     data-ng-cloak data-ng-controller="LexiconCtrl" dir="{{interfaceConfig.direction}}">
-    <div class="hdrnav row">
-        <div class="col-12">
-            <div class="hdrnav-container">
-                <div class="btn-group" uib-dropdown data-ng-class="interfaceConfig.pullToSide" data-ng-show="rights.canEditUsers()">
-                    <a class="btn btn-std" uib-dropdown-toggle data-ng-class="interfaceConfig.pullToSide"
-                       tooltip-placement="{{interfaceConfig.placementToSide}}"
-                       title="Settings" href="#">
-                        <i class="fa fa-cog"></i>
-                    </a>
-                    <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu data-ng-class="interfaceConfig.pullToSide">
-                        <a class="dropdown-item" ui-sref="configuration" data-translate="Configuration"></a>
-                        <a class="dropdown-item" ui-sref="viewSettings" data-translate="View Settings"></a>
-                        <div class="dropdown-divider"></div>
-                        <a class="dropdown-item" ui-sref="importExport" data-translate="Import Data"></a>
-                        <a class="dropdown-item" data-ng-href="/app/usermanagement/{{project.id}}"
-                           data-translate="User Management"></a>
-                        <a class="dropdown-item" ui-sref="settings" data-translate="Project Settings"></a>
-                        <div class="dropdown-divider" data-ng-show="showSync()"></div>
-                        <a class="dropdown-item" ui-sref="sync" data-ng-show="showSync()"
-                           data-translate="Synchronize"></a>
+    <div class="hdrnav container">
+        <div class="row">
+            <div class="col">
+                <div class="hdrnav-container">
+                    <div class="btn-group" uib-dropdown data-ng-class="interfaceConfig.pullToSide" data-ng-show="rights.canEditUsers()">
+                        <a class="btn btn-std" uib-dropdown-toggle data-ng-class="interfaceConfig.pullToSide"
+                           tooltip-placement="{{interfaceConfig.placementToSide}}"
+                           title="Settings" href="#">
+                            <i class="fa fa-cog"></i>
+                        </a>
+                        <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu data-ng-class="interfaceConfig.pullToSide">
+                            <a class="dropdown-item" ui-sref="configuration" data-translate="Configuration"></a>
+                            <a class="dropdown-item" ui-sref="viewSettings" data-translate="View Settings"></a>
+                            <div class="dropdown-divider"></div>
+                            <a class="dropdown-item" ui-sref="importExport" data-translate="Import Data"></a>
+                            <a class="dropdown-item" data-ng-href="/app/usermanagement/{{project.id}}"
+                               data-translate="User Management"></a>
+                            <a class="dropdown-item" ui-sref="settings" data-translate="Project Settings"></a>
+                            <div class="dropdown-divider" data-ng-show="showSync()"></div>
+                            <a class="dropdown-item" ui-sref="sync" data-ng-show="showSync()"
+                               data-translate="Synchronize"></a>
+                        </div>
                     </div>
+                    <div class="float-right return-button">
+                        <button class="btn btn-std" title="View the dictionary"
+                                tooltip-placement="{{interfaceConfig.placementNormal}}"
+                                data-ng-show="showDictionaryButton()"
+                                data-ng-click="gotoDictionary()">
+                            <i class="fa fa-arrow-circle-left"></i> {{'Dictionary' | translate}}
+                        </button>
+                    </div>
+                    <breadcrumbs id="top" class="breadcrumb d-none d-md-block"></breadcrumbs>
+                    <ol id="projectName" class="d-md-none text-center">{{project.projectName}}</ol>
                 </div>
-                <div class="float-right return-button">
-                    <button class="btn btn-std" title="View the dictionary"
-                            tooltip-placement="{{interfaceConfig.placementNormal}}"
-                            data-ng-show="showDictionaryButton()"
-                            data-ng-click="gotoDictionary()">
-                        <i class="fa fa-arrow-circle-left"></i> {{'Dictionary' | translate}}
-                    </button>
-                </div>
-                <breadcrumbs id="top" class="breadcrumb d-none d-md-block"></breadcrumbs>
-                <ol id="projectName" class="d-md-none text-center">{{project.projectName}}</ol>
             </div>
         </div>
     </div>

--- a/src/app_dependencies.json
+++ b/src/app_dependencies.json
@@ -3,6 +3,5 @@
   "intl-tel-input": { "path": "dist/intl-tel-input", "jsFile": "js/intlTelInput", "cssFile": "css/intlTelInput" },
   "offline-js": { "path": "dist/offline-js", "jsFile": "offline.min.js" },
   "rangy": { "path": "dist/rangy", "jsFile": ["rangy-core.js", "rangy-selectionsaverestore.js", "rangy-highlighter.js", "rangy-classapplier.js", "rangy-serializer.js", "rangy-textrange.js"] },
-  "textAngular": { "path": "dist/textangular", "jsFile": ["textAngular-sanitize", "textAngularSetup", "textAngular"], "jsMinFile": ["textAngular-sanitize", "textAngular"], "cssFile": "textAngular" },
-  "waypoints": { "path": "dist/angular-inview", "jsFile": "angular-inview.js" }
+  "textAngular": { "path": "dist/textangular", "jsFile": ["textAngular-sanitize", "textAngularSetup", "textAngular"], "jsMinFile": ["textAngular-sanitize", "textAngular"], "cssFile": "textAngular" }
 }

--- a/src/app_dependencies.json
+++ b/src/app_dependencies.json
@@ -3,5 +3,6 @@
   "intl-tel-input": { "path": "dist/intl-tel-input", "jsFile": "js/intlTelInput", "cssFile": "css/intlTelInput" },
   "offline-js": { "path": "dist/offline-js", "jsFile": "offline.min.js" },
   "rangy": { "path": "dist/rangy", "jsFile": ["rangy-core.js", "rangy-selectionsaverestore.js", "rangy-highlighter.js", "rangy-classapplier.js", "rangy-serializer.js", "rangy-textrange.js"] },
-  "textAngular": { "path": "dist/textangular", "jsFile": ["textAngular-sanitize", "textAngularSetup", "textAngular"], "jsMinFile": ["textAngular-sanitize", "textAngular"], "cssFile": "textAngular" }
+  "textAngular": { "path": "dist/textangular", "jsFile": ["textAngular-sanitize", "textAngularSetup", "textAngular"], "jsMinFile": ["textAngular-sanitize", "textAngular"], "cssFile": "textAngular" },
+  "waypoints": { "path": "dist/angular-inview", "jsFile": "angular-inview.js" }
 }

--- a/test/app/languageforge/lexicon/editor/e2e/editor-comments.spec.js
+++ b/test/app/languageforge/lexicon/editor/e2e/editor-comments.spec.js
@@ -24,36 +24,34 @@ describe('Editor Comments', function () {
     editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
   });
 
-  it('switch to comments page, add one comment', function () {
-    editorPage.edit.toCommentsLink.click();
+  it('click first comment bubble, add one comment', function () {
+    editorPage.comment.bubbles.first.click();
+    browser.sleep(1000);
     editorPage.comment.newComment.textarea.sendKeys('First comment on this word.');
     editorPage.comment.newComment.postBtn.click();
   });
 
-  it('comments page: check that comment shows up', function () {
+  it('comments panel: check that comment shows up', function () {
     var comment = editorPage.comment.getComment(0);
     expect(comment.wholeComment.isPresent()).toBe(true);
 
     // Earlier tests modify the avatar and name of the manager user; don't check those
     //expect(comment.avatar.getAttribute('src')).toContain(constants.avatar);
     //expect(comment.author.getText()).toEqual(constants.managerName);
-    expect(comment.score.getText()).toEqual('0');
+    expect(comment.score.getText()).toEqual('0 Likes');
     expect(comment.plusOne.isPresent()).toBe(true);
     expect(comment.content.getText()).toEqual('First comment on this word.');
     expect(comment.date.getText()).toMatch(/ago|in a few seconds/);
-
-    // This comment should have no "regarding" section
-    expect(comment.regarding.fieldLabel.isDisplayed()).toBe(false);
   });
 
-  it('comments page: add comment about a specific part of the entry', function () {
+  it('comments panel: add comment to another part of the entry', function () {
+    editorPage.comment.bubbles.second.click();
     editorPage.comment.newComment.textarea.clear();
     editorPage.comment.newComment.textarea.sendKeys('Second comment.');
-    editorPage.comment.entry.getOneFieldAllInputSystems('Word').first().click();
     editorPage.comment.newComment.postBtn.click();
   });
 
-  it('comments page: check that second comment shows up', function () {
+  it('comments panel: check that second comment shows up', function () {
     var comment = editorPage.comment.getComment(-1);
     expect(comment.wholeComment.isPresent()).toBe(true);
 
@@ -61,41 +59,56 @@ describe('Editor Comments', function () {
     //expect(comment.avatar.getAttribute('src')).toContain(constants.avatar);
     //expect(comment.author.getText()).toEqual(constants.managerName);
 
-    expect(comment.score.getText()).toEqual('0');
+    expect(comment.score.getText()).toEqual('0 Likes');
     expect(comment.plusOne.isPresent()).toBe(true);
     expect(comment.content.getText()).toEqual('Second comment.');
     expect(comment.date.getText()).toMatch(/ago|in a few seconds/);
 
-    // This comment should have a "regarding" section
-    expect(comment.regarding.fieldLabel.isDisplayed()).toBe(true);
-    var word    = constants.testEntry1.lexeme.th.value;
-    var definition = constants.testEntry1.senses[0].definition.en.value;
-    expect(comment.regarding.word.getText()).toEqual(word);
-    expect(comment.regarding.definition.getText()).toEqual(definition);
-    expect(comment.regarding.fieldLabel.getText()).toEqual('Word');
-    expect(comment.regarding.fieldWsid .getText()).toEqual('th');
+    // Check the "regarding" section
+    comment.regarding.toggle.click();
+    expect(comment.regarding.container.isDisplayed()).toBe(true);
+    var word    = constants.testEntry1.senses[0].definition.en.value;
     expect(comment.regarding.fieldValue.getText()).toEqual(word);
   });
 
-  it('comments page: click +1 button on first comment', function () {
+  it('comments panel: click +1 button on first comment', function () {
     var comment = editorPage.comment.getComment(0);
-    expect(comment.plusOne.getAttribute('data-ng-click')).not.toBe(null); // Should be clickable
-    comment.plusOne.click();
-    expect(comment.score.getText()).toEqual('1');
+    editorPage.comment.bubbles.first.click();
+
+    // Should be clickable
+    expect(comment.plusOneActive.getAttribute('data-ng-click')).not.toBe(null);
+    comment.plusOneActive.click();
+    expect(comment.score.getText()).toEqual('1 Like');
   });
 
-  it('comments page: +1 button disabled after clicking', function () {
+  it('comments panel: +1 button disabled after clicking', function () {
     var comment = editorPage.comment.getComment(0);
-    expect(comment.plusOne.getAttribute('data-ng-click')).toBe(null); // Should NOT be clickable
-    comment.plusOne.click();
-    expect(comment.score.getText()).toEqual('1'); // Should not change from previous test
+    expect(comment.plusOneInactive.isDisplayed()).toBe(true);
+
+    // Should NOT be clickable
+    expect(comment.plusOneInactive.getAttribute('data-ng-click')).toBe(null);
+    expect(comment.score.getText()).toEqual('1 Like'); // Should not change from previous test
   });
 
-  it('comments page: refresh returns to comment', function () {
+  it('comments panel: refresh returns to comment', function () {
     var comment = editorPage.comment.getComment(0);
     browser.refresh();
-    browser.wait(expectedCondition.visibilityOf(comment.content), CONDITION_TIMEOUT);
+    browser.wait(expectedCondition.visibilityOf(editorPage.comment.bubbles.first), CONDITION_TIMEOUT);
+    editorPage.comment.bubbles.first.click();
+    browser.sleep(1000);
     expect(comment.content.getText()).toEqual('First comment on this word.');
+  });
+
+  it('comments panel: close comments panel clicking on bubble', function () {
+    editorPage.comment.bubbles.first.click();
+    browser.sleep(1000);
+    expect(editorPage.commentDiv.getAttribute('class')).not.toContain('panel-visible');
+  });
+
+  it('comments panel: show all comments', function () {
+    editorPage.edit.toCommentsLink.click();
+    browser.sleep(1000);
+    expect(editorPage.commentDiv.getAttribute('class')).toContain('panel-visible');
   });
 
 });

--- a/test/app/languageforge/lexicon/pages/editorPage.js
+++ b/test/app/languageforge/lexicon/pages/editorPage.js
@@ -45,7 +45,7 @@ function EditorPage() {
   this.browseDiv = element(by.id('lexAppListView'));
   this.editDiv = element(by.id('lexAppEditView'));
   this.editToolbarDiv = element(by.className('lexAppToolbar'));
-  this.commentDiv = element(by.id('lexAppCommentView'));
+  this.commentDiv = element(by.className('comments-right-panel-container'));
 
   // --- Browse view ---
   this.browse = {
@@ -308,6 +308,11 @@ function EditorPage() {
   this.comment = {
     toEditLink: element(by.css('#toEditLink')),
 
+    bubbles: {
+      first: element.all(by.css('.dc-entry .commentBubble')).get(0),
+      second: element.all(by.css('.dc-entry .dc-sense .commentBubble')).get(0)
+    },
+
     // Top-row UI elements
     renderedDiv: this.commentDiv.element(by.css('dc-rendered')),
     filter: {
@@ -353,19 +358,7 @@ function EditorPage() {
     // Right half of page: comments
     newComment: {
       textarea: this.commentDiv.element(by.css('.newCommentForm')).element(by.css('textarea')),
-      postBtn: this.commentDiv.element(by.css('.newCommentForm')).element(by.buttonText('Post')),
-      regardingDiv: this.commentDiv.element(by.css('.newCommentForm'))
-        .element(by.css('.commentRegarding')),
-      regarding: {
-        clearBtn: this.commentDiv.element(by.css('.newCommentForm'))
-          .element(by.css('.commentRegarding')).element(by.css('i.fa-trash')),
-        fieldLabel: this.commentDiv.element(by.css('.newCommentForm'))
-          .element(by.css('.commentRegarding')).element(by.css('.regardingFieldName')),
-        fieldWsid: this.commentDiv.element(by.css('.newCommentForm'))
-          .element(by.css('.commentRegarding')).element(by.css('.regardingInputSystem')),
-        fieldValue: this.commentDiv.element(by.css('.newCommentForm'))
-          .element(by.css('.commentRegarding')).element(by.css('.regardingFieldValue'))
-      }
+      postBtn: this.commentDiv.element(by.css('.newCommentForm')).element(by.buttonText('Post'))
     },
     commentsList: this.commentDiv.all(by.repeater('comment in currentEntryCommentsFiltered')),
     getComment: function (commentNum) {
@@ -421,8 +414,10 @@ function EditorPage() {
       avatar: div.element(by.css('.comment-footer img')),
       author: div.element(by.binding('comment.authorInfo.createdByUserRef.name')),
       date: div.element(by.binding('comment.authorInfo.createdDate | relativetime')),
-      score: div.element(by.binding('comment.score')),
-      plusOne: div.element(by.css('.comment-footer i.fa-thumbs-o-up:not(.ng-hide)')),
+      score: div.element(by.css('.comment-interaction .likes')),
+      plusOneActive: div.element(by.css('.comment-actions .can-like')),
+      plusOneInactive: div.element(by.css('.comment-actions .liked')),
+      plusOne: div.element(by.css('.comment-actions i.fa-thumbs-o-up:not(.ng-hide)')),
 
       // Right side content
       content: div.element(by.binding('comment.content')),
@@ -434,6 +429,8 @@ function EditorPage() {
       regarding: {
         // NOTE: Any or all of these may be absent in a given comment. Use
         // isPresent() before calling expect().
+        toggle: div.element(by.css('.comment-body > button')),
+        container: div.element(by.css('.commentRegarding')),
         word: div.element(by.binding('comment.regarding.word')),
         definition: div.element(by.binding('comment.regarding.meaning')),
         fieldLabel: div.element(by.binding('comment.regarding.fieldNameForDisplay')),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,7 @@ var webpackConfig = {
       { from: './node_modules/offline-js/offline.min.js', to: 'offline-js' },
       { from: './node_modules/rangy/lib/', to: 'rangy' },
       { from: './node_modules/textangular/dist/', to: 'textangular' },
-      { from: './node_modules/zxcvbn/dist/', to: 'zxcvbn' },
-      { from: './node_modules/angular-inview/', to: 'angular-inview' }
+      { from: './node_modules/zxcvbn/dist/', to: 'zxcvbn' }
     ]),
     new webpack.ContextReplacementPlugin(
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,8 @@ var webpackConfig = {
       { from: './node_modules/offline-js/offline.min.js', to: 'offline-js' },
       { from: './node_modules/rangy/lib/', to: 'rangy' },
       { from: './node_modules/textangular/dist/', to: 'textangular' },
-      { from: './node_modules/zxcvbn/dist/', to: 'zxcvbn' }
+      { from: './node_modules/zxcvbn/dist/', to: 'zxcvbn' },
+      { from: './node_modules/angular-inview/', to: 'angular-inview' }
     ]),
     new webpack.ContextReplacementPlugin(
 


### PR DESCRIPTION
Hi Team

This request includes all the code for the new comments view being integrated into the entry view. I tried to my naming conventions for variables and classes to match what was already there but it did seem to change as I went along - nature of multiple developers I guess.

There is a new npm package installed: `angular-inview`. This allows for setting triggers of when a specific element is available in the current viewport (or an offset of the viewport). The original proposal from us was to hide the comment bubbles when not applicable to the current area a user was viewing. However, in practice, I've found it not overly helpful as it makes you wonder some bubbles aren't there and it forces you to have to scroll to see if there is a comment available at the top/bottom of the screen. I could decrease the offset but then all the hide/show logic would appear out of view which then makes it pointless to even have it there in the first place. The initial concern was there would be comment bubbles everywhere. I do feel that with the colour they are initially given they are not overwhelming in anyway so we could probably just leave them in place. This pull requests INCLUDES the logic for the show/hide trigger so you will need to make sure that package is installed and webpack re-built to get them in the dist directory.

You'll see two commits there from apex-nigel - I had my IDE set to this when I pushed them through. Let me know if its easy enough for you to change them at your end or if that's something I need to do.

## Testing

I've not been able to test on iOS devices as I had trouble getting them to connect to localhost on my machine. 

I've tested in the latest versions of:

- Firefox
- Chrome
- Microsoft Edge
- Android Chrome
- Android Samsung Internet

I had tried on the old Android kit-kat browser as Campell mentioned but the app itself didn't work at all let alone being able to test what I've done.

E2E tests have been updated to work with the updated entry view. I've kept the same ones there while also adding in a couple of new ones.

## Issues

One of the main issues, that is partially unresolved, is being able to tell which comment specifically relates to which part of the entry. The old comment view just listed all comments in a column and kept a copy of the original text it related to. With the new system they need to remain in context. Currently there is nothing stored in the DB that relates to a specific part of the entry screen so, when a field name is replicated (such as a meaning or example) it becomes impossible to tell which comment relates to which field. Although a check could be done on the value of a field this isn't ideal as, if the value is changed (i.e. it was spelt wrong) then the comment will disappear as its context has changed. For now I've kept the context based on the field name and the input system. For pictures, semantic domains, and multi-choice options, I was able to use the value as the interface doesn't allow it to change - only delete. Chris said he was going to provide a `senseId` to help provide better context.

## Screenshots

Updated entry view showing comment bubbles with comments and without:
![image](https://user-images.githubusercontent.com/17464863/35487715-b4cf3c68-04e3-11e8-8809-abb6060cba26.png)

Viewing a comment:
![image](https://user-images.githubusercontent.com/17464863/35487734-d25435e0-04e3-11e8-9d2b-81286673f75c.png)

Smaller viewports (tablets) will hide the words in the dictionary:
![image](https://user-images.githubusercontent.com/17464863/35487747-f74edd0a-04e3-11e8-8a6d-1228b9c415ae.png)

Mobile viewports will show the comments in an overlaid panel:
![image](https://user-images.githubusercontent.com/17464863/35487759-10335b20-04e4-11e8-9de4-7dc26e660198.png)

Let me know if you need clarification on anything else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/181)
<!-- Reviewable:end -->
