### PR TITLE
Allow comments to appear directly on the main entry

### DIFF
--- a/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
+++ b/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
@@ -81,7 +81,7 @@ export class LexiconCommentService {
           // As the promise runs when its ready the comments can double up if loadEntryComments is run multiple times
           if (this.comments.items.currentEntry.indexOf(comment) === -1) {
             let contextGuid = '';
-            if (comment.contextGuid !== undefined) {
+            if (comment.contextGuid !== undefined && comment.contextGuid !== '') {
               contextGuid = comment.contextGuid;
             } else {
               contextGuid = comment.regarding.field +

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comment-bubble.js
@@ -114,7 +114,8 @@ angular.module('palaso.ui.comments')
 
         $scope.isCommentingAvailable = function isCommentingAvailable() {
           return ($scope.control.currentEntry.id.indexOf('_new_') !== -1 ||
-            !$scope.control.rights.canComment());
+            !$scope.control.rights.canComment() ||
+            ($scope.field == 'entry' && !$scope.getCount()));
         };
 
         $scope.$watch('model', function () {

--- a/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
+++ b/src/angular-app/bellows/directive/palaso.ui.comments.comments-right-panel.html
@@ -22,7 +22,7 @@
                 </div>
             </div>
         </div>
-        <div ng-show="rights.canComment() && newComment.regarding.field && showNewComment" class="newCommentForm" ng-class="{'show': showNewComment, 'regard': newComment.regarding.field}">
+        <div ng-show="rights.canComment() && newComment.regarding.field && showNewComment && newComment.regarding.field != 'entry'" class="newCommentForm" ng-class="{'show': showNewComment, 'regard': newComment.regarding.field}">
             <div class="card card-default">
                 <div class="card-title" ng-show="currentEntryCommentsFiltered.length === 0">
                     <span class="sense-label">{{getNewCommentSenseLabel(newComment.regarding.field)}}</span> {{newComment.regarding.fieldNameForDisplay}}{{(newComment.regarding.inputSystemAbbreviation) ? ' - ' + newComment.regarding.inputSystemAbbreviation : ''}}

--- a/src/angular-app/languageforge/lexicon/core/lexicon-config.service.ts
+++ b/src/angular-app/languageforge/lexicon/core/lexicon-config.service.ts
@@ -114,6 +114,14 @@ export class LexiconConfigService {
         return search[fieldName];
       }
 
+      // Check if this is the main entry and setup some basic configuration
+      if (fieldName === 'entry') {
+        const entryConfig = new LexConfigMultiText();
+        entryConfig.type = 'multitext';
+        entryConfig.label = 'Entry';
+        return entryConfig;
+      }
+
       return undefined;
     });
   }

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -653,6 +653,11 @@ dc-entry .card {
       position: relative;
     }
   }
+  .comment-bubble-entry {
+    position: absolute;
+    right: 5px;
+    top: 6px;
+  }
   @include media-breakpoint-down(md) {
     .dc-multitext,
     .dc-multioptionlist,

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.html
@@ -10,6 +10,9 @@
                     <a href data-ng-click="deleteEntry()" class="dropdown-item">Delete Entry</a>
                 </div>
             </div>
+            <div class="comment-bubble-entry">
+                <comment-bubble control="control" field="fieldName" model="model" parent-context-guid="contextGuid"></comment-bubble>
+            </div>
             &nbsp;{{'Entry' | translate}}
         </div>
         <div class="card-body">

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.js
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.js
@@ -14,6 +14,7 @@ angular.module('palaso.ui.dc.entry', ['palaso.ui.dc.fieldrepeat', 'palaso.ui.dc.
       function ($scope, $state, rightsService) {
         $scope.$state = $state;
         $scope.contextGuid = '';
+        $scope.fieldName = 'entry';
 
         rightsService.getRights().then(function (rights) {
           $scope.rights = rights;

--- a/test/app/languageforge/lexicon/shared/editor.page.ts
+++ b/test/app/languageforge/lexicon/shared/editor.page.ts
@@ -308,7 +308,7 @@ export class EditorPage {
     toEditLink: element(by.id('toEditLink')),
 
     bubbles: {
-      first: element.all(by.css('.dc-entry .commentBubble')).get(0),
+      first: element.all(by.css('.dc-entry .commentBubble')).get(1),
       second: element.all(by.css('.dc-entry .dc-sense .commentBubble')).get(0)
     },
 


### PR DESCRIPTION
Relates to https://trello.com/c/5nmjsPhK

3 E2E tests are failing - same as `master`

New comments can not be posted directly against the entry - view only. Replying is allowed for any comments that do appear on the entry.

If no comments are set on the entry then the comment bubble is hidden. No point showing it as clicking it would effectively do nothing as you can't comment.

Have tested with a comment on the entry that has no `contextGuid` set. I've not been able to test with a real sync though - hopefully it is fine though. So long as the `contextGuid` is undefined OR an empty string then it will be fine. Otherwise, if the sync wants to be updated, the `contextGuid` can be set to `"entry"`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/244)
<!-- Reviewable:end -->
