### PR TITLE
Apex/comments migration

### DIFF
--- a/src/Api/Model/Shared/DbIntegrityHelper.php
+++ b/src/Api/Model/Shared/DbIntegrityHelper.php
@@ -3,6 +3,11 @@
 namespace Api\Model\Shared;
 
 use Api\Library\Shared\Palaso\DbScriptLogger;
+use Api\Model\Languageforge\Lexicon\LexCommentListModel;
+use Api\Model\Languageforge\Lexicon\LexCommentModel;
+use Api\Model\Languageforge\Lexicon\LexEntryModel;
+use Api\Model\Languageforge\Lexicon\LexProjectModel;
+use Api\Model\Shared\Command\ActivityCommands;
 use Api\Model\Shared\Command\ProjectCommands;
 use Api\Model\Shared\Command\UserCommands;
 use Api\Model\Shared\Mapper\MongoStore;
@@ -21,6 +26,8 @@ class DbIntegrityHelper extends DbScriptLogger
         $this->usersChecked = 0;
         $this->usersFixed = 0;
         $this->inactiveUsers = 0;
+        $this->commentsAvailable = 0;
+        $this->commentsMissingContextGuid = 0;
         $this->emails = array();
         $this->usernames = array();
         $this->usersNeverValidated = array();
@@ -38,23 +45,25 @@ class DbIntegrityHelper extends DbScriptLogger
     private $usernames;
     private $usersNeverValidated;
     private $usersNoEmail;
+    private $commentsAvailable;
+    private $commentsMissingContextGuid;
 
     public function checkProject($projectId) {
         $project = new ProjectModel($projectId);
         $this->projectsChecked++;
         #$this->info("Checking {$project->projectName}");
 
-        
+
         if ($project->projectName == '') {
             $this->fix("$projectId has an empty projectName. Setting to 'Unknown Project'");
             $this->projectsFixed++;
             $project->projectName = "Unknown Project Name";
         }
-        
+
         if ($project->projectCode == '') {
             $this->warn("{$project->projectName} has an empty projectCode.  This will certainly cause failures");
         }
-        
+
         // check that a database exists for this project
         try {
             $databaseName = $project->databaseName();
@@ -73,7 +82,7 @@ class DbIntegrityHelper extends DbScriptLogger
                 $this->warn("{$project->projectName} has no corresponding database. (could indicate a brand new project with no data");
             }
         }
-        
+
         if ($project->siteName == '') {
             $this->warn("{$project->projectName} has no corresponding website (will not appear on any site)");
         }
@@ -115,8 +124,13 @@ class DbIntegrityHelper extends DbScriptLogger
                 $ownerUserModel->write();
             }
         }
+
+        // Lexicon projects need to update comments that don't contain the contextGuid field
+        if ($project->appName == 'lexicon') {
+            $this->checkLexiconComments($project);
+        }
     }
-    
+
     public function checkUser($userId) {
         $this->usersChecked++;
         $user = new UserModel($userId);
@@ -163,7 +177,7 @@ class DbIntegrityHelper extends DbScriptLogger
         if ($userFixed) {
             $this->usersFixed++;
         }
-        
+
         if (!empty($user->email)) {
             $this->emails[] = $user->email;
         }
@@ -173,7 +187,7 @@ class DbIntegrityHelper extends DbScriptLogger
             $user->write();
         }
     }
-    
+
     public function generateSummary() {
         $duplicateEmails = self::_getDuplicates($this->emails);
         $duplicateEmailsCount = count($duplicateEmails);
@@ -214,6 +228,13 @@ class DbIntegrityHelper extends DbScriptLogger
             $this->info(count($this->usersDeleted) . " users deleted");
         }
 
