### PR TITLE
Fix operation of slider while playing and position of audio player

### DIFF
--- a/src/Site/views/scriptureforge/theme/default/sass/_global.scss
+++ b/src/Site/views/scriptureforge/theme/default/sass/_global.scss
@@ -363,10 +363,6 @@ $vote-width: 2em;
   display: block;
 }
 
-.audio-buttons {
-  margin-right: 0.5em;
-}
-
 .fieldset {
   legend {
     width: auto;

--- a/src/angular-app/bellows/directive/bootstrap4/pui-soundplayer.html
+++ b/src/angular-app/bellows/directive/bootstrap4/pui-soundplayer.html
@@ -1,7 +1,7 @@
 <a ng-click="togglePlayback()">
     <i class="fa {{iconClass()}}"></i>
 </a>
-<span class="controls" ng-show="controlsVisible()">
+<span class="controls">
     <span data-ng-if="audioElement.duration" class="audioProgress text-muted">
         {{currentTime()}} / {{duration()}}
     </span>

--- a/src/angular-app/bellows/directive/palaso-ui.scss
+++ b/src/angular-app/bellows/directive/palaso-ui.scss
@@ -218,17 +218,22 @@ pui-select-language div.scroll-table table {
   }
 }
 
+.audio-buttons a i.fa {
+    font-size: 2rem;
+}
+
 pui-soundplayer {
   display: flex;
+  width: 100%;
   .controls {
-      font-size: 1rem;
       display: flex;
+      width: 100%;
+      font-size: 1.05rem;
       align-items: center;
+      padding-left: 5pt;
       .seek-slider {
         flex-grow: 1;
-      }
-  }
-  .seek-slider {
-      height: auto;
+        height: auto;
+    }
   }
 }

--- a/src/angular-app/bellows/directive/soundplayer.js
+++ b/src/angular-app/bellows/directive/soundplayer.js
@@ -69,7 +69,8 @@ angular.module('palaso.ui.soundplayer', [])
 
         var previousFormattedTime = null;
         $scope.audioElement.addEventListener('timeupdate', function () {
-          slider.value = $scope.audioElement.currentTime;
+          if (!$scope.userMovingSlider) slider.value = $scope.audioElement.currentTime;
+
           // If the time as shown the user has changed, only then run a digest
           if (previousFormattedTime !== $scope.currentTime()) $scope.$digest();
         });
