### PR TITLE
Apex/comments fixes

### DIFF
--- a/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
+++ b/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
@@ -117,6 +117,7 @@ export class LexiconCommentService {
    * this should be called whenever new data is received
    */
   updateGlobalCommentCounts(): void {
+    this.comments.counts.byEntry = {};
     for (const comment of this.comments.items.all) {
       // add counts to global entry comment counts
       if (angular.isUndefined(this.comments.counts.byEntry[comment.entryRef])) {

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -77,12 +77,7 @@ angular.module('palaso.ui.comments')
               $scope.control.hideCommentsPanel();
             } else {
               $scope.control.setCommentContext($scope.contextGuid);
-              $scope.control.selectFieldForComment($scope.field,
-                $scope.model,
-                $scope.inputSystem.tag,
-                $scope.multiOptionValue,
-                $scope.pictureSrc,
-                $scope.contextGuid);
+              $scope.selectFieldForComment();
               if ($scope.multiOptionValue) {
                 var bubbleOffset = $scope.element.parents('.list-repeater').offset().top;
               } else {
@@ -97,6 +92,19 @@ angular.module('palaso.ui.comments')
             }
           };
         });
+
+        $scope.selectFieldForComment = function selectFieldForComment() {
+          $scope.control.selectFieldForComment($scope.field,
+            $scope.model,
+            $scope.inputSystem.tag,
+            $scope.multiOptionValue,
+            $scope.pictureSrc,
+            $scope.contextGuid);
+        };
+
+        $scope.$watch('model', function (newContent) {
+          $scope.selectFieldForComment();
+        }, true);
 
       }]
     };

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
@@ -8,6 +8,7 @@
             <!--suppress HtmlFormInputWithoutLabel -->
             <select ng-show="rights.canUpdateCommentStatus()" class="form-control custom-select" data-ng-model="commentFilter.status">
                 <option value="all">Show All</option>
+                <option value="resolved">Resolved</option>
                 <option value="unresolved">Unresolved</option>
                 <option ng-if="rights.canUpdateCommentStatus()" value="todo">Todo</option>
             </select>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
@@ -27,6 +27,9 @@
                 <div class="card-title" ng-show="currentEntryCommentsFiltered.length === 0">
                     <span class="sense-label">{{getNewCommentSenseLabel(newComment.regarding.field)}}</span> {{newComment.regarding.fieldNameForDisplay}}{{(newComment.regarding.inputSystemAbbreviation) ? ' - ' + newComment.regarding.inputSystemAbbreviation : ''}}
                 </div>
+                <div class="card-title" ng-show="currentEntryCommentsFiltered.length > 0">
+                    Start a new conversation thread
+                </div>
                 <div class="card-block">
                     <form ng-submit="postNewComment()">
                         <textarea required data-ng-model="newComment.content" class="form-control" placeholder="{{getNewCommentPlaceholderText()}}"  ></textarea>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
@@ -30,7 +30,7 @@
                     <form ng-submit="postNewComment()">
                         <textarea required data-ng-model="newComment.content" class="form-control" placeholder="{{getNewCommentPlaceholderText()}}"  ></textarea>
                         <div class="d-flex justify-content-end">
-                            <button type="submit" class="btn btn-sm btn-primary">Post</button>
+                            <button type="submit" class="btn btn-sm btn-primary" data-ng-disabled="posting">Post</button>
                         </div>
                     </form>
                 </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
