### PR TITLE
Improve "why this field is disabled" message

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.html
@@ -9,12 +9,14 @@
                 <!--
                 <dc-text class="dc-text"
                     fte-disabled="!($state.is('editor.entry') && control.rights.canEditEntry())"
+                    fte-disabled-reason="control.rights.sendReceive.isInProgress() ? 'sr-in-progress' : 'editing-not-permitted'"
                     fte-multiline="true"
                     fte-model="model.paragraphsHtml"
                     fte-dir="inputSystemDirection(model.inputSystem)"></dc-text>
                     -->
                 <dc-text class="dc-text"
                     fte-disabled="true"
+                    fte-disabled-reason="'would-lose-metadata'"
                     fte-multiline="true"
                     fte-model="model.paragraphsHtml"
                     fte-dir="inputSystemDirection(model.inputSystem)"></dc-text>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
@@ -11,6 +11,7 @@
                 <dc-text class="dc-text" data-ng-if="!isAudio(tag)"
                     fte-multiline="false"
                     fte-disabled="! ($state.is('editor.entry') && control.rights.canEditEntry()) || modelContainsSpan(tag)"
+                    fte-disabled-reason="modelContainsSpan(tag) ? 'would-lose-metadata' : control.rights.sendReceive.isInProgress() ? 'sr-in-progress' : 'editing-not-permitted'"
                     fte-toolbar="[[]]"
                     fte-model="model[tag].value"
                     fte-dir="inputSystemDirection(tag)"></dc-text>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-text.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-text.html
@@ -4,7 +4,7 @@
     ng-model="$ctrl.textFieldValue"
     ng-change="$ctrl.inputChanged()"
     ng-disabled="$ctrl.fteDisabled"
-    title="{{$ctrl.fteDisabled ? $ctrl.disabledMsg : ''}}">
+    title="{{$ctrl.fteDisabled ? $ctrl.disabledMsg() : ''}}">
 </div>
 
 <div ng-if="$ctrl.fteMultiline"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-text.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-text.js
@@ -279,8 +279,7 @@ angular.module('palaso.ui.dc.text', ['coreModule', 'textAngular'])
             return 'A Send/Receive is in progress. Any edits made now would be lost. Please '
               + 'wait until the Send/Receive has completed before making further edits.'
           case 'editing-not-permitted':
-            return 'You do not have permission to edit the data in this project. If you '
-              + 'need to edit this project, please contact the project manager.'
+            return '';  // When someone's just an observer on the project, we want NO explanation popup
           default:
             return 'This field cannot be edited.';
         }

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-text.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-text.js
@@ -262,15 +262,29 @@ angular.module('palaso.ui.dc.text', ['coreModule', 'textAngular'])
       fteModel: '=',
       fteToolbar: '=',
       fteDisabled: '=',
+      fteDisabledReason: '=',
       fteMultiline: '=',
       fteDir: '='
     },
     controller: ['$scope', 'sessionService', function ($scope, ss) {
       var ctrl = this;
       ctrl.fte = {};
-      ctrl.disabledMsg = 'This field cannot be edited because it contains metadata that would '
-        + 'be lost by editing in Language Forge. Fields with metadata may be edited in '
-        + 'Fieldworks Language Explorer.';
+      ctrl.disabledMsg = function disabledMsg() {
+        switch (ctrl.fteDisabledReason) {
+          case 'would-lose-metadata':
+            return 'This field cannot be edited because it contains metadata that would '
+              + 'be lost by editing in Language Forge. Fields with metadata may be edited in '
+              + 'Fieldworks Language Explorer.';
+          case 'sr-in-progress':
+            return 'A Send/Receive is in progress. Any edits made now would be lost. Please '
+              + 'wait until the Send/Receive has completed before making further edits.'
+          case 'editing-not-permitted':
+            return 'You do not have permission to edit the data in this project. If you '
+              + 'need to edit this project, please contact the project manager.'
+          default:
+            return 'This field cannot be edited.';
+        }
+      }
 
       if (!ctrl.fteMultiline) {
 


### PR DESCRIPTION
Text fields can be disabled for several reasons: the field contains metadata like `<span>` tags that would be lost if it's edited in LF. Or there's a Send/Receive in progress. Or the user doesn't have permission to edit the project (Observer role, for instance). These three cases should show different messages in the hover text.

This PR is merging into the `lf-qa` branch instead of master because we currently have QA branching off of master at a point a few commits back from HEAD. (Specifically, just before the commit where the unified-config feature was merged into master). And this code needs to go into QA so that we can deploy it to live in the upcoming deployment. Once QA is merged into `lf-live` and released, we will merge `lf-qa` and `lf-live` back into master, and this code will get into master at that time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/206)
<!-- Reviewable:end -->
