### PR TITLE
normalize spelling of Paratext

### DIFF
--- a/src/Api/Model/Scriptureforge/Sfchecks/AnswerModel.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/AnswerModel.php
@@ -38,6 +38,6 @@ class AnswerModel extends CommentModel
     /** @var ArrayOf<string> */
     public $tags;
 
-    /** @var Boolean Flag to be exported for ParaTExt Export */
+    /** @var Boolean Flag to be exported for Paratext Export */
     public $isToBeExported;
 }

--- a/src/Site/views/scriptureforge/theme/default/page/sfchecks_usersguide.html.twig
+++ b/src/Site/views/scriptureforge/theme/default/page/sfchecks_usersguide.html.twig
@@ -3,9 +3,9 @@
 {% block content %}
     <div class="content container">
         <h1>Scripture Checking App Users Guide</h1>
-        <h4><a name="exportusx"></a>How can I export USX from ParaTExt to be imported in the app?</h4>
-        <h5>Step 1: <a href="/resources/scriptureforge/sfchecks/ScriptureForgePluginV20140303.pud">Download the ParaTExt Scripture Forge plugin.  Install the plugin by double-clicking on it.</a></h5>
-        <h5>Step 2: In ParaTExt, export a chapter as USX and save it to a file.  The plugin adds a new menu item under the Tools menu called "Scripture Forge Export"</h5>
+        <h4><a name="exportusx"></a>How can I export USX from Paratext to be imported in the app?</h4>
+        <h5>Step 1: <a href="/resources/scriptureforge/sfchecks/ScriptureForgePluginV20140303.pud">Download the Paratext Scripture Forge plugin.  Install the plugin by double-clicking on it.</a></h5>
+        <h5>Step 2: In Paratext, export a chapter as USX and save it to a file.  The plugin adds a new menu item under the Tools menu called "Scripture Forge Export"</h5>
         <img src="/Site/views/scriptureforge/theme/default/image/usersguide/paratext_export.png" />
         <h5>Step 3: In the Scripture Checking App, create a new Text and choose the USX file to upload</h5>
         <img src="/Site/views/scriptureforge/theme/default/image/usersguide/usx_import.png" />

--- a/src/angular-app/bellows/apps/translate/core/translate-send-receive.service.ts
+++ b/src/angular-app/bellows/apps/translate/core/translate-send-receive.service.ts
@@ -135,7 +135,7 @@ export class TranslateSendReceiveService {
           case SendReceiveState.Syncing:
             this.notice.removeById(this.pendingMessageId);
             this.pendingMessageId = '';
-            this.notice.setLoading('Synchronizing with ParaTExt...');
+            this.notice.setLoading('Synchronizing with Paratext...');
             break;
           case SendReceiveState.Hold:
             this.notice.push(this.notice.ERROR, 'Well this is embarrassing. Something went ' +

--- a/src/angular-app/bellows/apps/translate/new-project/views/new-project-chooser.html
+++ b/src/angular-app/bellows/apps/translate/new-project/views/new-project-chooser.html
@@ -4,7 +4,7 @@
             <a class="btn btn-std btn-block" data-ng-class="$ctrl.interfaceConfig.pullNormal"
                 id="sendReceiveButton" data-ng-click="$ctrl.getProjectFromInternet()">
                 <i class="fa fa-cloud-download fa-lg fa-fw text-info"></i>
-                Get project from ParaTExt...
+                Get project from Paratext...
             </a>
         </div>
         <div class="form-group text-center">

--- a/src/angular-app/bellows/apps/translate/new-project/views/new-project-sr-credentials.html
+++ b/src/angular-app/bellows/apps/translate/new-project/views/new-project-sr-credentials.html
@@ -2,18 +2,18 @@
     <div class="row justify-content-center">
         <div class="col-md-10">
             <div class="text-center">
-                <h4 class ="no-space-break" data-translate="Get project from ParaTExt"></h4>
+                <h4 class ="no-space-break" data-translate="Get project from Paratext"></h4>
             </div>
             <div class="card card-default">
                 <div class="card-body">
                     <div class="text-center" data-ng-if="!$ctrl.isSignedIntoParatext && !$ctrl.isRetrievingParatextUserInfo">
                         <button class="btn btn-std" data-ng-click="$ctrl.signIntoParatext()">
-                            Sign into ParaTExt
+                            Sign into Paratext
                         </button>
                     </div>
                     <div class="text-center" data-ng-if="$ctrl.isRetrievingParatextUserInfo">
                         <i class="fa fa-spinner fa-spin"></i>
-                        <p>Retrieving ParaTExt information...</p>
+                        <p>Retrieving Paratext information...</p>
                     </div>
                     <div data-ng-if="$ctrl.isSignedIntoParatext && !$ctrl.isRetrievingParatextUserInfo">
                         <div class="form-group row">

--- a/src/angular-app/bellows/apps/translate/settings/sync.component.html
+++ b/src/angular-app/bellows/apps/translate/settings/sync.component.html
@@ -1,9 +1,9 @@
 <div class="container" data-ng-cloak>
     <br>
-    <h2 style="font-weight:normal">Synchronize Project with ParaTExt</h2>
+    <h2 style="font-weight:normal">Synchronize Project with Paratext</h2>
     <div class="card card-body bg-light">
         <div align="center">
-            <button class="btn btn-std" title="Send and Receive with ParaTExt"
+            <button class="btn btn-std" title="Send and Receive with Paratext"
                     data-placement="bottom"
                     data-ng-disabled="$ctrl.disableSyncButton"
                     data-ng-click="$ctrl.syncProject()">

--- a/src/angular-app/scriptureforge/sfchecks/partials/project.html
+++ b/src/angular-app/scriptureforge/sfchecks/partials/project.html
@@ -53,7 +53,7 @@
                         </div>
                         <div class="form-group">
                             <span class="text-info"><a data-ng-href="/sfchecks_usersguide#exportusx" target="_blank">
-                                  How can I export a USX file from ParaTExt?</a></span>
+                                  How can I export a USX file from Paratext?</a></span>
                         </div>
                     </div>
                     <div class="verse-range" uib-collapse="rangeSelectorCollapsed">

--- a/src/angular-app/scriptureforge/sfchecks/partials/questions-settings.html
+++ b/src/angular-app/scriptureforge/sfchecks/partials/questions-settings.html
@@ -117,9 +117,9 @@
                 <div data-ng-bind-html="uploadResult"></div>
             </form>
         </uib-tab>
-        <uib-tab heading="ParaTExt Export" id="questions-settings-paratext-tab">
+        <uib-tab heading="Paratext Export" id="questions-settings-paratext-tab">
             <div class="row outer-flex" data-ng-controller="ParatextExportTextCtrl">
-                <h4>Export Text Answers/Comments to a ParaTExt XML file</h4>
+                <h4>Export Text Answers/Comments to a Paratext XML file</h4>
                 <form class="col-sm-6" name="exportForm">
                     <div class="form-group">
                         <label><input type="checkbox" checked name="exportAnswers"

--- a/src/netcore-api/SIL.XForge.WebApi.Server/Controllers/UsersController.cs
+++ b/src/netcore-api/SIL.XForge.WebApi.Server/Controllers/UsersController.cs
@@ -25,10 +25,10 @@ namespace SIL.XForge.WebApi.Server.Controllers
         }
 
         /// <summary>
-        /// Gets ParaTExt information.
+        /// Gets Paratext information.
         /// </summary>
         /// <param name="id">The user id.</param>
-        /// <response code="204">The user has not logged into ParaTExt.</response>
+        /// <response code="204">The user has not logged into Paratext.</response>
         [HttpGet("{id}/paratext")]
         [SiteAuthorize(Domain.Users, Operation.ViewOwn)]
         [ProducesResponseType(typeof(ParatextUserInfoDto), StatusCodes.Status200OK)]

--- a/src/netcore-api/SIL.XForge.WebApi.Server/Services/ParatextSendReceiveRunner.cs
+++ b/src/netcore-api/SIL.XForge.WebApi.Server/Services/ParatextSendReceiveRunner.cs
@@ -206,7 +206,7 @@ namespace SIL.XForge.WebApi.Server.Services
                 return bookIds;
             }
 
