### PR TITLE
Fix when adding a comment and then changing an optionlist field befor…

### DIFF
--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -107,12 +107,14 @@ angular.module('palaso.ui.comments')
         };
 
         $scope.checkValidModelContextChange = function checkValidModelContextChange() {
-          if ($scope.configType === 'optionlist') {
+          var newComment = $scope.control.getNewComment();
+          if ($scope.configType === 'optionlist' &&
+              newComment.regarding.field === $scope.field) {
             $scope.selectFieldForComment();
           }
         };
 
-        $scope.$watch('model', function (newContent) {
+        $scope.$watch('model', function () {
           $scope.checkValidModelContextChange();
         }, true);
 

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -4,6 +4,7 @@
     </div>
     <div class="card-block" data-ng-class="{resolvedComment: comment.status == 'resolved'}">
         <div class="commentContentContainer">
+            <div class="ng-hide" data-ng-bind="comment.contextGuid"></div>
             <div class="comment-meta">
                 <div>
                     <img class="rounded-circle"

--- a/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.lex-comments-view.js
@@ -57,6 +57,10 @@ angular.module('palaso.ui.comments')
           };
         });
 
+        $scope.control.getNewComment = function getNewComment() {
+          return $scope.newComment;
+        };
+
         function getFieldValue(model, inputSystem) {
           // get value of option list
           if (angular.isDefined(model.value)) {

--- a/test/app/languageforge/lexicon/editor/e2e/editor-comments.spec.js
+++ b/test/app/languageforge/lexicon/editor/e2e/editor-comments.spec.js
@@ -24,16 +24,19 @@ describe('Editor Comments', function () {
     editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
   });
 
-  it('click first comment bubble, add one comment', function () {
+  it('click first comment bubble, type in a comment, add text to another part of the entry, ' +
+      'submit comment to appear on original field', function () {
     editorPage.comment.bubbles.first.click();
     browser.sleep(1000);
     editorPage.comment.newComment.textarea.sendKeys('First comment on this word.');
+    editorPage.edit.getMultiTextInputs('Definition').first().sendKeys('change value - ');
+    browser.sleep(500);
     editorPage.comment.newComment.postBtn.click();
   });
 
   it('comments panel: check that comment shows up', function () {
     var comment = editorPage.comment.getComment(0);
-    expect(comment.wholeComment.isPresent()).toBe(true);
+    expect(comment.contextGuid.getAttribute('textContent')).toEqual('lexeme.th');
 
     // Earlier tests modify the avatar and name of the manager user; don't check those
     //expect(comment.avatar.getAttribute('src')).toContain(constants.avatar);
@@ -45,6 +48,9 @@ describe('Editor Comments', function () {
   });
 
   it('comments panel: add comment to another part of the entry', function () {
+    editorPage.edit.getMultiTextInputs('Definition').first().clear().sendKeys(
+      constants.testEntry1.senses[0].definition.en.value
+    );
     editorPage.comment.bubbles.second.click();
     editorPage.comment.newComment.textarea.clear();
     editorPage.comment.newComment.textarea.sendKeys('Second comment.');
@@ -93,7 +99,8 @@ describe('Editor Comments', function () {
   it('comments panel: refresh returns to comment', function () {
     var comment = editorPage.comment.getComment(0);
     browser.refresh();
-    browser.wait(expectedCondition.visibilityOf(editorPage.comment.bubbles.first), CONDITION_TIMEOUT);
+    browser.wait(expectedCondition.visibilityOf(editorPage.comment.bubbles.first),
+      CONDITION_TIMEOUT);
     editorPage.comment.bubbles.first.click();
     browser.sleep(1000);
     expect(comment.content.getText()).toEqual('First comment on this word.');

--- a/test/app/languageforge/lexicon/pages/editorPage.js
+++ b/test/app/languageforge/lexicon/pages/editorPage.js
@@ -421,6 +421,7 @@ function EditorPage() {
 
       // Right side content
       content: div.element(by.binding('comment.content')),
+      contextGuid: div.element(by.binding('comment.contextGuid')),
       edit: {
         textarea: div.element(by.model('editingCommentContent')),
         updateBtn: div.element(by.buttonText('Update')),
@@ -435,7 +436,7 @@ function EditorPage() {
         definition: div.element(by.binding('comment.regarding.meaning')),
         fieldLabel: div.element(by.binding('comment.regarding.fieldNameForDisplay')),
         fieldWsid: div.element(by.binding('comment.regarding.inputSystem')),
-        fieldValue: div.element(by.css('.regardingFieldValue'))
+        fieldValue: div.element(by.css('.regardingFieldValue')),
       },
 
       // Replies (below content but above bottom controls)


### PR DESCRIPTION
Latest PR to address remaining issue with the context changing before submitting a comment:

- Fix when adding a comment and then changing an optionlist field before submitting the comment
- Updated E2E tests to test to ensure comments made appear within the intended context

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/186)
<!-- Reviewable:end -->