+        $this->info("\nCOMMENT REPORT\n");
+        $this->info("{$this->commentsAvailable } comments checked");
+        if ($this->commentsMissingContextGuid > 0) {
+            $this->info("{$this->commentsMissingContextGuid } comments fixed");
+        } else {
+            $this->info("No comments were found with the missing contextGuid field");
+        }
     }
 
     /**
@@ -228,14 +249,103 @@ class DbIntegrityHelper extends DbScriptLogger
         return $dups;
     }
 
+    /**
+     * @param $project ProjectModel
+     */
+    private function checkLexiconComments($project) {
+        $lexProject = new LexProjectModel($project->id->asString());
+        $commentList = new LexCommentListModel($lexProject);
+        $commentList->read();
+        // Loop through all comments on the project
+        foreach($commentList->entries as $comment) {
+            $this->commentsAvailable++;
+            // Only need to interact with comments that have no contextGuid
+            if(empty($comment['contextGuid'])) {
+                $lexComment = new LexCommentModel($project, $comment['id']);
+                $lexEntry = new LexEntryModel($project, $lexComment->entryRef->id);
+                $fieldName = $lexComment->regarding->field;
+                $fieldConfig = $this->getLexiconFieldConfig($lexProject, $fieldName);
+                // Construct the basics of the contextGuid
+                $contextGuid = $fieldName .
+                (!empty($lexComment->regarding->inputSystem) ? '.' . $lexComment->regarding->inputSystem : '');
+                if(isset($fieldConfig->type) && $fieldConfig->type === 'multioptionlist') {
+                    $contextGuid .= '#' . $lexComment->regarding->fieldValue;
+                }
+                // If there is only a single sense and example then we can also safely assume a comment
+                // belonging to that as well if required
+                if($this->isLexiconFieldSense($lexProject, $fieldName)) {
+                    if(count($lexEntry->senses) == 1) {
+                        $contextGuid = 'sense#' . $lexEntry->senses[0]->guid . ' ' . $contextGuid;
+                    } else {
+                        // If there is more than one we can try and guess based off the current value
+                        // compared to the value stored with the comment - this won't work if the value
+                        // has changed since the comment was made. If we can't find a match then
+                        // set the context to the entry itself so that it can be located still via the UI
+                        foreach($lexEntry->senses as $sense) {
+
+                        }
+                    }
+                } elseif($this->isLexiconFieldExample($lexProject, $fieldName)) {
+                    // Can only assume if there is also only a single sense
+                    if(count($lexEntry->senses) == 1) {
+                        if(count($lexEntry->senses[0]->examples) == 1) {
+                            $contextGuid = 'sense#' . $lexEntry->senses[0]->guid .
+                                          ' example#' . $lexEntry->senses[0]->examples[0]->guid .
+                                          ' ' . $contextGuid;
+                        }
+                    }
+                }
+                // Set the new contextGuid and update the comment
+                $lexComment->contextGuid = $contextGuid;
+//                ActivityCommands::updateCommentOnEntry($lexProject, $lexComment->entryRef->asString(), $lexComment);
+                $this->commentsMissingContextGuid++;
+            }
+        }
+    }
+
+    /**
+     * @param $lexProject LexProjectModel
+     * @param $fieldName string
+     * @return mixed|null
+     */
+    private function getLexiconFieldConfig($lexProject, $fieldName) {
+        $fieldConfig = null;
+        if(isset($lexProject->config->entry->fields[$fieldName])) {
+            $fieldConfig = $lexProject->config->entry->fields[$fieldName];
+        } elseif(isset($lexProject->config->entry->fields['senses']->fields[$fieldName])) {
+            $fieldConfig = $lexProject->config->entry->fields['senses']->fields[$fieldName];
+        } elseif(isset($lexProject->config->entry->fields['senses']->fields['examples']->fields[$fieldName])) {
+            $fieldConfig = $lexProject->config->entry->fields['senses']->fields[$fieldName];
+        }
+        return $fieldConfig;
+    }
+
+    /**
+     * @param $lexProject LexProjectModel
+     * @param $fieldName string
+     * @return bool
+     */
+    private function isLexiconFieldSense($lexProject, $fieldName) {
+        return isset($lexProject->config->entry->fields['senses']->fields[$fieldName]);
+    }
+
+    /**
+     * @param $lexProject LexProjectModel
+     * @param $fieldName string
+     * @return bool
+     */
+    private function isLexiconFieldExample($lexProject, $fieldName) {
+        return isset($lexProject->config->entry->fields['senses']->fields['examples']->fields[$fieldName]);
+    }
+
 }
 
 class DbIntegrityHelperResult
 {
     const OK = 'ok';
     const DEGRADED = 'degraded';
-    
+
     public $shouldDelete;
-    
+
     public $state;
 }

