### PR TITLE
Add sliders to audio player on both sites

### DIFF
--- a/src/angular-app/bellows/cssBootstrap4/palaso-ui.scss
+++ b/src/angular-app/bellows/cssBootstrap4/palaso-ui.scss
@@ -219,8 +219,14 @@ pui-select-language div.scroll-table table {
 }
 
 pui-soundplayer {
+  display: flex;
   .controls {
       font-size: 1rem;
+      display: flex;
+      align-items: center;
+      .seek-slider {
+        flex-grow: 1;
+      }
   }
   .seek-slider {
       height: auto;

--- a/src/angular-app/bellows/cssBootstrap4/palaso-ui.scss
+++ b/src/angular-app/bellows/cssBootstrap4/palaso-ui.scss
@@ -217,3 +217,12 @@ pui-select-language div.scroll-table table {
     width: 100%;
   }
 }
+
+pui-soundplayer {
+  .controls {
+      font-size: 1rem;
+  }
+  .seek-slider {
+      height: auto;
+  }
+}

--- a/src/angular-app/bellows/directive/bootstrap4/pui-soundplayer.html
+++ b/src/angular-app/bellows/directive/bootstrap4/pui-soundplayer.html
@@ -1,0 +1,7 @@
+<a ng-click="togglePlayback()">
+    <i class="fa {{iconClass()}}"></i>
+</a>
+<span data-ng-if="audioElement.duration && $ctrl.timeFormat" class="audioProgress text-muted">
+    {{currentTime()}} / {{duration()}}
+</span>
+<input style="height: auto;" type="range" min="0" max="{{durationInSeconds()}}" step="0.1" ng-show="seekVisible()" id="puiSoundplayerSlider">

--- a/src/angular-app/bellows/directive/bootstrap4/pui-soundplayer.html
+++ b/src/angular-app/bellows/directive/bootstrap4/pui-soundplayer.html
@@ -1,7 +1,9 @@
 <a ng-click="togglePlayback()">
     <i class="fa {{iconClass()}}"></i>
 </a>
-<span data-ng-if="audioElement.duration && $ctrl.timeFormat" class="audioProgress text-muted">
-    {{currentTime()}} / {{duration()}}
+<span class="controls" ng-show="controlsVisible()">
+    <span data-ng-if="audioElement.duration" class="audioProgress text-muted">
+        {{currentTime()}} / {{duration()}}
+    </span>
+    <input class="seek-slider" type="range" min="0" max="{{durationInSeconds()}}" value = 0 id="puiSoundplayerSlider">
 </span>
-<input style="height: auto;" type="range" min="0" max="{{durationInSeconds()}}" step="0.1" ng-show="seekVisible()" id="puiSoundplayerSlider">

--- a/src/angular-app/bellows/directive/soundplayer.js
+++ b/src/angular-app/bellows/directive/soundplayer.js
@@ -17,6 +17,8 @@ angular.module('palaso.ui.soundplayer', [])
             if ($scope.playing) {
               $scope.togglePlayback();
             }
+
+            $scope.audioElement.currentTime = 0;
           });
         });
 

