### PR TITLE
deploy: update for xenial server via vagrant

### DIFF
--- a/deploy/code.yml
+++ b/deploy/code.yml
@@ -10,9 +10,7 @@
         chdir: "{{item}}"
       changed_when: false
       when: inventory_hostname == "localhost"
-      with_items:
-        - /var/www/virtual/languageforge.org/htdocs
-        - /var/www/virtual/scriptureforge.org/htdocs
+      with_items: "{{site_src_paths}}"
 
     - name: bower install
       command: bower install --allow-root
@@ -20,9 +18,7 @@
         chdir: "{{item}}"
       changed_when: false
       when: inventory_hostname == "localhost"
-      with_items:
-        - /var/www/virtual/languageforge.org/htdocs
-        - /var/www/virtual/scriptureforge.org/htdocs
+      with_items: "{{site_src_paths}}"
 
     - name: factory reset mongodb to empty with admin user
       shell: php FactoryReset.php run

--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -88,14 +88,15 @@
           value: 'retry:no outbound email allowed'
       notify: restart postfix
 
-    - name: Ensure default_local folder does not exist (localhost)
+    # This stanza ensures that the /var/www/virtual/default_local links to wherever your source actually is.
+    - name: "Ensure Source Link: default_local folder does not exist (localhost)"
       file: path="/var/www/virtual/default_local" state=absent force=true
       when: inventory_hostname == "localhost"
-    - name: Get local dir (localhost)
+    - name: "Ensure Source Link: Get current location of the source code (localhost)"
       local_action: shell pwd
       register: local_dir
       when: inventory_hostname == "localhost"
-    - name: Ensure default_local link exists (localhost)
+    - name: "Ensure Source Link: default_local link exists (localhost)"
       file: src="{{local_dir.stdout | dirname | dirname | realpath}}" dest="/var/www/virtual/default_local" state=link group=www-data force=true
       when: inventory_hostname == "localhost"
 

--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -1,0 +1,23 @@
+---
+
+- name: "Dev: Install packages"
+  apt: name="{{item}}" state=present
+  with_items:
+    - chromium-browser
+
+- name: "Dev VSCode: Check if already installed"
+  command: dpkg-query -W code
+  register: dev_vscode
+  failed_when: dev_vscode.rc > 1
+  changed_when: dev_vscode.rc == 1
+
+- name: "Dev VSCode: Download"
+  get_url:
+    url: http://downloads.sil.org/vagrant/packages/code_1.7.2-1479766213_amd64.deb
+    dest: /home/vagrant/
+  when: dev_vscode.rc == 1
+
+- name: "Dev VSCode: Install"
+  apt: deb="/home/vagrant/code_1.7.2-1479766213_amd64.deb"
+  sudo: true
+  when: dev_vscode.rc == 1

--- a/deploy/playbook_create_config.yml
+++ b/deploy/playbook_create_config.yml
@@ -24,7 +24,7 @@
          value: '1'
        - property: 'roles_path'
          value: '/etc/ansible/roles:./roles_common:./roles'
-       - property: 'ssh_args'
-         value: '-o UserKnownHostsFile=.vagrant/known_hosts'
+       - property: 'pipelining'
+         value: 'true'
      when: cfg.stat.exists == False
 

--- a/deploy/playbook_xenial_server_vagrant.yml
+++ b/deploy/playbook_xenial_server_vagrant.yml
@@ -1,0 +1,10 @@
+---
+
+- include: dependencies.yml
+  vars:
+    deploy: lf_only
+- include: code.yml
+  vars:
+    site_src_paths:
+      - /home/vagrant/src/web-languageforge/src
+    lf_path: /home/vagrant/src/web-languageforge

--- a/deploy/playbook_xenial_vagrant.yml
+++ b/deploy/playbook_xenial_vagrant.yml
@@ -14,3 +14,4 @@
 - include: code.yml
   vars:
     lf_path: /home/vagrant/src/xForge/web-languageforge
+- include: dev.yml

--- a/deploy/vars_lf_only.yml
+++ b/deploy/vars_lf_only.yml
@@ -6,31 +6,15 @@
 mongo_path: /var/lib/mongodb
 php_log_folder: /var/log/php
 lf_path: /var/www/virtual/default_local/web-languageforge
-sf_path: /var/www/virtual/default_local/web-scriptureforge
+sf_path: "{{lf_path}}"
 
 ssl_letsencrypt_install: false
 
-ssl_items:
-  - name: scriptureforge
-    state: selfsign
-    request:
-        country_code: "TH"
-        state: "Chiang Mai"
-        locality: "Chiang Mai"
-        organization: "SIL"
-        organization_unit: ""
-        common_name: "scriptureforge.local"
-        alt_names:
-          - key: DNS.1
-            value: "www.scriptureforge.local"
-          - key: DNS.2
-            value: "scriptureforge.local"
-    sign:
+ssl_items: []
 
 apache_site_enable:
   - default_local.conf
   - languageforge_org.conf
-  - scriptureforge_org.conf
 
 apache_vhosts:
   - server_name: default.local
@@ -60,20 +44,3 @@ apache_vhosts:
         port: 80
         server_alias:
           - languageforge.local
-  - server_name: scriptureforge.org
-    server_admin: webmaster@palaso.org
-    server_file_name: scriptureforge_org
-    template: vhost_ssl.conf.j2
-    document_root: /var/www/virtual/scriptureforge.org/htdocs
-    link_to: "{{sf_path}}/src"
-    directory_extra:
-      - RewriteEngine On
-    virtual_hosts:
-      - has_ssl: false
-        port: 80
-        server_alias:
-          - scriptureforge.local
-      - has_ssl: true
-        port: 443
-        certificate_file: "scriptureforge.pem"
-        key_file: "scriptureforge.key"

--- a/deploy/xenial_server_taylor2017/Vagrantfile
+++ b/deploy/xenial_server_taylor2017/Vagrantfile
@@ -1,0 +1,89 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+$script = <<SCRIPT
+#if [ ! -f "/usr/bin/unattended-upgrade-org" ]; then
+#  killall unattended-upgrade
+#  cp /usr/bin/unattended-upgrade /usr/bin/unattended-upgrade-org
+#  > /usr/bin/unattended-upgrade
+#  killall unattended-upgrade
+#  rm -f /var/lib/apt/lists/lock
+#  rm -f /var/lib/apt/lists/*
+#fi
+
+apt-get update
+apt-get -y install software-properties-common python-software-properties
+add-apt-repository ppa:ansible/ansible
+apt-get update
+apt-get -y install git ansible
+
+cd /home/vagrant/src
+if [ ! -d "web-languageforge" ]; then
+  git clone --recurse-submodules https://github.com/sil-student-projects/web-languageforge.git 
+else
+  cd web-languageforge; git pull --ff-only --recurse-submodules 
+fi
+#cd /home/vagrant/src
+#if [ ! -d "web-scriptureforge" ]; then
+#  ln -sf /home/vagrant/src/web-languageforge /home/vagrant/src/web-scriptureforge
+#fi
+
+cd /home/vagrant/src/web-languageforge/deploy/; git checkout master-taylor; ansible-playbook -i hosts playbook_create_config.yml; chown vagrant.vagrant ansible.cfg; ansible-playbook -i hosts playbook_xenial_server_vagrant.yml
+
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "kaorimatz/ubuntu-16.04-amd64"
+  # Less secure but will work on NTFS which doesn't understand permissions / owner very well
+  config.ssh.insert_key = false
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "https://atlas.hashicorp.com/kaorimatz/ubuntu-16.04-amd64"
+
+  config.vm.define "xenial_server_taylor2017"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/home/vagrant/src",
+    id: "vagrant-root",
+    owner: "vagrant",
+    group: "www-data",
+    mount_options: ["dmode=775,fmode=664"]
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider :virtualbox do |vb|
+    # Don't boot with headless mode
+    vb.gui = true
+  
+    # Use VBoxManage to customize the VM. For example to change memory:
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
+    vb.customize ["modifyvm", :id, "--vram", 64]
+    vb.customize ["modifyvm", :id, "--accelerate3d", "off"]
+  end
+
+  # configure Vagrant's ssh shell to be a non-login one (avoids error "stdin: is not a tty error")
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+  config.vm.provision "shell", inline: $script
+
+#  config.vm.provision :ansible do |ansible|
+#    ansible.playbook = '../playbook_debian.yml'
+#    ansible.extra_vars = { ansible_ssh_user: 'vagrant', vagrant: true }
+#    ansible.verbose = 'v'
+#  end
+  
+end

