### PR TITLE
Activity feed API for Language Forge

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
@@ -55,6 +55,7 @@ class LexEntryCommands
         $project->lastEntryModifiedDate = $now;
         if (array_key_exists('id', $params) && $params['id'] != '') {
             $entry = new LexEntryModel($project, $params['id']);
+            $oldEntry = new LexEntryModel($project, $params['id']); // NOT $entry = $oldEntry
             $action = 'update';
         } else {
             $entry = new LexEntryModel($project);
@@ -77,9 +78,15 @@ class LexEntryCommands
 
         LexEntryDecoder::decode($entry, $params);
 
+        if ($action === 'update') {
+            $differences = $oldEntry->calculateDifferences($entry);
+        } else {
+            $differences = null;
+        }
+
         $entry->write();
         $project->write();
-        ActivityCommands::writeEntry($project, $userId, $entry, $action);
+        ActivityCommands::writeEntry($project, $userId, $entry, $action, $differences);
 
 //        SendReceiveCommands::queueProjectForUpdate($project, $mergeQueuePath);
 //        SendReceiveCommands::startLFMergeIfRequired($projectId, 'merge', $pidFilePath, $command);

--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -313,6 +313,29 @@ class LexEntryModel extends MapperModel
         return $differences;
     }
 
+    public function nameForActivityLog($preferredInputSystem = null)
+    {
+        if (isset($this->lexeme)) {
+            if (isset($preferredInputSystem) && $this->lexeme->hasForm($preferredInputSystem)) {
+                return $this->lexeme[$preferredInputSystem];
+            } elseif ($this->lexeme->count() > 0) {
+                foreach ($this->lexeme as $inputSystem => $content) {
+                    return (string)$content;
+                }
+            }
+        }
+        if (isset($this->citationForm)) {
+            if (isset($preferredInputSystem) && $this->citationForm->hasForm($preferredInputSystem)) {
+                return $this->citationForm[$preferredInputSystem];
+            } elseif ($this->citationForm->count() > 0) {
+                foreach ($this->citationForm as $inputSystem => $content) {
+                    return (string)$content;
+                }
+            }
+        }
+        return "";
+    }
+
     public function getPropertyDifference(LexEntryModel $otherModel, string $propertyName)
     {
         $type = $this->getPropertyType($propertyName);

--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -72,7 +72,6 @@ class LexEntryModel extends MapperModel
             'location',
             'morphologyType',
             'note',
-            'morphType',
             'pronunciation',
             'cvPattern',
             'tone',
@@ -182,15 +181,15 @@ class LexEntryModel extends MapperModel
         return $instance;
     }
 
