### PR TITLE
Paratext export contains question in context

### DIFF
--- a/test/php/library/scriptureforge/sfchecks/ParatextExportTest.php
+++ b/test/php/library/scriptureforge/sfchecks/ParatextExportTest.php
@@ -67,7 +67,7 @@ class ParatextExportTest extends TestCase
         );
         $download = ParatextExport::exportCommentsForText($project->id->asString(), $textId, $params);
 
-        $this->assertRegExp('/<Contents>first comment \(by user1/', $download['xml']);
+        $this->assertRegExp('/<Contents>\(user1 commented in reply to user3\) first comment/', $download['xml']);
         $this->assertRegExp('/\(Tags: export, to review\) \(10 Votes\)<\/Contents>/', $download['xml']);
     }
 
@@ -127,9 +127,9 @@ class ParatextExportTest extends TestCase
         $download = ParatextExport::exportCommentsForText($project->id->asString(), $textId, $params);
         //echo '<pre>' . print_r($download) . '</pre>';
 
-        $this->assertRegExp('/<Contents>third answer - very very very very long \(by user3/', $download['xml']);
-        $this->assertNotRegExp('/<Contents>second answer/', $download['xml']);
-        $this->assertRegExp('/<Contents>first answer/', $download['xml']);
+        $this->assertRegExp('/<Contents>\(Question\) the question \(Answered by user3\) third answer - very very very very long/', $download['xml']);
+        $this->assertNotRegExp('/second answer/', $download['xml']);
+        $this->assertRegExp('/first answer/', $download['xml']);
     }
 
     public function testExportCommentsForText_QuestionArchived_NoneExported()


### PR DESCRIPTION
This is in response to an user who found it hard to process answers and comments without seeing the question in context.

This will export the question title along with the answer.  Comments also now show who it was in reply to.

This is a minimal change to be able to ship this functionality out to an user.

Upon reviewing the code, it seemed to me that this class should be refactored to be a proper class without all static functions, and move the "main" static function to one of the Command classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/225)
<!-- Reviewable:end -->
