### PR TITLE
Fix highlight background color of typeahead

### DIFF
--- a/src/angular-app/bellows/directive/palaso-ui.scss
+++ b/src/angular-app/bellows/directive/palaso-ui.scss
@@ -27,10 +27,6 @@ div.typeahead ul {
 
   li {
     padding: 0.25rem;
-
-    &:hover {
-      background-color: $background-highlight;
-    }
   }
 }
 


### PR DESCRIPTION
The typeahead had a bright yellowish background for the item being hovered over. This made it illegible because the text goes to white on hover. There is already a dark blue background in place on hover. With these lines removed it looks how one would think it would.

Not sure how this became a problem, but before it just looked wrong and was illegible, and now it looks right.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/201)
<!-- Reviewable:end -->