-    protected function createProperty($name)
+    protected function getPropertyType($name)
     {
         switch ($name) {
             case 'senses':
-                return new ArrayOf('Api\Model\Languageforge\Lexicon\generateSense');
+                return "ArrayOf(LexSense)";
             case 'customFields':
-                return new MapOf('Api\Model\Languageforge\Lexicon\generateCustomField');
+                return "MapOf(CustomField)";
             case 'authorInfo':
-                return new LexAuthorInfo();
+                return "LexAuthorInfo";
 
             case 'lexeme':
             case 'citationForm':
@@ -206,15 +205,199 @@ class LexEntryModel extends MapperModel
             case 'literalMeaning':
             case 'note':  // TODO Notes need to be an array, and more capable than a multi-text. Notes have types. CP 2014-10
             case 'summaryDefinition':
-                return new LexMultiText();
+                return "LexMultiText";
             case 'environments':
-                return new LexMultiValue();
+                return "LexMultiValue";
             case 'location':
-                return new LexValue();
+                return "LexValue";
             case 'morphologyType':
+            default:
+                return "string";
+        }
+    }
+
+    protected function createProperty($name)
+    {
+        switch ($this->getPropertyType($name)) {
+            case 'ArrayOf(LexSense)': return new ArrayOf('Api\Model\Languageforge\Lexicon\generateSense');
+            case 'MapOf(CustomField)': return new MapOf('Api\Model\Languageforge\Lexicon\generateCustomField');
+            case 'LexAuthorInfo': return new LexAuthorInfo();
+            case 'LexMultiText': return new LexMultiText();
+            case 'LexMultiValue': return new LexMultiValue();
+            case 'LexValue': return new LexValue();
+
+            case 'string':
             default:
                 return '';
         }
+    }
+
+    protected function convertLexMultiTextDifferences(array $differences, string $propertyName)
+    {
+        // The LexMultiText->differences() function returns differences as an array looking like:
+        // [ ["inputSystem" => $key, "this" => $thisValue, "other" => $otherValue], ... ]
+        $result = [];
+        foreach ($differences as $difference) {
+            $inputSystem = $difference["inputSystem"];
+            $result["oldValue." . $propertyName . "." . $inputSystem] = $difference["this"];
+            $result["newValue." . $propertyName . "." . $inputSystem] = $difference["other"];
+        }
+        return $result;
+    }
+
+    protected function convertDifferences(array $difference, string $propertyName)
+    {
+        if (empty($difference)) {
+            return [];
+        }
+        return [ "oldValue." . $propertyName => $difference["this"],
+                 "newValue." . $propertyName => $difference["other"] ];
+    }
+
+    protected function getSenseDifferences($thisSenses, $otherSenses)
+    {
+        $differences = [];
+
+        $thisGuids = [];
+        $thisSensesByGuid = [];
+        foreach ($thisSenses as $sense) {
+            /** @var LexSense $sense */
+            $thisGuids[] = $sense->guid;
+            $thisSensesByGuid[$sense->guid] = $sense;
+        }
+        $otherGuids = [];
+        $otherSensesByGuid = [];
+        foreach ($otherSenses as $sense) {
+            /** @var LexSense $sense */
+            $otherGuids[] = $sense->guid;
+            $otherSensesByGuid[$sense->guid] = $sense;
+        }
+
+        $seenGuids = [];
+        $thisPositions = array_flip($thisGuids);
+        $otherPositions = array_flip($otherGuids);
+        foreach ($thisSensesByGuid as $guid => $thisSense) {
+            /** @var LexSense $thisSense */
+            $seenGuids[] = $guid;
+            $thisPosition  = $thisPositions[$guid];
+            $otherPosition = $otherPositions[$guid];
+            if ($otherPosition !== $thisPosition) {
+                $differences["movedFrom.senses#" . $guid] = $thisPosition;
+                $differences["movedTo.senses#" . $guid] = $otherPosition;
+            }
+            if (array_key_exists($guid, $otherSensesByGuid)) {
+                /** @var LexSense $otherSense */
+                $otherSense = $otherSensesByGuid[$guid];
+                $senseDifferences = $thisSense->differences($otherSense);
+                foreach ($senseDifferences as $key => $senseDifference) {
+                    if (substr($key, 0, 5) === "this.") {
+                        $newKey = str_replace("this.",  "oldValue.senses#" . $guid . ".", $key);
+                    } elseif (substr($key, 0, 6) === "other.") {
+                        $newKey = str_replace("other.", "newValue.senses#" . $guid . ".", $key);
+                    } else {
+                        $newKey = $key;
+                    }
+                    $differences[$newKey] = $senseDifference;
+                }
+            } else {
+                $differences["deleted.senses#" . $guid] = $thisSense->nameForActivityLog();
+            }
+        }
+        $addedGuids = array_diff($otherGuids, $seenGuids);
+        foreach ($addedGuids as $guid) {
+            /** @var LexSense $otherSense */
+            $otherSense = $otherSensesByGuid[$guid];
+            $differences["added.senses#" . $guid] = $otherSense->nameForActivityLog();
+        }
+
+        return $differences;
+    }
+
+    public function getPropertyDifference(LexEntryModel $otherModel, string $propertyName)
+    {
+        $type = $this->getPropertyType($propertyName);
+        switch ($type) {
+            case "LexMultiText":
+                /** @var LexMultiText $multiText */
+                $multiText = $this->$propertyName;
+                $difference = $multiText->differences($otherModel->$propertyName);
+                return $this->convertLexMultiTextDifferences($difference, $propertyName);
+            case "LexMultiValue":
+                /** @var LexMultiValue $multiValue */
+                $multiValue = $this->$propertyName;
+                $difference = $multiValue->differences($otherModel->$propertyName);
+                return $this->convertDifferences($difference, $propertyName);
+            case "LexMultiParagraph":
+                /** @var LexMultiParagraph $multiParagraph */
+                $multiParagraph = $this->$propertyName;
+                $difference = $multiParagraph->differences($otherModel->$propertyName);
+                return $this->convertDifferences($difference, $propertyName);
+            case "LexValue":
+                $thisValue  = (string)$this->$propertyName;
+                $otherValue = (string)$otherModel->$propertyName;
+
+                if ($thisValue === $otherValue) {
+                    return [];
+                } else {
+                    return ["oldValue." . $propertyName => $thisValue, "newValue." . $propertyName => $otherValue];
+                }
+            case "string":
+                $thisValue  = $this->$propertyName;
+                $otherValue = $otherModel->$propertyName;
+                if ($thisValue === $otherValue) {
+                    return [];
+                } else {
+                    return ["oldValue." . $propertyName => $thisValue, "newValue." . $propertyName => $otherValue];
+                }
+            case 'ArrayOf(LexSense)':
+                $thisSenses  = $this->$propertyName;
+                $otherSenses = $otherModel->$propertyName;
+                $result = $this->getSenseDifferences($thisSenses, $otherSenses);
+                return $result;
+            case 'MapOf(CustomField)':
+                // TODO: Implement this. Will probably have to refactor this function a bit to handle that one level of nesting
+                return [];
+            case 'LexAuthorInfo':
+                // We don't put authorInfo changes in the activity log
+                return [];
+            default:
+                return [];
+        }
+    }
+
+    public function calculateDifferences($otherModel)
+    {
+        // Perhaps this could be made generic enough to move to the MapperModel base class
+        $properties = [
+            'lexeme',
+            'senses',
+            'authorInfo',
+            'citationForm',
+            'customFields',
+            'entryBibliography',
+            'entryRestrictions',
+            'environments',
+            'etymology',
+            'etymologyGloss',
+            'etymologyComment',
+            'etymologySource',
+            'literalMeaning',
+            'location',
+            'morphologyType',
+            'note',
+            'pronunciation',
+            'cvPattern',
+            'tone',
+            'summaryDefinition'
+        ];
+        $result = [];
+        foreach ($properties as $property)
+        {
+            foreach ($this->getPropertyDifference($otherModel, $property) as $key => $difference) {
+                $result[$key] = $difference;
+            }
+        }
+        return $result;
     }
 
     public function hasSenses()

--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -280,10 +280,12 @@ class LexEntryModel extends MapperModel
             /** @var LexSense $thisSense */
             $seenGuids[] = $guid;
             $thisPosition  = $thisPositions[$guid];
-            $otherPosition = $otherPositions[$guid];
-            if ($otherPosition !== $thisPosition) {
-                $differences["movedFrom.senses#" . $guid] = $thisPosition;
-                $differences["movedTo.senses#" . $guid] = $otherPosition;
+            if (isset($otherPositions[$guid])) {
+                $otherPosition = $otherPositions[$guid];
+                if ($otherPosition !== $thisPosition) {
+                    $differences["movedFrom.senses#" . $guid] = $thisPosition;
+                    $differences["movedTo.senses#" . $guid] = $otherPosition;
+                }
             }
             if (array_key_exists($guid, $otherSensesByGuid)) {
                 /** @var LexSense $otherSense */

--- a/src/Api/Model/Languageforge/Lexicon/LexMultiText.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexMultiText.php
@@ -33,4 +33,26 @@ class LexMultiText extends MapOf
     {
         return array_key_exists($inputSystem, $this);
     }
+
+    public function differences(LexMultiText $otherMultiText)
+    {
+        $result = [];
+        $thisArr  = $this->getArrayCopy();
+        $otherArr = $otherMultiText->getArrayCopy();
+        $thisKeys  = array_keys($thisArr);
+        $otherKeys = array_keys($otherArr);
+        $allKeys = array_unique(array_merge($thisKeys, $otherKeys));
+        foreach ($allKeys as $key)
+        {
+            $thisValue  = isset($this[$key]) ? (string)$this[$key] : "";
+            $otherValue = isset($otherMultiText[$key]) ? (string)$otherMultiText[$key] : "";
+            if ($thisValue == $otherValue) continue;
+            $result[] = [
+                "inputSystem" => $key,
+                "this" => $thisValue,
+                "other" => $otherValue
+            ];
+        }
+        return $result;
+    }
 }

--- a/src/Api/Model/Languageforge/Lexicon/LexMultiValue.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexMultiValue.php
@@ -32,4 +32,49 @@ class LexMultiValue
             $this->values[] = $value;
         }
     }
