### PR TITLE
Commenting disabled for observers and anyone with no rights

### DIFF
--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -111,7 +111,7 @@ angular.module('palaso.ui.comments')
         $scope.setContextGuid();
 
         $scope.isCommentingAvailable = function isCommentingAvailable() {
-          return ($scope.control.currentEntry.id.indexOf('_new_') !== -1);
+          return ($scope.control.currentEntry.id.indexOf('_new_') !== -1 || !$scope.control.rights.canComment());
         };
 
         $scope.$watch('model', function () {

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -14,7 +14,7 @@
                         <div class="comment-date">{{comment.authorInfo.createdDate | relativetime}}</div>
                     </div>
                 </div>
-                <div class="dropdown" uib-dropdown data-ng-show="rights.canEditComment(comment.authorInfo.createdByUserRef.id) || rights.canDeleteComment(comment.authorInfo.createdByUserRef.id) && !comment.editing">
+                <div class="dropdown" uib-dropdown data-ng-show="rights.canComment() && rights.canEditComment(comment.authorInfo.createdByUserRef.id) || rights.canDeleteComment(comment.authorInfo.createdByUserRef.id) && !comment.editing">
                     <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle type="button"><i
                             class="fa fa-ellipsis-v"></i></button>
                     <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
@@ -95,7 +95,7 @@
                             </div>
                             <span class="reply-content">{{reply.content}}</span>
                         </div>
-                        <div data-ng-show="comment.status != 'resolved' && rights.canEditComment(reply.authorInfo.createdByUserRef.id)" class="reply-actions">
+                        <div data-ng-show="comment.status != 'resolved' && rights.canComment() && rights.canEditComment(reply.authorInfo.createdByUserRef.id)" class="reply-actions">
                             <div class="dropdown float-right" uib-dropdown>
                                 <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle
                                         type="button"><i class="fa fa-ellipsis-v"></i></button>
@@ -112,7 +112,7 @@
                             </div>
                         </div>
                     </div>
-                    <form data-ng-show="reply.editing" data-ng-submit="submitReply(reply)" class="reply-edit-form">
+                    <form data-ng-show="reply.editing && rights.canComment()" data-ng-submit="submitReply(reply)" class="reply-edit-form">
                         <!--suppress HtmlFormInputWithoutLabel -->
                         <textarea class="form-control" data-ng-model="reply.editingContent"
                                   pui-auto-focus="reply.isAutoFocusEditing"></textarea>
@@ -123,7 +123,7 @@
                     </form>
                 </div>
             </div>
-            <form ng-show="showNewReplyForm && comment.status != 'resolved'" class="commentNewReplyForm" data-ng-submit="submitReply(newReply)">
+            <form ng-show="showNewReplyForm && comment.status != 'resolved' && rights.canComment()" class="commentNewReplyForm" data-ng-submit="submitReply(newReply)">
                 <textarea class="form-control" required placeholder="Reply here.  Press Enter when done."
                           data-ng-model="newReply.editingContent" pui-auto-focus="isAutoFocusNewReply"
                           ng-keydown="submitReply(newReply, $event)"></textarea>

--- a/src/angular-app/languageforge/lexicon/editor/editor-abstract.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-abstract.html
@@ -36,7 +36,7 @@
                             </button>
                         </span>
                         <button id="toCommentsLink"
-                           class="btn btn-primary" data-ng-click="showComments()" title="Show Comments">
+                           class="btn btn-primary" data-ng-click="showComments()" data-ng-show="rights.canComment()" title="Show Comments">
                             <current-entry-comment-count></current-entry-comment-count>
                             <i class="fa fa-comments commentColor"></i>
                         </button>

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -1014,16 +1014,22 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
         if (exampleGuid && exampleIndex) {
           if (currentEntry.senses[senseIndex].examples[exampleIndex].hasOwnProperty(field)) {
             currentField = currentEntry.senses[senseIndex].examples[exampleIndex][field];
-            fieldConfig = $scope.config.entry.fields.senses.fields.examples.fields[field];
+            if ($scope.config.entry.fields.senses.fields.examples.fields.hasOwnProperty(field)) {
+              fieldConfig = $scope.config.entry.fields.senses.fields.examples.fields[field];
+            }
           }
         } else if (senseGuid && senseIndex) {
           if (currentEntry.senses[senseIndex].hasOwnProperty(field)) {
             currentField = currentEntry.senses[senseIndex][field];
-            fieldConfig = $scope.config.entry.fields.senses.fields[field];
+            if ($scope.config.entry.fields.senses.fields.hasOwnProperty(field)) {
+              fieldConfig = $scope.config.entry.fields.senses.fields[field];
+            }
           }
         } else if (currentEntry.hasOwnProperty(field)) {
           currentField = currentEntry[field];
-          fieldConfig = $scope.config.entry.fields[field];
+          if ($scope.config.entry.fields.hasOwnProperty(field)) {
+            fieldConfig = $scope.config.entry.fields[field];
+          }
         }
 
         if (currentField !== null) {


### PR DESCRIPTION
Applies to the following Trello cards:

https://trello.com/c/QqQ8Q8Od/1084-comment-bubbles-are-visible-for-observer-role-but-this-should-not-be-the-comment-bubbles-should-only-be-visible-for-the-permissi

https://trello.com/c/6q97M4FK/905-during-s-r-users-should-be-locked-out-of-comments

As I don't have the ability to test a S/R I am unable to completely test that it works. The logic is the same as the observer so in theory it will be fine. I tested it to some extent with the observer role so I'm pretty sure it will be ok. For the send receive in progress I decided not to hide the entire commenting panel if it was open but rather just hide the textarea and any buttons that would allow edit/delete functionality. If we decided to hide it then I suspect the user would get frustrated with it opening and closing after every little change to the entry. As I couldn't test a S/R I can't be 100% sure though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/193)
<!-- Reviewable:end -->
