### PR TITLE
Add build parameter for Gather Words client ID

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1005,6 +1005,11 @@ gulp.task('build-productionConfig', function () {
     googleClientSecret = 'googleClientSecret';
   }
 
+  var gatherWordsClientId = process.env.GATHERWORDS_CLIENT_ID;
+  if (gatherWordsClientId === undefined) {
+    gatherWordsClientId = 'gatherWordsClientId';
+  }
+
   var paratextClientId = process.env.PARATEXT_CLIENT_ID;
   if (paratextClientId === undefined) {
     paratextClientId = 'paratextClientId';
@@ -1044,6 +1049,10 @@ gulp.task('build-productionConfig', function () {
       // default: secrets_google_api_client_id.web.client_secret,
       default: googleClientSecret,
       type: 'string' })
+    .option('gatherWordsClientId', {
+      demand: false,
+      default: gatherWordsClientId,
+      type: 'string' })
     .option('paratextClientId', {
       demand: false,
       default: paratextClientId,
@@ -1079,6 +1088,9 @@ gulp.task('build-productionConfig', function () {
     .pipe(replace(
       /(define\('GOOGLE_CLIENT_SECRET', ').*;$/m,
       '$1' + params.googleClientSecret + '\');'))
+    .pipe(replace(
+      /(define\('GATHERWORDS_CLIENT_ID', ').*;$/m,
+      '$1' + params.gatherWordsClientId + '\');'))
     .pipe(replace(
       /(define\('PARATEXT_CLIENT_ID', ').*;$/m,
       '$1' + params.paratextClientId + '\');'))

--- a/src/Site/OAuth/OAuthJWTToken.php
+++ b/src/Site/OAuth/OAuthJWTToken.php
@@ -56,7 +56,8 @@ class OAuthJWTToken extends GoogleOAuth
             return false;
         }
 
-        if ($access["aud"] != ANDROID_CLIENT_ID)
+        // Currently only the Gather Words Android app should be using JWT tokens. 2018-04 RM
+        if ($access["aud"] != GATHERWORDS_CLIENT_ID)
         {
             return false;
         }

--- a/src/config.php
+++ b/src/config.php
@@ -67,6 +67,10 @@ if (! defined('GOOGLE_CLIENT_SECRET')) {
     define('GOOGLE_CLIENT_SECRET', 'googleClientSecret');
 }
 
+if (! defined('GATHERWORDS_CLIENT_ID')) {
+    define('GATHERWORDS_CLIENT_ID', 'gatherWordsClientId');
+}
+
 if (! defined('PARATEXT_CLIENT_ID')) {
     define('PARATEXT_CLIENT_ID', 'paratextClientId');
 }


### PR DESCRIPTION
This allows us to supply the OAuth client ID for the Gather Words appvia either a Gulp build parameter (`-- gatherWordsClientId`) or via the `GATHER_WORDS_CLIENT_ID` environment variable. We use the latter in our TeamCity build so that the client ID won't show up in logs. (Less important when it comes to client IDs, but important when it comes to client secrets — though the Android app OAuth process doesn't use client secrets.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/234)
<!-- Reviewable:end -->