+
+    public function differences(LexMultiValue $otherMultiValue)
+    {
+        // Shows differences between the arrays as whole values. Use individualDifferences function to see individual additions or removals.
+        if ($this->values == $otherMultiValue->values)
+        {
+            // Shortcut so we don't have to copy arrays just to find out they were already equal
+            return [];
+        }
+        $thisArr  = $this->values->getArrayCopy();
+        $otherArr = $otherMultiValue->values->getArrayCopy();
+        $thisJson = json_encode($thisArr);
+        $otherJson = json_encode($otherArr);
+        return ["this" => $thisJson, "other" => $otherJson];
+    }
+
+/* If individual differences between arrays (insertions and deletions) are desired, we could do it like this:
+    public function individualDifferences(LexMultiValue $otherMultiValue)
+    {
+        $result = [];
+        $thisArr  = $this->values->getArrayCopy();
+        $otherArr = $otherMultiValue->values->getArrayCopy();
+        $oursOnly = array_diff($thisArr, $otherArr);
+        $theirsOnly = array_diff($otherArr, $thisArr);
+        foreach ($oursOnly as $item)
+        {
+            $value = isset($item) ? (string)$item : "";
+            $result[] = [
+                "value" => $value,
+                "this" => $value,
+                "other" => ""
+            ];
+        }
+        foreach ($theirsOnly as $item)
+        {
+            $value = isset($item) ? (string)$item : "";
+            $result[] = [
+                "value" => $value,
+                "this" => "",
+                "other" => $value
+            ];
+        }
+        return $result;
+    }
+*/
 }

--- a/src/Api/Model/Languageforge/Lexicon/LexParagraph.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexParagraph.php
@@ -19,8 +19,17 @@ class LexParagraph extends ObjectForEncoding
         }
     }
 
