### PR TITLE
Fix layout of invite a friend dialog on SF

### DIFF
--- a/src/Site/views/scriptureforge/theme/default/sass/_global.scss
+++ b/src/Site/views/scriptureforge/theme/default/sass/_global.scss
@@ -297,6 +297,7 @@ nav {
 
 #inviteAFriend {
   height: 0;
+  margin-top: 5px;
 
   .fa-times {
     color: black;

--- a/src/angular-app/scriptureforge/sfchecks/sfchecks.html
+++ b/src/angular-app/scriptureforge/sfchecks/sfchecks.html
@@ -3,7 +3,7 @@
     <div id="sfchecks-hmenu" class="hdrnav">
         <div ng-controller="inviteAFriend" id="inviteAFriend" class="float-right" ng-show="showInviteDiv">
             <div class="overlay-bg" ng-show="showInviteForm">
-                <form class="form-inline" ng-submit="sendInvite();showInviteForm=false">
+                <form ng-submit="sendInvite();showInviteForm=false">
                     <div class="heading">
                         <span>Invite a friend to Scripture Forge</span>
                         <span><a href class="float-right" ng-click="showInviteForm=false"><i class="fa fa-times"></i></a></span>


### PR DESCRIPTION
I'm still not entirely certain how it broke or why it broke, but removing a class that made it display flex fixes it. E2e tests are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/197)
<!-- Reviewable:end -->
