### PR TITLE
Fixed comment context changing when editing other fields

### DIFF
--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -29,6 +29,10 @@ angular.module('palaso.ui.comments')
           ($scope.$parent.contextGuid ? ' ' : '') +
           $scope.field;
         lexConfig.getFieldConfig($scope.field).then(function (fieldConfig) {
+          if (!angular.isDefined($scope.configType)) {
+            $scope.configType = fieldConfig.type;
+          }
+
           if (fieldConfig.type === 'pictures' && angular.isDefined($scope.picture)) {
             $scope.pictureSrc = $scope.$parent.getPictureUrl($scope.picture);
             $scope.contextGuid += '#' + $scope.picture.guid; // Would prefer to use the ID
@@ -102,8 +106,14 @@ angular.module('palaso.ui.comments')
             $scope.contextGuid);
         };
 
+        $scope.checkValidModelContextChange = function checkValidModelContextChange() {
+          if ($scope.configType === 'optionlist') {
+            $scope.selectFieldForComment();
+          }
+        };
+
         $scope.$watch('model', function (newContent) {
-          $scope.selectFieldForComment();
+          $scope.checkValidModelContextChange();
         }, true);
 
       }]

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.js
@@ -31,7 +31,9 @@ angular.module('palaso.ui.comments')
 
         $scope.initializeNewComment = function initializeNewComment() {
           if ($scope.showNewComment && $scope.entry.id === $scope.newComment.entryRef) {
-            $scope.newComment.content = '';
+            if ($scope.posting) {
+              $scope.newComment.content = '';
+            }
           } else {
             $scope.newComment = {
               id: '',

--- a/src/angular-app/bellows/directive/palaso.ui.comments.regarding-field.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.regarding-field.js
@@ -17,7 +17,6 @@ angular.module('palaso.ui.comments')
 
         $scope.$watch('fieldConfig', function (newContent) {
           if (angular.isDefined(newContent)) {
-            console.log(newContent);
             $scope.setContent();
           }
         });


### PR DESCRIPTION
Fixed the latest bug in Trello that was introduced from the last PR.

- Fixed dynamic updating of comment context only when using an optionlist field type
- Only clear an existing comment after posting a comment and not on a refresh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/185)
<!-- Reviewable:end -->