--- a/src/angular-app/bellows/directive/soundplayer.js
+++ b/src/angular-app/bellows/directive/soundplayer.js
@@ -4,8 +4,7 @@ angular.module('palaso.ui.soundplayer', [])
   .component('puiSoundplayer', {
       bindings: {
         url: '<',
-        timeFormat: '<',
-        seekAlwaysVisible: '='
+        controlsAlwaysVisible: '<'
       },
       controller: ['$scope', function ($scope) {
         var ctrl = this;
@@ -55,11 +54,11 @@ angular.module('palaso.ui.soundplayer', [])
         };
 
         $scope.duration = function () {
-          return ctrl.timeFormat($scope.audioElement.duration * 1000);
+          return $scope.formatTimestamp($scope.audioElement.duration * 1000);
         };
 
         $scope.currentTime = function () {
-          return ctrl.timeFormat($scope.audioElement.currentTime * 1000);
+          return $scope.formatTimestamp($scope.audioElement.currentTime * 1000);
         };
 
         $scope.audioElement.addEventListener('loadedmetadata', function () {
@@ -70,16 +69,24 @@ angular.module('palaso.ui.soundplayer', [])
         $scope.audioElement.addEventListener('timeupdate', function () {
           slider.value = $scope.audioElement.currentTime;
           // If the time as shown the user has changed, only then run a digest
-          if (ctrl.currentTime && previousFormattedTime !== $scope.currentTime()) $scope.$digest();
+          if (previousFormattedTime !== $scope.currentTime()) $scope.$digest();
         });
 
-        $scope.seekVisible = function () {
-          return $scope.playing || $scope.seekAlwaysVisible;
+        $scope.controlsVisible = function () {
+          return $scope.playing || ctrl.controlsAlwaysVisible;
         };
 
         slider.addEventListener('change', function (e) {
           $scope.audioElement.currentTime = e.target.value;
         });
+
+        $scope.formatTimestamp = function formatTimestamp(timestamp) {
+          var totalSeconds = timestamp / 1000;
+          var minutes = Math.floor(totalSeconds / 60);
+          var seconds = Math.floor(totalSeconds % 60);
+          seconds = (seconds < 10 ? '0' : '') + seconds;
+          return minutes + ':' + seconds;
+        };
       }],
 
                                           // FIXME why is bootstrapVersion not defined here?

--- a/src/angular-app/bellows/directive/soundplayer.js
+++ b/src/angular-app/bellows/directive/soundplayer.js
@@ -4,22 +4,25 @@ angular.module('palaso.ui.soundplayer', [])
   .component('puiSoundplayer', {
       bindings: {
         url: '<',
-        timeFormat: '<'
+        timeFormat: '<',
+        seekAlwaysVisible: '='
       },
       controller: ['$scope', function ($scope) {
         var ctrl = this;
-        var mostRecentlyPlayedAudioElement;
+        var slider = document.getElementById('puiSoundplayerSlider');
         $scope.audioElement = document.createElement('audio');
         $scope.playing = false;
 
         $scope.audioElement.addEventListener('ended', function () {
           $scope.$apply(function () {
-            if ($scope.playing) $scope.togglePlayback();
+            if ($scope.playing) {
+              $scope.togglePlayback();
+            }
           });
         });
 
         ctrl.$onChanges = function (changes) {
-          if (changes.url.currentValue) {
+          if (changes.url && changes.url.currentValue) {
             if ($scope.playing) $scope.togglePlayback();
             $scope.audioElement.src = changes.url.currentValue;
           }
@@ -38,10 +41,17 @@ angular.module('palaso.ui.soundplayer', [])
 
           if ($scope.playing) {
             $scope.audioElement.play();
-            mostRecentlyPlayedAudioElement = $scope.audioElement;
           } else {
             $scope.audioElement.pause();
           }
+        };
+
+        $scope.currentTimeInSeconds = function () {
+          return $scope.audioElement.currentTime;
+        };
+
+        $scope.durationInSeconds = function () {
+          return $scope.audioElement.duration;
         };
 
         $scope.duration = function () {
@@ -56,13 +66,23 @@ angular.module('palaso.ui.soundplayer', [])
           $scope.$digest();
         });
 
+        var previousFormattedTime = null;
         $scope.audioElement.addEventListener('timeupdate', function () {
-          $scope.$digest();
+          slider.value = $scope.audioElement.currentTime;
+          // If the time as shown the user has changed, only then run a digest
+          if (ctrl.currentTime && previousFormattedTime !== $scope.currentTime()) $scope.$digest();
+        });
+
+        $scope.seekVisible = function () {
+          return $scope.playing || $scope.seekAlwaysVisible;
+        };
+
+        slider.addEventListener('change', function (e) {
+          $scope.audioElement.currentTime = e.target.value;
         });
       }],
 
-      template: '<a ng-click="togglePlayback()"><i class="fa {{iconClass()}}"></i></a>'
-        + '<span data-ng-if="audioElement.duration && $ctrl.timeFormat" ' +
-        'class="audioProgress text-muted">{{currentTime()}} / {{duration()}}</span>'
+                                          // FIXME why is bootstrapVersion not defined here?
+      templateUrl: '/angular-app/bellows/directive/' + 'bootstrap4' + '/pui-soundplayer.html'
     }
   );

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-audio.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-audio.html
@@ -45,7 +45,7 @@
 
     <!-- playback control -->
     <div class="player" data-ng-show="hasAudio() && !show.audioUpload" data-ng-class="dcControl.interfaceConfig.pullNormal">
-        <pui-soundplayer data-url="audioPlayUrl()" data-time-format="formatTimestamp" seek-always-visible="true"></pui-soundplayer>
+        <pui-soundplayer data-url="audioPlayUrl()" data-controls-always-visible="true"></pui-soundplayer>
     </div>
 
     <pui-mock-upload data-pui-do-upload="uploadAudio(file)"></pui-mock-upload><!-- Used to mock file upload. Assumes file is already in the right location. This should be removed from production code! IJH 2016-11 -->

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-audio.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-audio.html
@@ -45,7 +45,7 @@
 
     <!-- playback control -->
     <div class="player" data-ng-show="hasAudio() && !show.audioUpload" data-ng-class="dcControl.interfaceConfig.pullNormal">
-        <pui-soundplayer data-url="audioPlayUrl()" data-time-format="formatTimestamp"></pui-soundplayer>
+        <pui-soundplayer data-url="audioPlayUrl()" data-time-format="formatTimestamp" seek-always-visible="true"></pui-soundplayer>
     </div>
 
     <pui-mock-upload data-pui-do-upload="uploadAudio(file)"></pui-mock-upload><!-- Used to mock file upload. Assumes file is already in the right location. This should be removed from production code! IJH 2016-11 -->

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-audio.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-audio.js
@@ -50,14 +50,6 @@ angular.module('palaso.ui.dc.audio', ['palaso.ui.dc.multitext', 'palaso.ui.notic
           return url;
         };
 
-        $scope.formatTimestamp = function formatTimestamp(timestamp) {
-          var totalSeconds = timestamp / 1000;
-          var minutes = Math.floor(totalSeconds / 60);
-          var seconds = Math.floor(totalSeconds % 60);
-          seconds = (seconds < 10 ? '0' : '') + seconds;
-          return minutes + ':' + seconds;
-        };
-
         // strips the timestamp file prefix (returns everything after the '_')
         function originalFileName(filename) {
           if (angular.isUndefined(filename)) return '';

--- a/src/angular-app/scriptureforge/sfchecks/partials/question.html
+++ b/src/angular-app/scriptureforge/sfchecks/partials/question.html
@@ -1,8 +1,9 @@
 <div class="row">
     <h2 class="pull-left audio-buttons" data-ng-show="text.audioFileName">
-        <pui-soundplayer data-url="audioPlayUrl" uib-tooltip="Play audio"></pui-soundplayer>
         <a data-ng-show="project.allowAudioDownload" data-ng-href="{{audioDownloadUrl}}">
-            <i class="fa fa-arrow-circle-o-down" uib-tooltip="Download audio"></i></a>
+            <i class="fa fa-arrow-circle-o-down" uib-tooltip="Download audio"></i>
+        </a>
+        <pui-soundplayer data-url="audioPlayUrl" uib-tooltip="Play audio"></pui-soundplayer>
     </h2>
     <h2>{{text.title}}</h2>
 </div>

--- a/src/angular-app/scriptureforge/sfchecks/partials/questions.html
+++ b/src/angular-app/scriptureforge/sfchecks/partials/questions.html
@@ -62,9 +62,10 @@
     <div class="row">
         <div class="col-md-5" oncopy="return false;">
             <h2 class="pull-left audio-buttons" data-ng-show="text.audioFileName">
-                <pui-soundplayer data-url="audioPlayUrl" uib-tooltip="Play audio"></pui-soundplayer>
                 <a data-ng-show="project.allowAudioDownload" data-ng-href="{{audioDownloadUrl}}">
-                    <i class="fa fa-arrow-circle-o-down" uib-tooltip="Download audio"></i></a>
+                    <i class="fa fa-arrow-circle-o-down" uib-tooltip="Download audio"></i>
+                </a>
+                <pui-soundplayer data-url="audioPlayUrl" uib-tooltip="Play audio"></pui-soundplayer>
             </h2>
             <h2>{{text.title}}</h2>
             <div id="textcontrol" style="font-family: {{text.fontfamily}}" data-ng-bind-html="text.content"></div>

--- a/src/angular-app/scriptureforge/sfchecks/sass/sfchecks.scss
+++ b/src/angular-app/scriptureforge/sfchecks/sass/sfchecks.scss
@@ -234,3 +234,13 @@ div.new-item.collapse.in {
   padding: 5px;
   border: #C1DBC1 2px solid;
 }
+
+.audio-buttons {
+  display: flex;
+  > * {
+    margin: 3pt;
+  }
+  pui-soundplayer .audioProgress {
+    margin: 3pt;
+  }
+}


### PR DESCRIPTION
Language Forge:
![screenshot from 2018-02-08 16-15-41](https://user-images.githubusercontent.com/6140710/35999976-7e1c530e-0cef-11e8-87ff-cf1566fe8f26.png)

Scripture Forge, default state:
![screenshot from 2018-02-08 16-16-01](https://user-images.githubusercontent.com/6140710/35999975-7de87548-0cef-11e8-858c-f9586ebbbf47.png)

Scripture Forge, playing state:
![screenshot from 2018-02-08 16-16-29](https://user-images.githubusercontent.com/6140710/35999974-7dd43114-0cef-11e8-9b57-b7feec45ea25.png)

The UI on LF is good in my opinion, but the SF UI is a bit rough. I'm not entirely certain the best way to approach it, but I think it is acceptable for now.

There are, unfortunately, merge conflicts, but I believe they should be straightforward to resolve. If requested I would be happy to rebase.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/187)
<!-- Reviewable:end -->
