### PR TITLE
Fix bug where invited users can't do OAuth signup

### DIFF
--- a/src/Site/Controller/Validate.php
+++ b/src/Site/Controller/Validate.php
@@ -7,7 +7,8 @@ use Silex\Application;
 
 class Validate extends Base
 {
-    public function check(Application $app, $validateKey = '') {
+    public static function check(Application $app, $validateKey = '')
+    {
         $userActivated = false;
         $userModel = new UserModel();
         if ($userModel->readByProperty('validationKey', $validateKey)) {
@@ -17,9 +18,12 @@ class Validate extends Base
                 $userActivated = true;
             }
         }
+        return $userActivated;
+    }
 
-        if ($userActivated) {
-            $app['session']->getFlashBag()->add('infoMessage', 'Congratulations!  You email has been validated and you\'re ready to login.');
+    public function checkAndRedirect(Application $app, $validateKey = '') {
+        if (self::check($app, $validateKey)) {
+            $app['session']->getFlashBag()->add('infoMessage', 'Congratulations!  Your email has been validated and you\'re ready to login.');
         }
         return $app->redirect('/auth/login');
     }

--- a/src/Site/OAuth/OAuthBase.php
+++ b/src/Site/OAuth/OAuthBase.php
@@ -9,6 +9,7 @@ use League\OAuth2\Client\Token\AccessToken as OAuthAccessToken;
 use Silex\Application;
 use Site\Controller\Base;
 use Site\Controller\Exception;
+use Site\Controller\Validate;
 use Site\Model\UserWithId;
 use Site\Provider\AuthUserProvider;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -261,7 +262,18 @@ abstract class OAuthBase extends Base
                 } else {
                     // Found an email address matching this OAuth token, so add the token
                     $this->addOAuthIdToUserModel($userModel, $googleOAuthId);
+                    if (empty($userModel->username) && ! empty($userModel->email)) {
+                        // This can happen when someone is invited to join a project: they initially have an email address but no username
+                        // Since they logged in via OAuth, they don't care about their username, so just pick one for them
+                        $userModel->setUniqueUsernameFromString($userModel->email);
+                    }
                     $userModel->write();
+                    if (! empty($userModel->validationKey)) {
+                        // We'll consider that an OAuth login is equivalent to validating your email address.
+                        // NOTE: This needs to happen *after* the user model has been written above,
+                        // so that any changes made by Validate::check won't be overwritten by our write() call
+                        Validate::check($app, $userModel->validationKey);
+                    }
                     $success = $this->setSilexAuthToken($userModel, $app);
                     if (! $success) {
                         $this->addErrorMessage($app, 'Sorry, we couldn\'t process the ' . ucwords($this->getProviderName()) . ' login data. This may be a temporary failure, so please try again. If the problem persists, try logging in with a username and password instead.');

--- a/src/index.php
+++ b/src/index.php
@@ -256,7 +256,7 @@ $app->get('/public/{appName}/{projectId}', 'Site\Controller\App::view');
 $app->get('/public/{appName}/', 'Site\Controller\App::view');
 $app->get('/public/{appName}', 'Site\Controller\App::view');
 
-$app->get('/validate/{validateKey}', 'Site\Controller\Validate::check');
+$app->get('/validate/{validateKey}', 'Site\Controller\Validate::checkAndRedirect');
 $app->get('/auth/reset_password/{resetPasswordKey}', 'Site\Controller\Auth::view')->value('appName', 'reset_password');
 $app->get('/auth/{appName}',    'Site\Controller\Auth::view')->value('appName', 'login');
 $app->post('/auth/forgot_password', 'Site\Controller\Auth::forgotPassword')->bind('auth_forgot_password');


### PR DESCRIPTION
The cause was that the invite-a-user feature doesn't assign a username and requires validation. I decided that OAuth authentication counts as validating your email address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/230)
<!-- Reviewable:end -->