--- a/src/Api/Model/Shared/DbIntegrityHelper.php
+++ b/src/Api/Model/Shared/DbIntegrityHelper.php
@@ -7,8 +7,6 @@ use Api\Model\Languageforge\Lexicon\LexCommentListModel;
 use Api\Model\Languageforge\Lexicon\LexCommentModel;
 use Api\Model\Languageforge\Lexicon\LexEntryModel;
 use Api\Model\Languageforge\Lexicon\LexProjectModel;
-use Api\Model\Shared\Command\ActivityCommands;
-use Api\Model\Shared\Command\ProjectCommands;
 use Api\Model\Shared\Command\UserCommands;
 use Api\Model\Shared\Mapper\MongoStore;
 use Api\Model\Shared\Rights\ProjectRoles;
@@ -261,15 +259,34 @@ class DbIntegrityHelper extends DbScriptLogger
             $this->commentsAvailable++;
             // Only need to interact with comments that have no contextGuid
             if(empty($comment['contextGuid'])) {
+                $useEntryIdContext = false;
                 $lexComment = new LexCommentModel($project, $comment['id']);
                 $lexEntry = new LexEntryModel($project, $lexComment->entryRef->id);
                 $fieldName = $lexComment->regarding->field;
                 $fieldConfig = $this->getLexiconFieldConfig($lexProject, $fieldName);
                 // Construct the basics of the contextGuid
-                $contextGuid = $fieldName .
-                (!empty($lexComment->regarding->inputSystem) ? '.' . $lexComment->regarding->inputSystem : '');
-                if(isset($fieldConfig->type) && $fieldConfig->type === 'multioptionlist') {
-                    $contextGuid .= '#' . $lexComment->regarding->fieldValue;
+                $contextGuid = $fieldName;
+                if(!empty($lexComment->regarding->inputSystem)) {
+                    // The input system is a tricky one as there has been a bug where the language name
+                    // has been recorded against this field until a fix on 569d222 changed it to be the tag.
+                    // We need to identify if the inputSystem has been saved as the language name or the tag
+                    foreach($lexProject->inputSystems as $inputSystem) {
+                        if($inputSystem->languageName == $lexComment->regarding->inputSystem &&
+                            $inputSystem->abbreviation == $lexComment->regarding->inputSystemAbbreviation) {
+                            // Update the input system so that it is also updated in the DB
+                            $lexComment->regarding->inputSystem = $inputSystem->tag;
+                            break;
+                        }
+                    }
+                    // Now we can attach the input system knowing it is correct
+                    $contextGuid .= '.' . $lexComment->regarding->inputSystem;
+                }
+                if(isset($fieldConfig->type)) {
+                    if($fieldConfig->type === 'multioptionlist') {
+                        $contextGuid .= '#' . $lexComment->regarding->fieldValue;
+                    } elseif($fieldConfig->type === 'pictures') {
+                        $contextGuid = 'pictures#' . $lexComment->regarding->fieldValue;
+                    }
                 }
                 // If there is only a single sense and example then we can also safely assume a comment
                 // belonging to that as well if required
@@ -281,8 +298,13 @@ class DbIntegrityHelper extends DbScriptLogger
                         // compared to the value stored with the comment - this won't work if the value
                         // has changed since the comment was made. If we can't find a match then
                         // set the context to the entry itself so that it can be located still via the UI
+                        $useEntryIdContext = true;
                         foreach($lexEntry->senses as $sense) {
-
+                            if($this->checkLexiconFieldAgainstComment($sense, $fieldName, $fieldConfig, $lexComment)) {
+                                $contextGuid = 'sense#' . $sense->guid . ' ' . $contextGuid;
+                                $useEntryIdContext = false;
+                                break;
+                            }
                         }
                     }
                 } elseif($this->isLexiconFieldExample($lexProject, $fieldName)) {
@@ -293,11 +315,30 @@ class DbIntegrityHelper extends DbScriptLogger
                                           ' example#' . $lexEntry->senses[0]->examples[0]->guid .
                                           ' ' . $contextGuid;
                         }
+                    } else {
+                        // If there is more than one we can try and guess based off the current value
+                        // compared to the value stored with the comment - this won't work if the value
+                        // has changed since the comment was made. If we can't find a match then
+                        // set the context to the entry itself so that it can be located still via the UI
+                        $useEntryIdContext = true;
+                        foreach($lexEntry->senses as $sense) {
+                            foreach($sense->examples as $example) {
+                                if ($this->checkLexiconFieldAgainstComment($example, $fieldName, $fieldConfig, $lexComment)) {
+                                    $contextGuid = 'sense#' . $sense->guid . ' example#' . $example->guid . ' ' . $contextGuid;
+                                    $useEntryIdContext = false;
+                                    break;
+                                }
+                            }
+                        }
                     }
