### PR TITLE
Remove unused Editor Comments view

### DIFF
--- a/src/angular-app/bellows/directive/_palaso.ui.comments.dc-comment.scss
+++ b/src/angular-app/bellows/directive/_palaso.ui.comments.dc-comment.scss
@@ -235,12 +235,7 @@ div.commentListContainer {
   }
 }
 
-.selectableFieldForComment:hover {
-    background-color: #eee;
-    border: 1px solid $lf-lines;
-    border-radius: $border-radius;
-}
-.selectableFieldForComment, .selectableInputSystemFieldForComment {
+.selectableInputSystemFieldForComment {
     cursor: pointer;
     border: 1px solid transparent;
 }
@@ -252,7 +247,7 @@ div.commentListContainer {
 .selectableInputSystemFieldForComment:hover .input-group-addon {
     background-color: hsla(80, 100%, 50%, 0.1);
 }
-.selectableInputSystemFieldForComment .uneditable-input, .selectableFieldForComment .uneditable-input {
+.selectableInputSystemFieldForComment .uneditable-input {
     cursor: pointer;
 }
 

--- a/src/angular-app/languageforge/lexicon/editor/editor-abstract.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-abstract.html
@@ -9,11 +9,6 @@
                            title="Back to List">
                             <i class="fa fa-arrow-circle-left"></i>
                             <span class="d-none d-md-inline-block">List</span></a>
-
-                        <a id="toEditLink" data-ng-show="$state.is('editor.comments')" class="btn btn-std"
-                           data-ng-click="editEntry(currentEntry.id)" title="Return to Edit Entry">
-                            <i class="fa fa-arrow-circle-left"></i>
-                            Edit </a>
                     </div>
                     <div class="float-right" data-ng-show="$state.is('editor.entry')">
                         <span data-ng-if="rights.canEditEntry()">
@@ -35,12 +30,6 @@
                             <current-entry-comment-count></current-entry-comment-count>
                             <i class="fa fa-comments commentColor"></i>
                         </button>
-                    </div>
-                    <div class="float-right" data-ng-show="$state.is('editor.comments')">
-                        <div id="commentsCount" class="btn btn-std">
-                            <current-entry-comment-count></current-entry-comment-count>
-                            <i class="fa fa-comments commentColor"></i>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-comments.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-comments.html
@@ -1,2 +1,0 @@
-<lex-comments-view id="lexAppCommentView" class="animate-switch" entry-config="config.entry" entry="currentEntry"
-                   control="control"></lex-comments-view>

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -23,11 +23,6 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
         templateUrl: '/angular-app/languageforge/lexicon/editor/editor-entry.html',
         controller: 'EditorEntryCtrl'
       })
-      .state('editor.comments', {
-        url: '/entry/{entryId:[0-9a-z_]{6,24}}/comments',
-        templateUrl: '/angular-app/languageforge/lexicon/editor/editor-comments.html',
-        controller: 'EditorCommentsCtrl'
-      })
       ;
   }])
   .controller('EditorCtrl', ['$scope', 'userService', 'sessionService', 'lexEntryApiService', '$q',
@@ -664,11 +659,6 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
             }
           }
 
-          if ($state.is('editor.comments')) {
-            $scope.editEntryAndScroll(entryId);
-            $scope.showComments();
-          }
-
           if ($state.is('editor.entry')) {
             $scope.editEntryAndScroll(entryId);
           }
@@ -923,7 +913,7 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
                 return !isBlacklisted(key) && isMatch(value[key]);
               });
 
-            case 'string': return value.toUpperCase().indexOf(queryCapital) != -1;
+            case 'string': return value.toUpperCase().indexOf(queryCapital) !== -1;
             case 'null': return false;
             case 'boolean': return false;
             default:
@@ -1016,7 +1006,9 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
         var contextPart = '';
 
         for (var i in contextParts) {
-          if (angular.isDefined(contextParts[i]) && contextParts[i] !== '') {
+          if (contextParts.hasOwnProperty(i) && angular.isDefined(contextParts[i]) &&
+            contextParts[i] !== ''
+          ) {
             contextPart = contextParts[i].trim();
             if (contextPart.indexOf('sense#') !== -1) {
               senseGuid = contextPart.substr(6);
@@ -1039,11 +1031,14 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
 
         if (senseGuid) {
           for (var a in currentEntry.senses) {
-            if (currentEntry.senses[a].guid === senseGuid) {
+            if (currentEntry.senses.hasOwnProperty(a) && currentEntry.senses[a].guid === senseGuid
+            ) {
               senseIndex = a;
               if (exampleGuid) {
                 for (var b in currentEntry.senses[a].examples) {
-                  if (currentEntry.senses[a].examples[b].guid === exampleGuid) {
+                  if (currentEntry.senses[a].examples.hasOwnProperty(b) &&
+                    currentEntry.senses[a].examples[b].guid === exampleGuid
+                  ) {
                     exampleIndex = b;
                   }
                 }
@@ -1090,7 +1085,8 @@ angular.module('lexicon.editor', ['ui.router', 'ui.bootstrap', 'coreModule',
               // Semantic domains are in the global scope and appear to be English only
               // Will need to be updated once the system provides support for other languages
               for (var i in semanticDomains_en) {
-                if (semanticDomains_en[i].key === optionKey) {
+                if (semanticDomains_en.hasOwnProperty(i) && semanticDomains_en[i].key === optionKey
+                ) {
                   optionLabel = semanticDomains_en[i].value;
                 }
               }

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-fieldrepeat.html
@@ -1,7 +1,6 @@
 <div data-ng-repeat="fieldName in config.fieldOrder">
     <div data-ng-if="!config.fields[fieldName].hideIfEmpty || control.show.emptyFields ||
-        (config.fields[fieldName].hideIfEmpty && fieldContainsData(config.fields[fieldName].type, model[fieldName]))"
-        data-ng-class="{selectableFieldForComment: $state.is('editor.comments') && control.rights.canComment()}">
+        (config.fields[fieldName].hideIfEmpty && fieldContainsData(config.fields[fieldName].type, model[fieldName]))">
         <div data-ng-switch data-on="config.fields[fieldName].type" class="field-container">
             <div data-ng-switch-when="optionlist">
                 <dc-optionlist class="dc-item" control="control"

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multiparagraph.html
@@ -2,8 +2,7 @@
     <div class="form-group row comment-bubble-group">
         <label class="col-form-label col-lg-4 text-lg-right">{{config.label}}</label>
         <div class="controls col-lg-8">
-            <div class="input-group" data-ng-click="selectInputSystem(model.inputSystem)"
-                data-ng-class="{selectableInputSystemFieldForComment: $state.is('editor.comments') && control.rights.canComment()}">
+            <div class="input-group" data-ng-click="selectInputSystem(model.inputSystem)">
                 <span class="wsid input-group-addon notranslate"
                     title="{{inputSystems[model.inputSystem].languageName}}">{{inputSystems[model.inputSystem].abbreviation}}</span>
                 <!--

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.html
@@ -4,8 +4,7 @@
                data-ng-class="$first ? '' : 'd-none d-lg-inline-block'">
             <span data-ng-show="$first">{{config.label}}</span></label>
         <div class="controls" data-ng-class="config.type == 'pictures' ? 'col' : 'col-lg-8'">
-            <div class="input-group" data-ng-click="selectInputSystem(tag)"
-                 data-ng-class="{selectableInputSystemFieldForComment: $state.is('editor.comments') && control.rights.canComment()}">
+            <div class="input-group" data-ng-click="selectInputSystem(tag)">
                 <span class="wsid input-group-addon notranslate" tabindex="-1"
                     title="{{tag}} {{inputSystems[tag].languageName}}">{{inputSystems[tag].abbreviation}}</span>
                 <dc-text class="dc-text" data-ng-if="!isAudio(tag)"


### PR DESCRIPTION
Looks like we aren't using the **Editor Comments** view any more. This removes it and cleans up. E2E LF passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/220)
<!-- Reviewable:end -->