-            throw new InvalidOperationException("Error occurred while getting list of books from ParaTExt server.");
+            throw new InvalidOperationException("Error occurred while getting list of books from Paratext server.");
         }
 
         private void DeleteBookTextFiles(TranslateProject project, ParatextProject paratextProject,
@@ -268,13 +268,13 @@ namespace SIL.XForge.WebApi.Server.Services
                 if (!(await _paratextService.TryGetBookTextAsync(user, paratextProject.Id, bookId))
                     .TryResult(out bookText))
                 {
-                    throw new InvalidOperationException("Error occurred while getting book text from ParaTExt server.");
+                    throw new InvalidOperationException("Error occurred while getting book text from Paratext server.");
                 }
             }
             else if (!(await _paratextService.TryUpdateBookTextAsync(user, paratextProject.Id, bookId, revision,
                 newUsxElem.ToString())).TryResult(out bookText))
             {
-                throw new InvalidOperationException("Error occurred while updating book text on ParaTExt server.");
+                throw new InvalidOperationException("Error occurred while updating book text on Paratext server.");
             }
 
             bookTextElem = XElement.Parse(bookText);
@@ -292,7 +292,7 @@ namespace SIL.XForge.WebApi.Server.Services
             if (!(await _paratextService.TryGetBookTextAsync(user, paratextProject.Id, bookId))
                 .TryResult(out string bookText))
             {
-                throw new InvalidOperationException("Error occurred while getting book text from ParaTExt server.");
+                throw new InvalidOperationException("Error occurred while getting book text from Paratext server.");
             }
 
             var bookTextElem = XElement.Parse(bookText);

--- a/src/releasenotes/scriptureforge.md
+++ b/src/releasenotes/scriptureforge.md
@@ -4,7 +4,7 @@
 - Support for translating Scripture! (Beta)
     - Simple UI for translating from a source text
     - Automatically learns as you translate and provides suggested translations for words and phrases
-    - Send/receive support with ParaTExt
+    - Send/receive support with Paratext
 - Localization!  Help us get Scripture Forge localized into your national language
     - [See this post for instructions](https://community.scripture.software.sil.org/t/how-to-localize-scripture-forge-into-your-language/372)
 - Numerous internal improvements and bugfixes


### PR DESCRIPTION
This PR changes the spelling of "ParaTExt" to "Paratext" across our code-base

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/242)
<!-- Reviewable:end -->