@@ -80,6 +81,11 @@ angular.module('palaso.ui.soundplayer', [])
 
         slider.addEventListener('change', function (e) {
           $scope.audioElement.currentTime = e.target.value;
+          $scope.userMovingSlider = false;
+        });
+
+        slider.addEventListener('input', function(e) {
+          $scope.userMovingSlider = true;
         });
 
         $scope.formatTimestamp = function formatTimestamp(timestamp) {

--- a/src/angular-app/bellows/directive/soundplayer.js
+++ b/src/angular-app/bellows/directive/soundplayer.js
@@ -3,8 +3,7 @@
 angular.module('palaso.ui.soundplayer', [])
   .component('puiSoundplayer', {
       bindings: {
-        url: '<',
-        controlsAlwaysVisible: '<'
+        url: '<'
       },
       controller: ['$scope', function ($scope) {
         var ctrl = this;
@@ -74,10 +73,6 @@ angular.module('palaso.ui.soundplayer', [])
           // If the time as shown the user has changed, only then run a digest
           if (previousFormattedTime !== $scope.currentTime()) $scope.$digest();
         });
-
-        $scope.controlsVisible = function () {
-          return $scope.playing || ctrl.controlsAlwaysVisible;
-        };
 
         slider.addEventListener('change', function (e) {
           $scope.audioElement.currentTime = e.target.value;

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-audio.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-audio.html
@@ -45,7 +45,7 @@
 
     <!-- playback control -->
     <div class="player" data-ng-show="hasAudio() && !show.audioUpload" data-ng-class="dcControl.interfaceConfig.pullNormal">
-        <pui-soundplayer data-url="audioPlayUrl()" data-controls-always-visible="true"></pui-soundplayer>
+        <pui-soundplayer data-url="audioPlayUrl()"></pui-soundplayer>
     </div>
 
     <pui-mock-upload data-pui-do-upload="uploadAudio(file)"></pui-mock-upload><!-- Used to mock file upload. Assumes file is already in the right location. This should be removed from production code! IJH 2016-11 -->

--- a/src/angular-app/scriptureforge/sfchecks/partials/question.html
+++ b/src/angular-app/scriptureforge/sfchecks/partials/question.html
@@ -1,15 +1,15 @@
 <div class="row">
-    <h2 class="float-left audio-buttons" data-ng-show="text.audioFileName">
-        <a data-ng-show="project.allowAudioDownload" data-ng-href="{{audioDownloadUrl}}">
-            <i class="fa fa-arrow-circle-o-down" title="Download audio"></i>
-        </a>
-        <pui-soundplayer data-url="audioPlayUrl" title="Play audio"></pui-soundplayer>
-    </h2>
     <h2>{{text.title}}</h2>
 </div>
 <div class="row">
 
     <div class="col-md-6" oncopy="return false;">
+        <div class="audio-buttons" data-ng-show="text.audioFileName">
+            <a data-ng-show="project.allowAudioDownload" data-ng-href="{{audioDownloadUrl}}">
+                <i class="fa fa-arrow-circle-o-down" title="Download audio"></i>
+            </a>
+            <pui-soundplayer data-url="audioPlayUrl" title="Play audio"></pui-soundplayer>
+        </div>
         <div id="textcontrol" style="font-family: {{text.fontfamily}}" data-sil-selection data-sil-selected-text="selectedText" content="text.content"></div>
     </div>
     <div id="comments" class="col-md-6" data-ng-show="finishedLoading">

--- a/src/angular-app/scriptureforge/sfchecks/partials/questions.html
+++ b/src/angular-app/scriptureforge/sfchecks/partials/questions.html
@@ -71,13 +71,13 @@
     <hr>
     <div class="row">
         <div class="col-md-5" oncopy="return false;">
-            <h2 class="float-left audio-buttons" data-ng-show="text.audioFileName">
+            <h2>{{text.title}}</h2>
+            <div class="audio-buttons" data-ng-show="text.audioFileName">
                 <a data-ng-show="project.allowAudioDownload" data-ng-href="{{audioDownloadUrl}}">
                     <i class="fa fa-arrow-circle-o-down" title="Download audio"></i>
                 </a>
                 <pui-soundplayer data-url="audioPlayUrl" title="Play audio"></pui-soundplayer>
-            </h2>
-            <h2>{{text.title}}</h2>
+            </div>
             <div id="textcontrol" style="font-family: {{text.fontfamily}}" data-ng-bind-html="text.content"></div>
         </div>
         <div class="col-md-7">

--- a/src/angular-app/scriptureforge/sfchecks/sfchecks.scss
+++ b/src/angular-app/scriptureforge/sfchecks/sfchecks.scss
@@ -229,13 +229,3 @@ div.new-item.collapse.in {
   padding: 5px;
   border: #C1DBC1 2px solid;
 }
-
-.audio-buttons {
-  display: flex;
-  > * {
-    margin: 3pt;
-  }
-  pui-soundplayer .audioProgress {
-    margin: 3pt;
-  }
-}


### PR DESCRIPTION
This PR does two things:

- Previously when the audio was playing and the user tried to seek, the slider would keep jerking forward to the current playback position. Now the slider stops updating when the user is using it.
- Previously the audio player on SF was to the left of the title and expanded to show playback only when playing. Now it is below the title and the playback control is always visible.

I have not succeeded in running the e2e tests for this branch. As it stands I am unable to get any of the tests to run properly on master, so either they're broken on master already or (more likely) there's a problem with my setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/189)
<!-- Reviewable:end -->