-    protected function createProperty($name) {
+    protected function getPropertyType(string $name)
+    {
         switch ($name) {
+            default:
+                return 'string';
+        }
+    }
+
+    protected function createProperty(string $name) {
+        switch ($this->getPropertyType($name)) {
+            case 'string':
             default:
                 return '';
         }

--- a/src/Api/Model/Scriptureforge/Sfchecks/Command/QuestionCommands.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Command/QuestionCommands.php
@@ -243,9 +243,9 @@ class QuestionCommands
 
         if ($comment['id'] != '') {
             // TODO log the activity after we confirm that the comment was successfully updated ; cjh 2013-08
-            ActivityCommands::updateComment($projectModel, $questionId, $answerId, $newComment);
+            ActivityCommands::updateCommentOnQuestion($projectModel, $questionId, $answerId, $newComment);
         } else {
-            ActivityCommands::addComment($projectModel, $questionId, $answerId, $newComment);
+            ActivityCommands::addCommentOnQuestion($projectModel, $questionId, $answerId, $newComment);
         }
 
         $dto = array();

--- a/src/Api/Model/Shared/ActivityModel.php
+++ b/src/Api/Model/Shared/ActivityModel.php
@@ -25,6 +25,11 @@ class ActivityModel extends MapperModel
     const ADD_ENTRY = 'add_entry';
     const UPDATE_ENTRY = 'update_entry';
     const DELETE_ENTRY = 'delete_entry';
+    const ADD_LEX_COMMENT = 'add_lex_comment';
+    const UPDATE_LEX_COMMENT = 'update_lex_comment';
+    const UPDATE_LEX_COMMENT_STATUS = 'update_lex_comment_status';
+    const ADD_LEX_REPLY = 'add_lex_reply';
+    const UPDATE_LEX_REPLY = 'update_lex_reply';
 
     // content types for use with the addContent method
     const PROJECT = 'project';
@@ -32,6 +37,10 @@ class ActivityModel extends MapperModel
     const QUESTION = 'question';
     const ANSWER = 'answer';
     const COMMENT = 'comment';
+    const LEX_COMMENT = 'lexComment';
+    const LEX_COMMENT_CONTEXT = 'lexCommentContext';
+    const LEX_COMMENT_STATUS = 'lexCommentStatus';
+    const LEX_REPLY = 'lexReply';
     const USER = 'user';
     const USER2 = 'user2';
     const ENTRY = 'entry';

--- a/src/Api/Model/Shared/Command/ActivityCommands.php
+++ b/src/Api/Model/Shared/Command/ActivityCommands.php
@@ -195,9 +195,10 @@ class ActivityCommands
      * @param string $userId
      * @param LexEntryModel $entry
      * @param string $action
+     * @param array $actionContent
      * @return string activity id
      */
-    public static function writeEntry($projectModel, $userId, $entry, $action)
+    public static function writeEntry($projectModel, $userId, $entry, $action, $actionContent = null)
     {
         $activity = new ActivityModel($projectModel);
         $activity->entryRef->id = $entry->id->asString();
@@ -217,6 +218,12 @@ class ActivityCommands
 
         $activity->addContent(ActivityModel::ENTRY, $title);
         $activity->addContent(ActivityModel::USER, $user->username);
+
+        if (isset($actionContent)) {
+            foreach ($actionContent as $type => $content) {
+                $activity->addContent($type, $content);
+            }
+        }
 
         return $activity->write();
     }

--- a/src/Api/Model/Shared/Command/ActivityCommands.php
+++ b/src/Api/Model/Shared/Command/ActivityCommands.php
@@ -28,7 +28,7 @@ class ActivityCommands
      * @param string $mode
      * @return string activity id
      */
-    public static function updateComment($projectModel, $questionId, $answerId, $commentModel, $mode = "update")
+    public static function updateCommentOnQuestion($projectModel, $questionId, $answerId, $commentModel, $mode = "update")
     {
         $activity = new ActivityModel($projectModel);
         $question = new QuestionModel($projectModel, $questionId);
@@ -54,9 +54,9 @@ class ActivityCommands
         return $activityId;
     }
 
-    public static function addComment($projectModel, $questionId, $answerId, $commentModel)
+    public static function addCommentOnQuestion($projectModel, $questionId, $answerId, $commentModel)
     {
-        return ActivityCommands::updateComment($projectModel, $questionId, $answerId, $commentModel, "add");
+        return ActivityCommands::updateCommentOnQuestion($projectModel, $questionId, $answerId, $commentModel, "add");
     }
 
     /**

--- a/src/Api/Model/Shared/Command/ActivityCommands.php
+++ b/src/Api/Model/Shared/Command/ActivityCommands.php
@@ -3,6 +3,8 @@
 namespace Api\Model\Shared\Command;
 
 use Api\Model\Languageforge\Lexicon\Command\LexEntryCommands;
+use Api\Model\Languageforge\Lexicon\LexCommentModel;
+use Api\Model\Languageforge\Lexicon\LexCommentReply;
 use Api\Model\Languageforge\Lexicon\LexEntryModel;
 use Api\Model\Scriptureforge\Sfchecks\AnswerModel;
 use Api\Model\Scriptureforge\Sfchecks\QuestionModel;
@@ -15,6 +17,8 @@ use Api\Model\Shared\UserModel;
 use Api\Model\Shared\UnreadActivityModel;
 use Api\Model\Shared\UnreadAnswerModel;
 use Api\Model\Shared\UnreadCommentModel;
+use Api\Model\Shared\UnreadLexCommentModel;
+use Api\Model\Shared\UnreadLexReplyModel;
 use Api\Model\Shared\UnreadQuestionModel;
 
 class ActivityCommands
@@ -245,5 +249,132 @@ class ActivityCommands
         $activity->addContent(ActivityModel::ENTRY, $lexeme);
 
         return $activity->write();
+    }
+
+    /**
+     * @param ProjectModel $projectModel
+     * @param string $entryId
+     * @param LexCommentModel $commentModel
+     * @param string $mode
+     * @return string activity id
+     * @throws \Exception
+     */
+    public static function updateCommentOnEntry($projectModel, $entryId, $commentModel, $mode = "update")
+    {
+        $activity = new ActivityModel($projectModel);
+        $entry = new LexEntryModel($projectModel, $entryId);
+        if ($mode === 'update') {
+            $userId = $commentModel->authorInfo->modifiedByUserRef->asString();
+        } else {
+            $userId = $commentModel->authorInfo->createdByUserRef->asString();
+        }
+        $user = new UserModel($userId);
+        $activity->action = ($mode == 'update') ? ActivityModel::UPDATE_LEX_COMMENT : ActivityModel::ADD_LEX_COMMENT;
+        $activity->userRef->id = $userId;
+        $activity->entryRef->id = $entryId;
+        $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
+        $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
+        $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $activity->addContent(ActivityModel::USER, $user->username);
+        $activityId = $activity->write();
+        UnreadActivityModel::markUnreadForProjectMembers($activityId, $projectModel);
+        UnreadLexCommentModel::markUnreadForProjectMembers($commentModel->id->asString(), $projectModel, $entryId, $userId);
+
+        return $activityId;
+    }
+
+    /**
+     * @param ProjectModel $projectModel
+     * @param string $entryId
+     * @param LexCommentModel $commentModel
+     * @return string activity id
+     * @throws \Exception
+     */
+    public static function addCommentOnEntry($projectModel, $entryId, $commentModel)
+    {
+        return ActivityCommands::updateCommentOnEntry($projectModel, $entryId, $commentModel, "add");
+    }
+
+    /**
+     * @param ProjectModel $projectModel
+     * @param string $entryId
+     * @param LexCommentModel $commentModel
+     * @return string activity id
+     * @throws \Exception
+     */
+    public static function updateEntryCommentStatus($projectModel, $entryId, $commentModel)
+    {
+        $activity = new ActivityModel($projectModel);
+        $entry = new LexEntryModel($projectModel, $entryId);
+        $userId = $commentModel->authorInfo->modifiedByUserRef->asString();
+        $user = new UserModel($userId);
+        $activity->action = ActivityModel::UPDATE_LEX_COMMENT_STATUS;
+        $activity->userRef->id = $userId;
+        $activity->entryRef->id = $entryId;
+        $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
+        $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
+        $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $activity->addContent(ActivityModel::LEX_COMMENT_STATUS, $commentModel->status);
+        $activity->addContent(ActivityModel::USER, $user->username);
+        $activityId = $activity->write();
+        UnreadActivityModel::markUnreadForProjectMembers($activityId, $projectModel);
+        UnreadLexCommentModel::markUnreadForProjectMembers($commentModel->id->asString(), $projectModel, $entryId, $userId);
+
+        return $activityId;
+    }
+
+    /**
+     * @param ProjectModel $projectModel
+     * @param string $entryId
+     * @param LexCommentModel $commentModel
+     * @param LexCommentReply $replyModel
+     * @param string $mode
+     * @return string activity id
+     * @throws \Exception
+     */
+    public static function updateReplyToEntryComment($projectModel, $entryId, $commentModel, $replyModel, $mode = "update")
+    {
+        if ($mode === 'update') {
+            $userId = $commentModel->authorInfo->modifiedByUserRef->asString();
+        } else {
+            $userId = $commentModel->authorInfo->createdByUserRef->asString();
+        }
+        if ($mode === 'update') {
+            $user2Id = $replyModel->authorInfo->modifiedByUserRef->asString();
+        } else {
+            $user2Id = $replyModel->authorInfo->createdByUserRef->asString();
+        }
+        $user = new UserModel($userId);
+        $user2 = new UserModel($user2Id);
+        $activity = new ActivityModel($projectModel);
+        $activity->action = ($mode == 'update') ? ActivityModel::UPDATE_LEX_REPLY : ActivityModel::ADD_LEX_REPLY;
+        $activity->userRef->id = $userId;
+        $activity->userRef2->id = $user2Id;
+        $activity->entryRef->id = $entryId;
+        $entry = new LexEntryModel($projectModel, $entryId);
+        $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
+        $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
+        $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $activity->addContent(ActivityModel::LEX_REPLY, $replyModel->content);
+        $activity->addContent(ActivityModel::USER, $user->username);
+        $activity->addContent(ActivityModel::USER2, $user2->username);
+        $activityId = $activity->write();
+        UnreadActivityModel::markUnreadForProjectMembers($activityId, $projectModel);
+        UnreadLexReplyModel::markUnreadForProjectMembers($replyModel->id, $projectModel, $entryId, $userId);
+
+        return $activityId;
+    }
+
+    /**
+     * @param ProjectModel $projectModel
+     * @param string $entryId
+     * @param LexCommentModel $commentModel
+     * @param LexCommentReply $replyModel
+     * @return string activity id
+     * @throws \Exception
+     */
+    public static function addReplyToEntryComment($projectModel, $entryId, $commentModel, $replyModel)
+    {
+        return ActivityCommands::updateReplyToEntryComment($projectModel, $entryId, $commentModel, $replyModel, "add");
     }
 }

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -270,6 +270,12 @@ class RightsHelper
             case 'activity_list_dto':
                 return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW_OWN);
 
