### PR TITLE
Reordering senses and examples

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
@@ -27,6 +27,7 @@
         <!--suppress JSUnusedLocalSymbols -->
         <div data-ng-repeat="sense in $ctrl.model.senses">
             <dc-sense model="sense" config="$ctrl.config.fields.senses" control="$ctrl.control" index="$index"
+                      move="$ctrl.moveSense" num-senses="$ctrl.numSenses"
                       parent-context-guid="$ctrl.contextGuid" remove="$ctrl.deleteSense" ></dc-sense>
         </div>
     </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
@@ -59,6 +59,17 @@ export class FieldEntryController implements angular.IController {
       }, () => {});
   }
 
+  numSenses = () => this.model.senses.length;
+
+  moveSense = (index: number, distance: number) => {
+    const senses = this.model.senses;
+    const sense = senses[index];
+    const newPosition = index + distance;
+    if (newPosition < 0 || newPosition >= senses.length) throw new Error();
+    senses.splice(index, 1); // remove 1 element starting from index
+    senses.splice(newPosition, 0, sense); // insert sense, overwriting 0 elements
+  }
+
 }
 
 export const FieldEntryComponent: angular.IComponentOptions = {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
@@ -59,9 +59,9 @@ export class FieldEntryController implements angular.IController {
       }, () => {});
   }
 
-  numSenses = () => this.model.senses.length;
+  numSenses = (): number => this.model.senses.length;
 