--- a/deploy/xenial_taylor2017/SampleRun.log
+++ b/deploy/xenial_taylor2017/SampleRun.log
@@ -1,0 +1,2299 @@
+cambell@cambell-dell-nix:~/src/xForge/web-languageforge/deploy/xenial_taylor2017$ vagrant up
+Bringing machine 'default' up with 'virtualbox' provider...
+==> default: Importing base box 'xenial-gnome-amd64'...
+==> default: Matching MAC address for NAT networking...
+==> default: Setting the name of the VM: xenial_taylor2017_default_1480086887479_6810
+==> default: Clearing any previously set network interfaces...
+==> default: Preparing network interfaces based on configuration...
+    default: Adapter 1: nat
+==> default: Forwarding ports...
+    default: 22 => 2222 (adapter 1)
+==> default: Running 'pre-boot' VM customizations...
+==> default: Booting VM...
+==> default: Waiting for machine to boot. This may take a few minutes...
+    default: SSH address: 127.0.0.1:2222
+    default: SSH username: vagrant
+    default: SSH auth method: private key
+    default: Warning: Connection timeout. Retrying...
+==> default: Machine booted and ready!
+==> default: Checking for guest additions in VM...
+==> default: Mounting shared folders...
+    default: /vagrant => /shared/src/xForge/web-languageforge/deploy/xenial_taylor2017
+==> default: Running provisioner: shell...
+    default: Running: inline script
+==> default: unattended-upgrade: no process found
+==> default: unattended-upgrade: no process found
+==> default: rm: 
+==> default: cannot remove '/var/lib/apt/lists/partial'
+==> default: : Is a directory
+==> default:  Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy. Avoid writing scripts or custom code to deploy and update your applications— automate in a language that approaches plain English, using SSH, with no agents to install on remote systems.
+==> default: 
+==> default: http://ansible.com/
+==> default:  More info: https://launchpad.net/~ansible/+archive/ubuntu/ansible
+==> default: gpg: 
+==> default: keyring `/tmp/tmpi4iy7g2c/secring.gpg' created
+==> default: gpg: 
+==> default: keyring `/tmp/tmpi4iy7g2c/pubring.gpg' created
+==> default: gpg: 
+==> default: requesting key 7BB9C367 from hkp server keyserver.ubuntu.com
+==> default: gpg: 
+==> default: /tmp/tmpi4iy7g2c/trustdb.gpg: trustdb created
+==> default: gpg: 
+==> default: key 7BB9C367: public key "Launchpad PPA for Ansible, Inc." imported
+==> default: gpg: 
+==> default: Total number processed: 1
+==> default: gpg: 
+==> default:               imported: 1
+==> default:   (RSA: 1)
+==> default: OK
+==> default: Get:1 http://ppa.launchpad.net/ansible/ansible/ubuntu xenial InRelease [18.1 kB]
+==> default: Get:2 http://us.archive.ubuntu.com/ubuntu xenial InRelease [247 kB]
+==> default: Get:3 http://security.ubuntu.com/ubuntu xenial-security InRelease [102 kB]
+==> default: Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [177 kB]
+==> default: Get:5 http://ppa.launchpad.net/ansible/ansible/ubuntu xenial/main amd64 Packages [548 B]
+==> default: Get:6 http://security.ubuntu.com/ubuntu xenial-security/main i386 Packages [172 kB]
+==> default: Get:7 http://ppa.launchpad.net/ansible/ansible/ubuntu xenial/main i386 Packages [548 B]
+==> default: Get:8 http://ppa.launchpad.net/ansible/ansible/ubuntu xenial/main Translation-en [340 B]
+==> default: Get:9 http://security.ubuntu.com/ubuntu xenial-security/main Translation-en [71.2 kB]
+==> default: Get:10 http://security.ubuntu.com/ubuntu xenial-security/main amd64 DEP-11 Metadata [67.0 kB]
+==> default: Get:11 http://us.archive.ubuntu.com/ubuntu xenial-updates InRelease [102 kB]
+==> default: Get:12 http://security.ubuntu.com/ubuntu xenial-security/main DEP-11 64x64 Icons [38.3 kB]
+==> default: Get:13 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [6,576 B]
+==> default: Get:14 http://security.ubuntu.com/ubuntu xenial-security/restricted i386 Packages [6,528 B]
+==> default: Get:15 http://security.ubuntu.com/ubuntu xenial-security/restricted Translation-en [2,016 B]
+==> default: Get:16 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 DEP-11 Metadata [200 B]
+==> default: Get:17 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [62.5 kB]
+==> default: Get:18 http://security.ubuntu.com/ubuntu xenial-security/universe i386 Packages [60.3 kB]
+==> default: Get:19 http://security.ubuntu.com/ubuntu xenial-security/universe Translation-en [33.9 kB]
+==> default: Get:20 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 DEP-11 Metadata [19.4 kB]
+==> default: Get:21 http://security.ubuntu.com/ubuntu xenial-security/universe DEP-11 64x64 Icons [25.6 kB]
+==> default: Get:22 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [2,764 B]
+==> default: Get:23 http://security.ubuntu.com/ubuntu xenial-security/multiverse i386 Packages [2,928 B]
+==> default: Get:24 http://security.ubuntu.com/ubuntu xenial-security/multiverse Translation-en [1,124 B]
+==> default: Get:25 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 DEP-11 Metadata [212 B]
+==> default: Get:26 http://us.archive.ubuntu.com/ubuntu xenial-backports InRelease [102 kB]
+==> default: Get:27 http://security.ubuntu.com/ubuntu xenial-security/multiverse DEP-11 64x64 Icons [29 B]
+==> default: Get:28 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1,201 kB]
+==> default: Get:29 http://us.archive.ubuntu.com/ubuntu xenial/main i386 Packages [1,196 kB]
+==> default: Get:30 http://us.archive.ubuntu.com/ubuntu xenial/main Translation-en [568 kB]
+==> default: Get:31 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 DEP-11 Metadata [733 kB]
+==> default: Get:32 http://us.archive.ubuntu.com/ubuntu xenial/main DEP-11 64x64 Icons [409 kB]
+==> default: Get:33 http://us.archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [8,344 B]
+==> default: Get:34 http://us.archive.ubuntu.com/ubuntu xenial/restricted i386 Packages [8,684 B]
+==> default: Get:35 http://us.archive.ubuntu.com/ubuntu xenial/restricted Translation-en [2,908 B]
+==> default: Get:36 http://us.archive.ubuntu.com/ubuntu xenial/restricted amd64 DEP-11 Metadata [186 B]
+==> default: Get:37 http://us.archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [7,532 kB]
+==> default: Get:38 http://us.archive.ubuntu.com/ubuntu xenial/universe i386 Packages [7,512 kB]
+==> default: Get:39 http://us.archive.ubuntu.com/ubuntu xenial/universe Translation-en [4,354 kB]
+==> default: Get:40 http://us.archive.ubuntu.com/ubuntu xenial/universe amd64 DEP-11 Metadata [3,410 kB]
+==> default: Get:41 http://us.archive.ubuntu.com/ubuntu xenial/universe DEP-11 64x64 Icons [7,448 kB]
+==> default: Get:42 http://us.archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [144 kB]
+==> default: Get:43 http://us.archive.ubuntu.com/ubuntu xenial/multiverse i386 Packages [140 kB]
+==> default: Get:44 http://us.archive.ubuntu.com/ubuntu xenial/multiverse Translation-en [106 kB]
+==> default: Get:45 http://us.archive.ubuntu.com/ubuntu xenial/multiverse amd64 DEP-11 Metadata [63.8 kB]
+==> default: Get:46 http://us.archive.ubuntu.com/ubuntu xenial/multiverse DEP-11 64x64 Icons [230 kB]
+==> default: Get:47 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [426 kB]
+==> default: Get:48 http://us.archive.ubuntu.com/ubuntu xenial-updates/main i386 Packages [420 kB]
+==> default: Get:49 http://us.archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [164 kB]
+==> default: Get:50 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 DEP-11 Metadata [293 kB]
+==> default: Get:51 http://us.archive.ubuntu.com/ubuntu xenial-updates/main DEP-11 64x64 Icons [182 kB]
+==> default: Get:52 http://us.archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [6,576 B]
+==> default: Get:53 http://us.archive.ubuntu.com/ubuntu xenial-updates/restricted i386 Packages [6,528 B]
+==> default: Get:54 http://us.archive.ubuntu.com/ubuntu xenial-updates/restricted Translation-en [2,016 B]
+==> default: Get:55 http://us.archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 DEP-11 Metadata [157 B]
+==> default: Get:56 http://us.archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [365 kB]
+==> default: Get:57 http://us.archive.ubuntu.com/ubuntu xenial-updates/universe i386 Packages [362 kB]
+==> default: Get:58 http://us.archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [132 kB]
+==> default: Get:59 http://us.archive.ubuntu.com/ubuntu xenial-updates/universe amd64 DEP-11 Metadata [119 kB]
+==> default: Get:60 http://us.archive.ubuntu.com/ubuntu xenial-updates/universe DEP-11 64x64 Icons [137 kB]
+==> default: Get:61 http://us.archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [7,384 B]
+==> default: Get:62 http://us.archive.ubuntu.com/ubuntu xenial-updates/multiverse i386 Packages [6,172 B]
+==> default: Get:63 http://us.archive.ubuntu.com/ubuntu xenial-updates/multiverse Translation-en [2,988 B]
+==> default: Get:64 http://us.archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 DEP-11 Metadata [2,516 B]
+==> default: Get:65 http://us.archive.ubuntu.com/ubuntu xenial-updates/multiverse DEP-11 64x64 Icons [7,765 B]
+==> default: Get:66 http://us.archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [4,392 B]
+==> default: Get:67 http://us.archive.ubuntu.com/ubuntu xenial-backports/main i386 Packages [4,400 B]
+==> default: Get:68 http://us.archive.ubuntu.com/ubuntu xenial-backports/main Translation-en [3,104 B]
+==> default: Get:69 http://us.archive.ubuntu.com/ubuntu xenial-backports/main amd64 DEP-11 Metadata [208 B]
+==> default: Get:70 http://us.archive.ubuntu.com/ubuntu xenial-backports/main DEP-11 64x64 Icons [29 B]
+==> default: Get:71 http://us.archive.ubuntu.com/ubuntu xenial-backports/restricted amd64 DEP-11 Metadata [194 B]
+==> default: Get:72 http://us.archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [2,412 B]
+==> default: Get:73 http://us.archive.ubuntu.com/ubuntu xenial-backports/universe i386 Packages [2,412 B]
+==> default: Get:74 http://us.archive.ubuntu.com/ubuntu xenial-backports/universe Translation-en [1,216 B]
+==> default: Get:75 http://us.archive.ubuntu.com/ubuntu xenial-backports/universe amd64 DEP-11 Metadata [212 B]
+==> default: Get:76 http://us.archive.ubuntu.com/ubuntu xenial-backports/universe DEP-11 64x64 Icons [29 B]
+==> default: Get:77 http://us.archive.ubuntu.com/ubuntu xenial-backports/multiverse amd64 DEP-11 Metadata [212 B]
+==> default: Get:78 http://us.archive.ubuntu.com/ubuntu xenial-backports/multiverse DEP-11 64x64 Icons [29 B]
+==> default: AppStream cache update completed, but some metadata was ignored due to errors.
+==> default: Fetched 39.0 MB in 1min 25s (457 kB/s)
+==> default: Reading package lists...
+==> default: Reading package lists...
+==> default: Building dependency tree...
+==> default: Reading state information...
+==> default: The following additional packages will be installed:
+==> default:   git-man liberror-perl python-crypto python-ecdsa python-httplib2
+==> default:   python-jinja2 python-markupsafe python-paramiko python-setuptools
+==> default:   python-yaml sshpass
+==> default: Suggested packages:
+==> default:   git-daemon-run | git-daemon-sysvinit git-doc git-el git-email git-gui gitk
+==> default:   gitweb git-arch git-cvs git-mediawiki git-svn python-crypto-dbg
+==> default:   python-crypto-doc python-jinja2-doc python-setuptools-doc
+==> default: The following NEW packages will be installed:
+==> default:   ansible git git-man liberror-perl python-crypto python-ecdsa python-httplib2
+==> default:   python-jinja2 python-markupsafe python-paramiko python-setuptools
+==> default:   python-yaml sshpass
+==> default: 0 upgraded, 13 newly installed, 0 to remove and 259 not upgraded.
+==> default: Need to get 6,198 kB of archives.
+==> default: After this operation, 42.5 MB of additional disk space will be used.
+==> default: Get:1 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 python-markupsafe amd64 0.23-2build2 [15.5 kB]
+==> default: Get:2 http://ppa.launchpad.net/ansible/ansible/ubuntu xenial/main amd64 ansible all 2.2.0.0-1ppa~xenial [1,608 kB]
+==> default: Get:3 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 python-jinja2 all 2.8-1 [109 kB]
+==> default: Get:4 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 python-yaml amd64 3.11-3build1 [105 kB]
+==> default: Get:5 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 python-crypto amd64 2.6.1-6build1 [245 kB]
+==> default: Get:6 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 python-ecdsa all 0.13-2 [34.0 kB]
+==> default: Get:7 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 python-paramiko all 1.16.0-1 [109 kB]
+==> default: Get:8 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 python-httplib2 all 0.9.1+dfsg-1 [34.2 kB]
+==> default: Get:9 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 python-setuptools all 20.7.0-1 [169 kB]
+==> default: Get:10 http://us.archive.ubuntu.com/ubuntu xenial/universe amd64 sshpass amd64 1.05-1 [10.5 kB]
+==> default: Get:11 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 liberror-perl all 0.17-1.2 [19.6 kB]
+==> default: Get:12 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 git-man all 1:2.7.4-0ubuntu1 [735 kB]
+==> default: Get:13 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 git amd64 1:2.7.4-0ubuntu1 [3,006 kB]
+==> default: dpkg-preconfigure: unable to re-open stdin: No such file or directory
+==> default: Fetched 6,198 kB in 56s (110 kB/s)
+==> default: Selecting previously unselected package python-markupsafe.
+==> default: (Reading database ... 
+==> default: (Reading database ... 5%
+==> default: (Reading database ... 10%
+==> default: (Reading database ... 15%
+==> default: (Reading database ... 20%
+==> default: (Reading database ... 25%
+==> default: (Reading database ... 30%
+==> default: (Reading database ... 35%
+==> default: (Reading database ... 40%
+==> default: (Reading database ... 45%
+==> default: (Reading database ... 50%
+==> default: (Reading database ... 55%
+==> default: (Reading database ... 60%
+==> default: (Reading database ... 65%
+==> default: (Reading database ... 70%
+==> default: (Reading database ... 75%
+==> default: (Reading database ... 80%
+==> default: (Reading database ... 85%
+==> default: (Reading database ... 90%
+==> default: (Reading database ... 95%
+==> default: (Reading database ... 100%
+==> default: (Reading database ... 
+==> default: 151349 files and directories currently installed.)
+==> default: Preparing to unpack .../python-markupsafe_0.23-2build2_amd64.deb ...
+==> default: Unpacking python-markupsafe (0.23-2build2) ...
+==> default: Selecting previously unselected package python-jinja2.
+==> default: Preparing to unpack .../python-jinja2_2.8-1_all.deb ...
+==> default: Unpacking python-jinja2 (2.8-1) ...
+==> default: Selecting previously unselected package python-yaml.
+==> default: Preparing to unpack .../python-yaml_3.11-3build1_amd64.deb ...
+==> default: Unpacking python-yaml (3.11-3build1) ...
+==> default: Selecting previously unselected package python-crypto.
+==> default: Preparing to unpack .../python-crypto_2.6.1-6build1_amd64.deb ...
+==> default: Unpacking python-crypto (2.6.1-6build1) ...
+==> default: Selecting previously unselected package python-ecdsa.
+==> default: Preparing to unpack .../python-ecdsa_0.13-2_all.deb ...
+==> default: Unpacking python-ecdsa (0.13-2) ...
+==> default: Selecting previously unselected package python-paramiko.
+==> default: Preparing to unpack .../python-paramiko_1.16.0-1_all.deb ...
+==> default: Unpacking python-paramiko (1.16.0-1) ...
+==> default: Selecting previously unselected package python-httplib2.
+==> default: Preparing to unpack .../python-httplib2_0.9.1+dfsg-1_all.deb ...
+==> default: Unpacking python-httplib2 (0.9.1+dfsg-1) ...
+==> default: Selecting previously unselected package python-setuptools.
+==> default: Preparing to unpack .../python-setuptools_20.7.0-1_all.deb ...
+==> default: Unpacking python-setuptools (20.7.0-1) ...
+==> default: Selecting previously unselected package sshpass.
+==> default: Preparing to unpack .../sshpass_1.05-1_amd64.deb ...
+==> default: Unpacking sshpass (1.05-1) ...
+==> default: Selecting previously unselected package ansible.
+==> default: Preparing to unpack .../ansible_2.2.0.0-1ppa~xenial_all.deb ...
+==> default: Unpacking ansible (2.2.0.0-1ppa~xenial) ...
+==> default: Selecting previously unselected package liberror-perl.
+==> default: Preparing to unpack .../liberror-perl_0.17-1.2_all.deb ...
+==> default: Unpacking liberror-perl (0.17-1.2) ...
+==> default: Selecting previously unselected package git-man.
+==> default: Preparing to unpack .../git-man_1%3a2.7.4-0ubuntu1_all.deb ...
+==> default: Unpacking git-man (1:2.7.4-0ubuntu1) ...
+==> default: Selecting previously unselected package git.
+==> default: Preparing to unpack .../git_1%3a2.7.4-0ubuntu1_amd64.deb ...
+==> default: Unpacking git (1:2.7.4-0ubuntu1) ...
+==> default: Processing triggers for man-db (2.7.5-1) ...
+==> default: Setting up python-markupsafe (0.23-2build2) ...
+==> default: Setting up python-jinja2 (2.8-1) ...
+==> default: Setting up python-yaml (3.11-3build1) ...
+==> default: Setting up python-crypto (2.6.1-6build1) ...
+==> default: Setting up python-ecdsa (0.13-2) ...
+==> default: Setting up python-paramiko (1.16.0-1) ...
+==> default: Setting up python-httplib2 (0.9.1+dfsg-1) ...
+==> default: Setting up python-setuptools (20.7.0-1) ...
+==> default: Setting up sshpass (1.05-1) ...
+==> default: Setting up ansible (2.2.0.0-1ppa~xenial) ...
+==> default: Setting up liberror-perl (0.17-1.2) ...
+==> default: Setting up git-man (1:2.7.4-0ubuntu1) ...
+==> default: Setting up git (1:2.7.4-0ubuntu1) ...
+==> default: Cloning into 'web-languageforge'...
+==> default: Submodule 'deploy/roles/apache_config' (https://github.com/saygoweb/ansible-role-apache.git) registered for path 'deploy/roles/apache_config'
+==> default: Submodule 'deploy/roles_common' (https://github.com/sillsdev/ops-ansible-common-roles) registered for path 'deploy/roles_common'
+==> default: Cloning into 'deploy/roles/apache_config'...
+==> default: Submodule path 'deploy/roles/apache_config': checked out 'd863302268edf34e1d69de60568511350bf81347'
+==> default: Cloning into 'deploy/roles_common'...
+==> default: Submodule path 'deploy/roles_common': checked out 'cd7d87385bfc5f1965db35e5f5ee585e160f6738'
+==> default: Already on 'master-taylor'
+==> default: Your branch is up-to-date with 'origin/master-taylor'.
+==> default: 
+==> default: PLAY [Configure ansible.cfg] ***************************************************
+==> default: 
+==> default: TASK [setup] *******************************************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [Check if ansible.cfg exists] *********************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [Copy default ansible.cfg] ************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [Modify ansible.cfg] ******************************************************
+==> default: changed: [localhost] => (item={u'property': u'nocows', u'value': u'1'})
+==> default: changed: [localhost] => (item={u'property': u'roles_path', u'value': u'/etc/ansible/roles:./roles_common:./roles'})
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'property': u'ssh_args', u'value': u'-o UserKnownHostsFile=.vagrant/known_hosts'})
+==> default: 
+==> default: PLAY RECAP *********************************************************************
+==> default: localhost                  : ok=4    changed=2    unreachable=0    failed=0   
+==> default: 
+==> default: PLAY [Fix provisioning permissions] ********************************************
+==> default: 
+==> default: TASK [setup] *******************************************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [chown ~/src] *************************************************************
+==> default: ok: [localhost]
+==> default:  [WARNING]: Consider using file module with owner rather than running chown
+==> default: 
+==> default: cmd: chown -R vagrant.vagrant /home/vagrant/src
+==> default: 
+==> default: start: 2016-11-25 10:23:48.654489
+==> default: 
+==> default: end: 2016-11-25 10:23:48.664556
+==> default: 
+==> default: delta: 0:00:00.010067
+==> default: 
+==> default: PLAY [Deploy development environment for xForge (languageforge.org and scriptureforge.org)] ***
+==> default: 
+==> default: TASK [setup] *******************************************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [include_vars] ************************************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [Add PHP7.0 ppa for Trusty] ***********************************************
+==> default: skipping: [localhost]
+==> default: 
+==> default: TASK [Remove PHP5 for Trusty] **************************************************
+==> default: skipping: [localhost]
+==> default: 
+==> default: TASK [fix : stat] **************************************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [fix : copy] **************************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [ssl_config : Install packages.] ******************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [ssl_config : Ensure ssl path exist] **************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [ssl_config : LetsEncrypt: Check if already installed] ********************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [ssl_config : LetsEncrypt: Install certbot-auto] **************************
+==> default: skipping: [localhost]
+==> default: 
+==> default: TASK [ssl_config : LetsEncrypt: Install packages] ******************************
+==> default: skipping: [localhost]
+==> default: 
+==> default: TASK [ssl_config : LetsEncrypt: Install cron task] *****************************
+==> default: skipping: [localhost]
+==> default: 
+==> default: TASK [ssl_config : Create new key (if required)] *******************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None})
+==> default: 
+==> default: TASK [ssl_config : Create new request config file] *****************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None})
+==> default: 
+==> default: TASK [ssl_config : Create new request] *****************************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None})
+==> default: 
+==> default: TASK [ssl_config : Download requests] ******************************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None})
+==> default: 
+==> default: TASK [ssl_config : Summary] ****************************************************
+==> default: 
+==> default: msg: All items completed
+==> default: ok: [localhost -> localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None})
+==> default: 
+==> default: TASK [ssl_config : Copy certificate if present] ********************************
+==> default: skipping: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None}) 
+==> default: 
+==> default: TASK [ssl_config : Key match] **************************************************
+==> default: skipping: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None}) 
+==> default: 
+==> default: TASK [ssl_config : Self sign certificate] **************************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None})
+==> default: 
+==> default: TASK [ssl_config : Lets Encrypt sign certificate] ******************************
+==> default: skipping: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None}) 
+==> default: 
+==> default: TASK [ssl_config : Download certificate] ***************************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None})
+==> default: 
+==> default: TASK [ssl_config : Delete key] *************************************************
+==> default: skipping: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None}) 
+==> default: 
+==> default: TASK [ssl_config : Delete csr] *************************************************
+==> default: skipping: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None}) 
+==> default: 
+==> default: TASK [ssl_config : Delete cnf] *************************************************
+==> default: skipping: [localhost] => (item={u'state': u'selfsign', u'request': {u'locality': u'Chiang Mai', u'organization_unit': u'', u'alt_names': [{u'key': u'DNS.1', u'value': u'www.scriptureforge.local'}, {u'key': u'DNS.2', u'value': u'scriptureforge.local'}], u'state': u'Chiang Mai', u'country_code': u'TH', u'common_name': u'scriptureforge.local', u'organization': u'SIL'}, u'name': u'scriptureforge', u'sign': None}) 
+==> default: 
+==> default: TASK [apache_config : Add repository to install last Apache version] ***********
+==> default: skipping: [localhost]
+==> default: 
+==> default: TASK [apache_config : Install packages.] ***************************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=[u'apache2', u'rsync'])
+==> default: 
+==> default: TASK [apache_config : Add apache vhosts configurations] ************************
+==> default: changed: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [], u'port': 80}], u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/default_local', u'directory_options': [u'+Indexes', u'+FollowSymLinks']})
+==> default: changed: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80}], u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'})
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443}], u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'})
+==> default: 
+==> default: TASK [apache_config : Ensure apache SSL path exists] ***************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [apache_config : Ensure document base exists] *****************************
+==> default: changed: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [], u'port': 80}], u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/default_local', u'directory_options': [u'+Indexes', u'+FollowSymLinks']})
+==> default: changed: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80}], u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'})
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443}], u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'})
+==> default: 
+==> default: TASK [apache_config : Ensure document root exists (dir)] ***********************
+==> default: skipping: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443}], u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}) 
+==> default: skipping: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80}], u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'}) 
+==> default: skipping: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [], u'port': 80}], u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/default_local', u'directory_options': [u'+Indexes', u'+FollowSymLinks']}) 
+==> default: 
+==> default: TASK [apache_config : Ensure document root exists (link)] **********************
+==> default: changed: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [], u'port': 80}], u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/default_local', u'directory_options': [u'+Indexes', u'+FollowSymLinks']})
+==> default: changed: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80}], u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'})
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'virtual_hosts': [{u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443}], u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'})
+==> default: 
+==> default: TASK [apache_config : Copy key] ************************************************
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'directory_options': [u'+Indexes', u'+FollowSymLinks'], u'document_root': u'/var/www/virtual/default_local'}, {u'has_ssl': False, u'server_alias': [], u'port': 80})) 
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443}))
+==> default: 
+==> default: TASK [apache_config : Link key] ************************************************
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'directory_options': [u'+Indexes', u'+FollowSymLinks'], u'document_root': u'/var/www/virtual/default_local'}, {u'has_ssl': False, u'server_alias': [], u'port': 80})) 
+==> default: 
+==> default: TASK [apache_config : Fix key permissions] *************************************
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'directory_options': [u'+Indexes', u'+FollowSymLinks'], u'document_root': u'/var/www/virtual/default_local'}, {u'has_ssl': False, u'server_alias': [], u'port': 80})) 
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443}))
+==> default: 
+==> default: TASK [apache_config : Copy certificate] ****************************************
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'directory_options': [u'+Indexes', u'+FollowSymLinks'], u'document_root': u'/var/www/virtual/default_local'}, {u'has_ssl': False, u'server_alias': [], u'port': 80})) 
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443}))
+==> default: 
+==> default: TASK [apache_config : Link certificate] ****************************************
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'directory_options': [u'+Indexes', u'+FollowSymLinks'], u'document_root': u'/var/www/virtual/default_local'}, {u'has_ssl': False, u'server_alias': [], u'port': 80})) 
+==> default: 
+==> default: TASK [apache_config : Copy chain certificate if present] ***********************
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'directory_options': [u'+Indexes', u'+FollowSymLinks'], u'document_root': u'/var/www/virtual/default_local'}, {u'has_ssl': False, u'server_alias': [], u'port': 80})) 
+==> default: 
+==> default: TASK [apache_config : Link chain certificate if present] ***********************
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': True, u'certificate_file': u'scriptureforge.pem', u'key_file': u'scriptureforge.key', u'port': 443})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-scriptureforge/src', u'server_name': u'scriptureforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'scriptureforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/scriptureforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'scriptureforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge/src', u'server_name': u'languageforge.org', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'languageforge_org', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'document_root': u'/var/www/virtual/languageforge.org/htdocs'}, {u'has_ssl': False, u'server_alias': [u'languageforge.local'], u'port': 80})) 
+==> default: skipping: [localhost] => (item=({u'link_to': u'/home/vagrant/src/xForge/web-languageforge', u'server_name': u'default.local', u'server_admin': u'webmaster@palaso.org', u'server_file_name': u'default_local', u'template': u'vhost_ssl.conf.j2', u'directory_extra': [u'RewriteEngine On'], u'directory_options': [u'+Indexes', u'+FollowSymLinks'], u'document_root': u'/var/www/virtual/default_local'}, {u'has_ssl': False, u'server_alias': [], u'port': 80})) 
+==> default: 
+==> default: TASK [apache_config : Disable apache module] ***********************************
+==> default: skipping: [localhost] => (item=False) 
+==> default: 
+==> default: TASK [apache_config : Enable apache module] ************************************
+==> default: changed: [localhost] => (item=rewrite)
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=ssl)
+==> default: 
+==> default: TASK [apache_config : Disable apache site] *************************************
+==> default: changed: [localhost] => (item=000-default)
+==> default: 
+==> default: msg: All items completed
+==> default: ok: [localhost] => (item=default-ssl)
+==> default: 
+==> default: TASK [apache_config : Enable apache site] **************************************
+==> default: changed: [localhost] => (item=default_local.conf)
+==> default: changed: [localhost] => (item=languageforge_org.conf)
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=scriptureforge_org.conf)
+==> default: 
+==> default: TASK [install packages] ********************************************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=[u'libapache2-mod-php', u'php7.0-gd', u'php7.0-dev', u'php7.0-cli', u'php7.0-mbstring', u'php-pear', u'php-xdebug', u'mongodb-server', u'postfix', u'unzip', u'p7zip-full', u'npm'])
+==> default: 
+==> default: TASK [file] ********************************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [install Composer] ********************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: cmd: php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer
+==> default: 
+==> default: start: 2016-11-25 10:35:42.902585
+==> default: 
+==> default: end: 2016-11-25 10:36:30.567730
+==> default: 
+==> default: delta: 0:00:47.665145
+==> default: 
+==> default: stdout: Downloading 1.2.2...
+==> default: 
+==> default: Composer successfully installed to: /usr/local/bin/composer
+==> default: Use it: php /usr/local/bin/composer
+==> default: Some settings on your machine may cause stability issues with Composer.
+==> default: If you encounter issues, try to change the following:
+==> default: 
+==> default: The xdebug extension is loaded, this can slow down Composer a little.
+==> default: Disabling it when using Composer is recommended.
+==> default: 
+==> default: TASK [install Bower] ***********************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: cmd: npm install -g bower
+==> default: 
+==> default: start: 2016-11-25 10:36:30.656488
+==> default: 
+==> default: end: 2016-11-25 10:37:07.726567
+==> default: 
+==> default: delta: 0:00:37.070079
+==> default: 
+==> default: stdout: /usr/local/bin/bower -> /usr/local/lib/node_modules/bower/bin/bower
+==> default: /usr/local/lib
+==> default: ??? bower@1.8.0 
+==> default: 
+==> default: TASK [install gulp cli] ********************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: cmd: npm install -g gulp-cli
+==> default: 
+==> default: start: 2016-11-25 10:37:07.817209
+==> default: 
+==> default: end: 2016-11-25 10:47:53.288350
+==> default: 
+==> default: delta: 0:10:45.471141
+==> default: 
+==> default: stdout: /usr/local/bin/gulp -> /usr/local/lib/node_modules/gulp-cli/bin/gulp.js
+==> default: /usr/local/lib
+==> default: ??? gulp-cli@1.2.2 
+==> default:   ??? archy@1.0.0 
+==> default:   ??? chalk@1.1.3 
+==> default:   ? ??? ansi-styles@2.2.1 
+==> default:   ? ??? escape-string-regexp@1.0.5 
+==> default:   ? ??? has-ansi@2.0.0 
+==> default:   ? ? ??? ansi-regex@2.0.0 
+==> default:   ? ??? strip-ansi@3.0.1 
+==> default:   ? ??? supports-color@2.0.0 
+==> default:   ??? fancy-log@1.2.0 
+==> default:   ? ??? time-stamp@1.0.1 
+==> default:   ??? gulplog@1.0.0 
+==> default:   ? ??? glogg@1.0.0 
+==> default:   ?   ??? sparkles@1.0.0 
+==> default:   ??? interpret@1.0.1 
+==> default:   ??? liftoff@2.3.0 
+==> default:   ? ??? extend@3.0.0 
+==> default:   ? ??? findup-sync@0.4.3 
+==> default:   ? ? ??? detect-file@0.1.0 
+==> default:   ? ? ? ??? fs-exists-sync@0.1.0 
+==> default:   ? ? ??? is-glob@2.0.1 
+==> default:   ? ? ??? resolve-dir@0.1.1 
+==> default:   ? ?   ??? global-modules@0.2.3 
+==> default:   ? ?     ??? global-prefix@0.1.4 
+==> default:   ? ?     ? ??? ini@1.3.4 
+==> default:   ? ?     ? ??? osenv@0.1.3 
+==> default:   ? ?     ? ? ??? os-tmpdir@1.0.2 
+==> default:   ? ?     ? ??? which@1.2.12 
+==> default:   ? ?     ?   ??? isexe@1.1.2 
+==> default:   ? ?     ??? is-windows@0.2.0 
+==> default:   ? ??? fined@1.0.2 
+==> default:   ? ? ??? expand-tilde@1.2.2 
+==> default:   ? ? ??? lodash.assignwith@4.2.0 
+==> default:   ? ? ??? lodash.isempty@4.4.0 
+==> default:   ? ? ??? lodash.pick@4.4.0 
+==> default:   ? ? ??? parse-filepath@1.0.1 
+==> default:   ? ?   ??? is-absolute@0.2.6 
+==> default:   ? ?   ? ??? is-relative@0.2.1 
+==> default:   ? ?   ?   ??? is-unc-path@0.1.1 
+==> default:   ? ?   ?     ??? unc-path-regex@0.1.2 
+==> default:   ? ?   ??? map-cache@0.2.2 
+==> default:   ? ?   ??? path-root@0.1.1 
+==> default:   ? ?     ??? path-root-regex@0.1.2 
+==> default:   ? ??? flagged-respawn@0.3.2 
+==> default:   ? ??? lodash.mapvalues@4.6.0 
+==> default:   ? ??? rechoir@0.6.2 
+==> default:   ? ??? resolve@1.1.7 
+==> default:   ??? lodash.isfunction@3.0.8 
+==> default:   ??? lodash.isplainobject@4.0.6 
+==> default:   ??? lodash.isstring@4.0.1 
+==> default:   ??? lodash.sortby@4.7.0 
+==> default:   ??? matchdep@1.0.1 
+==> default:   ? ??? findup-sync@0.3.0 
+==> default:   ? ? ??? glob@5.0.15 
+==> default:   ? ?   ??? inflight@1.0.6 
+==> default:   ? ?   ? ??? wrappy@1.0.2 
+==> default:   ? ?   ??? inherits@2.0.3 
+==> default:   ? ?   ??? minimatch@3.0.3 
+==> default:   ? ?   ? ??? brace-expansion@1.1.6 
+==> default:   ? ?   ?   ??? balanced-match@0.4.2 
+==> default:   ? ?   ?   ??? concat-map@0.0.1 
+==> default:   ? ?   ??? once@1.4.0 
+==> default:   ? ?   ??? path-is-absolute@1.0.1 
+==> default:   ? ??? micromatch@2.3.11 
+==> default:   ? ? ??? arr-diff@2.0.0 
+==> default:   ? ? ? ??? arr-flatten@1.0.1 
+==> default:   ? ? ??? array-unique@0.2.1 
+==> default:   ? ? ??? braces@1.8.5 
+==> default:   ? ? ? ??? expand-range@1.8.2 
+==> default:   ? ? ? ? ??? fill-range@2.2.3 
+==> default:   ? ? ? ?   ??? is-number@2.1.0 
+==> default:   ? ? ? ?   ??? isobject@2.1.0 
+==> default:   ? ? ? ?   ? ??? isarray@1.0.0 
+==> default:   ? ? ? ?   ??? randomatic@1.1.6 
+==> default:   ? ? ? ?   ??? repeat-string@1.6.1 
+==> default:   ? ? ? ??? preserve@0.2.0 
+==> default:   ? ? ? ??? repeat-element@1.1.2 
+==> default:   ? ? ??? expand-brackets@0.1.5 
+==> default:   ? ? ? ??? is-posix-bracket@0.1.1 
+==> default:   ? ? ??? extglob@0.3.2 
+==> default:   ? ? ??? filename-regex@2.0.0 
+==> default:   ? ? ??? is-extglob@1.0.0 
+==> default:   ? ? ??? kind-of@3.0.4 
+==> default:   ? ? ? ??? is-buffer@1.1.4 
+==> default:   ? ? ??? normalize-path@2.0.1 
+==> default:   ? ? ??? object.omit@2.0.1 
+==> default:   ? ? ? ??? for-own@0.1.4 
+==> default:   ? ? ? ? ??? for-in@0.1.6 
+==> default:   ? ? ? ??? is-extendable@0.1.1 
+==> default:   ? ? ??? parse-glob@3.0.4 
+==> default:   ? ? ? ??? glob-base@0.3.0 
+==> default:   ? ? ? ? ??? glob-parent@2.0.0 
+==> default:   ? ? ? ??? is-dotfile@1.0.2 
+==> default:   ? ? ??? regex-cache@0.4.3 
+==> default:   ? ?   ??? is-equal-shallow@0.1.3 
+==> default:   ? ?   ??? is-primitive@2.0.0 
+==> default:   ? ??? stack-trace@0.0.9 
+==> default:   ??? mute-stdout@1.0.0 
+==> default:   ??? pretty-hrtime@1.0.3 
+==> default:   ??? semver-greatest-satisfied-range@1.0.0 
+==> default:   ? ??? semver@4.3.6 
+==> default:   ? ??? semver-regex@1.0.0 
+==> default:   ??? tildify@1.2.0 
+==> default:   ? ??? os-homedir@1.0.2 
+==> default:   ??? v8flags@2.0.11 
+==> default:   ? ??? user-home@1.1.1 
+==> default:   ??? wreck@6.3.0 
+==> default:   ? ??? boom@2.10.1 
+==> default:   ? ??? hoek@2.16.3 
+==> default:   ??? yargs@3.32.0 
+==> default:     ??? camelcase@2.1.1 
+==> default:     ??? cliui@3.2.0 
+==> default:     ? ??? wrap-ansi@2.0.0 
+==> default:     ??? decamelize@1.2.0 
+==> default:     ??? os-locale@1.4.0 
+==> default:     ? ??? lcid@1.0.0 
+==> default:     ?   ??? invert-kv@1.0.0 
+==> default:     ??? string-width@1.0.2 
+==> default:     ? ??? code-point-at@1.1.0 
+==> default:     ? ??? is-fullwidth-code-point@1.0.0 
+==> default:     ?   ??? number-is-nan@1.0.1 
+==> default:     ??? window-size@0.1.4 
+==> default:     ??? y18n@3.2.1 
+==> default: 
+==> default: TASK [php log folder exists] ***************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [php.ini changes] *********************************************************
+==> default: changed: [localhost] => (item={u'property': u'memory_limit', u'value': u'256M'})
+==> default: changed: [localhost] => (item={u'property': u'display_errors', u'value': u'On'})
+==> default: changed: [localhost] => (item={u'property': u'display_startup_errors', u'value': u'On'})
+==> default: changed: [localhost] => (item={u'property': u'error_log', u'value': u'/var/log/php/php_error.log'})
+==> default: changed: [localhost] => (item={u'property': u'post_max_size', u'value': u'60M'})
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'property': u'upload_max_filesize', u'value': u'60M'})
+==> default: 
+==> default: TASK [postfix | halt emails in output queue] ***********************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item={u'property': u'default_transport', u'value': u'retry:no outbound email allowed'})
+==> default: 
+==> default: TASK [Ensure default_local folder does not exist (localhost)] ******************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [Get local dir (localhost)] ***********************************************
+==> default: changed: [localhost -> localhost]
+==> default: 
+==> default: cmd: pwd
+==> default: 
+==> default: start: 2016-11-25 10:47:54.293672
+==> default: 
+==> default: end: 2016-11-25 10:47:54.295008
+==> default: 
+==> default: delta: 0:00:00.001336
+==> default: 
+==> default: stdout: /home/vagrant/src/xForge/web-languageforge/deploy
+==> default: 
+==> default: TASK [Ensure default_local link exists (localhost)] ****************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [apt_key] *****************************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [apt_repository] **********************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [apt_repository] **********************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [install LfMerge package] *************************************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=[u'lfmerge'])
+==> default: 
+==> default: TASK [ensure www-data group exists] ********************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [make www-data user a member of fieldworks group] *************************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [ensure www-data has setguid, group-writeable .local folder] **************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [Ensure folder permissions] ***********************************************
+==> default: ok: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/src', u'mode': u'u=rwX,g=rX,o=rX'})
+==> default: ok: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/src', u'mode': u'u=rwX,g=rX,o=rX'})
+==> default: ok: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/test', u'mode': u'u=rwX,g=rX,o=rX'})
+==> default: ok: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/test', u'mode': u'u=rwX,g=rX,o=rX'})
+==> default: ok: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/docs', u'mode': u'u=rwX,g=rX,o=rX'})
+==> default: 
+==> default: msg: All items completed
+==> default: ok: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/docs', u'mode': u'u=rwX,g=rX,o=rX'})
+==> default: 
+==> default: TASK [Ensure www-data has permission to folders] *******************************
+==> default: changed: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/src/assets', u'mode': u'u=rwX,g=rwX'})
+==> default: ok: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/src/assets', u'mode': u'u=rwX,g=rwX'})
+==> default: changed: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/src/cache', u'mode': u'u=rwX,g=rwX'})
+==> default: 
+==> default: msg: All items completed
+==> default: ok: [localhost] => (item={u'path': u'/home/vagrant/src/xForge/web-languageforge/src/cache', u'mode': u'u=rwX,g=rwX'})
+==> default: 
+==> default: TASK [Ensure /var/lib/languageforge directory is writeable (for LfMerge)] ******
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [Ensure /var/www/.local directory is writeable (for LfMerge)] *************
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [install PECL mongo extension] ********************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: cmd: yes '' | /usr/bin/pecl install mongodb
+==> default: 
+==> default: start: 2016-11-25 11:01:39.631073
+==> default: 
+==> default: end: 2016-11-25 11:02:51.897766
+==> default: 
+==> default: delta: 0:01:12.266693
+==> default: 
+==> default: stdout: downloading mongodb-1.1.9.tgz ...
+==> default: Starting to download mongodb-1.1.9.tgz (806,532 bytes)
+==> default: ..........done: 806,532 bytes
+==> default: 360 source files, building
+==> default: running: phpize
+==> default: Configuring for:
+==> default: PHP Api Version:         20151012
+==> default: Zend Module Api No:      20151012
+==> default: Zend Extension Api No:   320151012
+==> default: building in /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9
+==> default: running: /tmp/pear/temp/mongodb/configure --with-php-config=/usr/bin/php-config
+==> default: checking for grep that handles long lines and -e... /bin/grep
+==> default: checking for egrep... /bin/grep -E
+==> default: checking for a sed that does not truncate output... /bin/sed
+==> default: checking for cc... cc
+==> default: checking whether the C compiler works... yes
+==> default: checking for C compiler default output file name... a.out
+==> default: checking for suffix of executables...
+==> default: checking whether we are cross compiling... no
+==> default: checking for suffix of object files... o
+==> default: checking whether we are using the GNU C compiler... yes
+==> default: checking whether cc accepts -g... yes
+==> default: checking for cc option to accept ISO C89... none needed
+==> default: checking how to run the C preprocessor... cc -E
+==> default: checking for icc... no
+==> default: checking for suncc... no
+==> default: checking whether cc understands -c and -o together... yes
+==> default: checking for system library directory... lib
+==> default: checking if compiler supports -R... no
+==> default: checking if compiler supports -Wl,-rpath,... yes
+==> default: checking build system type... x86_64-pc-linux-gnu
+==> default: checking host system type... x86_64-pc-linux-gnu
+==> default: checking target system type... x86_64-pc-linux-gnu
+==> default: checking for PHP prefix... /usr
+==> default: checking for PHP includes... -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib
+==> default: checking for PHP extension directory... /usr/lib/php/20151012
+==> default: checking for PHP installed headers prefix... /usr/include/php/20151012
+==> default: checking if debug is enabled... no
+==> default: checking if zts is enabled... no
+==> default: checking for re2c... no
+==> default: configure: WARNING: You will need re2c 0.13.4 or later if you want to regenerate PHP parsers.
+==> default: checking for gawk... no
+==> default: checking for nawk... nawk
+==> default: checking if nawk is broken... no
+==> default: checking whether to enable mongodb support... yes, shared
+==> default: checking OpenSSL dir for mongodb... yes
+==> default: checking PHP version... 70008
+==> default: checking whether to enable developer build flags... no
+==> default: checking whether to enable code coverage... no
+==> default: checking whether to use system libbson... no
+==> default: checking configuring libmongoc... ...
+==> default: checking whether to use system libmongoc... no
+==> default: checking for pkg-config... /usr/bin/pkg-config
+==> default: checking for pcre-dir install prefix... yes, shared
+==> default: checking for pcre... found in /usr
+==> default: checking for Cyrus SASL support... auto
+==> default: checking for SASL... not found
+==> default: checking if weak symbols are supported... yes
+==> default: checking if compiler needs -Werror to reject unknown flags... no
+==> default: checking for the pthreads library -lpthreads... no
+==> default: checking whether pthreads work without any flags... no
+==> default: checking whether pthreads work with -Kthread... no
+==> default: checking whether pthreads work with -kthread... no
+==> default: checking for the pthreads library -llthread... no
+==> default: checking whether pthreads work with -pthread... yes
+==> default: checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+==> default: checking if more special flags are required for pthreads... no
+==> default: checking for PTHREAD_PRIO_INHERIT... yes
+==> default: checking for shm_open... no
+==> default: checking for shm_open in -lrt... yes
+==> default: checking for __sync_add_and_fetch_4... yes
+==> default: checking for __sync_add_and_fetch_8... yes
+==> default: checking for strnlen... yes
+==> default: checking for snprintf... yes
+==> default: checking for _set_output_format... no
+==> default: checking for ANSI C header files... yes
+==> default: checking for sys/types.h... yes
+==> default: checking for sys/stat.h... yes
+==> default: checking for stdlib.h... yes
+==> default: checking for string.h... yes
+==> default: checking for memory.h... yes
+==> default: checking for strings.h... yes
+==> default: checking for inttypes.h... yes
+==> default: checking for stdint.h... yes
+==> default: checking for unistd.h... yes
+==> default: checking for struct timespec... yes
+==> default: checking for library containing clock_gettime... none required
+==> default: checking for pthread_join in LIBS= with CFLAGS=-pthread..
+==> default: . yes
+==> default: checking if compiler needs -Werror to reject unknown flags... no
+==> default: checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
+==> default: checking if more special flags are required for pthreads... no
+==> default: checking for PTHREAD_PRIO_INHERIT... (cached) yes
+==> default: checking whether PTHREAD_ONCE_INIT needs braces... no
+==> default: checking for stdint-types....... "(putting them into /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-stdint.h)"
+==> default: checking for uintptr_t... yes
+==> default: checking for uint64_t... yes
+==> default: ... seen our uintptr_t in stdint.h (uint64_t too)
+==> default: creating /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-stdint.h : __TMP_PEAR_TEMP_MONGODB_SRC_LIBBSON_SRC_BSON_BSON_STDINT_H
+==> default: checking for int_least32_t... yes
+==> default: checking for int_fast32_t... yes
+==> default: ..adding include stdint.h
+==> default: ... seen good stdint.h inttypes
+==> default: ... seen good uint64_t
+==> default: ... DONE /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-stdint.h
+==> default: checking whether byte ordering is bigendian... no
+==> default: checking for stdbool.h that conforms to C99... yes
+==> default: checking for _Bool... yes
+==> default: checking for clock_gettime... yes
+==> default: checking for strnlen... (cached) yes
+==> default: checking for snprintf... (cached) yes
+==> default: configure: Current version (from VERSION_CURRENT file): 1.3.6
+==> default: configure: creating ./config.status
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-config.h
+==> default: configure: creating ./config.status
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-config.h
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-version.h
+==> default: configure: Current version (from VERSION_CURRENT file): 1.3.6
+==> default: configure: creating ./config.status
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-config.h
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-version.h
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-config.h
+==> default: configure: creating ./config.status
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-config.h
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-version.h
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-config.h
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-version.h
+==> default: checking how to print strings... printf
+==> default: checking for a sed that does not truncate output... (cached) /bin/sed
+==> default: checking for fgrep... /bin/grep -F
+==> default: checking for ld used by cc... /usr/bin/ld
+==> default: checking if the linker (/usr/bin/ld) is GNU ld... yes
+==> default: checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
+==> default: checking the name lister (/usr/bin/nm -B) interface... BSD nm
+==> default: checking whether ln -s works... yes
+==> default: checking the maximum length of command line arguments... 1572864
+==> default: checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
+==> default: checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
+==> default: checking for /usr/bin/ld option to reload object files... -r
+==> default: checking for objdump... objdump
+==> default: checking how to recognize dependent libraries... pass_all
+==> default: checking for dlltool... no
+==> default: checking how to associate runtime and link libraries... printf %s
+==> default: 
+==> default: checking for ar... ar
+==> default: checking for archiver @FILE support... @
+==> default: checking for strip... strip
+==> default: checking for ranlib... ranlib
+==> default: checking for gawk... (cached) nawk
+==> default: checking command to parse /usr/bin/nm -B output from cc object... ok
+==> default: checking for sysroot... no
+==> default: checking for a working dd... /bin/dd
+==> default: checking how to truncate binary pipes... /bin/dd bs=4096 count=1
+==> default: checking for mt... mt
+==> default: checking if mt is a manifest tool... no
+==> default: checking for dlfcn.h... yes
+==> default: checking for objdir... .libs
+==> default: checking if cc supports -fno-rtti -fno-exceptions... no
+==> default: checking for cc option to produce PIC... -fPIC -DPIC
+==> default: checking if cc PIC flag -fPIC -DPIC works... yes
+==> default: checking if cc static flag -static works... yes
+==> default: checking if cc supports -c -o file.o... yes
+==> default: checking if cc supports -c -o file.o... (cached) yes
+==> default: checking whether the cc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
+==> default: checking whether -lc should be explicitly linked in... no
+==> default: checking dynamic linker characteristics... GNU/Linux ld.so
+==> default: checking how to hardcode library paths into programs... immediate
+==> default: checking whether stripping libraries is possible... yes
+==> default: checking if libtool supports shared libraries... yes
+==> default: checking whether to build shared libraries... yes
+==> default: checking whether to build static libraries... no
+==> default: configure: creating ./config.status
+==> default: 
+==> default: mongodb was configured with the following options:
+==> default: 
+==> default: Build configuration:
+==> default:   CFLAGS                                           : -g -O2
+==> default:   Extra CFLAGS                                     :  -pthread
+==> default:   Developers flags (slow)                          :
+==> default:   Code Coverage flags (extra slow)                 :
+==> default:   System mongoc                                    : no
+==> default:   System libbson                                   : no
+==> default:   LDFLAGS                                          :
+==> default:   EXTRA_LDFLAGS                                    :
+==> default:   MONGODB_SHARED_LIBADD                            :  -lssl -lcrypto -lrt
+==> default: 
+==> default: Please submit bugreports at:
+==> default:   https://jira.mongodb.org/browse/PHPC
+==> default: 
+==> default: 
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-config.h
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-version.h
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-config.h
+==> default: config.status: creating /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-version.h
+==> default: config.status: creating config.h
+==> default: config.status: executing libtool commands
+==> default: running: make
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/bson.c -o src/bson.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/bson.c  -fPIC -DPIC -o src/.libs/bson.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/Type.c -o src/BSON/Type.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/Type.c  -fPIC -DPIC -o src/BSON/.libs/Type.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/Unserializable.c -o src/BSON/Unserializable.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/Unserializable.c  -fPIC -DPIC -o src/BSON/.libs/Unserializable.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/Serializable.c -o src/BSON/Serializable.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/Serializable.c  -fPIC -DPIC -o src/BSON/.libs/Serializable.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/Persistable.c -o src/BSON/Persistable.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/Persistable.c  -fPIC -DPIC -o src/BSON/.libs/Persistable.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/Binary.c -o src/BSON/Binary.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/
+==> default: main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/Binary.c  -fPIC -DPIC -o src/BSON/.libs/Binary.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/Javascript.c -o src/BSON/Javascript.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/Javascript.c  -fPIC -DPIC -o src/BSON/.libs/Javascript.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/MaxKey.c -o src/BSON/MaxKey.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/MaxKey.c  -fPIC -DPIC -o src/BSON/.libs/MaxKey.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/MinKey.c -o src/BSON/MinKey.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/MinKey.c  -fPIC -DPIC -o src/BSON/.libs/MinKey.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/ObjectID.c -o src/BSON/ObjectID.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/ObjectID.c  -fPIC -DPIC -o src/BSON/.libs/ObjectID.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/Regex.c -o src/BSON/Regex.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/Regex.c  -fPIC -DPIC -o src/BSON/.libs/Regex.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/Timestamp.c -o src/BSON/Timestamp.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/Timestamp.c  -fPIC -DPIC -o src/BSON/.libs/Timestamp.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/BSON/UTCDateTime.c -o src/BSON/UTCDateTime.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/BSON/UTCDateTime.c  -fPIC -DPIC -o src/BSON/.libs/UTCDateTime.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Command.c -o src/MongoDB/Command.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Command.c  -fPIC -DPIC -o src/MongoDB/.libs/Command.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012
+==> default: /Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Cursor.c -o src/MongoDB/Cursor.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Cursor.c  -fPIC -DPIC -o src/MongoDB/.libs/Cursor.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/CursorId.c -o src/MongoDB/CursorId.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/CursorId.c  -fPIC -DPIC -o src/MongoDB/.libs/CursorId.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Manager.c -o src/MongoDB/Manager.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Manager.c  -fPIC -DPIC -o src/MongoDB/.libs/Manager.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Query.c -o src/MongoDB/Query.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Query.c  -fPIC -DPIC -o src/MongoDB/.libs/Query.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/ReadConcern.c -o src/MongoDB/ReadConcern.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/ReadConcern.c  -fPIC -DPIC -o src/MongoDB/.libs/ReadConcern.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/ReadPreference.c -o src/MongoDB/ReadPreference.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/ReadPreference.c  -fPIC -DPIC -o src/MongoDB/.libs/ReadPreference.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Server.c -o src/MongoDB/Server.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Server.c  -fPIC -DPIC -o src/MongoDB/.libs/Server.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/BulkWrite.c -o src/MongoDB/BulkWrite.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/BulkWrite.c  -fPIC -DPIC -o src/MongoDB/.libs/BulkWrite.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/WriteConcern.c -o src/MongoDB/WriteConcern.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151
+==> default: 012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/WriteConcern.c  -fPIC -DPIC -o src/MongoDB/.libs/WriteConcern.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/WriteConcernError.c -o src/MongoDB/WriteConcernError.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/WriteConcernError.c  -fPIC -DPIC -o src/MongoDB/.libs/WriteConcernError.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/WriteError.c -o src/MongoDB/WriteError.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/WriteError.c  -fPIC -DPIC -o src/MongoDB/.libs/WriteError.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/WriteResult.c -o src/MongoDB/WriteResult.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/WriteResult.c  -fPIC -DPIC -o src/MongoDB/.libs/WriteResult.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/Exception.c -o src/MongoDB/Exception/Exception.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/Exception.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/Exception.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/LogicException.c -o src/MongoDB/Exception/LogicException.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/LogicException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/LogicException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/RuntimeException.c -o src/MongoDB/Exception/RuntimeException.
+==> default: lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/RuntimeException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/RuntimeException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/UnexpectedValueException.c -o src/MongoDB/Exception/Unexpecte
+==> default: dValueException.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/UnexpectedValueException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/UnexpectedValueException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/InvalidArgumentException.c -o src/MongoDB/Exception/InvalidAr
+==> default: gumentException.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/InvalidArgumentException.c  -fPIC -
+==> default: DPIC -o src/MongoDB/Exception/.libs/InvalidArgumentException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/ConnectionException.c -o src/MongoDB/Exception/ConnectionExce
+==> default: ption.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/ConnectionException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/ConnectionException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/AuthenticationException.c -o src/MongoDB/Exception/Authentica
+==> default: tionException.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/AuthenticationException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/AuthenticationException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/SSLConnectionException.c -o src/MongoDB/Exception/SSLConnecti
+==> default: onException.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/SSLConnectionException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/SSLConnectionException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/ExecutionTimeoutException.c -o src/MongoDB/Exception/Executio
+==> default: nTimeoutException.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSO
+==> default: N/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/ExecutionTimeoutException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/ExecutionTimeoutException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/ConnectionTimeoutException.c -o src/MongoDB/Exception/Connect
+==> default: ionTimeoutException.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/ConnectionTimeoutException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/ConnectionTimeoutException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/WriteException.c -o src/MongoDB/Exception/WriteException.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/WriteException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/WriteException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/BulkWriteException.c -o src/MongoDB/Exception/BulkWriteExcept
+==> default: ion.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/MongoDB/Exception/BulkWriteException.c  -fPIC -DPIC -o src/MongoDB/Exception/.libs/BulkWriteException.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/contrib/php-ssl.c -o src/contrib/php-ssl.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/contrib/php-ssl.c  -fPIC -DPIC -o src/contrib/.libs/php-ssl.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-bu
+==> default: ild-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_version.c -o src/
+==> default: libbson/src/yajl/yajl_version.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_version.c  -fPIC -DPIC -o src/libbson/src/yajl/.libs/yajl_version.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl.c -o src/libbson/
+==> default: src/yajl/yajl.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl.c  -fPIC -DPIC -o src/libbson/src/yajl/.libs/yajl.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_encode.c -o src/l
+==> default: ibbson/src/yajl/yajl_encode.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_encode.c  -fPIC -DPIC -o src/libbson/src/yajl/.libs/yajl_encode.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_lex.c -o src/libb
+==> default: son/src/yajl/yajl_lex.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_lex.c  -fPIC -DPIC -o src/libbson/src/yajl/.libs/yajl_lex.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_parser.c -o src/l
+==> default: ibbson/src/yajl/yajl_parser.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_parser.c  -fPIC -DPIC -o src/libbson/src/yajl/.libs/yajl_parser.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_buf.c -o src/libb
+==> default: son/src/yajl/yajl_buf.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_buf.c  -fPIC -DPIC -o src/libbson/src/yajl/.libs/yajl_buf.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_tree.c -o src/lib
+==> default: bson/src/yajl/yajl_tree.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_tree.c  -fPIC -DPIC -o src/libbson/src/yajl/.libs/yajl_tree.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_alloc.c -o src/li
+==> default: bbson/src/yajl/yajl_alloc.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_alloc.c  -fPIC -DPIC -o src/libbson/src/yajl/.libs/yajl_alloc.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/t
+==> default: mp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_gen.c -o src/libb
+==> default: son/src/yajl/yajl_gen.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/yajl/yajl_gen.c  -fPIC -DPIC -o src/libbson/src/yajl/.libs/yajl_gen.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bcon.c -o src/libbson/
+==> default: src/bson/bcon.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bcon.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bcon.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson.c -o src/libbson/
+==> default: src/bson/bson.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-atomic.c -o src/l
+==> default: ibbson/src/bson/bson-atomic.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-atomic.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-atomic.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-clock.c -o src/li
+==> default: bbson/src/bson/bson-clock.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-clock.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-clock.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-context.c -o src/
+==> default: libbson/src/bson/bson-context.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-context.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-context.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-error.c -o src/li
+==> default: bbson/src/bson/bson-error.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-error.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-error.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-iter.c -o src/lib
+==> default: bson/src/bson/bson-iter.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-iter.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-iter.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/t
+==> default: mp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-iso8601.c -o src/
+==> default: libbson/src/bson/bson-iso8601.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-iso8601.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-iso8601.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-json.c -o src/lib
+==> default: bson/src/bson/bson-json.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-json.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-json.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-keys.c -o src/lib
+==> default: bson/src/bson/bson-keys.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-keys.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-keys.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-md5.c -o src/libb
+==> default: son/src/bson/bson-md5.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-md5.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-md5.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-memory.c -o src/l
+==> default: ibbson/src/bson/bson-memory.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-memory.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-memory.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-oid.c -o src/libb
+==> default: son/src/bson/bson-oid.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-oid.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-oid.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-reader.c -o src/l
+==> default: ibbson/src/bson/bson-reader.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-reader.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-reader.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-string.c -o src/l
+==> default: ibbson/src/bson/bson-string.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-string.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-string.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear
+==> default: -build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-timegm.c -o src/l
+==> default: ibbson/src/bson/bson-timegm.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-timegm.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-timegm.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-utf8.c -o src/lib
+==> default: bson/src/bson/bson-utf8.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-utf8.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-utf8.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-value.c -o src/li
+==> default: bbson/src/bson/bson-value.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-value.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-value.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-version-functions
+==> default: .c -o src/libbson/src/bson/bson-version-functions.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-version-functions.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-version-functions.
+==> default: o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-writer.c -o src/l
+==> default: ibbson/src/bson/bson-writer.lo
+==> default: libtool: compile:  cc -Isrc/libbson/src/bson/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libbson/src/bson/bson-writer.c  -fPIC -DPIC -o src/libbson/src/bson/.libs/bson-writer.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-arr
+==> default: ay.c -o src/libmongoc/src/mongoc/mongoc-array.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-array.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-array.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-asy
+==> default: nc.c -o src/libmongoc/src/mongoc/mongoc-async.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-async.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-async.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-asy
+==> default: nc-cmd.c -o src/libmongoc/src/mongoc/mongoc-async-cmd.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-async-cmd.c  -fPIC -DPIC -o src/libm
+==> default: ongoc/src/mongoc/.libs/mongoc-async-
+==> default: cmd.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-buf
+==> default: fer.c -o src/libmongoc/src/mongoc/mongoc-buffer.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-buffer.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-buffer.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-bul
+==> default: k-operation.c -o src/libmongoc/src/mongoc/mongoc-bulk-operation.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-bulk-operation.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-b
+==> default: ulk-operation.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-b64
+==> default: .c -o src/libmongoc/src/mongoc/mongoc-b64.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-b64.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-b64.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cli
+==> default: ent.c -o src/libmongoc/src/mongoc/mongoc-client.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-client.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-client.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cli
+==> default: ent-pool.c -o src/libmongoc/src/mongoc/mongoc-client-pool.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-client-pool.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-clie
+==> default: nt-pool.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-clu
+==> default: ster.c -o src/libmongoc/src/mongoc/mongoc-cluster.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cluster.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-cluster.
+==> default: o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-col
+==> default: lection.c -o src/libmongoc/src/mongoc/mongoc-collection.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-collection.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-colle
+==> default: ction.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cou
+==> default: nters.c -o src/libmongoc/src/mongoc/mongoc-counters.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/
+==> default: mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-counters.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-counter
+==> default: s.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cur
+==> default: sor.c -o src/libmongoc/src/mongoc/mongoc-cursor.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cursor.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-cursor.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cur
+==> default: sor-array.c -o src/libmongoc/src/mongoc/mongoc-cursor-array.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cursor-array.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-cur
+==> default: sor-array.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cur
+==> default: sor-transform.c -o src/libmongoc/src/mongoc/mongoc-cursor-transform.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cursor-transform.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc
+==> default: -cursor-transform.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cur
+==> default: sor-cursorid.c -o src/libmongoc/src/mongoc/mongoc-cursor-cursorid.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-cursor-cursorid.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-
+==> default: cursor-cursorid.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-dat
+==> default: abase.c -o src/libmongoc/src/mongoc/mongoc-database.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-database.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-databas
+==> default: e.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-fin
+==> default: d-and-modify.c -o src/libmongoc/src/mongoc/mongoc-find-and-modify.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-find-and-modify.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-
+==> default: find-and-modify.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-ini
+==> default: t.c -o src/libmongoc/src/mongoc/mongoc-init.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-init.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-init.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-gri
+==> default: dfs.c -o src/libm
+==> default: ongoc/src/mongoc/mongoc-gridfs.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-gridfs.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-gridfs.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-gri
+==> default: dfs-file.c -o src/libmongoc/src/mongoc/mongoc-gridfs-file.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-gridfs-file.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-grid
+==> default: fs-file.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-gri
+==> default: dfs-file-page.c -o src/libmongoc/src/mongoc/mongoc-gridfs-file-page.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-gridfs-file-page.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc
+==> default: -gridfs-file-page.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-gri
+==> default: dfs-file-list.c -o src/libmongoc/src/mongoc/mongoc-gridfs-file-list.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-gridfs-file-list.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc
+==> default: -gridfs-file-list.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-hos
+==> default: t-list.c -o src/libmongoc/src/mongoc/mongoc-host-list.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-host-list.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-host-l
+==> default: ist.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-ind
+==> default: ex.c -o src/libmongoc/src/mongoc/mongoc-index.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-index.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-index.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-lis
+==> default: t.c -o src/libmongoc/src/mongoc/mongoc-list.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-list.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-list.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-log
+==> default: .c -o src/libmongoc/src/mongoc/mongoc-log.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-log.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-log.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongod
+==> default: b/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-mat
+==> default: cher-op.c -o src/libmongoc/src/mongoc/mongoc-matcher-op.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-matcher-op.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-match
+==> default: er-op.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-mat
+==> default: cher.c -o src/libmongoc/src/mongoc/mongoc-matcher.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-matcher.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-matcher.
+==> default: o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-mem
+==> default: cmp.c -o src/libmongoc/src/mongoc/mongoc-memcmp.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-memcmp.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-memcmp.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-opc
+==> default: ode.c -o src/libmongoc/src/mongoc/mongoc-opcode.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/t
+==> default: emp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-opcode.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-opcode.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-que
+==> default: ue.c -o src/libmongoc/src/mongoc/mongoc-queue.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-queue.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-queue.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-rea
+==> default: d-concern.c -o src/libmongoc/src/mongoc/mongoc-read-concern.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-read-concern.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-rea
+==> default: d-concern.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-rea
+==> default: d-prefs.c -o src/libmongoc/src/mongoc/mongoc-read-prefs.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-read-prefs.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-read-
+==> default: prefs.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-rpc
+==> default: .c -o src/libmongoc/src/mongoc/mongoc-rpc.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-rpc.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-rpc.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmong
+==> default: oc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-set
+==> default: .c -o src/libmongoc/src/mongoc/mongoc-set.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-set.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-set.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-ser
+==> default: ver-description.c -o src/libmongoc/src/mongoc/mongoc-server-description.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-server-description.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mong
+==> default: oc-server-description.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-ser
+==> default: ver-stream.c -o src/libmongoc/src/mongoc/mongoc-server-stream.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-server-stream.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-se
+==> default: rver-stream.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-soc
+==> default: ket.c -o src/libmongoc/src/mongoc/mongoc-socket.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-socket.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-socket.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-str
+==> default: eam.c -o src/libmongoc/src/mongoc/mongoc-stream.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-stream.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-stream.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-str
+==> default: eam-buffered.c -o src/libmongoc/src/mongoc/mongoc-stream-buffered.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-stream-buffered.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-
+==> default: stream-buffered.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-str
+==> default: eam-file.c -o src/libmongoc/src/mongoc/mongoc-stream-file.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-stream-file.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-stre
+==> default: am-file.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-str
+==> default: eam-gridfs.c -o src/libmongoc/src/mongoc/mongoc-stream-gridfs.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tm
+==> default: p/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-stream-gridfs.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-st
+==> default: ream-gridfs.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-str
+==> default: eam-socket.c -o src/libmongoc/src/mongoc/mongoc-stream-socket.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-stream-socket.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-st
+==> default: ream-socket.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-top
+==> default: ology.c -o src/libmongoc/src/mongoc/mongoc-topology.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-topology.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-topolog
+==> default: y.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-top
+==> default: ology-scanner.c -o src/libmongoc/src/mongoc/mongoc-topology-scanner.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-topology-scanner.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc
+==> default: -topology-scanner.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-top
+==> default: ology-description.c -o src/libmongoc/src/mongoc/mongoc-topology-description.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-topology-description.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mo
+==> default: ngoc-topology-description.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-uri
+==> default: .c -o src/libmongoc/src/mongoc/mongoc-uri.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-uri.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-uri.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-uti
+==> default: l.c -o src/libmongoc/src/mongoc/mongoc-util.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-util.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-util.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-ver
+==> default: sion-functions.c -o src/libmongoc/src/mongoc/mongoc-version-functions.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-version-functions.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongo
+==> default: c-version-functions.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-wri
+==> default: te-command.c -o src/libmongoc/src/mongoc/mongoc-write-command
+==> default: .lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-write-command.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-wr
+==> default: ite-command.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-wri
+==> default: te-concern.c -o src/libmongoc/src/mongoc/mongoc-write-concern.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-write-concern.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-wr
+==> default: ite-concern.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-ran
+==> default: d.c -o src/libmongoc/src/mongoc/mongoc-rand.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-rand.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-rand.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-scr
+==> default: am.c -o src/libmongoc/src/mongoc/mongoc-scram.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-scram.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-scram.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-str
+==> default: eam-tls.c -o src/libmongoc/src/mongoc/mongoc-stream-tls.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-stream-tls.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-strea
+==> default: m-tls.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-ssl
+==> default: .c -o src/libmongoc/src/mongoc/mongoc-ssl.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-ssl.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-ssl.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc  -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-sas
+==> default: l.c -o src/libmongoc/src/mongoc/mongoc-sasl.lo
+==> default: libtool: compile:  cc -Isrc/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/mongoc-sasl.c  -fPIC -DPIC -o src/libmongoc/src/mongoc/.libs/mongoc-sasl.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/php_phongo.c -o php_phongo.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/php_phongo.c  -fPIC -DPIC -o .libs/php_phongo.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=compile cc    -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_
+==> default: COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -c /tmp/pear/temp/mongodb/phongo_compat.c -o phongo_compat.lo
+==> default: libtool: compile:  cc -I. -I/tmp/pear/temp/mongodb -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/ -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H -g -O2 -pthread -c /tmp/pear/temp/mongodb/phongo_compat.c  -fPIC -DPIC -o .libs/phongo_compat.o
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=link cc -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/include -I/tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/main -I/tmp/pear/temp/mongodb -I/usr/include/php/20151012 -I/usr/include/php/20151012/main -I/usr/include/php/20151012/TSRM -I/usr/include/php/20151012/Zend -I/usr/include/php/20151012/ext -I/usr/include/php/20151012/ext/date/lib -I/tmp/pear/temp/mongodb/src/BSON/ -I/tmp/pear/temp/mongodb/src/MongoDB/ -I/tmp/pear/temp/mongodb/src/MongoDB/Exception/ -I/tmp/pear/temp/mongodb/src/contrib/ -I/tmp/pear/temp/mongodb/src/libmongoc/src/mongoc/ -I/tmp/pear/temp/mongodb/src/libbson/src/ -I/tmp/pear/temp/mongodb/src/libbson/src/yajl/ -I/tmp/pear/temp/mongodb/src/libbson/src/bson/  -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_TRACE -DHAVE_CONFIG_H  -g -O2 -pthread  -o mongodb.la -export-dynamic -avoid-version -prefer-pic -module -rpath /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/modules  src/bson.lo
+==> default: src/BSON/Type.lo src/BSON/Unserializable.lo src/BSON/Serializable.lo src/BSON/Persistable.lo src/BSON/Binary.lo src/BSON/Javascript.lo src/BSON/MaxKey.lo src/BSON/MinKey.lo src/BSON/ObjectID.lo src/BSON/Regex.lo src/BSON/Timestamp.lo src/BSON/UTCDateTime.lo src/MongoDB/Command.lo src/MongoDB/Cursor.lo src/MongoDB/CursorId.lo src/MongoDB/Manager.lo src/MongoDB/Query.lo src/MongoDB/ReadConcern.lo src/MongoDB/ReadPreference.lo src/MongoDB/Server.lo src/MongoDB/BulkWrite.lo src/MongoDB/WriteConcern.lo src/MongoDB/WriteConcernError.lo src/MongoDB/WriteError.lo src/MongoDB/WriteResult.lo src/MongoDB/Exception/Exception.lo src/MongoDB/Exception/LogicException.lo src/MongoDB/Exception/RuntimeException.lo src/MongoDB/Exception/UnexpectedValueException.lo src/MongoDB/Exception/InvalidArgumentException.lo src/MongoDB/Exception/ConnectionException.lo src/MongoDB/Exception/AuthenticationException.lo src/MongoDB/Exception/SSLConnectionException.lo src/MongoDB/Exception/ExecutionTimeoutException.lo src/MongoDB/Exception/Co
+==> default: nnectionTimeoutException.lo src/MongoDB/Exception/WriteException.lo src/MongoDB/Exception/BulkWriteException.lo src/contrib/php-ssl.lo src/libbson/src/yajl/yajl_version.lo src/libbson/src/yajl/yajl.lo src/libbson/src/yajl/yajl_encode.lo src/libbson/src/yajl/yajl_lex.lo src/libbson/src/yajl/yajl_parser.lo src/libbson/src/yajl/yajl_buf.lo src/libbson/src/yajl/yajl_tree.lo src/libbson/src/yajl/yajl_alloc.lo src/libbson/src/yajl/yajl_gen.lo src/libbson/src/bson/bcon.lo src/libbson/src/bson/bson.lo src/libbson/src/bson/bson-atomic.lo src/libbson/src/bson/bson-clock.lo src/libbson/src/bson/bson-context.lo src/libbson/src/bson/bson-error.lo src/libbson/src/bson/bson-iter.lo src/libbson/src/bson/bson-iso8601.lo src/libbson/src/bson/bson-json.lo src/libbson/src/bson/bson-keys.lo src/libbson/src/bson/bson-md5.lo src/libbson/src/bson/bson-memory.lo src/libbson/src/bson/bson-oid.lo src/libbson/src/bson/bson-reader.lo src/libbson/src/bson/bson-string.lo src/libbson/src/bson/bson-timegm.lo src/libbson/src/bson/bson-utf8.l
+==> default: o src/libbson/src/bson/bson-value.lo src/libbson/src/bson/bson-version-functions.lo src/libbson/src/bson/bson-writer.lo src/libmongoc/src/mongoc/mongoc-array.lo src/libmongoc/src/mongoc/mongoc-async.lo src/libmongoc/src/mongoc/mongoc-async-cmd.lo src/libmongoc/src/mongoc/mongoc-buffer.lo src/libmongoc/src/mongoc/mongoc-bulk-operation.lo src/libmongoc/src/mongoc/mongoc-b64.lo src/libmongoc/src/mongoc/mongoc-client.lo src/libmongoc/src/mongoc/mongoc-client-pool.lo src/libmongoc/src/mongoc/mongoc-cluster.lo src/libmongoc/src/mongoc/mongoc-collection.lo src/libmongoc/src/mongoc/mongoc-counters.lo src/libmongoc/src/mongoc/mongoc-cursor.lo src/libmongoc/src/mongoc/mongoc-cursor-array.lo src/libmongoc/src/mongoc/mongoc-cursor-transform.lo src/libmongoc/src/mongoc/mongoc-cursor-cursorid.lo src/libmongoc/src/mongoc/mongoc-database.lo src/libmongoc/src/mongoc/mongoc-find-and-modify.lo src/libmongoc/src/mongoc/mongoc-init.lo src/libmongoc/src/mongoc/mongoc-gridfs.lo src/libmongoc/src/mongoc/mongoc-gridfs-file.lo src/li
+==> default: bmongoc/src/mongoc/mongoc-gridfs-file-page.lo src/libmongoc/src/mongoc/mongoc-gridfs-file-list.lo src/libmongoc/src/mongoc/mongoc-host-list.lo src/libmongoc/src/mongoc/mongoc-index.lo src/libmongoc/src/mongoc/mongoc-list.lo src/libmongoc/src/mongoc/mongoc-log.lo src/libmongoc/src/mongoc/mongoc-matcher-op.lo src/libmongoc/src/mongoc/mongoc-matcher.lo src/libmongoc/src/mongoc/mongoc-memcmp.lo src/libmongoc/src/mongoc/mongoc-opcode.lo src/libmongoc/src/mongoc/mongoc-queue.lo src/libmongoc/src/mongoc/mongoc-read-concern.lo src/libmongoc/src/mongoc/mongoc-read-prefs.lo src/libmongoc/src/mongoc/mongoc-rpc.lo src/libmongoc/src/mongoc/mongoc-set.lo src/libmongoc/src/mongoc/mongoc-server-description.lo src/libmongoc/src/mongoc/mongoc-server-stream.lo src/libmongoc/src/mongoc/mongoc-socket.lo src/libmongoc/src/mongoc/mongoc-stream.lo src/libmongoc/src/mongoc/mongoc-stream-buffered.lo src/libmongoc/src/mongoc/mongoc-stream-file.lo src/libmongoc/src/mongoc/mongoc-stream-gridfs.lo src/libmongoc/src/mongoc/mongoc-stream-s
+==> default: ocket.lo src/libmongoc/src/mongoc/mongoc-topology.lo src/libmongoc/src/mongoc/mongoc-topology-scanner.lo src/libmongoc/src/mongoc/mongoc-topology-description.lo src/libmongoc/src/mongoc/mongoc-uri.lo src/libmongoc/src/mongoc/mongoc-util.lo src/libmongoc/src/mongoc/mongoc-version-functions.lo src/libmongoc/src/mongoc/mongoc-write-command.lo src/libmongoc/src/mongoc/mongoc-write-concern.lo src/libmongoc/src/mongoc/mongoc-rand.lo src/libmongoc/src/mongoc/mongoc-scram.lo src/libmongoc/src/mongoc/mongoc-stream-tls.lo src/libmongoc/src/mongoc/mongoc-ssl.lo src/libmongoc/src/mongoc/mongoc-sasl.lo php_phongo.lo phongo_compat.lo -lssl -lcrypto -lrt
+==> default: libtool: link: cc -shared  -fPIC -DPIC  src/.libs/bson.o src/BSON/.libs/Type.o src/BSON/.libs/Unserializable.o src/BSON/.libs/Serializable.o src/BSON/.libs/Persistable.o src/BSON/.libs/Binary.o src/BSON/.libs/Javascript.o src/BSON/.libs/MaxKey.o src/BSON/.libs/MinKey.o src/BSON/.libs/ObjectID.o src/BSON/.libs/Regex.o src/BSON/.libs/Timestamp.o src/BSON/.libs/UTCDateTime.o src/MongoDB/.libs/Command.o src/MongoDB/.libs/Cursor.o src/MongoDB/.libs/CursorId.o src/MongoDB/.libs/Manager.o src/MongoDB/.libs/Query.o src/MongoDB/.libs/ReadConcern.o src/MongoDB/.libs/ReadPreference.o src/MongoDB/.libs/Server.o src/MongoDB/.libs/BulkWrite.o src/MongoDB/.libs/WriteConcern.o src/MongoDB/.libs/WriteConcernError.o src/MongoDB/.libs/WriteError.o src/MongoDB/.libs/WriteResult.o src/MongoDB/Exception/.libs/Exception.o src/MongoDB/Exception/.libs/LogicException.o src/MongoDB/Exception/.libs/RuntimeException.o src/MongoDB/Exception/.libs/UnexpectedValueException.o src/MongoDB/Exception/.libs/InvalidArgumentException.o src/MongoD
+==> default: B/Exception/.libs/ConnectionException.o src/MongoDB/Exception/.libs/AuthenticationException.o src/MongoDB/Exception/.libs/SSLConnectionException.o src/MongoDB/Exception/.libs/ExecutionTimeoutException.o src/MongoDB/Exception/.libs/ConnectionTimeoutException.o src/MongoDB/Exception/.libs/WriteException.o src/MongoDB/Exception/.libs/BulkWriteException.o src/contrib/.libs/php-ssl.o src/libbson/src/yajl/.libs/yajl_version.o src/libbson/src/yajl/.libs/yajl.o src/libbson/src/yajl/.libs/yajl_encode.o src/libbson/src/yajl/.libs/yajl_lex.o src/libbson/src/yajl/.libs/yajl_parser.o src/libbson/src/yajl/.libs/yajl_buf.o src/libbson/src/yajl/.libs/yajl_tree.o src/libbson/src/yajl/.libs/yajl_alloc.o src/libbson/src/yajl/.libs/yajl_gen.o src/libbson/src/bson/.libs/bcon.o src/libbson/src/bson/.libs/bson.o src/libbson/src/bson/.libs/bson-atomic.o src/libbson/src/bson/.libs/bson-clock.o src/libbson/src/bson/.libs/bson-context.o src/libbson/src/bson/.libs/bson-error.o src/libbson/src/bson/.libs/bson-iter.o src/libbson/src/bson
+==> default: /.libs/bson-iso8601.o src/libbson/src/bson/.libs/bson-json.o src/libbson/src/bson/.libs/bson-keys.o src/libbson/src/bson/.libs/bson-md5.o src/libbson/src/bson/.libs/bson-memory.o src/libbson/src/bson/.libs/bson-oid.o src/libbson/src/bson/.libs/bson-reader.o src/libbson/src/bson/.libs/bson-string.o src/libbson/src/bson/.libs/bson-timegm.o src/libbson/src/bson/.libs/bson-utf8.o src/libbson/src/bson/.libs/bson-value.o src/libbson/src/bson/.libs/bson-version-functions.o src/libbson/src/bson/.libs/bson-writer.o src/libmongoc/src/mongoc/.libs/mongoc-array.o src/libmongoc/src/mongoc/.libs/mongoc-async.o src/libmongoc/src/mongoc/.libs/mongoc-async-cmd.o src/libmongoc/src/mongoc/.libs/mongoc-buffer.o src/libmongoc/src/mongoc/.libs/mongoc-bulk-operation.o src/libmongoc/src/mongoc/.libs/mongoc-b64.o src/libmongoc/src/mongoc/.libs/mongoc-client.o src/libmongoc/src/mongoc/.libs/mongoc-client-pool.o src/libmongoc/src/mongoc/.libs/mongoc-cluster.o src/libmongoc/src/mongoc/.libs/mongoc-collection.o src/libmongoc/src/mongoc/
+==> default: .libs/mongoc-counters.o src/libmongoc/src/mongoc/.libs/mongoc-cursor.o src/libmongoc/src/mongoc/.libs/mongoc-cursor-array.o src/libmongoc/src/mongoc/.libs/mongoc-cursor-transform.o src/libmongoc/src/mongoc/.libs/mongoc-cursor-cursorid.o src/libmongoc/src/mongoc/.libs/mongoc-database.o src/libmongoc/src/mongoc/.libs/mongoc-find-and-modify.o src/libmongoc/src/mongoc/.libs/mongoc-init.o src/libmongoc/src/mongoc/.libs/mongoc-gridfs.o src/libmongoc/src/mongoc/.libs/mongoc-gridfs-file.o src/libmongoc/src/mongoc/.libs/mongoc-gridfs-file-page.o src/libmongoc/src/mongoc/.libs/mongoc-gridfs-file-list.o src/libmongoc/src/mongoc/.libs/mongoc-host-list.o src/libmongoc/src/mongoc/.libs/mongoc-index.o src/libmongoc/src/mongoc/.libs/mongoc-list.o src/libmongoc/src/mongoc/.libs/mongoc-log.o src/libmongoc/src/mongoc/.libs/mongoc-matcher-op.o src/libmongoc/src/mongoc/.libs/mongoc-matcher.o src/libmongoc/src/mongoc/.libs/mongoc-memcmp.o src/libmongoc/src/mongoc/.libs/mongoc-opcode.o src/libmongoc/src/mongoc/.libs/mongoc-queue.o
+==> default:  src/libmongoc/src/mongoc/.libs/mongoc-read-concern.o src/libmongoc/src/mongoc/.libs/mongoc-read-prefs.o src/libmongoc/src/mongoc/.libs/mongoc-rpc.o src/libmongoc/src/mongoc/.libs/mongoc-set.o src/libmongoc/src/mongoc/.libs/mongoc-server-description.o src/libmongoc/src/mongoc/.libs/mongoc-server-stream.o src/libmongoc/src/mongoc/.libs/mongoc-socket.o src/libmongoc/src/mongoc/.libs/mongoc-stream.o src/libmongoc/src/mongoc/.libs/mongoc-stream-buffered.o src/libmongoc/src/mongoc/.libs/mongoc-stream-file.o src/libmongoc/src/mongoc/.libs/mongoc-stream-gridfs.o src/libmongoc/src/mongoc/.libs/mongoc-stream-socket.o src/libmongoc/src/mongoc/.libs/mongoc-topology.o src/libmongoc/src/mongoc/.libs/mongoc-topology-scanner.o src/libmongoc/src/mongoc/.libs/mongoc-topology-description.o src/libmongoc/src/mongoc/.libs/mongoc-uri.o src/libmongoc/src/mongoc/.libs/mongoc-util.o src/libmongoc/src/mongoc/.libs/mongoc-version-functions.o src/libmongoc/src/mongoc/.libs/mongoc-write-command.o src/libmongoc/src/mongoc/.libs/mongoc-w
+==> default: rite-concern.o src/libmongoc/src/mongoc/.libs/mongoc-rand.o src/libmongoc/src/mongoc/.libs/mongoc-scram.o src/libmongoc/src/mongoc/.libs/mongoc-stream-tls.o src/libmongoc/src/mongoc/.libs/mongoc-ssl.o src/libmongoc/src/mongoc/.libs/mongoc-sasl.o .libs/php_phongo.o .libs/phongo_compat.o   -lssl -lcrypto -lrt  -g -O2 -pthread   -pthread -Wl,-soname -Wl,mongodb.so -o .libs/mongodb.so
+==> default: libtool: link: ( cd ".libs" && rm -f "mongodb.la" && ln -s "../mongodb.la" "mongodb.la" )
+==> default: /bin/bash /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/libtool --mode=install cp ./mongodb.la /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/modules
+==> default: libtool: install: cp ./.libs/mongodb.so /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/modules/mongodb.so
+==> default: libtool: install: cp ./.libs/mongodb.lai /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/modules/mongodb.la
+==> default: libtool: finish: PATH="/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/snap/bin:/snap/bin:/snap/bin:/snap/bin:/sbin" ldconfig -n /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/modules
+==> default: ----------------------------------------------------------------------
+==> default: Libraries have been installed in:
+==> default:    /tmp/pear/temp/pear-build-rootOOfmt8/mongodb-1.1.9/modules
+==> default: 
+==> default: If you ever happen to want to link against installed libraries
+==> default: in a given directory, LIBDIR, you must either use libtool, and
+==> default: specify the full pathname of the library, or use the '-LLIBDIR'
+==> default: flag during linking and do at least one of the following:
+==> default:    - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
+==> default:      during execution
+==> default:    - add LIBDIR to the 'LD_RUN_PATH' environment variable
+==> default:      during linking
+==> default:    - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
+==> default:    - have your system administrator add LIBDIR to '/etc/ld.so.conf'
+==> default: 
+==> default: See any operating system documentation about shared libraries for
+==> default: more information, such as the ld(1) and ld.so(8) manual pages.
+==> default: ----------------------------------------------------------------------
+==> default: 
+==> default: Build complete.
+==> default: Don't forget to run 'make test'.
+==> default: 
+==> default: running: make INSTALL_ROOT="/tmp/pear/temp/pear-build-rootOOfmt8/install-mongodb-1.1.9" install
+==> default: Installing shared extensions:     /tmp/pear/temp/pear-build-rootOOfmt8/install-mongodb-1.1.9/usr/lib/php/20151012/
+==> default: running: find "/tmp/pear/temp/pear-build-rootOOfmt8/install-mongodb-1.1.9" | xargs ls -dils
+==> default: 1836827    4 drwxr-xr-x 3 root root    4096 Nov 25 11:02 /tmp/pear/temp/pear-build-rootOOfmt8/install-mongodb-1.1.9
+==> default: 1837118    4 drwxr-xr-x 3 root root    4096 Nov 25 11:02 /tmp/pear/temp/pear-build-rootOOfmt8/install-mongodb-1.1.9/usr
+==> default: 1837119    4 drwxr-xr-x 3 root root    4096 Nov 25 11:02 /tmp/pear/temp/pear-build-rootOOfmt8/install-mongodb-1.1.9/usr/lib
+==> default: 1837120    4 drwxr-xr-x 3 root root    4096 Nov 25 11:02 /tmp/pear/temp/pear-build-rootOOfmt8/install-mongodb-1.1.9/usr/lib/php
+==> default: 1837121    4 drwxr-xr-x 2 root root    4096 Nov 25 11:02 /tmp/pear/temp/pear-build-rootOOfmt8/install-mongodb-1.1.9/usr/lib/php/20151012
+==> default: 1837117 3268 -rwxr-xr-x 1 root root 3342768 Nov 25 11:02 /tmp/pear/temp/pear-build-rootOOfmt8/install-mongodb-1.1.9/usr/lib/php/20151012/mongodb.so
+==> default: 
+==> default: Build process completed successfully
+==> default: Installing '/usr/lib/php/20151012/mongodb.so'
+==> default: install ok: channel://pecl.php.net/mongodb-1.1.9
+==> default: configuration option "php_ini" is not set to php.ini location
+==> default: You should add "extension=mongodb.so" to php.ini
+==> default: 
+==> default: stderr: yes: standard output: Broken pipe
+==> default: 
+==> default: TASK [install PECL mongo extension | enable module in mods-available] **********
+==> default: changed: [localhost]
+==> default: 
+==> default: msg: line added
+==> default: 
+==> default: TASK [install PECL mongo extension | ensure conf.d exists] *********************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [install PECL mongo extension | add mods-available in cli/conf.d] *********
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [install PECL mongo extension | add mods-available in apache2/conf.d] *****
+==> default: changed: [localhost]
+==> default: 
+==> default: TASK [Set Apache umask to 002] *************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: msg: line added
+==> default: 
+==> default: TASK [update the mongo config file] ********************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [ensure mongodb is running (and enable it at boot)] ***********************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [add host aliases] ********************************************************
+==> default: changed: [localhost] => (item=default.local)
+==> default: changed: [localhost] => (item=languageforge.local)
+==> default: changed: [localhost] => (item=scriptureforge.local)
+==> default: changed: [localhost] => (item=jamaicanpsalms.scriptureforge.local)
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=demo.scriptureforge.local)
+==> default: 
+==> default: TASK [install npm dependencies] ************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: cmd: npm install
+==> default: 
+==> default: start: 2016-11-25 11:02:53.190905
+==> default: 
+==> default: end: 2016-11-25 11:53:10.929926
+==> default: 
+==> default: delta: 0:50:17.739021
+==> default: 
+==> default: stdout: 
+==> default: > phantomjs-prebuilt@2.1.13 install /home/vagrant/src/xForge/web-languageforge/node_modules/phantomjs-prebuilt
+==> default: > node install.js
+==> default: 
+==> default: PhantomJS not found on PATH
+==> default: Downloading https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
+==> default: Saving to /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+==> default: Receiving...
+==> default: 
+==> default: Received 22866K total.
+==> default: Extracting tar contents (via spawned process)
+==> default: Removing /home/vagrant/src/xForge/web-languageforge/node_modules/phantomjs-prebuilt/lib/phantom
+==> default: Copying extracted folder /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2-extract-1480092782521/phantomjs-2.1.1-linux-x86_64 -> /home/vagrant/src/xForge/web-languageforge/node_modules/phantomjs-prebuilt/lib/phantom
+==> default: Writing location.js file
+==> default: Done. Phantomjs binary available at /home/vagrant/src/xForge/web-languageforge/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs
+==> default: xForge@0.1.0 /home/vagrant/src/xForge/web-languageforge
+==> default: ??? async@1.4.2 
+==> default: ??? gulp@4.0.0-alpha.2  (git://github.com/gulpjs/gulp.git#e9e5ab7e70080e1bfb5650a4fdc4c8849e70b3e0)
+==> default: ? ??? glob-watcher@3.0.0 
+==> default: ? ? ??? async-done@1.2.2 
+==> default: ? ? ? ??? end-of-stream@1.1.0 
+==> default: ? ? ? ? ??? once@1.3.3 
+==> default: ? ? ? ??? next-tick@1.0.0 
+==> default: ? ? ? ??? stream-exhaust@1.0.1 
+==> default: ? ? ??? lodash.assignwith@4.2.0 
+==> default: ? ? ??? lodash.debounce@4.0.8 
+==> default: ? ??? gulp-cli@1.2.2 
+==> default: ? ? ??? archy@1.0.0 
+==> default: ? ? ??? interpret@1.0.1 
+==> default: ? ? ??? liftoff@2.3.0 
+==> default: ? ? ? ??? findup-sync@0.4.3 
+==> default: ? ? ? ? ??? detect-file@0.1.0 
+==> default: ? ? ? ? ? ??? fs-exists-sync@0.1.0 
+==> default: ? ? ? ? ??? resolve-dir@0.1.1 
+==> default: ? ? ? ?   ??? global-modules@0.2.3 
+==> default: ? ? ? ?     ??? global-prefix@0.1.4 
+==> default: ? ? ? ?     ? ??? osenv@0.1.3 
+==> default: ? ? ? ?     ??? is-windows@0.2.0 
+==> default: ? ? ? ??? fined@1.0.2 
+==> default: ? ? ? ? ??? expand-tilde@1.2.2 
+==> default: ? ? ? ? ??? lodash.isempty@4.4.0 
+==> default: ? ? ? ? ??? lodash.pick@4.4.0 
+==> default: ? ? ? ? ??? parse-filepath@1.0.1 
+==> default: ? ? ? ?   ??? is-absolute@0.2.6 
+==> default: ? ? ? ?   ? ??? is-relative@0.2.1 
+==> default: ? ? ? ?   ?   ??? is-unc-path@0.1.1 
+==> default: ? ? ? ?   ?     ??? unc-path-regex@0.1.2 
+==> default: ? ? ? ?   ??? map-cache@0.2.2 
+==> default: ? ? ? ?   ??? path-root@0.1.1 
+==> default: ? ? ? ?     ??? path-root-regex@0.1.2 
+==> default: ? ? ? ??? flagged-respawn@0.3.2 
+==> default: ? ? ? ??? lodash.mapvalues@4.6.0 
+==> default: ? ? ? ??? resolve@1.1.7 
+==> default: ? ? ??? lodash.isfunction@3.0.8 
+==> default: ? ? ??? lodash.isplainobject@4.0.6 
+==> default: ? ? ??? lodash.isstring@4.0.1 
+==> default: ? ? ??? lodash.sortby@4.7.0 
+==> default: ? ? ??? matchdep@1.0.1 
+==> default: ? ? ? ??? findup-sync@0.3.0 
+==> default: ? ? ? ??? micromatch@2.3.11 
+==> default: ? ? ? ? ??? arr-diff@2.0.0 
+==> default: ? ? ? ? ? ??? arr-flatten@1.0.1 
+==> default: ? ? ? ? ??? braces@1.8.5 
+==> default: ? ? ? ? ? ??? expand-range@1.8.2 
+==> default: ? ? ? ? ? ? ??? fill-range@2.2.3 
+==> default: ? ? ? ? ? ?   ??? is-number@2.1.0 
+==> default: ? ? ? ? ? ?   ??? isobject@2.1.0 
+==> default: ? ? ? ? ? ?   ??? randomatic@1.1.6 
+==> default: ? ? ? ? ? ??? preserve@0.2.0 
+==> default: ? ? ? ? ? ??? repeat-element@1.1.2 
+==> default: ? ? ? ? ??? expand-brackets@0.1.5 
+==> default: ? ? ? ? ? ??? is-posix-bracket@0.1.1 
+==> default: ? ? ? ? ??? extglob@0.3.2 
+==> default: ? ? ? ? ??? filename-regex@2.0.0 
+==> default: ? ? ? ? ??? kind-of@3.0.4 
+==> default: ? ? ? ? ? ??? is-buffer@1.1.4 
+==> default: ? ? ? ? ??? normalize-path@2.0.1 
+==> default: ? ? ? ? ??? object.omit@2.0.1 
+==> default: ? ? ? ? ? ??? for-own@0.1.4 
+==> default: ? ? ? ? ? ? ??? for-in@0.1.6 
+==> default: ? ? ? ? ? ??? is-extendable@0.1.1 
+==> default: ? ? ? ? ??? parse-glob@3.0.4 
+==> default: ? ? ? ? ? ??? glob-base@0.3.0 
+==> default: ? ? ? ? ? ??? is-dotfile@1.0.2 
+==> default: ? ? ? ? ??? regex-cache@0.4.3 
+==> default: ? ? ? ?   ??? is-equal-shallow@0.1.3 
+==> default: ? ? ? ?   ??? is-primitive@2.0.0 
+==> default: ? ? ? ??? stack-trace@0.0.9 
+==> default: ? ? ??? mute-stdout@1.0.0 
+==> default: ? ? ??? pretty-hrtime@1.0.3 
+==> default: ? ? ??? semver-greatest-satisfied-range@1.0.0 
+==> default: ? ? ? ??? semver-regex@1.0.0 
+==> default: ? ? ??? tildify@1.2.0 
+==> default: ? ? ? ??? os-homedir@1.0.2 
+==> default: ? ? ??? v8flags@2.0.11 
+==> default: ? ? ? ??? user-home@1.1.1 
+==> default: ? ? ??? wreck@6.3.0 
+==> default: ? ? ? ??? boom@2.10.1 
+==> default: ? ? ? ??? hoek@2.16.3 
+==> default: ? ? ??? yargs@3.32.0 
+==> default: ? ?   ??? camelcase@2.1.1 
+==> default: ? ?   ??? window-size@0.1.4 
+==> default: ? ??? undertaker@1.0.0 
+==> default: ? ? ??? bach@1.0.0 
+==> default: ? ? ? ??? async-settle@1.0.0 
+==> default: ? ? ? ??? lodash.filter@4.6.0 
+==> default: ? ? ? ??? lodash.foreach@4.5.0 
+==> default: ? ? ? ??? lodash.initial@4.1.1 
+==> default: ? ? ? ??? lodash.last@3.0.0 
+==> default: ? ? ? ??? now-and-later@1.0.0 
+==> default: ? ? ??? es6-weak-map@2.0.1 
+==> default: ? ? ? ??? d@0.1.1 
+==> default: ? ? ? ??? es5-ext@0.10.12 
+==> default: ? ? ? ??? es6-iterator@2.0.0 
+==> default: ? ? ? ???
+==> default:  es6-symbol@3.1.0 
+==> default: ? ? ??? last-run@1.1.1 
+==> default: ? ? ? ??? default-resolution@2.0.0 
+==> default: ? ? ??? lodash.defaults@4.2.0 
+==> default: ? ? ??? lodash.flatten@4.4.0 
+==> default: ? ? ??? lodash.map@4.6.0 
+==> default: ? ? ??? lodash.reduce@4.6.0 
+==> default: ? ? ??? undertaker-registry@1.0.0 
+==> default: ? ??? vinyl-fs@2.4.4 
+==> default: ?   ??? duplexify@3.5.0 
+==> default: ?   ? ??? end-of-stream@1.0.0 
+==> default: ?   ? ? ??? once@1.3.3 
+==> default: ?   ? ??? stream-shift@1.0.0 
+==> default: ?   ??? glob-stream@5.3.5 
+==> default: ?   ? ??? glob@5.0.15 
+==> default: ?   ? ??? glob-parent@3.0.1 
+==> default: ?   ? ? ??? is-glob@3.1.0 
+==> default: ?   ? ? ? ??? is-extglob@2.1.0 
+==> default: ?   ? ? ??? path-dirname@1.0.2 
+==> default: ?   ? ??? ordered-read-streams@0.3.0 
+==> default: ?   ? ??? through2@0.6.5 
+==> default: ?   ? ? ??? readable-stream@1.0.34 
+==> default: ?   ? ?   ??? isarray@0.0.1 
+==> default: ?   ? ??? to-absolute-glob@0.1.1 
+==> default: ?   ? ? ??? extend-shallow@2.0.1 
+==> default: ?   ? ??? unique-stream@2.2.1 
+==> default: ?   ?   ??? json-stable-stringify@1.0.1 
+==> default: ?   ?     ??? jsonify@0.0.0 
+==> default: ?   ??? gulp-sourcemaps@1.6.0 
+==> default: ?   ? ??? convert-source-map@1.3.0 
+==> default: ?   ??? is-valid-glob@0.3.0 
+==> default: ?   ??? lazystream@1.0.0 
+==> default: ?   ??? lodash.isequal@4.4.0 
+==> default: ?   ??? merge-stream@1.0.1 
+==> default: ?   ??? object-assign@4.1.0 
+==> default: ?   ??? strip-bom@2.0.0 
+==> default: ?   ? ??? is-utf8@0.2.1 
+==> default: ?   ??? strip-bom-stream@1.0.0 
+==> default: ?   ? ??? first-chunk-stream@1.0.0 
+==> default: ?   ??? through2-filter@2.0.0 
+==> default: ?   ??? vali-date@1.0.0 
+==> default: ?   ??? vinyl@1.2.0 
+==> default: ??? gulp-concat@2.6.1 
+==> default: ? ??? concat-with-sourcemaps@1.0.4 
+==> default: ? ??? through2@2.0.1 
+==> default: ? ? ??? readable-stream@2.0.6 
+==> default: ? ? ??? xtend@4.0.1 
+==> default: ? ??? vinyl@2.0.1 
+==> default: ?   ??? clone@1.0.2 
+==> default: ?   ??? clone-buffer@1.0.0 
+==> default: ?   ??? clone-stats@1.0.0 
+==> default: ?   ??? cloneable-readable@1.0.0 
+==> default: ?   ??? is-stream@1.1.0 
+==> default: ?   ??? remove-trailing-separator@1.0.1 
+==> default: ?   ??? replace-ext@1.0.0 
+==> default: ??? gulp-exec@2.1.3 
+==> default: ? ??? gulplog@1.0.0 
+==> default: ?   ??? glogg@1.0.0 
+==> default: ??? gulp-jshint@2.0.4 
+==> default: ? ??? lodash@4.17.2 
+==> default: ? ??? minimatch@3.0.3 
+==> default: ? ? ??? brace-expansion@1.1.6 
+==> default: ? ?   ??? balanced-match@0.4.2 
+==> default: ? ?   ??? concat-map@0.0.1 
+==> default: ? ??? rcloader@0.2.2 
+==> default: ?   ??? lodash.assign@4.2.0 
+==> default: ?   ??? lodash.isobject@3.0.2 
+==> default: ?   ??? lodash.merge@4.6.0 
+==> default: ?   ??? rcfinder@0.1.9 
+==> default: ?     ??? lodash.clonedeep@4.5.0 
+==> default: ??? gulp-livereload@3.8.1 
+==> default: ? ??? chalk@0.5.1 
+==> default: ? ? ??? ansi-styles@1.1.0 
+==> default: ? ? ??? escape-string-regexp@1.0.5 
+==> default: ? ? ??? has-ansi@0.1.0 
+==> default: ? ? ? ??? ansi-regex@0.2.1 
+==> default: ? ? ??? strip-ansi@0.3.0 
+==> default: ? ? ??? supports-color@0.2.0 
+==> default: ? ??? debug@2.3.3 
+==> default: ? ? ??? ms@0.7.2 
+==> default: ? ??? event-stream@3.3.4 
+==> default: ? ? ??? duplexer@0.1.1 
+==> default: ? ? ??? from@0.1.3 
+==> default: ? ? ??? map-stream@0.1.0 
+==> default: ? ? ??? pause-stream@0.0.11 
+==> default: ? ? ??? split@0.3.3 
+==> default: ? ? ??? stream-combiner@0.0.4 
+==> default: ? ? ??? through@2.3.8 
+==> default: ? ??? lodash.assign@3.2.0 
+==> default: ? ? ??? lodash._baseassign@3.2.0 
+==> default: ? ? ??? lodash._createassigner@3.1.1 
+==> default: ? ? ? ??? lodash._bindcallback@3.0.1 
+==> default: ? ? ??? lodash.keys@3.1.2 
+==> default: ? ?   ??? lodash._getnative@3.9.1 
+==> default: ? ?   ??? lodash.isarguments@3.1.0 
+==> default: ? ?   ??? lodash.isarray@3.0.4 
+==> default: ? ??? mini-lr@0.1.9 
+==> default: ?   ??? faye-websocket@0.7.3 
+==> default: ?   ? ??? websocket-driver@0.6.5 
+==> default: ?   ?   ??? websocket-extensions@0.1.1 
+==> default: ?   ??? livereload-js@2.2.2 
+==> default: ?   ??? parseurl@1.3.1 
+==> default: ?   ??? qs@2.2.5 
+==> default: ??? gulp-markdown@1.2.0 
+==> default: ? ??? marked@0.3.6 
+==> default: ??? gulp-phpunit@0.21.4 
+==> default: ? ??? chalk@1.1.3 
+==> default: ? ? ??? ansi-styles@2.2.1 
+==> default: ? ? ??? has-ansi@2.0.0 
+==> default: ? ? ? ??? ansi-regex@2.0.0 
+==> default: ? ? ??? strip-ansi@3.0.1 
+==> default: ? ? ??? supports-color@2.0.0 
+==> default: ? ??? gulp-messenger@0.24.0 
+==> default: ? ? ??? bowser@1.4.5 
+==> default: ? ? ??? defaults@1.0.3 
+==> default: ? ? ??? detect-node@2.0.3 
+==> default: ? ? ??? gulp@3.9.1 
+==> default: ? ? ? ??? deprecated@0.0.1 
+==> default: ? ? ? ??? minimist@1.2.0 
+==> default: ? ? ? ??? orchestrator@0.3.8 
+==> default: ? ? ? ? ??? end-of-stream@0.1.5 
+==> default: ? ? ? ? ? ??? once@1.3.3 
+==> default: ? ? ? ? ??? sequencify@0.0.7 
+==> default: ? ? ? ? ??? stream-consume@0.1.0 
+==> default: ? ? ? ??? vinyl-fs@0.3.14 
+==> default: ? ? ?   ??? glob-stream@3.1.18 
+==> default: ? ? ?   ? ??? glob@4.5.3 
+==> default: ? ? ?   ? ??? glob2base@0.0.12 
+==> default: ? ? ?   ? ? ??? find-index@0.1.1 
+==> default: ? ? ?   ? ??? minimatch@2.0.10 
+==> default: ? ? ?   ? ??? ordered-read-streams@0.1.0 
+==> default: ? ? ?   ? ??? through2@0.6.5 
+==> default: ? ? ?   ? ??? unique-stream@1.0.0 
+==> default: ? ? ?   ??? glob-watcher@0.0.6 
+==> default: ? ? ?   ? ??? gaze@0.5.2 
+==> default: ? ? ?   ?   ??? globule@0.1.0 
+==> default: ? ? ?   ?     ??? glob@3.1.21 
+==> default: ? ? ?   ?     ? ??? graceful-fs@1.2.3 
+==> default: ? ? ?   ?     ? ??? inherits@1.0.2 
+==> default: ? ? ?   ?     ??? lodash@1.0.2 
+==> default: ? ? ?   ?     ??? minimatch@0.2.14 
+==> default: ? ? ?   ??? graceful-fs@3.0.11 
+==> default: ? ? ?   ? ??? natives@1.1.0 
+==> default: ? ? ?   ??? strip-bom@1.0.0 
+==> default: ? ? ?   ??? through2@0.6.5 
+==> default: ? ? ?   ? ??? readable-stream@1.0.34 
+==> default: ? ? ?   ?   ??? isarray@0.0.1 
+==> default: ? ? ?   ??? vinyl@0.4.6 
+==> default: ? ? ?     ??? clone@0.2.0 
+==> default: ? ? ??? is_js@0.8.0 
+==> default: ? ? ??? lodash@3.10.1 
+==> default: ? ? ??? lodash-deep@1.6.0 
+==> default: ? ? ??? moment@2.14.1 
+==> default: ? ? ??? path-exists@3.0.0 
+==> default: ? ? ??? pretty-hrtime@1.0.2 
+==> default: ? ? ??? purdy@2.2.0 
+==> default: ? ? ? ??? chalk@0.4.0 
+==> default: ? ? ? ? ??? ansi-styles@1.0.0 
+==> default: ? ? ? ? ??? has-color@0.1.7 
+==> default: ? ? ? ? ??? strip-ansi@0.1.1 
+==> default: ? ? ? ??? joi@6.10.1 
+==> default: ? ? ?   ??? isemail@1.2.0 
+==> default: ? ? ?   ??? topo@1.1.0 
+==> default: ? ? ??? sprintf-js@1.0.3 
+==> default: ? ? ??? winston@2.2.0 
+==> default: ? ?   ??? async@1.0.0 
+==> default: ? ?   ??? colors@1.0.3 
+==> default: ? ?   ??? cycle@1.0.3 
+==> default: ? ?   ??? eyes@0.1.8 
+==> default: ? ?   ??? pkginfo@0.3.1 
+==> default: ? ??? gulp-notify@2.2.0 
+==> default: ? ? ??? lodash.template@3.6.2 
+==> default: ? ? ??? node.extend@1.1.6 
+==> default: ? ? ? ??? is@3.2.0 
+==> default: ? ? ??? through2@0.6.5 
+==> default: ? ?   ??? readable-stream@1.0.34 
+==> default: ? ?     ??? isarray@0.0.1 
+==> default: ? ??? map-stream@0.0.6 
+==> default: ? ??? node-notifier@4.6.1 
+==> default: ? ? ??? cli-usage@0.1.4 
+==> default: ? ? ? ??? marked-terminal@1.7.0 
+==> default: ? ? ?   ??? cardinal@1.0.0 
+==> default: ? ? ?   ? ??? ansicolors@0.2.1 
+==> default: ? ? ?   ? ??? redeyed@1.0.1 
+==> default: ? ? ?   ?   ??? esprima@3.0.0 
+==> default: ? ? ?   ??? cli-table@0.3.1 
+==> default: ? ? ?   ??? node-emoji@1.4.1 
+==> default: ? ? ?     ??? string.prototype.codepointat@0.2.0 
+==> default: ? ? ??? growly@1.3.0 
+==> default: ? ? ??? lodash.clonedeep@3.0.2 
+==> default: ? ? ? ??? lodash._baseclone@3.3.0 
+==> default: ? ? ?   ??? lodash._arraycopy@3.0.0 
+==> default: ? ? ?   ??? lodash._arrayeach@3.0.0 
+==> default: ? ? ?   ??? lodash._basefor@3.0.3 
+==> default: ? ? ??? minimist@1.2.0 
+==> default: ? ? ??? semver@5.3.0 
+==> default: ? ? ??? shellwords@0.1.0 
+==> default: ? ??? shelljs@0.7.4 
+==> default: ?   ??? glob@7.1.1 
+==> default: ?   ??? rechoir@0.6.2 
+==> default: ??? gulp-protractor@3.0.0 
+==> default: ? ??? async@1.5.2 
+==> default: ? ??? dargs@4.1.0 
+==> default: ?   ??? number-is-nan@1.0.1 
+==> default: ??? gulp-rename@1.2.2 
+==> default: ??? gulp-replace@0.5.4 
+==> default: ? ??? istextorbinary@1.0.2 
+==> default: ? ? ??? binaryextensions@1.0.1 
+==> default: ? ? ??? textextensions@1.0.2 
+==> default: ? ??? readable-stream@2.2.2 
+==> default: ? ? ??? buffer-shims@1.0.0 
+==> default: ? ? ??? core-util-is@1.0.2 
+==> default: ? ? ??? inherits@2.0.3 
+==> default: ? ? ??? isarray@1.0.0 
+==> default: ? ? ??? process-nextick-args@1.0.7 
+==> default: ? ? ??? string_decoder@0.10.31 
+==> default: ? ? ??? util-deprecate@1.0.2 
+==> default: ? ??? replacestream@4.0.2 
+==> default: ??? gulp-uglify@2.0.0 
+==> default: ? ??? has-gulplog@0.1.0 
+==> default: ? ? ??? sparkles@1.0.0 
+==> default: ? ??? make-error-cause@1.2.2 
+==> default: ? ? ??? make-error@1.2.1 
+==> default: ? ??? uglify-js@2.7.0 
+==> default: ? ? ??? async@0.2.10 
+==> default: ? ? ??? uglify-to-browserify@1.0.2 
+==> default: ? ? ??? yargs@3.10.0 
+==> default: ? ?   ??? camelcase@1.2.1 
+==> default: ? ?   ??? cliui@2.1.0 
+==> default: ? ?   ? ??? center-align@0.1.3 
+==> default: ? ?   ? ? ??? align-text@0.1.4 
+==> default: ? ?   ? ? ? ??? longest@1.0.1 
+==> default: ? ?   ? ? ? ??? repeat-string@1.6.1 
+==> default: ? ?   ? ? ??? lazy-cache@1.0.4 
+==> default: ? ?   ? ??? right-align@0.1.3 
+==> default: ? ?   ? ??? wordwrap@0.0.2 
+==> default: ? ?   ??? window-size@0.1.0 
+==> default: ? ??? uglify-save-license@0.4.1 
+==> default: ? ??? vinyl-sourcemaps-apply@0.2.1 
+==> default: ??? gulp-util@3.0.7 
+==> default: ? ??? array-differ@1.0.0 
+==> default: ? ??? array-uniq@1.0.3 
+==> default: ? ??? beeper@1.1.1 
+==> default: ? ??? dateformat@1.0.12 
+==> default: ? ? ??? get-stdin@4.0.1 
+==> default: ? ? ??? meow@3.7.0 
+==> default: ? ?   ??? camelcase-keys@2.1.0 
+==> default: ? ?   ??? loud-rejection@1.6.0 
+==> default: ? ?   ? ??? currently-unhandled@0.4.1 
+==> default: ? ?   ? ? ??? array-find-index@1.0.2 
+==> default: ? ?   ? ??? signal-exit@3.0.1 
+==> default: ? ?   ??? map-obj@1.0.1 
+==> default: ? ?   ??? minimist@1.2.0 
+==> default: ? ?   ??? normalize-package-data@2.3.5 
+==> default: ? ?   ? ??? hosted-git-info@2.1.5 
+==> default: ? ?   ? ??? is-builtin-module@1.0.0 
+==> default: ? ?   ? ? ??? builtin-modules@1.1.1 
+==> default: ? ?   ? ??? validate-npm-package-license@3.0.1 
+==> default: ? ?   ?   ??? spdx-correct@1.0.2 
+==> default: ? ?   ?   ? ??? spdx-license-ids@1.2.2 
+==> default: ? ?   ?   ??? spdx-expression-parse@1.0.4 
+==> default: ? ?   ??? redent@1.0.0 
+==> default: ? ?   ? ??? indent-string@2.1.0 
+==> default: ? ?   ? ? ??? repeating@2.0.1 
+==> default: ? ?   ? ?   ??? is-finite@1.0.2 
+==> default: ? ?   ? ??? strip-indent@1.0.1 
+==> default: ? ?   ??? trim-newlines@1.0.0 
+==> default: ? ??? fancy-log@1.2.0 
+==> default: ? ? ??? time-stamp@1.0.1 
+==> default: ? ??? lodash._reescape@3.0.0 
+==> default: ? ??? lodash._reevaluate@3.0.0 
+==> default: ? ??? lodash._reinterpolate@3.0.0 
+==> default: ? ??? lodash.template@3.6.2 
+==> default: ? ? ??? lodash._basecopy@3.0.1 
+==> default: ? ? ??? lodash._basetostring@3.0.1 
+==> default: ? ? ??? lodash._basevalues@3.0.0 
+==> default: ? ? ??? lodash._isiterateecall@3.0.9 
+==> default: ? ? ??? lodash.escape@3.2.0 
+==> default: ? ? ? ??? lodash._root@3.0.1 
+==> default: ? ? ??? lodash.restparam@3.6.1 
+==> default: ? ? ??? lodash.templatesettings@3.1.1 
+==> default: ? ??? minimist@1.2.0 
+==> default: ? ??? multipipe@0.1.2 
+==> default: ? ? ??? duplexer2@0.0.2 
+==> default: ? ?   ??? readable-stream@1.1.14 
+==> default: ? ?     ??? isarray@0.0.1 
+==> default: ? ??? object-assign@3.0.0 
+==> default: ? ??? replace-ext@0.0.1 
+==> default: ? ??? vinyl@0.5.3 
+==> default: ?   ??? clone-stats@0.0.1 
+==> default: ??? jasmine-core@2.5.2 
+==> default: ??? jasmine-reporters@2.2.0 
+==> default: ? ??? jasmine@2.4.1 
+==> default: ? ? ??? glob@3.2.11 
+==> default: ? ? ? ??? minimatch@0.3.0 
+==> default: ? ? ?   ??? lru-cache@2.7.3 
+==> default: ? ? ?   ??? sigmund@1.0.1 
+==> default: ? ? ??? jasmine-core@2.4.1 
+==> default: ? ??? mkdirp@0.5.1 
+==> default: ? ? ??? minimist@0.0.8 
+==> default: ? ??? xmldom@0.1.22 
+==> default: ??? jshint@2.9.4 
+==> default: ? ??? cli@1.0.1 
+==> default: ? ? ??? glob@7.1.1 
+==> default: ? ??? console-browserify@1.1.0 
+==> default: ? ? ??? date-now@0.1.4 
+==> default: ? ??? exit@0.1.2 
+==> default: ? ??? htmlparser2@3.8.3 
+==> default: ? ? ??? domelementtype@1.3.0 
+==> default: ? ? ??? domhandler@2.3.0 
+==> default: ? ? ??? domutils@1.5.1 
+==> default: ? ? ? ??? dom-serializer@0.1.0 
+==> default: ? ? ?   ??? domelementtype@1.1.3 
+==> default: ? ? ?   ??? entities@1.1.1 
+==> default: ? ? ??? entities@1.0.0 
+==> default: ? ? ??? readable-stream@1.1.14 
+==> default: ? ?   ??? isarray@0.0.1 
+==> default: ? ??? lodash@3.7.0 
+==> default: ? ??? shelljs@0.3.0 
+==> default: ? ??? strip-json-comments@1.0.4 
+==> default: ??? jshint-stylish@2.2.1 
+==> default: ? ??? log-symbols@1.0.2 
+==> default: ? ??? plur@2.1.2 
+==> default: ? ? ??? irregular-plurals@1.2.0 
+==> default: ? ??? string-length@1.0.1 
+==> default: ? ??? text-table@0.2.0 
+==> default: ??? karma@1.3.0 
+==> default: ? ??? bluebird@3.4.6 
+==> default: ? ??? body-parser@1.14.2 
+==> default: ? ? ??? bytes@2.2.0 
+==> default: ? ? ??? content-type@1.0.2 
+==> default: ? ? ??? debug@2.2.0 
+==> default: ? ? ? ??? ms@0.7.1 
+==> default: ? ? ??? depd@1.1.0 
+==> default: ? ? ??? http-errors@1.3.1 
+==> default: ? ? ? ??? statuses@1.3.1 
+==> default: ? ? ??? iconv-lite@0.4.13 
+==> default: ? ? ??? on-finished@2.3.0 
+==> default: ? ? ? ??? ee-first@1.1.1 
+==> default: ? ? ??? qs@5.2.0 
+==> default: ? ? ??? raw-body@2.1.7 
+==> default: ? ? ? ??? bytes@2.4.0 
+==> default: ? ? ? ??? unpipe@1.0.0 
+==> default: ? ? ??? type-is@1.6.14 
+==> default: ? ?   ??? media-typer@0.3.0 
+==> default: ? ??? chokidar@1.6.1 
+==> default: ? ? ??? anymatch@1.3.0 
+==> default: ? ? ? ??? arrify@1.0.1 
+==> default: ? ? ??? async-each@1.0.1 
+==> default: ? ? ??? glob-parent@2.0.0 
+==> default: ? ? ??? is-binary-path@1.0.1 
+==> default: ? ? ? ??? binary-extensions@1.7.0 
+==> default: ? ? ??? is-glob@2.0.1 
+==> default: ? ? ? ??? is-extglob@1.0.0 
+==> default: ? ? ??? path-is-absolute@1.0.1 
+==> default: ? ? ??? readdirp@2.1.0 
+==> default: ? ?   ??? set-immediate-shim@1.0.1 
+==> default: ? ??? colors@1.1.2 
+==> default: ? ??? combine-lists@1.0.1 
+==> default: ? ??? connect@3.5.0 
+==> default: ? ? ??? debug@2.2.0 
+==> default: ? ? ? ??? ms@0.7.1 
+==> default: ? ? ??? finalhandler@0.5.0 
+==> default: ? ? ? ??? debug@2.2.0 
+==> default: ? ? ? ? ??? ms@0.7.1 
+==> default: ? ? ? ??? escape-html@1.0.3 
+==> default: ? ? ??? utils-merge@1.0.0 
+==> default: ? ??? core-js@2.4.1 
+==> default: ? ??? di@0.0.1 
+==> default: ? ??? dom-serialize@2.2.1 
+==> default: ? ? ??? custom-event@1.0.1 
+==> default: ? ? ??? ent@2.2.0 
+==> default: ? ? ??? extend@3.0.0 
+==> default: ? ? ??? void-elements@2.0.1 
+==> default: ? ??? expand-braces@0.1.2 
+==> default: ? ? ??? array-slice@0.2.3 
+==> default: ? ? ??? array-unique@0.2.1 
+==> default: ? ? ??? braces@0.1.5 
+==> default: ? ?   ??? expand-range@0.1.1 
+==> default: ? ?     ??? is-number@0.1.1 
+==> default: ? ?     ??? repeat-string@0.2.2 
+==> default: ? ??? glob@7.1.1 
+==> default: ? ? ??? fs.realpath@1.0.0 
+==> default: ? ? ??? inflight@1.0.6 
+==> default: ? ? ? ??? wrappy@1.0.2 
+==> default: ? ? ??? once@1.4.0 
+==> default: ? ??? graceful-fs@4.1.11 
+==> default: ? ??? http-proxy@1.15.2 
+==> default: ? ? ??? eventemitter3@1.2.0 
+==> default: ? ? ??? requires-port@1.0.0 
+==> default: ? ??? isbinaryfile@3.0.1 
+==> default: ? ??? lodash@3.10.1 
+==> default: ? ??? log4js@0.6.38 
+==> default: ? ? ??? readable-stream@1.0.34 
+==> default: ? ? ? ??? isarray@0.0.1 
+==> default: ? ? ??? semver@4.3.6 
+==> default: ? ??? mime@1.3.4 
+==> default: ? ??? optimist@0.6.1 
+==> default: ? ? ??? wordwrap@0.0.3 
+==> default: ? ??? qjobs@1.1.5 
+==> default: ? ??? range-parser@1.2.0 
+==> default: ? ??? rimraf@2.5.4 
+==> default: ? ? ??? glob@7.1.1 
+==> default: ? ??? socket.io@1.4.7 
+==> default: ? ? ??? debug@2.2.0 
+==> default: ? ? ? ??? ms@0.7.1 
+==> default: ? ? ??? engine.io@1.6.10 
+==> default: ? ? ? ??? accepts@1.1.4 
+==> default: ? ? ? ? ??? mime-types@2.0.14 
+==> default: ? ? ? ? ? ??? mime-db@1.12.0 
+==> default: ? ? ? ? ??? negotiator@0.4.9 
+==> default: ? ? ? ??? base64id@0.1.0 
+==> default: ? ? ? ??? debug@2.2.0 
+==> default: ? ? ? ? ??? ms@0.7.1 
+==> default: ? ? ? ??? engine.io-parser@1.2.4 
+==> default: ? ? ? ? ??? after@0.8.1 
+==> default: ? ? ? ? ??? arraybuffer.slice@0.0.6 
+==> default: ? ? ? ? ??? base64-arraybuffer@0.1.2 
+==> default: ? ? ? ? ??? blob@0.0.4 
+==> default: ? ? ? ? ??? has-binary@0.1.6 
+==> default: ? ? ? ? ? ??? isarray@0.0.1 
+==> default: ? ? ? ? ??? utf8@2.1.0 
+==> default: ? ? ? ??? ws@1.0.1 
+==> default: ? ? ??? has-binary@0.1.7 
+==> default: ? ? ? ??? isarray@0.0.1 
+==> default: ? ? ??? socket.io-adapter@0.4.0 
+==> default: ? ? ? ??? debug@2.2.0 
+==> default: ? ? ? ? ??? ms@0.7.1 
+==> default: ? ? ? ??? socket.io-parser@2.2.2 
+==> default: ? ? ?   ??? debug@0.7.4 
+==> default: ? ? ?   ??? isarray@0.0.1 
+==> default: ? ? ?   ??? json3@3.2.6 
+==> default: ? ? ??? socket.io-client@1.4.6 
+==> default: ? ? ? ??? backo2@1.0.2 
+==> default: ? ? ? ??? component-bind@1.0.0 
+==> default: ? ? ? ??? component-emitter@1.2.0 
+==> default: ? ? ? ??? debug@2.2.0 
+==> default: ? ? ? ? ??? ms@0.7.1 
+==> default: ? ? ? ??? engine.io-client@1.6.9 
+==> default: ? ? ? ? ??? component-inherit@0.0.3 
+==> default: ? ? ? ? ??? debug@2.2.0 
+==> default: ? ? ? ? ? ??? ms@0.7.1 
+==> default: ? ? ? ? ??? has-cors@1.1.0 
+==> default: ? ? ? ? ??? parsejson@0.0.1 
+==> default: ? ? ? ? ??? parseqs@0.0.2 
+==> default: ? ? ? ? ??? ws@1.0.1 
+==> default: ? ? ? ? ??? xmlhttprequest-ssl@1.5.1 
+==> default: ? ? ? ? ??? yeast@0.1.2 
+==> default: ? ? ? ??? indexof@0.0.1 
+==> default: ? ? ? ??? object-component@0.0.3 
+==> default: ? ? ? ??? parseuri@0.0.4 
+==> default: ? ? ? ? ??? better-assert@1.0.2 
+==> default: ? ? ? ?   ??? callsite@1.0.0 
+==> default: ? ? ? ??? to-array@0.1.4 
+==> default: ? ? ??? socket.io-parser@2.2.6 
+==> default: ? ?   ??? benchmark@1.0.0 
+==> default: ? ?   ??? component-emitter@1.1.2 
+==> default: ? ?   ??? debug@2.2.0 
+==> default: ? ?   ? ??? ms@0.7.1 
+==> default: ? ?   ??? isarray@0.0.1 
+==> default: ? ?   ??? json3@3.3.2 
+==> default: ? ??? source-map@0.5.6 
+==> default: ? ??? tmp@0.0.28 
+==> default: ? ? ??? os-tmpdir@1.0.2 
+==> default: ? ??? useragent@2.1.9 
+==> default: ?   ??? lru-cache@2.2.4 
+==> default: ??? karma-chrome-launcher@1.0.1 
+==> default: ? ??? fs-access@1.0.1 
+==> default: ? ? ??? null-check@1.0.0 
+==> default: ? ??? which@1.2.12 
+==> default: ?   ??? isexe@1.1.2 
+==> default: ??? karma-jasmine@1.0.2 
+==> default: ??? karma-phantomjs-launcher@1.0.2 
+==> default: ??? karma-teamcity-reporter@1.0.0 
+==> default: ??? lodash.template@4.4.0 
+==> default: ? ??? lodash.templatesettings@4.1.0 
+==> default: ??? path@0.12.7 
+==> default: ? ??? process@0.11.9 
+==> default: ? ??? util@0.10.3 
+==> default: ?   ??? inherits@2.0.1 
+==> default: ??? phantomjs-prebuilt@2.1.13 
+==> default: ? ??? es6-promise@4.0.5 
+==> default: ? ??? extract-zip@1.5.0 
+==> default: ? ? ??? concat-stream@1.5.0 
+==> default: ? ? ? ??? readable-stream@2.0.6 
+==> default: ? ? ? ??? typedarray@0.0.6 
+==> default: ? ? ??? debug@0.7.4 
+==> default: ? ? ??? mkdirp@0.5.0 
+==> default: ? ? ??? yauzl@2.4.1 
+==> default: ? ?   ??? fd-slicer@1.0.1 
+==> default: ? ?     ??? pend@1.2.0 
+==> default: ? ??? fs-extra@0.30.0 
+==> default: ? ? ??? jsonfile@2.4.0 
+==> default: ? ? ??? klaw@1.3.1 
+==> default: ? ??? hasha@2.2.0 
+==> default: ? ? ??? pinkie-promise@2.0.1 
+==> default: ? ?   ??? pinkie@2.0.4 
+==> default: ? ??? kew@0.7.0 
+==> default: ? ??? progress@1.1.8 
+==> default: ? ??? request@2.74.0 
+==> default: ? ? ??? aws-sign2@0.6.0 
+==> default: ? ? ??? aws4@1.5.0 
+==> default: ? ? ??? bl@1.1.2 
+==> default: ? ? ? ??? readable-stream@2.0.6 
+==> default: ? ? ??? caseless@0.11.0 
+==> default: ? ? ??? combined-stream@1.0.5 
+==> default: ? ? ? ??? delayed-stream@1.0.0 
+==> default: ? ? ??? forever-agent@0.6.1 
+==> default: ? ? ??? form-data@1.0.1 
+==> default: ? ? ? ??? async@2.1.4 
+==> default: ? ? ??? har-validator@2.0.6 
+==> default: ? ? ? ??? commander@2.9.0 
+==> default: ? ? ? ? ??? graceful-readlink@1.0.1 
+==> default: ? ? ? ??? is-my-json-valid@2.15.0 
+==> default: ? ? ?   ??? generate-function@2.0.0 
+==> default: ? ? ?   ??? generate-object-property@1.2.0 
+==> default: ? ? ?   ? ??? is-property@1.0.2 
+==> default: ? ? ?   ??? jsonpointer@4.0.0 
+==> default: ? ? ??? hawk@3.1.3 
+==> default: ? ? ? ??? cryptiles@2.0.5 
+==> default: ? ? ? ??? sntp@1.0.9 
+==> default: ? ? ??? http-signature@1.1.1 
+==> default: ? ? ? ??? assert-plus@0.2.0 
+==> default: ? ? ? ??? jsprim@1.3.1 
+==> default: ? ? ? ? ??? extsprintf@1.0.2 
+==> default: ? ? ? ? ??? json-schema@0.2.3 
+==> default: ? ? ? ? ??? verror@1.3.6 
+==> default: ? ? ? ??? sshpk@1.10.1 
+==> default: ? ? ?   ??? asn1@0.2.3 
+==> default: ? ? ?   ??? assert-plus@1.0.0 
+==> default: ? ? ?   ??? bcrypt-pbkdf@1.0.0 
+==> default: ? ? ?   ??? dashdash@1.14.1 
+==> default: ? ? ?   ? ??? assert-plus@1.0.0 
+==> default: ? ? ?   ??? ecc-jsbn@0.1.1 
+==> default: ? ? ?   ??? getpass@0.1.6 
+==> default: ? ? ?   ? ??? assert-plus@1.0.0 
+==> default: ? ? ?   ??? jodid25519@1.0.2 
+==> default: ? ? ?   ??? jsbn@0.1.0 
+==> default: ? ? ?   ??? tweetnacl@0.14.3 
+==> default: ? ? ??? is-typedarray@1.0.0 
+==> default: ? ? ??? isstream@0.1.2 
+==> default: ? ? ??? json-stringify-safe@5.0.1 
+==> default: ? ? ??? mime-types@2.1.13 
+==> default: ? ? ? ??? mime-db@1.25.0 
+==> default: ? ? ??? node-uuid@1.4.7 
+==> default: ? ? ??? oauth-sign@0.8.2 
+==> default: ? ? ??? qs@6.2.1 
+==> default: ? ? ??? stringstream@0.0.5 
+==> default: ? ? ??? tough-cookie@2.3.2 
+==> default: ? ? ? ??? punycode@1.4.1 
+==> default: ? ? ??? tunnel-agent@0.4.3 
+==> default: ? ??? request-progress@2.0.1 
+==> default: ?   ??? throttleit@1.0.0 
+==> default: ??? protractor@4.0.11 
+==> default: ? ??? @types/jasmine@2.5.38 
+==> default: ? ??? @types/node@6.0.51 
+==> default: ? ??? @types/q@0.0.32 
+==> default: ? ??? @types/selenium-webdriver@2.53.35 
+==> default: ? ??? adm-zip@0.4.7 
+==> default: ? ??? glob@7.1.1 
+==> default: ? ??? jasminewd2@0.0.10 
+==> default: ? ??? q@1.4.1 
+==> default: ? ??? saucelabs@1.3.0 
+==> default: ? ? ??? https-proxy-agent@1.0.0 
+==> default: ? ?   ??? agent-base@2.0.1 
+==> default: ? ?     ??? semver@5.0.3 
+==> default: ? ??? selenium-webdriver@2.53.3 
+==> default: ? ? ??? adm-zip@0.4.4 
+==> default: ? ? ??? tmp@0.0.24 
+==> default: ? ? ??? ws@1.1.1 
+==> default: ? ? ? ??? options@0.0.6 
+==> default: ? ? ? ??? ultron@1.0.2 
+==> default: ? ? ??? xml2js@0.4.4 
+==> default: ? ?   ??? sax@0.6.1 
+==> default: ? ?   ??? xmlbuilder@8.2.2 
+==> default: ? ??? source-map-support@0.4.6 
+==> default: ? ??? webdriver-manager@10.2.8 
+==> default: ?   ??? del@2.2.2 
+==> default: ?   ? ??? globby@5.0.0 
+==> default: ?   ? ? ??? array-union@1.0.2 
+==> default: ?   ? ? ??? glob@7.1.1 
+==> default: ?   ? ??? is-path-cwd@1.0.0 
+==> default: ?   ? ??? is-path-in-cwd@1.0.0 
+==> default: ?   ? ? ??? is-path-inside@1.0.0 
+==> default: ?   ? ?   ??? path-is-inside@1.0.2 
+==> default: ?   ? ??? pify@2.3.0 
+==> default: ?   ??? ini@1.3.4 
+==> default: ?   ??? minimist@1.2.0 
+==> default: ?   ??? request@2.79.0 
+==> default: ?   ? ??? form-data@2.1.2 
+==> default: ?   ? ? ??? asynckit@0.4.0 
+==> default: ?   ? ??? qs@6.3.0 
+==> default: ?   ? ??? uuid@3.0.0 
+==> default: ?   ??? semver@5.3.0 
+==> default: ??? yargs@6.4.0 
+==> default:   ??? camelcase@3.0.0 
+==> default:   ??? cliui@3.2.0 
+==> default:   ? ??? wrap-ansi@2.0.0 
+==> default:   ??? decamelize@1.2.0 
+==> default:   ??? get-caller-file@1.0.2 
+==> default:   ??? os-locale@1.4.0 
+==> default:   ? ??? lcid@1.0.0 
+==> default:   ?   ??? invert-kv@1.0.0 
+==> default:   ?
+==> default: ?? read-pkg-up@1.0.1 
+==> default:   ? ??? find-up@1.1.2 
+==> default:   ? ? ??? path-exists@2.1.0 
+==> default:   ? ??? read-pkg@1.1.0 
+==> default:   ?   ??? load-json-file@1.1.0 
+==> default:   ?   ? ??? parse-json@2.2.0 
+==> default:   ?   ?   ??? error-ex@1.3.0 
+==> default:   ?   ?     ??? is-arrayish@0.2.1 
+==> default:   ?   ??? path-type@1.1.0 
+==> default:   ??? require-directory@2.1.1 
+==> default:   ??? require-main-filename@1.0.1 
+==> default:   ??? set-blocking@2.0.0 
+==> default:   ??? string-width@1.0.2 
+==> default:   ? ??? code-point-at@1.1.0 
+==> default:   ? ??? is-fullwidth-code-point@1.0.0 
+==> default:   ??? which-module@1.0.0 
+==> default:   ??? window-size@0.2.0 
+==> default:   ??? y18n@3.2.1 
+==> default:   ??? yargs-parser@4.1.0 
+==> default:     ??? camelcase@3.0.0 
+==> default: 
+==> default: stderr: WARN engine gulp-messenger@0.24.0: wanted: {"node":">= 4.4"} (current: {"node":"4.2.6","npm":"3.5.2"})
+==> default: npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
+==> default: npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
+==> default: npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
+==> default: npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
+==> default: npm WARN deprecated node-uuid@1.4.7: use uuid module instead
+==> default: npm WARN prefer global marked@0.3.6 should be installed with -g
+==> default: npm WARN optional Skipping failed optional dependency /chokidar/fsevents:
+==> default: npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.15
+==> default: 
+==> default: RUNNING HANDLER [fix : restart rsyslog] ****************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: RUNNING HANDLER [apache_config : Restart apache] *******************************
+==> default: changed: [localhost]
+==> default: 
+==> default: RUNNING HANDLER [restart postfix] **********************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: PLAY [Deploy development environment for xForge (languageforge.org and scriptureforge.org)] ***
+==> default: 
+==> default: TASK [setup] *******************************************************************
+==> default: ok: [localhost]
+==> default: 
+==> default: TASK [composer install] ********************************************************
+==> default: ok: [localhost] => (item=/var/www/virtual/languageforge.org/htdocs)
+==> default: 
+==> default: msg: All items completed
+==> default: ok: [localhost] => (item=/var/www/virtual/scriptureforge.org/htdocs)
+==> default: 
+==> default: TASK [bower install] ***********************************************************
+==> default: ok: [localhost] => (item=/var/www/virtual/languageforge.org/htdocs)
+==> default: 
+==> default: msg: All items completed
+==> default: ok: [localhost] => (item=/var/www/virtual/scriptureforge.org/htdocs)
+==> default: 
+==> default: TASK [factory reset mongodb to empty with admin user] **************************
+==> default: changed: [localhost]
+==> default: 
+==> default: cmd: php FactoryReset.php run
+==> default: 
+==> default: start: 2016-11-25 12:09:44.328553
+==> default: 
+==> default: end: 2016-11-25 12:09:44.435003
+==> default: 
+==> default: delta: 0:00:00.106450
+==> default: 
+==> default: stdout: 
+==> default: Script being run on your LOCAL MACHINE khrap
+==> default: Mongo host option: ""
+==> default: 
+==> default: 0 projects will be deleted
+==> default: 
+==> default: Dropping main database...
+==> default: 
+==> default: Dropping other dbs on the server (like test dbs)
+==> default: mongo --quiet  --eval 'db.getMongo().getDBNames().forEach(function(i){  if (i.indexOf("sf_") == 0 || i.indexOf("scriptureforge") == 0) { print("Dropping " + i); db.getSiblingDB(i).dropDatabase()}})'
+==> default: Dropping scriptureforge
+==> default: 
+==> default: Creating local user: admin password: password
+==> default: PLAY [Install Dev Tools] *******************************************************
+==> default: 
+==> default: TASK [Dev: Install packages] ***************************************************
+==> default: 
+==> default: msg: All items completed
+==> default: changed: [localhost] => (item=[u'chromium-browser'])
+==> default: 
+==> default: TASK [Dev VSCode: Check if already installed] **********************************
+==> default: changed: [localhost]
+==> default: 
+==> default: cmd: dpkg-query -W code
+==> default: 
+==> default: start: 2016-11-25 19:11:37.964268
+==> default: 
+==> default: end: 2016-11-25 19:11:37.993222
+==> default: 
+==> default: delta: 0:00:00.028954
+==> default: 
+==> default: stderr: dpkg-query: no packages found matching code
+==> default: 
+==> default: TASK [Dev VSCode: Download] ****************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: msg: OK (34493480 bytes)
+==> default: 
+==> default: TASK [Dev VSCode: Install] *****************************************************
+==> default: changed: [localhost]
+==> default: 
+==> default: stdout: Selecting previously unselected package code.
+==> default: (Reading database ... 166771 files and directories currently installed.)
+==> default: Preparing to unpack .../code_1.7.2-1479766213_amd64.deb ...
+==> default: Unpacking code (1.7.2-1479766213) ...
+==> default: Setting up code (1.7.2-1479766213) ...
+==> default: Processing triggers for gnome-menus (3.13.3-6ubuntu3.1) ...
+==> default: Processing triggers for desktop-file-utils (0.22-1ubuntu5) ...
+==> default: Processing triggers for mime-support (3.59ubuntu1) ...
+==> default: 
+==> default: 
+==> default: PLAY RECAP *********************************************************************
+==> default: localhost                  : ok=66   changed=50   unreachable=0    failed=0   
+
+cambell@cambell-dell-nix:~/src/xForge/web-languageforge/deploy/xenial_taylor2017$ 
+

--- a/deploy/xenial_taylor2017/Vagrantfile
+++ b/deploy/xenial_taylor2017/Vagrantfile
@@ -1,0 +1,98 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+$script = <<SCRIPT
+if [ ! -f "/usr/bin/unattended-upgrade-org" ]; then
+  killall unattended-upgrade
+  cp /usr/bin/unattended-upgrade /usr/bin/unattended-upgrade-org
+  > /usr/bin/unattended-upgrade
+  killall unattended-upgrade
+  rm -f /var/lib/apt/lists/lock
+  rm -f /var/lib/apt/lists/*
+fi
+if [ ! -d "/home/vagrant/src" ]; then
+  mkdir /home/vagrant/src
+fi
+cd /home/vagrant/src
+add-apt-repository ppa:ansible/ansible
+apt-get update
+apt-get -y install git ansible
+if [ ! -d "/home/vagrant/src/xForge" ]; then
+  mkdir /home/vagrant/src/xForge
+fi
+cd /home/vagrant/src/xForge
+if [ ! -d "web-languageforge" ]; then
+  git clone --recurse-submodules https://github.com/sil-student-projects/web-languageforge.git 
+else
+  cd web-languageforge; git pull --ff-only --recurse-submodules 
+fi
+cd /home/vagrant/src/xForge
+if [ ! -d "web-scriptureforge" ]; then
+  ln -s /home/vagrant/src/xForge/web-languageforge /home/vagrant/src/xForge/web-scriptureforge
+fi
+
+cd /home/vagrant/src/xForge/web-languageforge/deploy/; git checkout master-taylor; ansible-playbook -i hosts playbook_create_config.yml; chown vagrant.vagrant ansible.cfg; ansible-playbook -i hosts playbook_xenial_vagrant.yml
+
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "xenial-gnome-amd64"
+  # Less secure but will work on NTFS which doesn't understand permissions / owner very well
+  config.ssh.insert_key = false
+  
+  config.vm.box_url = "http://downloads.sil.org/vagrant/xenial-gnome-amd64.box"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network :forwarded_port, guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network :private_network, ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider :virtualbox do |vb|
+    # Don't boot with headless mode
+    vb.gui = true
+  
+    # Use VBoxManage to customize the VM. For example to change memory:
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
+    vb.customize ["modifyvm", :id, "--vram", 64]
+    vb.customize ["modifyvm", :id, "--accelerate3d", "off"]
+  end
+
+  # configure Vagrant's ssh shell to be a non-login one (avoids error "stdin: is not a tty error")
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+
+  config.vm.provision "shell", inline: $script
+  
+  #config.vm.provision :ansible do |ansible|
+  #  ansible.playbook = '../playbook_lxde.yml'
+  #  ansible.extra_vars = { ansible_ssh_user: 'vagrant', vagrant: true }
+  # 
+  #  ansible.verbose = 'v'
+  #end
+end


### PR DESCRIPTION
I'm not sure if this is useful or not.  This was work done for the last Taylor group circa Jan 2017.

- Updated vars_palaso to prevent LetsEncrypt installing
- Use of site_src_paths to allow one or multiple deploys under /var/www/...
- Fix the default created config to use pipelining over ssh.
- 2 x Vagrantfiles. 1 for Xenial and 1 for Xenial Server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/237)
<!-- Reviewable:end -->
