### PR TITLE
Hide comment bubbles for new entries until the word has been saved

### DIFF
--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.html
@@ -1,4 +1,4 @@
-<div class="commentBubbleContainer" ng-class="(!active ? 'comment-inactivate' : '')">
+<div class="commentBubbleContainer" ng-class="(!active ? 'comment-inactivate' : '')" ng-hide="isCommentingAvailable()">
     <a ng-click="getComments()" title="{{(active) ? 'Show Comments' : 'Please wait while comments are setup'}}" class="commentBubble" ng-class="(getCountForDisplay() < 1 ? 'noCount' : '')">
         <i class="fa fa-spinner fa-spin" ng-hide="active"></i>
         <i class="fa fa-comments" ng-show="active"></i><span class="commentCount" style="">{{getCountForDisplay()}}</span>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -48,18 +48,6 @@ angular.module('palaso.ui.comments')
               return;
             }
 
-            // Make sure there is an entry ID as you can't comment on a new entry until it is saved
-            if ($scope.control.currentEntry.id.indexOf('_new_') !== -1) {
-              $scope.control.saveCurrentEntry(true, function () {
-                // Need to also check against this promise as the callback above doesn't include it
-                $scope.control.editorService.refreshEditorData().then(function () {
-                  $scope.getComments();
-                });
-              });
-
-              return false;
-            }
-
             if ($scope.control.commentContext.contextGuid === $scope.contextGuid) {
               $scope.control.hideCommentsPanel();
             } else {
@@ -121,6 +109,10 @@ angular.module('palaso.ui.comments')
         };
 
         $scope.setContextGuid();
+
+        $scope.isCommentingAvailable = function isCommentingAvailable() {
+          return ($scope.control.currentEntry.id.indexOf('_new_') !== -1);
+        };
 
         $scope.$watch('model', function () {
           $scope.checkValidModelContextChange();


### PR DESCRIPTION
Refers to Trello card:

https://trello.com/c/e3Hy9Er0/1083-comments-spinner-continues-to-spin-indefinitely

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/192)
<!-- Reviewable:end -->
