### PR TITLE
Mongo mapper trims empty fields

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Config/LexConfiguration.php
+++ b/src/Api/Model/Languageforge/Lexicon/Config/LexConfiguration.php
@@ -30,7 +30,7 @@ class LexConfiguration
     {
         $this->tasks = new MapOf(
             function ($data) {
-                switch ($data['type']) {
+                switch ($data['type'] ?? "") {
                     case LexTask::DASHBOARD:
                         return new LexTaskDashboard();
                     case LexTask::SEMDOM:

--- a/src/Api/Model/Languageforge/Semdomtrans/Command/SemDomTransItemCommands.php
+++ b/src/Api/Model/Languageforge/Semdomtrans/Command/SemDomTransItemCommands.php
@@ -16,10 +16,7 @@ class SemDomTransItemCommands
      */
     public static function update($data, $projectId) {
         $projectModel = new SemDomTransProjectModel($projectId);
-        $previousItemModel = new SemDomTransItemModel($projectModel);
-        if ($data["id"] != '') {
-            $previousItemModel->read($data['id']);
-        }
+        $previousItemModel = new SemDomTransItemModel($projectModel, $data["id"] ?? "");
 
         $guid = $data["xmlGuid"];
         $s = new SemDomTransItemModel($projectModel);

--- a/src/Api/Model/Scriptureforge/Sfchecks/Command/QuestionCommands.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Command/QuestionCommands.php
@@ -141,7 +141,7 @@ class QuestionCommands
         $answerId = $question->writeAnswer($answer);
 
         // Re-read question model to pick up new answer
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $newAnswer = $question->readAnswer($answerId);
         if ($answerJson['id'] != '') {
             // TODO log the activity after we confirm that the comment was successfully updated ; cjh 2013-08
@@ -235,7 +235,7 @@ class QuestionCommands
         JsonDecoder::decode($commentModel, $comment);
         $commentModel->userRef->id = $authorId;
         $commentId = QuestionModel::writeComment($projectModel->databaseName(), $questionId, $answerId, $commentModel);
-        $questionModel->read($questionId);
+        $questionModel = new QuestionModel($projectModel, $questionId);
         $newComment = $questionModel->readComment($answerId, $commentId);
         $commentDTO = QuestionCommentDto::encodeComment($newComment);
 

--- a/src/Api/Model/Scriptureforge/Sfchecks/Command/QuestionCommands.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Command/QuestionCommands.php
@@ -21,11 +21,9 @@ class QuestionCommands
     {
         $projectModel = new ProjectModel($projectId);
         ProjectCommands::checkIfArchivedAndThrow($projectModel);
-        $questionModel = new QuestionModel($projectModel);
-        $isNewQuestion = ($object['id'] == '');
-        if (!$isNewQuestion) {
-            $questionModel->read($object['id']);
-        }
+        $questionId = $object['id'] ?? '';
+        $isNewQuestion = ($questionId == '');
+        $questionModel = new QuestionModel($projectModel, $questionId);
         JsonDecoder::decode($questionModel, $object);
         $questionId = $questionModel->write();
         if ($isNewQuestion) {

--- a/src/Api/Model/Scriptureforge/Sfchecks/Command/TextCommands.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Command/TextCommands.php
@@ -54,11 +54,9 @@ class TextCommands
     {
         $projectModel = new ProjectModel($projectId);
         ProjectCommands::checkIfArchivedAndThrow($projectModel);
-        $textModel = new TextModel($projectModel);
-        $isNewText = ($object['id'] == '');
-        if (!$isNewText) {
-            $textModel->read($object['id']);
-        }
+        $textId = $object['id'] ?? '';
+        $isNewText = ($textId == '');
+        $textModel = new TextModel($projectModel, $textId);
         JsonDecoder::decode($textModel, $object);
         TextCommands::makeValidRange($object);
         if (TextCommands::hasRange($object)) {

--- a/src/Api/Model/Shared/Command/UserCommands.php
+++ b/src/Api/Model/Shared/Command/UserCommands.php
@@ -569,8 +569,7 @@ class UserCommands
     public static function sendJoinRequest($projectId, $userId, $website, DeliveryInterface $delivery = null)
     {
         $newUser = new UserModel($userId);
-        $project = new ProjectModel();
-        $project->read($projectId);
+        $project = new ProjectModel($projectId);
 
         // Make sure the user exists on the site
         if (!$newUser->hasRoleOnSite($website)) {
@@ -606,8 +605,7 @@ class UserCommands
     public static function acceptJoinRequest($projectId, $userId, $website, $role, DeliveryInterface $delivery = null)
     {
         $newUser = new UserModel($userId);
-        $project = new ProjectModel();
-        $project->read($projectId);
+        $project = new ProjectModel($projectId);
 
         ProjectCommands::updateUserRole($projectId, $userId, $role);
 

--- a/src/Api/Model/Shared/Mapper/MapperModel.php
+++ b/src/Api/Model/Shared/Mapper/MapperModel.php
@@ -40,7 +40,7 @@ class MapperModel extends ObjectForEncoding
      * @see MongoMapper::read()
      * @throws \Exception
      */
-    public function read($id)
+    protected function read($id)
     {
         if ($this->_mapper->exists($id)) {
             $this->_mapper->read($this, $id);

--- a/test/php/model/languageforge/lexicon/command/LexCommentCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexCommentCommandsTest.php
@@ -31,14 +31,13 @@ class LexCommentCommandsTest extends TestCase
             'fieldNameForDisplay' => 'Word',
             'inputSystemAbbreviation' => 'th',
             'inputSystem' => 'th',
-            'word' => '',
-            'meaning' => ''
         );
 
         $data = array(
             'id' => '',
             'content' => $commentContent,
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
 
         $commentList = new LexCommentListModel($project);
@@ -52,7 +51,7 @@ class LexCommentCommandsTest extends TestCase
         $commentArray = $commentList->entries[0];
         $this->assertEquals($commentContent, $commentArray['content']);
         $this->assertEquals($regarding, $commentArray['regarding']);
-        $this->assertEquals(0, $commentArray['score']);
+        $this->assertEquals(0, $commentArray['score'] ?? 0);
         $this->assertEquals('open', $commentArray['status']);
     }
 
@@ -74,7 +73,8 @@ class LexCommentCommandsTest extends TestCase
         $data = array(
             'id' => '',
             'content' => 'hi there!',
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
         $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
 
@@ -111,7 +111,8 @@ class LexCommentCommandsTest extends TestCase
         $data = array(
             'id' => '',
             'content' => 'hi there!',
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
         $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
         $comment = new LexCommentModel($project, $commentId);
@@ -149,7 +150,8 @@ class LexCommentCommandsTest extends TestCase
         $data = array(
             'id' => '',
             'content' => 'hi there!',
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
         $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
         $comment = new LexCommentModel($project, $commentId);
@@ -198,7 +200,8 @@ class LexCommentCommandsTest extends TestCase
         $data = array(
             'id' => '',
             'content' => 'hi there!',
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
         $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
         $comment = new LexCommentModel($project, $commentId);
@@ -235,7 +238,8 @@ class LexCommentCommandsTest extends TestCase
         $data = array(
             'id' => '',
             'content' => 'hi there!',
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
         $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
         $comment = new LexCommentModel($project, $commentId);
@@ -276,7 +280,8 @@ class LexCommentCommandsTest extends TestCase
         $data = array(
             'id' => '',
             'content' => 'hi there!',
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
         $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
         $comment = new LexCommentModel($project, $commentId);
@@ -310,7 +315,8 @@ class LexCommentCommandsTest extends TestCase
         $data = array(
             'id' => '',
             'content' => 'hi there!',
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
         $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
         $comment = new LexCommentModel($project, $commentId);
@@ -355,7 +361,8 @@ class LexCommentCommandsTest extends TestCase
         $data = array(
             'id' => '',
             'content' => 'hi there!',
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
         $commentId = LexCommentCommands::updateComment($project->id->asString(), $user1Id, $environ->website, $data);
         $comment = new LexCommentModel($project, $commentId);
@@ -386,7 +393,8 @@ class LexCommentCommandsTest extends TestCase
         $data = array(
             'id' => '',
             'content' => 'hi there!',
-            'regarding' => $regarding
+            'regarding' => $regarding,
+            'contextGuid' => 'lexeme.th'
         );
         $commentId = LexCommentCommands::updateComment($project->id->asString(), $user1Id, $environ->website, $data);
         $comment = new LexCommentModel($project, $commentId);

--- a/test/php/model/languageforge/lexicon/command/LexCommentCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexCommentCommandsTest.php
@@ -124,7 +124,7 @@ class LexCommentCommandsTest extends TestCase
         $this->assertCount(0, $comment->replies);
 
         $replyId = LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
-        $comment->read($commentId);
+        $comment = new LexCommentModel($project, $commentId);
 
         $reply = $comment->getReply($replyId);
 
@@ -164,7 +164,7 @@ class LexCommentCommandsTest extends TestCase
         LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
         $replyId = LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
 
-        $comment->read($commentId);
+        $comment = new LexCommentModel($project, $commentId);
         $reply = $comment->getReply($replyId);
 
         $this->assertEquals($replyData['content'], $reply->content);
@@ -175,7 +175,7 @@ class LexCommentCommandsTest extends TestCase
         );
 
         LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
-        $comment->read($commentId);
+        $comment = new LexCommentModel($project, $commentId);
         $reply = $comment->getReply($replyId);
 
         $this->assertCount(2, $comment->replies);
@@ -214,7 +214,7 @@ class LexCommentCommandsTest extends TestCase
         LexCommentCommands::deleteComment($project->id->asString(), $userId, $environ->website, $commentId);
 
         $commentList->read();
-        $comment->read($commentId);
+        $comment = new LexCommentModel($project, $commentId);
 
         $this->assertEquals(0, $commentList->count);
         $this->assertTrue($comment->isDeleted);
@@ -252,13 +252,13 @@ class LexCommentCommandsTest extends TestCase
         LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
         $replyId = LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
 
-        $comment->read($commentId);
+        $comment = new LexCommentModel($project, $commentId);
 
         $this->assertCount(2, $comment->replies);
 
         LexCommentCommands::deleteReply($project->id->asString(), $userId, $environ->website, $commentId, $replyId);
 
-        $comment->read($commentId);
+        $comment = new LexCommentModel($project, $commentId);
         $this->assertCount(1, $comment->replies);
     }
 
@@ -290,7 +290,7 @@ class LexCommentCommandsTest extends TestCase
 
         LexCommentCommands::updateCommentStatus($project->id->asString(), $commentId, LexCommentModel::STATUS_RESOLVED);
 
-        $comment->read($commentId);
+        $comment = new LexCommentModel($project, $commentId);
 
         $this->assertEquals(LexCommentModel::STATUS_RESOLVED, $comment->status);
     }
@@ -371,7 +371,7 @@ class LexCommentCommandsTest extends TestCase
         LexCommentCommands::plusOneComment($project->id->asString(), $user1Id, $commentId);
         LexCommentCommands::plusOneComment($project->id->asString(), $user2Id, $commentId);
 
-        $comment->read($commentId);
+        $comment = new LexCommentModel($project, $commentId);
         $this->assertEquals(2, $comment->score);
     }
 
@@ -403,7 +403,7 @@ class LexCommentCommandsTest extends TestCase
         LexCommentCommands::plusOneComment($project->id->asString(), $user1Id, $commentId);
         LexCommentCommands::plusOneComment($project->id->asString(), $user1Id, $commentId);
 
-        $comment->read($commentId);
+        $comment = new LexCommentModel($project, $commentId);
         $this->assertEquals(1, $comment->score);
     }
 }

--- a/test/php/model/languageforge/lexicon/command/LexCommentCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexCommentCommandsTest.php
@@ -324,6 +324,7 @@ class LexCommentCommandsTest extends TestCase
         $this->assertEquals(LexCommentModel::STATUS_OPEN, $comment->status);
 
         // save data for rest of this test
+        self::$save['project'] = $project;
         self::$save['environ'] = $environ;
         self::$save['commentId'] = $commentId;
         self::$save['comment'] = $comment;
@@ -337,7 +338,7 @@ class LexCommentCommandsTest extends TestCase
      */
     public function testUpdateCommentStatus_InvalidStatus()
     {
-        self::$save['comment']->read(self::$save['commentId']);
+        self::$save['comment'] = new LexCommentModel(self::$save['project'], self::$save['commentId']);
 
         $this->assertEquals(LexCommentModel::STATUS_OPEN, self::$save['comment']->status);
     }

--- a/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
@@ -186,7 +186,7 @@ class LexEntryCommandsTest extends TestCase
         LexEntryCommands::updateEntry($projectId, $params, $userId);
 
         $updatedEntry = LexEntryCommands::readEntry($projectId, $entryId);
-        $this->assertEquals('', $updatedEntry['lexeme']['th']['value']);
+        $this->assertEquals('', $updatedEntry['lexeme']['th']['value'] ?? "");
     }
 /* Ignore test for send receive v1.1 since dirtySR counter is not being incremented on edit. IJH 2015-02
     public function testUpdateEntry_ProjectHasSendReceive_EntryHasGuidAndDirtySRIncremented()

--- a/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
@@ -186,7 +186,7 @@ class LexEntryCommandsTest extends TestCase
         LexEntryCommands::updateEntry($projectId, $params, $userId);
 
         $updatedEntry = LexEntryCommands::readEntry($projectId, $entryId);
-        $this->assertEquals('', $updatedEntry['lexeme']['th']['value'] ?? "");
+        $this->assertFalse(isset($updatedEntry['lexeme']['th']['value']));
     }
 /* Ignore test for send receive v1.1 since dirtySR counter is not being incremented on edit. IJH 2015-02
     public function testUpdateEntry_ProjectHasSendReceive_EntryHasGuidAndDirtySRIncremented()

--- a/test/php/model/languageforge/lexicon/command/SendReceiveCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/SendReceiveCommandsTest.php
@@ -332,6 +332,7 @@ class SendReceiveCommandsTest extends TestCase
 
         $status = SendReceiveCommands::getProjectStatus($projectId, $mockStatePath);
         $this->assertEquals('LF_UNSYNCED', $status['SRState']);
+        // TODO: The assert above is intermittently failing with "Undefined index: SRState", but not every time. Figure out why; I suspect a race condition of some kind. - RM 2018-03
     }
 
     public function testGetProjectStatus_HasSendReceiveAndStateFileNotJson_NoException()

--- a/test/php/model/scriptureforge/Sfchecks/AnswerModelTest.php
+++ b/test/php/model/scriptureforge/Sfchecks/AnswerModelTest.php
@@ -21,7 +21,7 @@ class AnswerModelTest extends TestCase
         $questionId = $question->write();
 
         // List
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $this->assertCount(0, $question->answers);
 
         // Create
@@ -48,7 +48,8 @@ class AnswerModelTest extends TestCase
         // Note: Updates to the AnswerModel should not clobber child nodes such as comments. Hence this test.
         // See https://github.com/sillsdev/sfwebchecks/issues/39
         unset($otherAnswer->comments[$commentId]);
-        $otherQuestion->read($otherQuestion->id->asString());
+        // Re-read
+        $otherQuestion = new QuestionModel($project, $otherQuestion->id->asString());
         $otherId = $otherQuestion->writeAnswer($otherAnswer);
         $this->assertEquals($id, $otherId);
 
@@ -66,7 +67,7 @@ class AnswerModelTest extends TestCase
         QuestionModel::removeAnswer($project->databaseName(), $questionId, $id);
 
         // List
-        $otherQuestion->read($questionId);
+        $otherQuestion = new QuestionModel($project, $questionId);
         $this->assertCount(0, $otherQuestion->answers);
     }
 }

--- a/test/php/model/scriptureforge/Sfchecks/command/QuestionCommandsTest.php
+++ b/test/php/model/scriptureforge/Sfchecks/command/QuestionCommandsTest.php
@@ -111,8 +111,9 @@ class QuestionCommandsTest extends TestCase
 
         $count = QuestionCommands::archiveQuestions($project->id->asString(), array($question1->id->asString()));
 
-        $question1->read($question1->id->asString());
-        $question2->read($question2->id->asString());
+        // Refresh questions from Mongo
+        $question1 = new QuestionModel($project, $question1->id->asString());
+        $question2 = new QuestionModel($project, $question2->id->asString());
         $this->assertEquals(1, $count);
         $this->assertTrue($question1->isArchived);
         $this->assertEquals(false, $question2->isArchived);
@@ -139,8 +140,9 @@ class QuestionCommandsTest extends TestCase
 
         $count = QuestionCommands::publishQuestions($project->id->asString(), array($question1->id->asString()));
 
-        $question1->read($question1->id->asString());
-        $question2->read($question2->id->asString());
+        // Refresh questions from Mongo
+        $question1 = new QuestionModel($project, $question1->id->asString());
+        $question2 = new QuestionModel($project, $question2->id->asString());
         $this->assertEquals(1, $count);
         $this->assertFalse($question1->isArchived);
         $this->assertTrue($question2->isArchived);
@@ -272,7 +274,7 @@ class QuestionCommandsTest extends TestCase
 
         QuestionCommands::updateAnswer($project->id->asString(), $questionId, $answerArray, $user2Id);
 
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $newAnswer = $question->readAnswer($answerId);
         $this->assertEquals($user1Id, $newAnswer->userRef->asString());
     }
@@ -308,7 +310,7 @@ class QuestionCommandsTest extends TestCase
 
         QuestionCommands::updateAnswer($project->id->asString(), $questionId, $answerArray, $user1Id);
 
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $newAnswer = $question->readAnswer($answerId);
         $this->assertEquals('updated answer', $newAnswer->content);
         $this->assertCount(1, $newAnswer->tags);
@@ -339,7 +341,7 @@ class QuestionCommandsTest extends TestCase
 
         $dto = QuestionCommands::updateAnswerExportFlag($project->id->asString(), $questionId, $answerId, $isToBeExported);
 
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $newAnswer = $question->readAnswer($answerId);
         $this->assertTrue($newAnswer->isToBeExported);
         $this->assertTrue($dto[$answerId]['isToBeExported']);
@@ -368,7 +370,7 @@ class QuestionCommandsTest extends TestCase
 
         $dto = QuestionCommands::updateAnswerTags($project->id->asString(), $questionId, $answerId, $tagsArray);
 
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $newAnswer = $question->readAnswer($answerId);
         $this->assertCount(1, $newAnswer->tags);
         $this->assertEquals('updatedTag', $newAnswer->tags[0]);
@@ -410,7 +412,7 @@ class QuestionCommandsTest extends TestCase
         );
 
         QuestionCommands::updateComment($project->id->asString(), $questionId, $answerId, $commentArray, $user2Id);
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $newComment = $question->readComment($answerId, $commentId);
         $this->assertEquals($user1Id, $newComment->userRef->asString());
     }

--- a/test/php/model/scriptureforge/Sfchecks/command/SfchecksUploadCommandsTest.php
+++ b/test/php/model/scriptureforge/Sfchecks/command/SfchecksUploadCommandsTest.php
@@ -28,7 +28,7 @@ class SfchecksUploadCommandsTest extends TestCase
 
         $response = SfchecksUploadCommands::uploadFile($projectId, 'audio', $tmpFilePath);
 
-        $text->read($textId);
+        $text = new TextModel($project, $textId);
         $assetsFolderPath = $project->getAssetsFolderPath();
         $filePath = SfchecksUploadCommands::mediaFilePath($assetsFolderPath, $textId, $fileName);
         $projectSlug = $project->databaseName();

--- a/test/php/model/scriptureforge/Sfchecks/command/TextCommandsTest.php
+++ b/test/php/model/scriptureforge/Sfchecks/command/TextCommandsTest.php
@@ -55,8 +55,9 @@ class TextCommandsTest extends TestCase
 
         $count = TextCommands::archiveTexts($project->id->asString(), array($text1->id->asString()));
 
-        $text1->read($text1->id->asString());
-        $text2->read($text2->id->asString());
+        // Refresh texts from Mongo
+        $text1 = new TextModel($project, $text1->id->asString());
+        $text2 = new TextModel($project, $text2->id->asString());
         $this->assertEquals(1, $count);
         $this->assertTrue($text1->isArchived);
         $this->assertNotTrue($text2->isArchived);
@@ -80,8 +81,9 @@ class TextCommandsTest extends TestCase
 
         $count = TextCommands::publishTexts($project->id->asString(), array($text1->id->asString()));
 
-        $text1->read($text1->id->asString());
-        $text2->read($text2->id->asString());
+        // Refresh texts from Mongo
+        $text1 = new TextModel($project, $text1->id->asString());
+        $text2 = new TextModel($project, $text2->id->asString());
         $this->assertEquals(1, $count);
         $this->assertNotTrue($text1->isArchived);
         $this->assertTrue($text2->isArchived);

--- a/test/php/model/shared/CommentModelTest.php
+++ b/test/php/model/shared/CommentModelTest.php
@@ -26,7 +26,7 @@ class CommentModelTest extends TestCase
         $answerId = $question->writeAnswer($answer);
 
         // List
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $count = count($question->answers[$answerId]->comments);
         $this->assertEquals(0, $count);
 
@@ -64,7 +64,7 @@ class CommentModelTest extends TestCase
         QuestionModel::removeComment($project->databaseName(), $questionId, $answerId, $id);
 
         // List
-        $otherQuestion->read($questionId);
+        $otherQuestion = new QuestionModel($project, $questionId);
         $count = count($otherQuestion->answers[$answerId]->comments);
         $this->assertEquals(0, $count);
     }

--- a/test/php/model/shared/ProjectModelTest.php
+++ b/test/php/model/shared/ProjectModelTest.php
@@ -235,6 +235,7 @@ class ProjectModelTest extends TestCase
         $project->remove();
 
         // re-read the user
+        $user = new UserModel($userId);
         $user->read($userId);
 
         $this->assertFalse($user->isMemberOfProject($projectId));

--- a/test/php/model/shared/ProjectModelTest.php
+++ b/test/php/model/shared/ProjectModelTest.php
@@ -236,7 +236,6 @@ class ProjectModelTest extends TestCase
 
         // re-read the user
         $user = new UserModel($userId);
-        $user->read($userId);
 
         $this->assertFalse($user->isMemberOfProject($projectId));
     }

--- a/test/php/model/shared/UserModelTest.php
+++ b/test/php/model/shared/UserModelTest.php
@@ -374,7 +374,9 @@ class UserModelTest extends TestCase
         $user->remove();
 
         // re-read the project
-        $project->read($project->id->asString());
+        $projectId = $project->id->asString();
+        $project = new \Api\Model\Shared\ProjectModel();
+        $project->read($projectId);
 
         $this->assertFalse($project->userIsMember($userId));
 

--- a/test/php/model/shared/UserModelTest.php
+++ b/test/php/model/shared/UserModelTest.php
@@ -375,8 +375,7 @@ class UserModelTest extends TestCase
 
         // re-read the project
         $projectId = $project->id->asString();
-        $project = new \Api\Model\Shared\ProjectModel();
-        $project->read($projectId);
+        $project = new \Api\Model\Shared\ProjectModel($projectId);
 
         $this->assertFalse($project->userIsMember($userId));
 

--- a/test/php/model/shared/UserUnreadModelTest.php
+++ b/test/php/model/shared/UserUnreadModelTest.php
@@ -85,6 +85,8 @@ class UserUnreadModelTest extends TestCase
         $otherUnreadModel->markRead($activityId);
         $otherUnreadModel->write();
 
+        // Re-read the unread activity
+        $unreadModel = new UnreadActivityModel($userId1, $project->id->asString());
         $unreadModel->read();
         $this->assertFalse($unreadModel->isUnread($activityId));
 
@@ -109,6 +111,8 @@ class UserUnreadModelTest extends TestCase
         $otherUnreadModel->markAllRead();
         $otherUnreadModel->write();
 
+        // Re-read the unread activity
+        $unreadModel = new UnreadActivityModel($userId1, $project->id->asString());
         $unreadModel->read();
         $this->assertFalse($unreadModel->isUnread($activityId1));
         $this->assertFalse($unreadModel->isUnread($activityId2));
@@ -163,6 +167,8 @@ class UserUnreadModelTest extends TestCase
         $otherUnreadModel->markAllRead();
         $otherUnreadModel->write();
 
+        // Re-read the unread question model
+        $unreadModel = new UnreadQuestionModel($userId1, $project->id->asString());
         $unreadModel->read();
         $this->assertFalse($unreadModel->isUnread($qId1));
         $this->assertFalse($unreadModel->isUnread($qId2));

--- a/test/php/model/shared/commands/ActivityCommandsTest.php
+++ b/test/php/model/shared/commands/ActivityCommandsTest.php
@@ -203,7 +203,7 @@ class ActivityCommandsTest extends TestCase
 
     private function updateAnswer($project, $question, $questionId, $answerId, $newContent): array
     {
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $answer_updated = $question->readAnswer($answerId);
         $answer_updated->content = $newContent;
         $question->writeAnswer($answer_updated);
@@ -213,7 +213,7 @@ class ActivityCommandsTest extends TestCase
 
     private function updateComment($project, $question, $questionId, $answerId, $comment1Id, $newContent): array
     {
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $comment1_updated = $question->readComment($answerId, $comment1Id);
         $comment1_updated->content = $newContent;
         QuestionModel::writeComment($project->databaseName(), $questionId, $answerId, $comment1_updated);

--- a/test/php/model/shared/commands/ProjectCommandsTest.php
+++ b/test/php/model/shared/commands/ProjectCommandsTest.php
@@ -73,7 +73,7 @@ class ProjectCommandsTest extends TestCase
 
         ProjectCommands::archiveProject($projectId, $ownerId);
 
-        $project->read($projectId);
+        $project = new ProjectModel($projectId);
         $this->assertTrue($project->isArchived);
     }
 
@@ -113,7 +113,7 @@ class ProjectCommandsTest extends TestCase
 
         $count = ProjectCommands::publishProjects(array($projectId));
 
-        $project->read($projectId);
+        $project = new ProjectModel($projectId);
         $this->assertEquals(1, $count);
         $this->assertFalse($project->isArchived);
     }
@@ -168,8 +168,8 @@ class ProjectCommandsTest extends TestCase
         $updatedUserId = ProjectCommands::updateUserRole($projectId, $userId);
 
         // read from disk again
-        $sameProject->read($projectId);
-        $sameUser->read($updatedUserId);
+        $sameProject = new ProjectModel($projectId);
+        $sameUser = new UserModel($updatedUserId);
 
         // user still in project once and project still has one user
         $this->assertEquals(1, $sameProject->listUsers()->count);

--- a/test/php/model/shared/dto/ActivityListDtoTest.php
+++ b/test/php/model/shared/dto/ActivityListDtoTest.php
@@ -244,14 +244,14 @@ class ActivityListDtoTest extends TestCase
         $a8 = ActivityCommands::addCommentOnQuestion($project, $questionId, $answerId, $comment2);
 
         // updated answer
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $answer_updated = $question->readAnswer($answerId);
         $answer_updated->content = "first answer revised";
         $question->writeAnswer($answer_updated);
         $a9 = ActivityCommands::updateAnswer($project, $questionId, $answer_updated);
 
         // updated comment1
-        $question->read($questionId);
+        $question = new QuestionModel($project, $questionId);
         $comment1_updated = $question->readComment($answerId, $comment1Id);
         $comment1_updated->content = "first comment revised";
         QuestionModel::writeComment($project->databaseName(), $questionId, $answerId, $comment1_updated);


### PR DESCRIPTION
There are a few fields that will cause test failures if they're trimmed when empty, because of some assumptions in our code (like "a question will always have an answers array", for example). The `shouldKeepKey` function ensures that those fields will still be persisted even if they're empty. This is not a great long-term solution; it would be better to find and correct all those assumptions. But in the short term, this works and makes all PHP unit tests pass.

All PHP unit tests passing with this PR, and all E2E tests for Language Forge. (I haven't yet run E2E tests for Scripture Forge due to a misconfiguration on my laptop).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/194)
<!-- Reviewable:end -->