+                }
+                // Use the entry ID as context in cases where it can't be figured out
+                if($useEntryIdContext || empty($contextGuid)) {
+                    $contextGuid = 'entry#' . $lexEntry->guid;
                 }
                 // Set the new contextGuid and update the comment
                 $lexComment->contextGuid = $contextGuid;
-//                ActivityCommands::updateCommentOnEntry($lexProject, $lexComment->entryRef->asString(), $lexComment);
+                $lexComment->write();
                 $this->commentsMissingContextGuid++;
             }
         }
@@ -315,7 +356,7 @@ class DbIntegrityHelper extends DbScriptLogger
         } elseif(isset($lexProject->config->entry->fields['senses']->fields[$fieldName])) {
             $fieldConfig = $lexProject->config->entry->fields['senses']->fields[$fieldName];
         } elseif(isset($lexProject->config->entry->fields['senses']->fields['examples']->fields[$fieldName])) {
-            $fieldConfig = $lexProject->config->entry->fields['senses']->fields[$fieldName];
+            $fieldConfig = $lexProject->config->entry->fields['senses']->fields['examples']->fields[$fieldName];
         }
         return $fieldConfig;
     }
@@ -336,6 +377,54 @@ class DbIntegrityHelper extends DbScriptLogger
      */
     private function isLexiconFieldExample($lexProject, $fieldName) {
         return isset($lexProject->config->entry->fields['senses']->fields['examples']->fields[$fieldName]);
+    }
+
+    /**
+     * @param $context object
+     * @param $fieldName string
+     * @param $fieldConfig object
+     * @param $lexComment LexCommentModel
+     * @return bool
+     */
+    private function checkLexiconFieldAgainstComment($context, $fieldName, $fieldConfig, $lexComment) {
+        $contextValue = '';
+        $regardingValue = $lexComment->regarding->fieldValue;
+        if(isset($context->{$fieldName})) {
+            if($fieldConfig->type == 'pictures') {
+                foreach ($context->{$fieldName} as $picture) {
+                    if (empty($lexComment->regarding->inputSystem)) {
+                        // Some values, perhaps from an original bug when comments were first created with context
+                        // Have a # in the value i.e. value#value
+                        if ($picture->guid . '#' . $picture->guid == $regardingValue || $picture->guid == $regardingValue) {
+                            $contextValue = $regardingValue;
+                        }
+                    } else {
+                        if (isset($picture->caption[$lexComment->regarding->inputSystem])) {
+                            $contextValue = $picture->guid . ' ' . $fieldConfig->type . '.' . $lexComment->regarding->inputSystem;
+                        }
+                    }
+                }
+            } elseif(!empty($lexComment->regarding->inputSystem)) {
+                if(isset($context->{$fieldName}[$lexComment->regarding->inputSystem])) {
+                    $contextValue = $context->{$fieldName}[$lexComment->regarding->inputSystem]->value;
+                }
+            } elseif(isset($context->{$fieldName}->value)) {
+                $contextValue = $context->{$fieldName}->value;
+            } elseif(isset($context->{$fieldName}->values)) {
+                foreach($context->{$fieldName}->values as $fieldValue) {
+                    // Some values, perhaps from an original bug when comments were first created with context
+                    // Have a # in the value for multi list options and semantic domains i.e. value#value
+                    if ($fieldValue . '#' . $fieldValue == $regardingValue || $fieldValue == $regardingValue) {
+                        $contextValue = $regardingValue;
+                        break;
+                    }
+                }
+            }
+        }
+        if(!empty($contextValue) && $contextValue == $regardingValue) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.html
@@ -32,7 +32,7 @@
                     <regarding-field class="form-control" content="comment.regarding.fieldValue" control="control"
                          field="comment.regarding.field" field-config="commentRegardingFieldConfig" ng-hide="isCommentRegardingPicture"></regarding-field>
                     <div data-ng-if="isCommentRegardingPicture">
-                        <img data-ng-src="{{comment.regarding.fieldValue}}">
+                        <img data-ng-src="{{getCommentRegardingPictureSource()}}">
                     </div>
                 </div>
                 <div class="commentContent" data-ng-hide="comment.editing" data-ng-bind="comment.content"></div>

--- a/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.dc-comment.js
@@ -183,9 +183,41 @@ angular.module('palaso.ui.comments')
                   $scope.control.commentContext.contextGuid === ''))
               ) {
               return contextParts.option.label;
+            } else if (contextParts.fieldConfig.type === 'pictures' &&
+                  !contextParts.inputSystem &&
+                  $scope.control.commentContext.contextGuid === '') {
+              return 'Something different just to force it to display';
             } else {
               return contextParts.value;
             }