+            case 'activity_list_dto_for_current_project':
+                return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW_OWN);
+
+            case 'activity_list_dto_for_lexical_entry':
+                return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
+
             case 'session_getSessionData':
                 return true;
 

--- a/src/Api/Model/Shared/UnreadLexCommentModel.php
+++ b/src/Api/Model/Shared/UnreadLexCommentModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Api\Model\Shared;
+
+class UnreadLexCommentModel extends UserUnreadModel
+{
+    public function __construct($userId, $projectId, $questionId)
+    {
+        parent::__construct(ActivityModel::LEX_COMMENT, $userId, $projectId, $questionId);
+    }
+}

--- a/src/Api/Model/Shared/UnreadLexReplyModel.php
+++ b/src/Api/Model/Shared/UnreadLexReplyModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Api\Model\Shared;
+
+class UnreadLexReplyModel extends UserUnreadModel
+{
+    public function __construct($userId, $projectId, $questionId)
+    {
+        parent::__construct(ActivityModel::LEX_REPLY, $userId, $projectId, $questionId);
+    }
+}

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -415,6 +415,18 @@ class Sf
         return ActivityListDto::getActivityForUser($this->website->domain, $this->userId);
     }
 
+    public function activity_list_dto_for_current_project()
+    {
+        $projectModel = new ProjectModel($this->projectId);
+        return ActivityListDto::getActivityForOneProject($projectModel, $this->userId);
+    }
+
+    public function activity_list_dto_for_lexical_entry($entryId)
+    {
+        $projectModel = new ProjectModel($this->projectId);
+        return ActivityListDto::getActivityForOneLexEntry($projectModel, $entryId);
+    }
+
     /*
      * --------------------------------------------------------------- SCRIPTUREFORGE ---------------------------------------------------------------
      */

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -410,21 +410,21 @@ class Sf
     // ---------------------------------------------------------------
     // Activity Log
     // ---------------------------------------------------------------
-    public function activity_list_dto()
+    public function activity_list_dto($filterParams = [])
     {
-        return ActivityListDto::getActivityForUser($this->website->domain, $this->userId);
+        return ActivityListDto::getActivityForUser($this->website->domain, $this->userId, $filterParams);
     }
 
-    public function activity_list_dto_for_current_project()
+    public function activity_list_dto_for_current_project($filterParams = [])
     {
         $projectModel = new ProjectModel($this->projectId);
-        return ActivityListDto::getActivityForOneProject($projectModel, $this->userId);
+        return ActivityListDto::getActivityForOneProject($projectModel, $this->userId, $filterParams);
     }
 
