### PR TITLE
Move delete button into ellipsis menu

### DIFF
--- a/src/angular-app/bellows/directive/palaso-ui.scss
+++ b/src/angular-app/bellows/directive/palaso-ui.scss
@@ -237,3 +237,8 @@ pui-soundplayer {
     }
   }
 }
+
+.ellipsis-menu-toggle {
+  padding-top: 0;
+  padding-bottom: 0;
+}

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.html
@@ -1,10 +1,14 @@
 <div class="dc-entry">
-    <div class="card card-outline-primary">
+    <div class="card card-outline-primary entry-card">
         <div class="card-header">
             <div data-ng-if="rights.canDeleteEntry() && $state.is('editor.entry')"
-                 class="deleteX float-right">
-                <i data-ng-click="deleteEntry()" id="deleteEntry" title="Delete this entry"
-                   class="fa fa-trash"></i>
+                class="dropdown float-right" uib-dropdown>
+                <a class="btn ellipsis-menu-toggle pui-no-caret" uib-dropdown-toggle>
+                    <span class="fa fa-ellipsis-v"></span>
+                </a>
+                <div class="dropdown-menu-right" uib-dropdown-menu>
+                    <a href data-ng-click="deleteEntry()" class="dropdown-item">Delete Entry</a>
+                </div>
             </div>
             &nbsp;{{'Entry' | translate}}
         </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.html
@@ -1,9 +1,13 @@
 <div class="dc-example card">
     <div class="card-header">
         <div ng-show="control.rights.canEditEntry() && $state.is('editor.entry')"
-             class="deleteX float-right">
-            <i data-ng-click="remove(index)" title="Delete Example"
-               class="fa fa-trash"></i>
+             class="dropdown float-right" uib-dropdown>
+             <a class="btn ellipsis-menu-toggle pui-no-caret" uib-dropdown-toggle>
+                 <span class="fa fa-ellipsis-v"></span>
+             </a>
+             <div class="dropdown-menu-right" uib-dropdown-menu>
+                 <a href data-ng-click="remove(index)" class="dropdown-item">Delete Example {{index+1}}</a>
+             </div>
         </div>
         Example <span class="notranslate">{{index+1}}</span>
     </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.html
@@ -1,9 +1,13 @@
 <div class="dc-sense card">
     <div class="meaning-label card-header">
         <div data-ng-if="control.rights.canEditEntry() && $state.is('editor.entry')"
-             class="deleteX float-right">
-            <i data-ng-click="remove(index)" title="Delete Meaning {{index+1}}"
-               class="fa fa-trash"></i>
+            class="dropdown float-right" uib-dropdown>
+            <a class="btn ellipsis-menu-toggle pui-no-caret" uib-dropdown-toggle>
+                <span class="fa fa-ellipsis-v"></span>
+            </a>
+            <div class="dropdown-menu-right" uib-dropdown-menu>
+                <a href data-ng-click="remove(index)" class="dropdown-item">Delete Meaning {{index+1}}</a>
+            </div>
         </div>
         Meaning <span class="notranslate">{{index+1}}</span>
     </div>

--- a/test/app/languageforge/lexicon/editor/e2e/editor-entry.spec.js
+++ b/test/app/languageforge/lexicon/editor/e2e/editor-entry.spec.js
@@ -582,7 +582,8 @@ describe('Editor List and Entry', function () {
 
   it('remove new word to restore original word count', function () {
     editorPage.browse.findEntryByLexeme(constants.testEntry3.lexeme.th.value).click();
-    editorPage.edit.deleteBtn.click();
+    editorPage.edit.actionMenu.click();
+    editorPage.edit.deleteMenuItem.click();
     util.clickModalButton('Delete Entry');
     expect(editorPage.edit.getEntryCount()).toBe(3);
   });

--- a/test/app/languageforge/lexicon/pages/editorPage.js
+++ b/test/app/languageforge/lexicon/pages/editorPage.js
@@ -169,7 +169,8 @@ function EditorPage() {
 
     // Top-row
     renderedDiv: this.editDiv.element(by.className('dc-rendered-entryContainer')),
-    deleteBtn: this.editDiv.element(by.id('deleteEntry')),
+    actionMenu: this.editDiv.element(by.css('.entry-card .card-header .ellipsis-menu-toggle')),
+    deleteMenuItem: this.editDiv.element(by.css('.entry-card .card-header .dropdown-menu .dropdown-item')),
 
     // Helper functions for retrieving various field values
     fields: this.editDiv.all(by.repeater('fieldName in config.fieldOrder')),


### PR DESCRIPTION
Previously each entry, sense, and example had a trash can for a delete button. The trash can has been replaced with a vertical ellipsis that opens a dropdown menu. Currently the dropdown menu has only one action (to delete). This is in preparation to add menu items to move a sense or example up or down (when applicable).

All e2e tests are passing on both LF and SF, though this change only affects LF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/195)
<!-- Reviewable:end -->