+          };
+
+          $scope.getCommentRegardingPictureSource = function getCommentRegardingPictureSource() {
+            if (!$scope.isCommentRegardingPicture) {
+              return '';
+            }
+
+            var contextParts = $scope.control.getContextParts($scope.comment.contextGuid);
+            var imageSrc = '';
+            var pictures = null;
+            if (contextParts.example.guid) {
+              pictures = $scope.control.currentEntry.senses[contextParts.sense.index]
+                .examples[contextParts.example.index].pictures;
+            } else if (contextParts.sense.guid) {
+              pictures = $scope.control.currentEntry.senses[contextParts.sense.index].pictures;
+            }
+
+            for (var i in pictures) {
+              if (pictures[i].guid === contextParts.value) {
+                imageSrc = pictures[i].fileName;
+              }
+            }
+
+            if (imageSrc) {
+              imageSrc = '/assets/lexicon/' + $scope.control.project.slug + '/pictures/' + imageSrc;
+            }
+
+            return imageSrc;
           };
 
         }],

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -987,6 +987,9 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
             } else if (contextPart.indexOf('#') !== -1) {
               field = contextPart.substr(0, contextPart.indexOf('#'));
               optionKey = contextPart.substr(contextPart.indexOf('#') + 1);
+              if (optionKey.indexOf('.') !== -1) {
+                inputSystem = optionKey.substr(optionKey.indexOf('.') + 1);
+              }
             } else if (contextPart.indexOf('.') !== -1) {
               field = contextPart.substr(0, contextPart.indexOf('.'));
               inputSystem = contextPart.substr(contextPart.indexOf('.') + 1);

--- a/test/php/model/languageforge/lexicon/command/LexCommentCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexCommentCommandsTest.php
@@ -1,0 +1,401 @@
+<?php
+
+use Api\Model\Languageforge\Lexicon\Command\LexCommentCommands;
+use Api\Model\Languageforge\Lexicon\LexCommentModel;
+use Api\Model\Languageforge\Lexicon\LexCommentListModel;
+use PHPUnit\Framework\TestCase;
+
+class LexCommentCommandsTest extends TestCase
+{
+    /** @var mixed[] Data storage between tests */
+    private static $save;
+
+    public static function setUpBeforeClass()
+    {
+        self::$save = [];
+    }
+
+    public function testUpdateComment_NewComment_CommentAdded()
+    {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $userId = $environ->createUser('joe', 'joe', 'joe');
+
+        $commentContent = "My first comment";
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'fieldNameForDisplay' => 'Word',
+            'inputSystemAbbreviation' => 'th',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+
+        $data = array(
+            'id' => '',
+            'content' => $commentContent,
+            'regarding' => $regarding
+        );
+
+        $commentList = new LexCommentListModel($project);
+        $commentList->read();
+        $this->assertEquals(0, $commentList->count);
+
+        LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
+
+        $commentList->read();
+        $this->assertEquals(1, $commentList->count);
+        $commentArray = $commentList->entries[0];
+        $this->assertEquals($commentContent, $commentArray['content']);
+        $this->assertEquals($regarding, $commentArray['regarding']);
+        $this->assertEquals(0, $commentArray['score']);
+        $this->assertEquals('open', $commentArray['status']);
+    }
+
+    public function testUpdateComment_ExistingComment_CommentUpdated()
+    {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $userId = $environ->createUser('joe', 'joe', 'joe');
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+        $data = array(
+            'id' => '',
+            'content' => 'hi there!',
+            'regarding' => $regarding
+        );
+        $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
+
+        $newCommentContent = "My first comment";
+
+        $data = array(
+            'id' => $commentId,
+            'content' => $newCommentContent,
+        );
+        LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
+
+        $comment = new LexCommentModel($project, $commentId);
+
+        $this->assertEquals($newCommentContent, $comment->content);
+        $this->assertEquals(0, $comment->score);
+        $this->assertEquals('open', $comment->status);
+    }
+
+    public function testUpdateReply_NewReply_ReplyAdded()
+    {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $userId = $environ->createUser('joe', 'joe', 'joe');
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+        $data = array(
+            'id' => '',
+            'content' => 'hi there!',
+            'regarding' => $regarding
+        );
+        $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
+        $comment = new LexCommentModel($project, $commentId);
+        $replyData = array(
+            'id' => '',
+            'content' => 'my first reply'
+        );
+
+        $this->assertCount(0, $comment->replies);
+
+        $replyId = LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
+        $comment->read($commentId);
+
+        $reply = $comment->getReply($replyId);
+
+        $this->assertCount(1, $comment->replies);
+        $this->assertEquals($replyData['content'], $reply->content);
+    }
+
+    public function testUpdateReply_ExistingReply_ReplyAdded()
+    {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $userId = $environ->createUser('joe', 'joe', 'joe');
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+        $data = array(
+            'id' => '',
+            'content' => 'hi there!',
+            'regarding' => $regarding
+        );
+        $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
+        $comment = new LexCommentModel($project, $commentId);
+        $replyData = array(
+            'id' => '',
+            'content' => 'my first reply'
+        );
+
+        // add two replies
+        LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
+        $replyId = LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
+
+        $comment->read($commentId);
+        $reply = $comment->getReply($replyId);
+
+        $this->assertEquals($replyData['content'], $reply->content);
+
+        $replyData = array(
+            'id' => $replyId,
+            'content' => 'an updated reply'
+        );
+
+        LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
+        $comment->read($commentId);
+        $reply = $comment->getReply($replyId);
+
+        $this->assertCount(2, $comment->replies);
+        $this->assertEquals($replyData['content'], $reply->content);
+    }
+
+    public function testDeleteComment_CommentMarkedDeletedAndNotInList()
+    {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $userId = $environ->createUser('joe', 'joe', 'joe');
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+        $data = array(
+            'id' => '',
+            'content' => 'hi there!',
+            'regarding' => $regarding
+        );
+        $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
+        $comment = new LexCommentModel($project, $commentId);
+        $this->assertFalse($comment->isDeleted);
+
+        $commentList = new LexCommentListModel($project);
+        $commentList->read();
+        $this->assertEquals(1, $commentList->count);
+
+        LexCommentCommands::deleteComment($project->id->asString(), $userId, $environ->website, $commentId);
+
+        $commentList->read();
+        $comment->read($commentId);
+
+        $this->assertEquals(0, $commentList->count);
+        $this->assertTrue($comment->isDeleted);
+    }
+
+    public function testDeleteReply_ReplyDeleted()
+    {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $userId = $environ->createUser('joe', 'joe', 'joe');
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+        $data = array(
+            'id' => '',
+            'content' => 'hi there!',
+            'regarding' => $regarding
+        );
+        $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
+        $comment = new LexCommentModel($project, $commentId);
+        $replyData = array(
+            'id' => '',
+            'content' => 'my first reply'
+        );
+
+        // add two replies
+        LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
+        $replyId = LexCommentCommands::updateReply($project->id->asString(), $userId, $environ->website, $commentId, $replyData);
+
+        $comment->read($commentId);
+
+        $this->assertCount(2, $comment->replies);
+
+        LexCommentCommands::deleteReply($project->id->asString(), $userId, $environ->website, $commentId, $replyId);
+
+        $comment->read($commentId);
+        $this->assertCount(1, $comment->replies);
+    }
+
+    public function testUpdateCommentStatus_ValidStatus_StatusUpdated()
+    {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $userId = $environ->createUser('joe', 'joe', 'joe');
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+        $data = array(
+            'id' => '',
+            'content' => 'hi there!',
+            'regarding' => $regarding
+        );
+        $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
+        $comment = new LexCommentModel($project, $commentId);
+
+        $this->assertEquals(LexCommentModel::STATUS_OPEN, $comment->status);
+
+        LexCommentCommands::updateCommentStatus($project->id->asString(), $commentId, LexCommentModel::STATUS_RESOLVED);
+
+        $comment->read($commentId);
+
+        $this->assertEquals(LexCommentModel::STATUS_RESOLVED, $comment->status);
+    }
+
+    public function testUpdateCommentStatus_InvalidStatus_Exception()
+    {
+        $this->expectException(Exception::class);
+
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $userId = $environ->createUser('joe', 'joe', 'joe');
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+        $data = array(
+            'id' => '',
+            'content' => 'hi there!',
+            'regarding' => $regarding
+        );
+        $commentId = LexCommentCommands::updateComment($project->id->asString(), $userId, $environ->website, $data);
+        $comment = new LexCommentModel($project, $commentId);
+
+        $this->assertEquals(LexCommentModel::STATUS_OPEN, $comment->status);
+
+        // save data for rest of this test
+        self::$save['environ'] = $environ;
+        self::$save['commentId'] = $commentId;
+        self::$save['comment'] = $comment;
+
+        LexCommentCommands::updateCommentStatus($project->id->asString(), $commentId, 'malicious code; rm -rf');
+
+        // nothing runs in the current test function after an exception. IJH 2014-11
+    }
+    /**
+     * @depends testUpdateCommentStatus_InvalidStatus_Exception
+     */
+    public function testUpdateCommentStatus_InvalidStatus()
+    {
+        self::$save['comment']->read(self::$save['commentId']);
+
+        $this->assertEquals(LexCommentModel::STATUS_OPEN, self::$save['comment']->status);
+    }
+
+    public function testPlusOneComment_UserFirstTime_IncreasedScore()
+    {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $user1Id = $environ->createUser('joe', 'joe', 'joe');
+        $user2Id = $environ->createUser('jim', 'jim', 'jim');
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+        $data = array(
+            'id' => '',
+            'content' => 'hi there!',
+            'regarding' => $regarding
+        );
+        $commentId = LexCommentCommands::updateComment($project->id->asString(), $user1Id, $environ->website, $data);
+        $comment = new LexCommentModel($project, $commentId);
+
+        $this->assertEquals(0, $comment->score);
+        LexCommentCommands::plusOneComment($project->id->asString(), $user1Id, $commentId);
+        LexCommentCommands::plusOneComment($project->id->asString(), $user2Id, $commentId);
+
+        $comment->read($commentId);
+        $this->assertEquals(2, $comment->score);
+    }
+
+    public function testPlusOneComment_UserAlready_ScoreIsSame()
+    {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $user1Id = $environ->createUser('joe', 'joe', 'joe');
+
+        $regarding = array(
+            'field' => 'lexeme',
+            'fieldValue' => 'Word 1',
+            'inputSystem' => 'th',
+            'word' => '',
+            'meaning' => ''
+        );
+        $data = array(
+            'id' => '',
+            'content' => 'hi there!',
+            'regarding' => $regarding
+        );
+        $commentId = LexCommentCommands::updateComment($project->id->asString(), $user1Id, $environ->website, $data);
+        $comment = new LexCommentModel($project, $commentId);
+
+        $this->assertEquals(0, $comment->score);
+        LexCommentCommands::plusOneComment($project->id->asString(), $user1Id, $commentId);
+        LexCommentCommands::plusOneComment($project->id->asString(), $user1Id, $commentId);
+
+        $comment->read($commentId);
+        $this->assertEquals(1, $comment->score);
+    }
+}

--- a/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
@@ -120,7 +120,7 @@ class LexEntryCommandsTest extends TestCase
 
     }
 
-    public function disabled_testUpdateEntry_DataPersists()  // Temporarily disabled to get TeamCity to build 2018-02-21 RM
+    public function testUpdateEntry_DataPersists()
     {
         $project = self::$environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
         $projectId = $project->id->asString();


### PR DESCRIPTION
Created migration script for comments that have no contextGuid available so that they now appear in the context they were likely to have been made in.

Trello Card:
https://trello.com/c/yGJuYzVD/1038-migration-script-comments-that-were-created-before-this-new-feature-got-merged-dont-increase-the-comment-counter-next-to-the-fie

Part of the fix also includes changing the `comment.regarding.inputSystem` to use the `tag` as opposed to the `languageName` that was recently fixed in `569d222`

There is also a fix to display a thumbnail of any pictures when viewing comments from the global button in the header:
![image](https://user-images.githubusercontent.com/17464863/36997953-3bbc0474-2120-11e8-8565-237c62d40c5c.png)