-    public function activity_list_dto_for_lexical_entry($entryId)
+    public function activity_list_dto_for_lexical_entry($entryId, $filterParams = [])
     {
         $projectModel = new ProjectModel($this->projectId);
-        return ActivityListDto::getActivityForOneLexEntry($projectModel, $entryId);
+        return ActivityListDto::getActivityForOneLexEntry($projectModel, $entryId, $filterParams);
     }
 
     /*

--- a/src/angular-app/bellows/apps/activity/activity-app.component.ts
+++ b/src/angular-app/bellows/apps/activity/activity-app.component.ts
@@ -49,7 +49,12 @@ export class ActivityAppController implements angular.IController {
       { label: 'Activity' }
     ]);
 
-    this.activityService.listActivity(result => {
+    // Example of showing all activities between two dates:
+    // var now = new Date();
+    // var lastWeek = new Date(now.valueOf() - 1000 * 60 * 60 * 24 * 7);    //  7 days in milliseconds
+    // var lastMonth = new Date(now.valueOf() - 1000 * 60 * 60 * 24 * 30);  // 30 days in milliseconds
+    // this.activityService.listActivity({startDate: lastMonth, endDate: lastWeek}, result => { ... });
+    this.activityService.listActivity({}, result => {
       if (result.ok) {
         this.activities = [];
         this.unread = result.data.unread;

--- a/src/angular-app/bellows/core/api/activity.service.ts
+++ b/src/angular-app/bellows/core/api/activity.service.ts
@@ -8,4 +8,11 @@ export class ActivityService {
     return this.api.call('activity_list_dto', [], callback);
   }
 
+  listActivityForCurrentProject(callback?: JsonRpcCallback) {
+    return this.api.call('activity_list_dto_for_current_project', [], callback);
+  }
+
+  listActivityForLexicalEntry(entryId: string, callback?: JsonRpcCallback) {
+    return this.api.call('activity_list_dto_for_lexical_entry', [entryId], callback);
+  }
 }

--- a/src/angular-app/bellows/core/api/activity.service.ts
+++ b/src/angular-app/bellows/core/api/activity.service.ts
@@ -1,18 +1,25 @@
 import { ApiService, JsonRpcCallback } from './api.service';
 
+export class FilterParams {
+  startDate?: Date;
+  endDate?: Date;
+  limit?: number;
+  skip?: number;
+}
+
 export class ActivityService {
   static $inject: string[] = ['apiService'];
   constructor(private api: ApiService) {}
 
-  listActivity(callback?: JsonRpcCallback) {
-    return this.api.call('activity_list_dto', [], callback);
+  listActivity(filterParams: FilterParams, callback?: JsonRpcCallback) {
+    return this.api.call('activity_list_dto', [filterParams], callback);
   }
 
-  listActivityForCurrentProject(callback?: JsonRpcCallback) {
-    return this.api.call('activity_list_dto_for_current_project', [], callback);
+  listActivityForCurrentProject(filterParams: FilterParams, callback?: JsonRpcCallback) {
+    return this.api.call('activity_list_dto_for_current_project', [filterParams], callback);
   }
 
-  listActivityForLexicalEntry(entryId: string, callback?: JsonRpcCallback) {
-    return this.api.call('activity_list_dto_for_lexical_entry', [entryId], callback);
+  listActivityForLexicalEntry(entryId: string, filterParams: FilterParams, callback?: JsonRpcCallback) {
+    return this.api.call('activity_list_dto_for_lexical_entry', [entryId, filterParams], callback);
   }
 }

--- a/test/php/model/languageforge/lexicon/LexMultiParagraphTest.php
+++ b/test/php/model/languageforge/lexicon/LexMultiParagraphTest.php
@@ -22,23 +22,26 @@ class MultiParagraphInMap
 
 class LexMultiParagraphTest extends TestCase
 {
+    public function addParagraph(LexMultiParagraph $multiPara, string $content = null, string $styleName = null)
+    {
+        $newPara = new LexParagraph();
+        if (isset($content)) {
+            $newPara->content = $content;
+        }
+        if (isset($styleName)) {
+            $newPara->styleName = $styleName;
+        }
+        $multiPara->paragraphs->append($newPara);
+    }
+
     public function testToHTMLAndFromHTML_ExistingModel_RoundTripDataIdentical()
     {
         $multiParagraph = new LexMultiParagraph();
         $multiParagraph->inputSystem = 'en';
 
-        $paragraph1 = new LexParagraph();
-        $paragraph1->styleName = 'styleA';
-        $paragraph1->content = 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>';
-        $multiParagraph->paragraphs->append($paragraph1);
-
-        $paragraph2 = new LexParagraph();
-        $paragraph2->content = 'This is the second paragraph in <span lang="es">la lingua Espanol</span>';
-        $multiParagraph->paragraphs->append($paragraph2);
-
-        $paragraph3 = new LexParagraph();
-        $paragraph3->styleName = 'styleC';
-        $multiParagraph->paragraphs->append($paragraph3);
+        $this->addParagraph($multiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($multiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($multiParagraph, null, 'styleC');
 
         $html = $multiParagraph->toHtml();
         $this->assertTrue(is_string($html));
@@ -47,6 +50,161 @@ class LexMultiParagraphTest extends TestCase
         $newMultiParagraph->fromHtml($html);
 
         $this->assertEquals($multiParagraph, $newMultiParagraph);
+    }
+
+    public function testToHTMLAndFromHTML_ExistingModel_RoundTripDataProducesNoDifferences()
+    {
+        $multiParagraph = new LexMultiParagraph();
+        $multiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($multiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($multiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($multiParagraph, null, 'styleC');
+
+        $html = $multiParagraph->toHtml();
+        $this->assertTrue(is_string($html));
+
+        $newMultiParagraph = new LexMultiParagraph($multiParagraph->guid);
+        $newMultiParagraph->fromHtml($html);
+
+        $differences = $multiParagraph->differences($newMultiParagraph);
+        $this->assertEquals([], $differences);
+    }
+
+    public function testToHTMLAndFromHTML_ExistingModel_DifferencesFunctionDoesNotTestGuidChanges()
+    {
+        $multiParagraph = new LexMultiParagraph();
+        $multiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($multiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($multiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($multiParagraph, null, 'styleC');
+
+        $html = $multiParagraph->toHtml();
+        $this->assertTrue(is_string($html));
+
+        $newMultiParagraph = new LexMultiParagraph();  // We do not re-use $multiParagraph->guid here, so the new paragraph has a *different* GUID
+        $newMultiParagraph->fromHtml($html);
+
+        $differences = $multiParagraph->differences($newMultiParagraph);
+        // The differences() function does not care about GUIDs, so this time too, it will produce no differences
+        $this->assertEquals([], $differences);
+    }
+
+    public function testDifferences_SameObject_NoDifferences()
+    {
+        $multiParagraph = new LexMultiParagraph();
+        $multiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($multiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($multiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($multiParagraph, null, 'styleC');
+
+        $newMultiParagraph = $multiParagraph;
+        $differences = $multiParagraph->differences($newMultiParagraph);
+        $this->assertEquals([], $differences);
+    }
+
+    public function testDifferences_SameDataDifferentObject_NoDifferences()
+    {
+        $multiParagraph = new LexMultiParagraph();
+        $multiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($multiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($multiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($multiParagraph, null, 'styleC');
+
+        $newMultiParagraph = new LexMultiParagraph();
+        $newMultiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($newMultiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($newMultiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($newMultiParagraph, null, 'styleC');
+
+        $differences = $multiParagraph->differences($newMultiParagraph);
+        $this->assertEquals([], $differences);
+    }
+
+    public function testDifferences_OnePaaragraphRemoved_AllParagraphsInDifferences()
+    {
+        $multiParagraph = new LexMultiParagraph();
+        $multiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($multiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($multiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($multiParagraph, null, 'styleC');
+
+        $newMultiParagraph = new LexMultiParagraph();
+        $newMultiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($newMultiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($newMultiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+
+        $differences = $multiParagraph->differences($newMultiParagraph);
+        $this->assertEquals([ "this" => $multiParagraph->toHtml(), "other" => $newMultiParagraph->toHtml() ], $differences);
+    }
+
+    public function testDifferences_OnePaaragraphAdded_AllParagraphsInDifferences()
+    {
+        $multiParagraph = new LexMultiParagraph();
+        $multiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($multiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($multiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+
+        $newMultiParagraph = new LexMultiParagraph();
+        $newMultiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($newMultiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($newMultiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($newMultiParagraph, null, 'styleC');
+
+        $differences = $multiParagraph->differences($newMultiParagraph);
+        $this->assertEquals([ "this" => $multiParagraph->toHtml(), "other" => $newMultiParagraph->toHtml() ], $differences);
+    }
+
+    public function testDifferences_WeHaveNoParagraphsAndTheyDo_AllParagraphsInDifferences()
+    {
+        $multiParagraph = new LexMultiParagraph();
+        $multiParagraph->inputSystem = 'en';
+
+        $newMultiParagraph = new LexMultiParagraph();
+        $newMultiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($newMultiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($newMultiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($newMultiParagraph, null, 'styleC');
+
+        $differences = $multiParagraph->differences($newMultiParagraph);
+        $this->assertEquals([ "this" => $multiParagraph->toHtml(), "other" => $newMultiParagraph->toHtml() ], $differences);
+    }
+
+    public function testDifferences_TheyHaveNoParagraphsAndWeDo_AllParagraphsInDifferences()
+    {
+        $multiParagraph = new LexMultiParagraph();
+        $multiParagraph->inputSystem = 'en';
+
+        $this->addParagraph($multiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($multiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($multiParagraph, null, 'styleC');
+
+        $newMultiParagraph = new LexMultiParagraph();
+        $newMultiParagraph->inputSystem = 'en';
+
+        $differences = $multiParagraph->differences($newMultiParagraph);
+        $this->assertEquals([ "this" => $multiParagraph->toHtml(), "other" => $newMultiParagraph->toHtml() ], $differences);
+    }
+
+    public function testDifferences_NoParagraphsForUsOrThem_NoDifferences()
+    {
+        $multiParagraph = new LexMultiParagraph();
+        $multiParagraph->inputSystem = 'en';
+
+        $newMultiParagraph = new LexMultiParagraph();
+        $newMultiParagraph->inputSystem = 'en';
+
+        $differences = $multiParagraph->differences($newMultiParagraph);
+        $this->assertEquals([], $differences);
     }
 
     public function testFromHTML_MultipleClassValues_GuidExtracted()
@@ -98,18 +256,9 @@ class LexMultiParagraphTest extends TestCase
         $multiParagraph = new LexMultiParagraph();
         $multiParagraph->inputSystem = 'en';
 
-        $paragraph1 = new LexParagraph();
-        $paragraph1->styleName = 'styleA';
-        $paragraph1->content = 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>';
-        $multiParagraph->paragraphs->append($paragraph1);
-
-        $paragraph2 = new LexParagraph();
-        $paragraph2->content = 'This is the second paragraph in <span lang="es">la lingua Espanol</span>';
-        $multiParagraph->paragraphs->append($paragraph2);
-
-        $paragraph3 = new LexParagraph();
-        $paragraph3->styleName = 'styleC';
-        $multiParagraph->paragraphs->append($paragraph3);
+        $this->addParagraph($multiParagraph, 'This is the first paragraph in <span lang="de">die Deutsche Sprache</span>', 'styleA');
+        $this->addParagraph($multiParagraph, 'This is the second paragraph in <span lang="es">la lingua Espanol</span>');
+        $this->addParagraph($multiParagraph, null, 'styleC');
 
         $params = json_decode(json_encode(LexDbeDtoEntriesEncoder::encode($multiParagraph)), true);
 

--- a/test/php/model/shared/LexMultiTextTest.php
+++ b/test/php/model/shared/LexMultiTextTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use Api\Model\Languageforge\Lexicon\LexMultiText;
+use PHPUnit\Framework\TestCase;
+
+class LexMultiTextTest extends TestCase
+{
+    public function createMultitext(array $values)
+    {
+        $multiText = new LexMultiText();
+        foreach ($values as $key => $value)
+        {
+            $multiText->form($key, $value);
+        }
+        return $multiText;
+    }
+
+    public function doTest($one, $two, $expectedDifferences)
+    {
+        $multiText1 = $this->createMultitext($one);
+        $multiText2 = $this->createMultitext($two);
+        $differences = $multiText1->differences($multiText2);
+        $this->assertEquals($expectedDifferences, $differences);
+    }
+
+    public function testSameTextDifferentInputSystems()
+    {
+        $one = ["fr" => "bonjour"];
+        $two = ["en" => "bonjour"];
+        $expectedDifferences = [
+            [ "inputSystem" => "fr", "this" => "bonjour", "other" => "" ],
+            [ "inputSystem" => "en", "this" => "", "other" => "bonjour" ],
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testEmptyStringInOneInputSystem()
+    {
+        $one = ["fr" => "bonjour"];
+        $two = ["fr" => ""];
+        $expectedDifferences = [
+            [ "inputSystem" => "fr", "this" => "bonjour", "other" => "" ],
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testOneInputSystemRemoved()
+    {
+        $one = ["fr" => "bonjour"];
+        $two = [];
+        $expectedDifferences = [
+            [ "inputSystem" => "fr", "this" => "bonjour", "other" => "" ],
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testOneInputSystemAdded()
+    {
+        $one = [];
+        $two = ["fr" => "bonjour"];
+        $expectedDifferences = [
+            [ "inputSystem" => "fr", "this" => "", "other" => "bonjour" ],
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testSameDataNoDifferences()
+    {
+        $one = ["fr" => "bonjour"];
+        $two = ["fr" => "bonjour"];
+        $expectedDifferences = [];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testSameDataMultipleInputSystemsNoDifferences()
+    {
+        $one = ["fr" => "bonjour", "en" => "hello"];
+        $two = ["fr" => "bonjour", "en" => "hello"];
+        $expectedDifferences = [];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testBothEmptyNoDifferences()
+    {
+        $one = ["fr" => ""];
+        $two = ["fr" => ""];
+        $expectedDifferences = [];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testNullInBothComparedBothWays()
+    {
+        $one = ["fr" => null];
+        $two = ["fr" => null];
+        $expectedDifferences = [];
+        $this->doTest($one, $two, $expectedDifferences);
+        $this->doTest($two, $one, $expectedDifferences);
+    }
+
+    public function testNullIsEquivalentToEmptyBothWays()
+    {
+        $one = ["fr" => null];
+        $two = ["fr" => ""];
+        $expectedDifferences = [];
+        $this->doTest($one, $two, $expectedDifferences);
+        $this->doTest($two, $one, $expectedDifferences);
+    }
+
+    public function testTwoSetsOfChanges()
+    {
+        $one = ["fr" => "bonjour", "en" => "hello"];
+        $two = ["fr" => "au revoir", "en" => "goodbye"];
+        $expectedDifferences = [
+            [ "inputSystem" => "fr", "this" => "bonjour", "other" => "au revoir" ],
+            [ "inputSystem" => "en", "this" => "hello", "other" => "goodbye" ],
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testTwoChangesAndOneDeletion()
+    {
+        $one = ["fr" => "bonjour", "en" => "hello", "xyz" => "will be deleted"];
+        $two = ["fr" => "au revoir", "en" => "goodbye"];
+        $expectedDifferences = [
+            [ "inputSystem" => "fr",  "this" => "bonjour", "other" => "au revoir" ],
+            [ "inputSystem" => "en",  "this" => "hello", "other" => "goodbye" ],
+            [ "inputSystem" => "xyz", "this" => "will be deleted", "other" => "" ],
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testTwoChangesAndOneAddition()
+    {
+        $one = ["fr" => "bonjour", "en" => "hello"];
+        $two = ["fr" => "au revoir", "en" => "goodbye", "xyz" => "will be deleted"];
+        $expectedDifferences = [
+            [ "inputSystem" => "fr",  "this" => "bonjour", "other" => "au revoir" ],
+            [ "inputSystem" => "en",  "this" => "hello", "other" => "goodbye" ],
+            [ "inputSystem" => "xyz", "this" => "", "other" => "will be deleted" ],
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testTwoChangesOneDeletionAndOneAddition()
+    {
+        $one = ["fr" => "bonjour", "en" => "hello", "xyz" => "will be deleted"];
+        $two = ["fr" => "au revoir", "en" => "goodbye", "abc" => "is new"];
+        $expectedDifferences = [
+            [ "inputSystem" => "fr",  "this" => "bonjour", "other" => "au revoir" ],
+            [ "inputSystem" => "en",  "this" => "hello", "other" => "goodbye" ],
+            [ "inputSystem" => "xyz", "this" => "will be deleted", "other" => "" ],
+            [ "inputSystem" => "abc", "this" => "", "other" => "is new" ],
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+}

--- a/test/php/model/shared/LexMultiValueTest.php
+++ b/test/php/model/shared/LexMultiValueTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Api\Model\Languageforge\Lexicon\LexMultiValue;
+use PHPUnit\Framework\TestCase;
+
+class LexMultiValueTest extends TestCase
+{
+
+    public function doTest(array $one, array $two, array $expectedDifferences)
+    {
+        $multiValue1 = LexMultiValue::createFromArray($one);
+        $multiValue2 = LexMultiValue::createFromArray($two);
+        $differences = $multiValue1->differences($multiValue2);
+        $this->assertEquals($expectedDifferences, $differences);
+    }
+
+    public function testDifferences()
+    {
+        $one = ["one"];
+        $two = ["two"];
+        $expectedDifferences = [
+            "this" => json_encode($one),
+            "other" => json_encode($two)
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testInsertionStillShowsWholeArrayDifferences()
+    {
+        $one = ["one"];
+        $two = ["one", "two"];
+        $expectedDifferences = [
+            "this" => json_encode($one),
+            "other" => json_encode($two)
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testRemovalStillShowsWholeArrayDifferences()
+    {
+        $one = ["one", "two"];
+        $two = ["one"];
+        $expectedDifferences = [
+            "this" => json_encode($one),
+            "other" => json_encode($two)
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testReorderingStillShowsWholeArrayDifferences()
+    {
+        $one = ["one", "two"];
+        $two = ["two", "one"];
+        $expectedDifferences = [
+            "this" => json_encode($one),
+            "other" => json_encode($two)
+        ];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testSameArrayObject_NoDifferences()
+    {
+        $one = ["one", "two"];
+        $two = $one;
+        $expectedDifferences = [];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testEqualArraysButDifferentObjects_NoDifferences()
+    {
+        $one = ["one", "two"];
+        $two = ["one", "two"];
+        $expectedDifferences = [];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testSameEmptyArrayObject_NoDifferences()
+    {
+        $one = [];
+        $two = $one;
+        $expectedDifferences = [];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+
+    public function testEqualEmptyArraysButDifferentObjects_NoDifferences()
+    {
+        $one = [];
+        $two = [];
+        $expectedDifferences = [];
+        $this->doTest($one, $two, $expectedDifferences);
+    }
+}

--- a/test/php/model/shared/commands/ActivityCommandsTest.php
+++ b/test/php/model/shared/commands/ActivityCommandsTest.php
@@ -197,7 +197,7 @@ class ActivityCommandsTest extends TestCase
         $comment->content = $commentText;
         $comment->userRef->id = $userId;
         $commentId = QuestionModel::writeComment($project->databaseName(), $questionId, $answerId, $comment);
-        $activity = ActivityCommands::addComment($project, $questionId, $answerId, $comment);
+        $activity = ActivityCommands::addCommentOnQuestion($project, $questionId, $answerId, $comment);
         return [$comment, $commentId, $activity];
     }
 
@@ -217,7 +217,7 @@ class ActivityCommandsTest extends TestCase
         $comment1_updated = $question->readComment($answerId, $comment1Id);
         $comment1_updated->content = $newContent;
         QuestionModel::writeComment($project->databaseName(), $questionId, $answerId, $comment1_updated);
-        $a10 = ActivityCommands::updateComment($project, $questionId, $answerId, $comment1_updated);
+        $a10 = ActivityCommands::updateCommentOnQuestion($project, $questionId, $answerId, $comment1_updated);
         return [$comment1_updated, $a10];
     }
 

--- a/test/php/model/shared/dto/ActivityListDtoTest.php
+++ b/test/php/model/shared/dto/ActivityListDtoTest.php
@@ -235,13 +235,13 @@ class ActivityListDtoTest extends TestCase
         $comment1->content = "first comment";
         $comment1->userRef->id = $user1Id;
         $comment1Id = QuestionModel::writeComment($project->databaseName(), $questionId, $answerId, $comment1);
-        $a7 = ActivityCommands::addComment($project, $questionId, $answerId, $comment1);
+        $a7 = ActivityCommands::addCommentOnQuestion($project, $questionId, $answerId, $comment1);
 
         $comment2 = new CommentModel();
         $comment2->content = "second comment";
         $comment2->userRef->id = $user2Id;
         QuestionModel::writeComment($project->databaseName(), $questionId, $answerId, $comment2);
-        $a8 = ActivityCommands::addComment($project, $questionId, $answerId, $comment2);
+        $a8 = ActivityCommands::addCommentOnQuestion($project, $questionId, $answerId, $comment2);
 
         // updated answer
         $question->read($questionId);
@@ -255,7 +255,7 @@ class ActivityListDtoTest extends TestCase
         $comment1_updated = $question->readComment($answerId, $comment1Id);
         $comment1_updated->content = "first comment revised";
         QuestionModel::writeComment($project->databaseName(), $questionId, $answerId, $comment1_updated);
-        $a10 = ActivityCommands::updateComment($project, $questionId, $answerId, $comment1_updated);
+        $a10 = ActivityCommands::updateCommentOnQuestion($project, $questionId, $answerId, $comment1_updated);
 
         $dto = ActivityListDto::getActivityForProject($project);
 


### PR DESCRIPTION
The activity list API is missing a couple of unit tests for the new entry or project API calls, but I've tested them by hand and they do return the right DTO data structure. I also think that some thought could be given to how the "old" API could be improved, at least with a view to making the names more consistent (e.g., `getActivityForUser` doesn't actually get the activity of a single user; rather, it gets *all* available activity, and the "ForUser" part of the name just refers to which user should be considered as having *seen* all that activity. Whereas `getActivityForProject` is actually getting the activity for a single project. The naming is inconsistent at the moment, which may cause future confusion).

This is ready for review, and could be merged into master so that work on the frontend can proceed while I write unit tests. I wouldn't want to deploy it without unit tests, but if merging this will allow frontend work to proceed faster, then we can merge it now and I'll create another PR for unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/190)
<!-- Reviewable:end -->