-  moveSense = (index: number, distance: number) => {
+  moveSense = (index: number, distance: number): void => {
     const senses = this.model.senses;
     const sense = senses[index];
     const newPosition = index + distance;

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.html
@@ -2,12 +2,20 @@
     <div class="card-header">
         <div data-ng-show="$ctrl.control.rights.canEditEntry() && $ctrl.isAtEditorEntry()"
              class="dropdown float-right" uib-dropdown>
-             <a class="btn ellipsis-menu-toggle pui-no-caret" uib-dropdown-toggle>
-                 <span class="fa fa-ellipsis-v"></span>
-             </a>
-             <div class="dropdown-menu-right" uib-dropdown-menu>
-                 <a href data-ng-click="$ctrl.remove($ctrl.index)" class="dropdown-item">Delete Example {{$ctrl.index+1}}</a>
-             </div>
+            <a class="btn ellipsis-menu-toggle pui-no-caret" uib-dropdown-toggle>
+                <span class="fa fa-ellipsis-v"></span>
+            </a>
+            <div class="dropdown-menu-right" uib-dropdown-menu>
+                <a href data-ng-click="$ctrl.remove($ctrl.index)" class="dropdown-item">
+                    <span class="fa fa-trash"></span> Delete Example {{$ctrl.index+1}}
+                </a>
+                <a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="dropdown-item">
+                    <span class="fa fa-arrow-up"></span> Move Up
+                </a>
+                <a href data-ng-show="$ctrl.index+1 < $ctrl.numExamples()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="dropdown-item">
+                    <span class="fa fa-arrow-down"></span> Move Down
+                </a>
+            </div>
         </div>
         Example <span class="notranslate">{{$ctrl.index+1}}</span>
     </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.ts
@@ -46,8 +46,8 @@ export const FieldExampleComponent: angular.IComponentOptions = {
     config: '<',
     control: '<',
     index: '<',
-    move: '<',
-    numExamples: '<',
+    move: '&',
+    numExamples: '&',
     parentContextGuid: '<',
     remove: '&'
   },

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.ts
@@ -46,6 +46,8 @@ export const FieldExampleComponent: angular.IComponentOptions = {
     config: '<',
     control: '<',
     index: '<',
+    move: '<',
+    numExamples: '<',
     parentContextGuid: '<',
     remove: '&'
   },

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.ts
@@ -46,8 +46,8 @@ export const FieldExampleComponent: angular.IComponentOptions = {
     config: '<',
     control: '<',
     index: '<',
-    move: '&',
-    numExamples: '&',
+    move: '<',
+    numExamples: '<',
     parentContextGuid: '<',
     remove: '&'
   },

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
@@ -6,7 +6,15 @@
                 <span class="fa fa-ellipsis-v"></span>
             </a>
             <div class="dropdown-menu-right" uib-dropdown-menu>
-                <a href data-ng-click="$ctrl.remove($ctrl.index)" class="dropdown-item">Delete Meaning {{$ctrl.index+1}}</a>
+                <a href data-ng-click="$ctrl.remove($ctrl.index)" class="dropdown-item">
+                    <span class="fa fa-trash"></span> Delete Meaning {{$ctrl.index+1}}
+                </a>
+                <a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="dropdown-item">
+                    <span class="fa fa-arrow-up"></span> Move Up
+                </a>
+                <a href data-ng-show="$ctrl.index+1 < $ctrl.numSenses()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="dropdown-item">
+                    <span class="fa fa-arrow-down"></span> Move Down
+                </a>
             </div>
         </div>
         Meaning <span class="notranslate">{{$ctrl.index+1}}</span>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
@@ -25,6 +25,7 @@
             <!--suppress JSUnusedLocalSymbols -->
             <div data-ng-repeat="example in $ctrl.model.examples">
                 <dc-example model="example" config="$ctrl.config.fields.examples" control="$ctrl.control" index="$index"
+                            move="$ctrl.moveExample" num-examples="$ctrl.numExamples"
                             parent-context-guid="$ctrl.contextGuid" remove="$ctrl.deleteExample" ></dc-example>
             </div>
             <div data-ng-if="$ctrl.control.rights.canEditEntry() && $ctrl.isAtEditorEntry()" class="addItem">

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
@@ -47,6 +47,17 @@ export class FieldSenseController implements angular.IController {
     this.control.hideRightPanel();
   }
 
+  numExamples = () => this.model.examples.length;
+
+  moveExample = (index: number, distance: number) => {
+    const examples = this.model.examples;
+    const example = examples[index];
+    const newPosition = index + distance;
+    if (newPosition < 0 || newPosition >= examples.length) throw new Error();
+    examples.splice(index, 1); // remove 1 element starting from index
+    examples.splice(newPosition, 0, example); // insert example, overwriting 0 elements
+  }
+
   deleteExample = (index: number): void => {
     const deletemsg = 'Are you sure you want to delete the example <b>\' ' +
       LexiconUtilityService.getExample(this.control.config, this.config.fields.examples as LexConfigFieldList,

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
@@ -78,8 +78,8 @@ export const FieldSenseComponent: angular.IComponentOptions = {
     config: '<',
     control: '<',
     index: '<',
-    numSenses: '&',
-    move: '&',
+    numSenses: '<',
+    move: '<',
     parentContextGuid: '<',
     remove: '&'
   },

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
@@ -47,9 +47,9 @@ export class FieldSenseController implements angular.IController {
     this.control.hideRightPanel();
   }
 
-  numExamples = () => this.model.examples.length;
+  numExamples = (): number => this.model.examples.length;
 
-  moveExample = (index: number, distance: number) => {
+  moveExample = (index: number, distance: number): void => {
     const examples = this.model.examples;
     const example = examples[index];
     const newPosition = index + distance;
@@ -78,8 +78,8 @@ export const FieldSenseComponent: angular.IComponentOptions = {
     config: '<',
     control: '<',
     index: '<',
-    numSenses: '<',
-    move: '<',
+    numSenses: '&',
+    move: '&',
     parentContextGuid: '<',
     remove: '&'
   },

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
@@ -67,6 +67,8 @@ export const FieldSenseComponent: angular.IComponentOptions = {
     config: '<',
     control: '<',
     index: '<',
+    numSenses: '<',
+    move: '<',
     parentContextGuid: '<',
     remove: '&'
   },

--- a/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
@@ -418,7 +418,6 @@ describe('Lexicon E2E Editor List and Entry', () => {
   });
 
   it('word with multiple meanings: edit page has correct example sentences, translations', () => {
-    // Empty array elements are a work-around for getFieldValues after SemDom directive added. DDW
     expect<any>(editorUtil.getFieldValues('Sentence')).toEqual([
       { th: constants.testMultipleMeaningEntry1.senses[0].examples[0].sentence.th.value },
       { th: constants.testMultipleMeaningEntry1.senses[0].examples[1].sentence.th.value },
@@ -448,7 +447,6 @@ describe('Lexicon E2E Editor List and Entry', () => {
     ]);
 
     // First item is empty Etymology Source, now that View Settings all default to visible. IJH
-    // Empty array elements are a work-around for getFieldValues after SemDom directive added. IJH
     expect<any>(editorUtil.getFieldValues('Source')).toEqual([
       { en: constants.testMultipleMeaningEntry1.senses[0].source.en.value },
       { en: constants.testMultipleMeaningEntry1.senses[1].source.en.value }

--- a/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
@@ -420,9 +420,9 @@ describe('Lexicon E2E Editor List and Entry', () => {
   it('word with multiple meanings: edit page has correct example sentences, translations', () => {
     // Empty array elements are a work-around for getFieldValues after SemDom directive added. DDW
     expect<any>(editorUtil.getFieldValues('Sentence')).toEqual([
-      '', { th: constants.testMultipleMeaningEntry1.senses[0].examples[0].sentence.th.value },
+      { th: constants.testMultipleMeaningEntry1.senses[0].examples[0].sentence.th.value },
       { th: constants.testMultipleMeaningEntry1.senses[0].examples[1].sentence.th.value },
-      '', { th: constants.testMultipleMeaningEntry1.senses[1].examples[0].sentence.th.value },
+      { th: constants.testMultipleMeaningEntry1.senses[1].examples[0].sentence.th.value },
       { th: constants.testMultipleMeaningEntry1.senses[1].examples[1].sentence.th.value }
     ]);
     expect<any>(editorUtil.getFieldValues('Translation')).toEqual([
@@ -450,10 +450,19 @@ describe('Lexicon E2E Editor List and Entry', () => {
     // First item is empty Etymology Source, now that View Settings all default to visible. IJH
     // Empty array elements are a work-around for getFieldValues after SemDom directive added. IJH
     expect<any>(editorUtil.getFieldValues('Source')).toEqual([
-      { en: '' }, '',
-      { en: constants.testMultipleMeaningEntry1.senses[0].source.en.value }, '',
+      { en: constants.testMultipleMeaningEntry1.senses[0].source.en.value },
       { en: constants.testMultipleMeaningEntry1.senses[1].source.en.value }
     ]);
+  });
+
+  it('senses can be reordered and deleted', () => {
+    editorPage.edit.sense.actionMenus.first().click();
+    editorPage.edit.sense.moveDown.first().click();
+    expect<any>(editorUtil.getFieldValues('Definition')).toEqual([
+      { en: constants.testMultipleMeaningEntry1.senses[1].definition.en.value },
+      { en: constants.testMultipleMeaningEntry1.senses[0].definition.en.value }
+    ]);
+    editorPage.edit.saveBtn.click();
   });
 
   it('back to browse page, create new word', () => {

--- a/test/app/languageforge/lexicon/shared/editor.page.ts
+++ b/test/app/languageforge/lexicon/shared/editor.page.ts
@@ -267,6 +267,13 @@ export class EditorPage {
 
     senses: element.all(by.css('dc-sense')),
 
+    sense: {
+      actionMenus: this.editDiv.all(by.css('dc-sense .ellipsis-menu-toggle')),
+      deleteSense: this.editDiv.all(by.css('dc-sense .ellipsis-menu-toggle ~ .dropdown-menu fa-trash')),
+      moveUp: this.editDiv.all(by.css('dc-sense .ellipsis-menu-toggle ~ .dropdown-menu .fa-arrow-up')),
+      moveDown: this.editDiv.all(by.css('dc-sense .ellipsis-menu-toggle ~ .dropdown-menu .fa-arrow-down')),
+    },
+
     pictures: {
       list: EditorUtil.getOneField('Pictures'),
       images: EditorUtil.getOneField('Pictures').all(by.css('img')),

--- a/test/app/languageforge/lexicon/shared/editor.util.ts
+++ b/test/app/languageforge/lexicon/shared/editor.util.ts
@@ -106,8 +106,13 @@ export class EditorUtil {
   }
 
   static getFields(searchLabel: string, rootElem: ElementFinder = element(by.className('dc-entry'))) {
-    return rootElem.all(by.cssContainingText('div[data-ng-repeat="fieldName in $ctrl.config.fieldOrder"]',
-      searchLabel));
+    return rootElem.all(by.cssContainingText('div[data-ng-repeat="fieldName in $ctrl.config.fieldOrder"]', searchLabel)).filter(elem => {
+      return elem.getText().then(text => {
+        // getText returns text including child elements, which for fields is generally on a new line
+        if(text.indexOf('\n') !== -1) text = text.substring(0, text.indexOf('\n'));
+        return text === searchLabel;
+      })
+    });
   }
 
   getFieldValues(searchLabel: string, rootElem: ElementFinder = element(by.className('dc-entry')),

--- a/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
@@ -1460,17 +1460,14 @@ class LexEntryCommandsTest extends TestCase
         $example2 = $sense1['examples'][1];
         $sense1['examples'][0] = $example2;
         $sense1['examples'][1] = $example1;
-        $sense2['examples'] = array();
+        $sense2['examples'] = [];
         $params['senses'][0] = $sense2;
         $params['senses'][1] = $sense1;
-
-        print_r($params);
 
         $userId = self::$environ->createUser('john', 'john', 'john');
 
         $params = json_decode(json_encode(LexEntryCommands::updateEntry($projectId, $params, $userId)));
 
-        print_r($params);
         $this->assertEquals($sense1['guid'], $params->senses[1]->guid);
         $this->assertEquals($sense2['guid'], $params->senses[0]->guid);
         $this->assertEquals($example1['guid'], $params->senses[1]->examples[1]->guid);


### PR DESCRIPTION
Reordering senses and examples in the UI is functional and the e2e tests pass. The PHP test, however, is failing, and there appear to be issues with GUIDs changing due to reordering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/209)
<!-- Reviewable:end -->