@@ -30,7 +30,7 @@ angular.module('palaso.ui.comments')
         };
 
         $scope.initializeNewComment = function initializeNewComment() {
-          if ($scope.showNewComment) {
+          if ($scope.showNewComment && $scope.entry.id === $scope.newComment.entryRef) {
             $scope.newComment.content = '';
           } else {
             $scope.newComment = {

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
@@ -178,8 +178,8 @@ angular.module('palaso.ui.comments')
           if ($scope.currentEntryCommentsFiltered.length === 0) {
             label = $filter('translate')('Your comment goes here.  Be the first to share!');
           } else if ($scope.currentEntryCommentsFiltered.length > 0) {
-            label = $filter('translate')('Start a new conversation thread. ' +
-              'Enter your comment here.');
+            label = $filter('translate')('Start a new conversation relating to the ' +
+              $scope.newComment.regarding.fieldNameForDisplay);
           } else {
             label = $filter('translate')('Join the discussion and type your comment here.');
           }

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
@@ -23,6 +23,7 @@ angular.module('palaso.ui.comments')
          */
         $scope.showNewComment = false;
         $scope.senseLabel = '';
+        $scope.posting = false;
         $scope.commentInteractiveStatus = {
           id: '',
           visible: false
@@ -194,6 +195,7 @@ angular.module('palaso.ui.comments')
         };
 
         $scope.postNewComment = function postNewComment() {
+          $scope.posting = true;
           commentService.update($scope.newComment, function (result) {
             if (result.ok) {
               $scope.control.editorService.refreshEditorData().then(function () {
@@ -201,6 +203,7 @@ angular.module('palaso.ui.comments')
                 $scope.loadComments();
                 $scope.initializeNewComment();
                 $scope.newComment.regarding = previousComment.regarding;
+                $scope.posting = false;
               });
             }
           });

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
@@ -72,6 +72,10 @@ angular.module('palaso.ui.comments')
                 if (comment.status === 'todo') {
                   return true;
                 }
+              } else if ($scope.commentFilter.status === 'resolved') {
+                if (comment.status === 'resolved') {
+                  return true;
+                }
               } else { // show unresolved comments
                 if (comment.status !== 'resolved') {
                   return true;

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
@@ -178,8 +178,12 @@ angular.module('palaso.ui.comments')
           if ($scope.currentEntryCommentsFiltered.length === 0) {
             label = $filter('translate')('Your comment goes here.  Be the first to share!');
           } else if ($scope.currentEntryCommentsFiltered.length > 0) {
-            label = $filter('translate')('Start a new conversation relating to the ' +
-              $scope.newComment.regarding.fieldNameForDisplay);
+            if (angular.isDefined($scope.newComment)) {
+              label = $filter('translate')('Start a new conversation relating to the ' +
+                $scope.newComment.regarding.fieldNameForDisplay);
+            } else {
+              label = $filter('translate')('Start a new conversation');
+            }
           } else {
             label = $filter('translate')('Join the discussion and type your comment here.');
           }

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -41,7 +41,7 @@
                 <button ng-show="!comment.editing && isOriginalRelevant()" class="btn btn-std btn-sm" ng-click="comment.regarding.visible = !comment.regarding.visible">
                     (<span ng-show="!comment.regarding.visible">view</span><span ng-show="comment.regarding.visible">hide</span> original meaning)</button>
                 <div class="commentRegarding" data-ng-show="comment.regarding.field && comment.regarding.visible === true && !comment.editing">
-                    <regarding-field class="form-control" content="comment.regarding.fieldValue"
+                    <regarding-field class="form-control" content="comment.regarding.fieldValue" control="control"
                          field-config="commentRegardingFieldConfig" ng-hide="isCommentRegardingPicture"></regarding-field>
                     <div data-ng-if="isCommentRegardingPicture">
                         <img data-ng-src="{{comment.regarding.fieldValue}}">

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -125,11 +125,11 @@
                 </div>
             </div>
             <form ng-show="showNewReplyForm && comment.status != 'resolved'" class="commentNewReplyForm" data-ng-submit="submitReply(newReply)">
-                <textarea class="form-control" placeholder="Reply here.  Press Enter when done."
+                <textarea class="form-control" required placeholder="Reply here.  Press Enter when done."
                           data-ng-model="newReply.editingContent" pui-auto-focus="isAutoFocusNewReply"></textarea>
                 <div class="d-flex justify-content-end">
                     <a href class="btn btn-sm btn-std" data-ng-click="showCommentReplies()">Hide</a>
-                    <button type="submit" class="btn btn-sm btn-primary"><i class="fa fa-reply"></i> Reply</button>
+                    <button type="submit" class="btn btn-sm btn-primary" data-ng-disabled="posting"><i class="fa fa-reply"></i> Reply</button>
                 </div>
             </form>
         </div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -38,7 +38,7 @@
                         </button>
                     </div>
                 </div>
-                <button ng-show="!comment.editing" class="btn btn-std btn-sm" ng-click="comment.regarding.visible = !comment.regarding.visible">
+                <button ng-show="!comment.editing && isOriginalRelevant()" class="btn btn-std btn-sm" ng-click="comment.regarding.visible = !comment.regarding.visible">
                     (<span ng-show="!comment.regarding.visible">view</span><span ng-show="comment.regarding.visible">hide</span> original meaning)</button>
                 <div class="commentRegarding" data-ng-show="comment.regarding.field && comment.regarding.visible === true && !comment.editing">
                     <regarding-field class="form-control" content="comment.regarding.fieldValue"

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
@@ -153,6 +153,14 @@ angular.module('palaso.ui.comments')
             return $scope.$parent.getSenseLabel($scope.comment.regarding.field, $scope.comment.contextGuid);
           };
 
+          $scope.isOriginalRelevant = function isOriginalRelevant() {
+            if ($scope.comment.regarding.fieldValue) {
+              return true;
+            } else {
+              return false;
+            }
+          };
+
         }],
 
       link: function (scope, element, attrs, controller) {

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
@@ -17,6 +17,8 @@ angular.module('palaso.ui.comments')
 
           $scope.editingCommentContent = '';
 
+          $scope.posting = false;
+
           if ($scope.comment.regarding.field && angular.isDefined($scope.control.configService)) {
             $scope.control.configService.getFieldConfig($scope.comment.regarding.field)
               .then(function (config) {
@@ -55,6 +57,7 @@ angular.module('palaso.ui.comments')
 
           $scope.submitReply = function submitReply(reply) {
             hideInputFields();
+            $scope.posting = true;
             reply.content = angular.copy(reply.editingContent);
             delete reply.editingContent;
             updateReply($scope.comment.id, reply);
@@ -74,6 +77,7 @@ angular.module('palaso.ui.comments')
             commentService.updateStatus(commentId, status, function (result) {
               if (result.ok) {
                 $scope.control.editorService.refreshEditorData().then($scope.loadComments);
+                $scope.posting = false;
               }
             });
           };

--- a/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.scss
@@ -174,6 +174,10 @@ $WildSand: #f6f6f6;
             cursor: pointer;
             display: flex;
             align-items: center;
+            color: $Eden;
+            &:hover {
+              color: lighten($BlueRibbon, 10%);
+            }
             i {
               font-size: 16px;
               margin-right: 4px;

--- a/src/angular-app/bellows/directive/palaso.ui.comments.regarding-field.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.regarding-field.js
@@ -13,15 +13,37 @@ angular.module('palaso.ui.comments')
         fieldConfig: '='
       },
       controller: ['$scope', function ($scope) {
-        if (!angular.isUndefined($scope.content)) {
-          $scope.contentArr = $scope.content.split('#');
-        }
+        $scope.contentArr = [];
 
-        $scope.$watch('content', function (newContent) {
+        $scope.$watch('fieldConfig', function (newContent) {
           if (angular.isDefined(newContent)) {
-            $scope.contentArr = newContent.split('#');
+            console.log(newContent);
+            $scope.setContent();
           }
         });
+
+        $scope.setContent = function setContent() {
+          if (angular.isDefined($scope.fieldConfig)) {
+            if (!angular.isUndefined($scope.content)) {
+              if ($scope.fieldConfig.type === 'optionlist') {
+                var optionlists = $scope.control.config.optionlists;
+                for (var listCode in optionlists) {
+                  if (listCode === $scope.fieldConfig.listCode) {
+                    for (var i in optionlists[listCode].items) {
+                      if (optionlists[listCode].items[i].key === $scope.content) {
+                        $scope.contentArr[0] = optionlists[listCode].items[i].value;
+                      }
+                    }
+                  }
+                }
+              } else {
+                $scope.contentArr = $scope.content.split('#');
+              }
+            }
+          }
+        };
+
+        $scope.setContent();
       }]
     };
   }]);

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -453,6 +453,10 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
           $scope.saveCurrentEntry();
           setCurrentEntry($scope.entries[editorService.getIndexInList(id, $scope.entries)]);
           commentService.loadEntryComments(id);
+          if ($scope.commentPanelVisible === true && $scope.commentContext.contextGuid !== '') {
+            $scope.showComments();
+            $scope.setCommentContext('', '');
+          }
         }
 
         if ($state.is('editor.entry')) {
@@ -461,7 +465,6 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
           $state.go('editor.entry', { entryId: id });
         }
 
-        $scope.hideCommentsPanel();
       };
 
       $scope.newEntry = function newEntry() {

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -689,7 +689,7 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
 
       // Comments View
       $scope.showComments = function showComments() {
-        if ($scope.commentPanelVisible === true && $scope.commentContext.field === '') {
+        if ($scope.commentPanelVisible === true && $scope.commentContext.contextGuid === '') {
           $scope.hideCommentsPanel();
 
           // Reset the comment context AFTER the panel starts hiding

--- a/test/app/languageforge/lexicon/editor/e2e/editor-comments.spec.js
+++ b/test/app/languageforge/lexicon/editor/e2e/editor-comments.spec.js
@@ -111,4 +111,10 @@ describe('Editor Comments', function () {
     expect(editorPage.commentDiv.getAttribute('class')).toContain('panel-visible');
   });
 
+  it('comments panel: close all comments clicking on main comments button', function () {
+    editorPage.edit.toCommentsLink.click();
+    browser.sleep(1000);
+    expect(editorPage.commentDiv.getAttribute('class')).not.toContain('panel-visible');
+  });
+
 });


### PR DESCRIPTION
Latest round of updates to the new comments panel integration into the entry view.

Updates include:
- Submit/reply buttons are now disabled when clicking submit button to avoid double clicks
- When viewing all comments you can now click the main comments button again to close the panel
- Changing entries now also forces a change of the context and entry ID for any new comments
- View original meaning will now only display if there is an original value (for historic comments)
- Can now filter by resolved comments
- Improved layout for adding a new comment under and existing thread so as not to confuse it with replying
- Deleting comments now recalculates the total comments on the entry correctly
- Option list field types now display the label instead of the value stored with the comment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/184)
<!-- Reviewable:end -->
