### PR TITLE
Navigate to last selected segment when opening project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2617,6 +2617,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "requires": {
+        "exit-on-epipe": "1.0.1",
+        "printj": "1.1.2"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
@@ -3774,6 +3783,11 @@
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
     "expand-braces": {
       "version": "0.1.2",
@@ -11384,6 +11398,11 @@
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
+    },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
     },
     "private": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "angularjs-slider": "^6.2.3",
     "bootstrap": "4.0.0-beta.2",
     "core-js": "^2.4.1",
+    "crc-32": "^1.2.0",
     "font-awesome": "^4.7.0",
     "intl-tel-input": "9.2.7",
     "jquery": "3.1.1",

--- a/src/Api/Model/Shared/Translate/Command/TranslateProjectCommands.php
+++ b/src/Api/Model/Shared/Translate/Command/TranslateProjectCommands.php
@@ -236,7 +236,9 @@ class TranslateProjectCommands
             array_key_exists('isDocumentOrientationTargetRight', $data) ||
             array_key_exists('isFormattingOptionsShown', $data) ||
             array_key_exists('hasConfidenceOverride', $data) ||
-            array_key_exists('confidenceThreshold', $data)
+            array_key_exists('confidenceThreshold', $data) ||
+            array_key_exists('selectedSegmentRef', $data) ||
+            array_key_exists('selectedSegmentChecksum', $data)
         ) {
             if (!array_key_exists($userId, $usersPreferences)) {
                 $usersPreferences[$userId] = new TranslateUserPreferences();
@@ -258,8 +260,12 @@ class TranslateProjectCommands
                 $usersPreferences[$userId]->hasConfidenceOverride = $data['hasConfidenceOverride'];
             }
 
-            if (array_key_exists('confidenceThreshold', $data)) {
-                $usersPreferences[$userId]->confidenceThreshold = $data['confidenceThreshold'];
+            if (array_key_exists('selectedSegmentRef', $data)) {
+                $usersPreferences[$userId]->selectedSegmentRef = $data['selectedSegmentRef'];
+            }
+
+            if (array_key_exists('selectedSegmentChecksum', $data)) {
+                $usersPreferences[$userId]->selectedSegmentChecksum = $data['selectedSegmentChecksum'];
             }
         }
     }

--- a/src/Api/Model/Shared/Translate/TranslateConfig.php
+++ b/src/Api/Model/Shared/Translate/TranslateConfig.php
@@ -104,6 +104,8 @@ class TranslateUserPreferences
         $this->isDocumentOrientationTargetRight = true;
         $this->isFormattingOptionsShown = false;
         $this->selectedDocumentSetId = '';
+        $this->selectedSegmentRef = '';
+        $this->selectedSegmentChecksum = 0;
     }
 
     /** @var float */
@@ -120,6 +122,12 @@ class TranslateUserPreferences
 
     /** @var string */
     public $selectedDocumentSetId;
+
+    /** @var string */
+    public $selectedSegmentRef;
+
+    /** @var int [s] */
+    public $selectedSegmentChecksum;
 }
 
 class TranslateConfigMetrics

--- a/src/angular-app/bellows/apps/translate/editor/editor.component.html
+++ b/src/angular-app/bellows/apps/translate/editor/editor.component.html
@@ -4,7 +4,6 @@
 </label>
 <div id="toolbar" class="row flex-no-grow align-items-center">
     <span class="ql-formats">
-        <a class="btn btn-primary" href="#" data-ng-click="$ctrl.gotoProjects()">Save &amp; Close</a>
         <a class="btn btn-secondary" href="#" data-ng-click="$ctrl.train()"
            data-ng-if="!$ctrl.isTraining && $ctrl.hasDocumentSets() && $ctrl.tecRights.canEditProject()">Train</a>
         <uib-progress class="training" data-ng-if="$ctrl.isTraining" title="Training">

--- a/src/angular-app/bellows/apps/translate/shared/model/translate-config.model.ts
+++ b/src/angular-app/bellows/apps/translate/shared/model/translate-config.model.ts
@@ -22,11 +22,13 @@ export class TranslateConfigDocumentSets {
 }
 
 export class TranslateUserPreferences {
-  confidenceThreshold: number;
-  hasConfidenceOverride: boolean;
-  isDocumentOrientationTargetRight: boolean;
-  isFormattingOptionsShown: boolean;
-  selectedDocumentSetId: string;
+  confidenceThreshold?: number;
+  hasConfidenceOverride?: boolean;
+  isDocumentOrientationTargetRight?: boolean;
+  isFormattingOptionsShown?: boolean;
+  selectedDocumentSetId?: string;
+  selectedSegmentRef?: string;
+  selectedSegmentChecksum?: number;
 }
 
 export class TranslateConfigMetrics {

--- a/src/netcore-api/SIL.XForge.WebApi.Server/Models/Translate/TranslateUserPreferences.cs
+++ b/src/netcore-api/SIL.XForge.WebApi.Server/Models/Translate/TranslateUserPreferences.cs
@@ -7,5 +7,7 @@ namespace SIL.XForge.WebApi.Server.Models.Translate
         public bool IsDocumentOrientationTargetRight { get; set; } = true;
         public bool IsFormattingOptionsShown { get; set; }
         public string SelectedDocumentSetId { get; set; } = "";
+        public string SelectedSegmentRef { get; set; } = "";
+        public int SelectedSegmentChecksum { get; set; }
     }
 }


### PR DESCRIPTION
- Save the ref of the last segment that the user was editing along with a checksum for the segment.
- When the user opens the project again, navigate to the saved segment.
- Check if the segment has changed by checking the checksum.
- The "Save & Close" button is no longer necessary, since a changed segment will eventually be trained when the user switches segments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/221)
<!-- Reviewable:end -->
