### PR TITLE
E2E Activity Feed tests fixed

### DIFF
--- a/src/Api/Model/Scriptureforge/Sfchecks/Command/QuestionCommands.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Command/QuestionCommands.php
@@ -17,7 +17,7 @@ use Palaso\Utilities\CodeGuard;
 
 class QuestionCommands
 {
-    public static function updateQuestion($projectId, $object)
+    public static function updateQuestion($projectId, $object, $userId)
     {
         $projectModel = new ProjectModel($projectId);
         ProjectCommands::checkIfArchivedAndThrow($projectModel);
@@ -27,7 +27,7 @@ class QuestionCommands
         JsonDecoder::decode($questionModel, $object);
         $questionId = $questionModel->write();
         if ($isNewQuestion) {
-            ActivityCommands::addQuestion($projectModel, $questionId, $questionModel);
+            ActivityCommands::addQuestion($projectModel, $questionId, $questionModel, $userId);
         }
 
         return $questionId;

--- a/src/Api/Model/Scriptureforge/Sfchecks/Command/TextCommands.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Command/TextCommands.php
@@ -45,12 +45,15 @@ class TextCommands
         return ((int) $object['startCh'] || (int) $object['startVs'] || (int) $object['endCh'] || (int) $object['endVs']);
     }
 
-    /**
-     * @param string $projectId
-     * @param array $object (json encoded)
-     * @return string Id of text updated/added
-     */
-    public static function updateText($projectId, $object)
+	/**
+	 * @param string $projectId
+	 * @param array $object (json encoded)
+	 * @param $userId
+	 *
+	 * @return string Id of text updated/added
+	 * @throws \Api\Library\Shared\Palaso\Exception\ResourceNotAvailableException
+	 */
+    public static function updateText($projectId, $object, $userId)
     {
         $projectModel = new ProjectModel($projectId);
         ProjectCommands::checkIfArchivedAndThrow($projectModel);
@@ -71,7 +74,7 @@ class TextCommands
         }
         $textId = $textModel->write();
         if ($isNewText) {
-            ActivityCommands::addText($projectModel, $textId, $textModel);
+            ActivityCommands::addText($projectModel, $textId, $textModel, $userId);
         }
 
         return $textId;

--- a/src/Api/Model/Scriptureforge/Sfchecks/Command/TextCommands.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Command/TextCommands.php
@@ -45,14 +45,14 @@ class TextCommands
         return ((int) $object['startCh'] || (int) $object['startVs'] || (int) $object['endCh'] || (int) $object['endVs']);
     }
 
-	/**
-	 * @param string $projectId
-	 * @param array $object (json encoded)
-	 * @param $userId
-	 *
-	 * @return string Id of text updated/added
-	 * @throws \Api\Library\Shared\Palaso\Exception\ResourceNotAvailableException
-	 */
+    /**
+     * @param string $projectId
+     * @param array $object (json encoded)
+     * @param $userId
+     *
+     * @return string Id of text updated/added
+     * @throws \Api\Library\Shared\Palaso\Exception\ResourceNotAvailableException
+     */
     public static function updateText($projectId, $object, $userId)
     {
         $projectModel = new ProjectModel($projectId);

--- a/src/Api/Model/Shared/Command/ActivityCommands.php
+++ b/src/Api/Model/Shared/Command/ActivityCommands.php
@@ -98,18 +98,22 @@ class ActivityCommands
         return ActivityCommands::updateAnswer($projectModel, $questionId, $answerModel, 'add');
     }
 
-    /**
-     *
-     * @param ProjectModel $projectModel
-     * @param string $textId
-     * @param TextModel $textModel
-     * @return string activity id
-     */
-    public static function addText($projectModel, $textId, $textModel)
+	/**
+	 *
+	 * @param ProjectModel $projectModel
+	 * @param string $textId
+	 * @param TextModel $textModel
+	 * @param string $userId
+	 *
+	 * @return string activity id
+	 * @throws \Exception
+	 */
+    public static function addText($projectModel, $textId, $textModel, $userId)
     {
         $activity = new ActivityModel($projectModel);
         $activity->action = ActivityModel::ADD_TEXT;
         $activity->textRef->id = $textId;
+        $activity->userRef = $userId;
         $activity->addContent(ActivityModel::TEXT, $textModel->title);
         $activityId = $activity->write();
         UnreadActivityModel::markUnreadForProjectMembers($activityId, $projectModel);
@@ -118,17 +122,21 @@ class ActivityCommands
         return $activityId;
     }
 
-    /**
-     * @param ProjectModel $projectModel
-     * @param string $questionId
-     * @param QuestionModel $questionModel
-     * @return string activity id
-     */
-    public static function addQuestion($projectModel, $questionId, $questionModel)
+	/**
+	 * @param ProjectModel $projectModel
+	 * @param string $questionId
+	 * @param QuestionModel $questionModel
+	 * @param string $userId
+	 *
+	 * @return string activity id
+	 * @throws \Exception
+	 */
+    public static function addQuestion($projectModel, $questionId, $questionModel, $userId)
     {
         $activity = new ActivityModel($projectModel);
         $text = new TextModel($projectModel, $questionModel->textRef->asString());
         $activity->action = ActivityModel::ADD_QUESTION;
+        $activity->userRef = $userId;
         $activity->textRef->id = $questionModel->textRef->asString();
         $activity->questionRef->id = $questionId;
         $activity->addContent(ActivityModel::TEXT, $text->title);

--- a/src/Api/Model/Shared/Command/ActivityCommands.php
+++ b/src/Api/Model/Shared/Command/ActivityCommands.php
@@ -98,22 +98,22 @@ class ActivityCommands
         return ActivityCommands::updateAnswer($projectModel, $questionId, $answerModel, 'add');
     }
 
-	/**
-	 *
-	 * @param ProjectModel $projectModel
-	 * @param string $textId
-	 * @param TextModel $textModel
-	 * @param string $userId
-	 *
-	 * @return string activity id
-	 * @throws \Exception
-	 */
+    /**
+     *
+     * @param ProjectModel $projectModel
+     * @param string $textId
+     * @param TextModel $textModel
+     * @param string $userId
+     *
+     * @return string activity id
+     * @throws \Exception
+     */
     public static function addText($projectModel, $textId, $textModel, $userId)
     {
         $activity = new ActivityModel($projectModel);
         $activity->action = ActivityModel::ADD_TEXT;
         $activity->textRef->id = $textId;
-        $activity->userRef = $userId;
+        $activity->userRef->id = $userId;
         $activity->addContent(ActivityModel::TEXT, $textModel->title);
         $activityId = $activity->write();
         UnreadActivityModel::markUnreadForProjectMembers($activityId, $projectModel);
@@ -122,21 +122,21 @@ class ActivityCommands
         return $activityId;
     }
 
-	/**
-	 * @param ProjectModel $projectModel
-	 * @param string $questionId
-	 * @param QuestionModel $questionModel
-	 * @param string $userId
-	 *
-	 * @return string activity id
-	 * @throws \Exception
-	 */
+    /**
+     * @param ProjectModel $projectModel
+     * @param string $questionId
+     * @param QuestionModel $questionModel
+     * @param string $userId
+     *
+     * @return string activity id
+     * @throws \Exception
+     */
     public static function addQuestion($projectModel, $questionId, $questionModel, $userId)
     {
         $activity = new ActivityModel($projectModel);
         $text = new TextModel($projectModel, $questionModel->textRef->asString());
         $activity->action = ActivityModel::ADD_QUESTION;
-        $activity->userRef = $userId;
+        $activity->userRef->id = $userId;
         $activity->textRef->id = $questionModel->textRef->asString();
         $activity->questionRef->id = $questionId;
         $activity->addContent(ActivityModel::TEXT, $text->title);

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -526,7 +526,7 @@ class Sf
     // ---------------------------------------------------------------
     public function text_update($object)
     {
-        return TextCommands::updateText($this->projectId, $object);
+        return TextCommands::updateText($this->projectId, $object, $this->userId);
     }
 
     public function text_read($textId)
@@ -560,7 +560,7 @@ class Sf
     // ---------------------------------------------------------------
     public function question_update($object)
     {
-        return QuestionCommands::updateQuestion($this->projectId, $object);
+        return QuestionCommands::updateQuestion($this->projectId, $object, $this->userId);
     }
 
     public function question_read($questionId)

--- a/src/angular-app/bellows/apps/activity/activity-container.component.html
+++ b/src/angular-app/bellows/apps/activity/activity-container.component.html
@@ -2,12 +2,12 @@
     <div class="activity-header">
         <div class="activity-filter-options">
             <!--suppress HtmlFormInputWithoutLabel -->
-            <select class="custom-select" data-ng-model="$ctrl.filterUser" data-ng-change="$ctrl.triggerFilter()"
+            <select id="filter_by_user" class="custom-select" data-ng-model="$ctrl.filterUser" data-ng-change="$ctrl.triggerFilter()"
                 data-ng-options="item as item.username for item in $ctrl.filterUsers">
                 <option value="">All Users</option>
             </select>
             <!--suppress HtmlFormInputWithoutLabel -->
-            <select class="custom-select" data-ng-model="$ctrl.filterType" data-ng-change="$ctrl.triggerFilter()"
+            <select id="filter_by_type" class="custom-select" data-ng-model="$ctrl.filterType" data-ng-change="$ctrl.triggerFilter()"
                 data-ng-options="item as item.label for item in $ctrl.activityTypes">
                 <option value="">All Events</option>
             </select>
@@ -120,14 +120,18 @@
                                                     answer to &ldquo;<a href="{{item.questionHref}}">{{item.content.question}}</a>&rdquo;
                                                     on <a href="{{item.textHref}}">{{item.content.text}}</a>
                                                     in <a href="{{item.projectHref}}">{{item.content.project}}</a>
-                                                    <p class="indented" data-ng-bind-html="item.content.answer"></p>
-                                                    <hr>
-                                                    <p class="indented">{{item.content.comment}} - {{item.userRef.username}}</p>
+                                                   <div class="activity-comment">
+                                                        <i class="fa fa-quote-left"></i>
+                                                        <div data-ng-bind-html="item.content.answer"></div>
+                                                        <i class="fa fa-quote-right"></i>
+                                                    </div>
+                                                    <p class="indented notranslate">{{item.content.comment}}</p>
                                                 </div>
 
                                                 <div data-ng-switch-when="add_question-project">
-                                                    Has a new question in the
-                                                    <a href="{{item.projectHref}}">{{item.content.project}}</a> project
+                                                    Has a new question
+                                                    on <a href="{{item.textHref}}">{{item.content.text}}</a>
+                                                    in <a href="{{item.projectHref}}">{{item.content.project}}</a> project
                                                     <p class="indented">&ldquo;<a href="{{item.questionHref}}">{{item.content.question}}</a>&rdquo;</p>
                                                 </div>
 

--- a/test/app/bellows/shared/activity.page.ts
+++ b/test/app/bellows/shared/activity.page.ts
@@ -1,6 +1,5 @@
 import {browser, by, element} from 'protractor';
 import {ElementFinder} from 'protractor/built/element';
-import {Utils} from "./utils";
 
 // This object handles the activity page and provides methods to access items in the activity list
 export class SfActivityPage {

--- a/test/app/bellows/shared/activity.page.ts
+++ b/test/app/bellows/shared/activity.page.ts
@@ -1,22 +1,25 @@
 import {browser, by, element} from 'protractor';
 import {ElementFinder} from 'protractor/built/element';
+import {Utils} from "./utils";
 
 // This object handles the activity page and provides methods to access items in the activity list
 export class SfActivityPage {
   activityURL = '/app/activity';
-  activitiesList = element.all(by.repeater('item in $ctrl.filteredActivities'));
+  activitiesList = element.all(by.className('activity-content'));
+  activityGroups = element.all(by.className('activity-user-group'));
+  filterByUser = element(by.id('filter_by_user'));
 
   // Navigate to the Activity page
   get() {
     browser.get(browser.baseUrl + this.activityURL);
   }
 
-  static clickOnAllActivity() {
-    element(by.id('activity-showAllActivityButton')).click();
+  clickOnAllActivity() {
+    this.filterByUser.element(by.css('option:nth-child(1)')).click();
   }
 
-  static clickOnShowOnlyMyActivity() {
-    element(by.id('activity-showOnlyMyActivityButton')).click();
+  clickOnShowOnlyMyActivity() {
+    this.filterByUser.element(by.css('option:nth-child(2)')).click();
   }
 
   // Returns the number of items in the activity list
@@ -34,11 +37,23 @@ export class SfActivityPage {
     return this.activitiesList.map((elem: ElementFinder) => elem.getText());
   }
 
+  getActivityGroup(index: number) {
+    return SfActivityPage.getPartsOfActivity(this.activityGroups.get(index));
+  }
+
   // Prints the entire activity list
   //noinspection JSUnusedGlobalSymbols
   printActivitiesNames() {
     (this.activitiesList).each((names: ElementFinder) => {
       names.getText().then(console.log);
     });
+  }
+
+  static getPartsOfActivity(div: ElementFinder) {
+    return {
+      activity: div,
+      user: div.element(by.className('activity-username')).getText(),
+      activities: div.all(by.className('activity-content')).map((elem: ElementFinder) => elem.getText())
+    };
   }
 }

--- a/test/app/scriptureforge/activity/activity.e2e-spec.ts
+++ b/test/app/scriptureforge/activity/activity.e2e-spec.ts
@@ -509,7 +509,8 @@ describe('Activity E2E Test', () => {
       activityPage.get();
       activityPage.activityGroups.filter((item: ElementFinder) => {
         // Look for activity items that do not contain our username
-        return (item.element(by.className('activity-username')).getText().then((text: string) => {
+        const activityGroup = SfActivityPage.getPartsOfActivity(item);
+        return (activityGroup.user.then((text: string) => {
           return text.indexOf(username) === -1;
         }));
       }).then((activityItems: ElementFinder[]) => {
@@ -521,7 +522,8 @@ describe('Activity E2E Test', () => {
       activityPage.clickOnShowOnlyMyActivity();
       activityPage.activityGroups.filter((item: ElementFinder) => {
         // Look for activity items that do not contain our username
-        return (item.element(by.className('activity-username')).getText().then((text: string) => {
+        const activityGroup = SfActivityPage.getPartsOfActivity(item);
+        return (activityGroup.user.then((text: string) => {
           return text.indexOf(username) === -1;
         }));
       }).then((activityItems: ElementFinder[]) => {
@@ -533,7 +535,8 @@ describe('Activity E2E Test', () => {
       activityPage.clickOnAllActivity();
       activityPage.activityGroups.filter((item: ElementFinder) => {
         // Look for activity items that do not contain our username
-        return (item.element(by.className('activity-username')).getText().then((text: string) => {
+        const activityGroup = SfActivityPage.getPartsOfActivity(item);
+        return (activityGroup.user.then((text: string) => {
           return text.indexOf(username) === -1;
         }));
       }).then((activityItems: ElementFinder[]) => {

--- a/test/app/scriptureforge/activity/activityCustomMatchers.d.ts
+++ b/test/app/scriptureforge/activity/activityCustomMatchers.d.ts
@@ -1,7 +1,7 @@
 declare namespace jasmine {
   interface Matchers<T> {
     toContainMultilineMatch(regex: RegExp): boolean;
-    toContainMatch(text: string): boolean;
+    toContainMatch(text: RegExp): boolean;
 
   }
 }

--- a/test/app/setupTestEnvironment.php
+++ b/test/app/setupTestEnvironment.php
@@ -258,25 +258,25 @@ if ($site == 'scriptureforge') {
         'id' => '',
         'title' => $constants['testText1Title'],
         'content' => $constants['testText1Content']
-    ));
+    ), $adminUserId);
     $text2 = TextCommands::updateText($testProjectId, array(
         'id' => '',
         'title' => $constants['testText2Title'],
         'content' => $constants['testText2Content']
-    ));
+    ), $adminUserId);
 
     $question1 = QuestionCommands::updateQuestion($testProjectId, array(
         'id' => '',
         'textRef' => $text1,
         'title' => $constants['testText1Question1Title'],
         'description' => $constants['testText1Question1Content']
-    ));
+    ), $adminUserId);
     $question2 = QuestionCommands::updateQuestion($testProjectId, array(
         'id' => '',
         'textRef' => $text1,
         'title' => $constants['testText1Question2Title'],
         'description' => $constants['testText1Question2Content']
-    ));
+    ), $adminUserId);
 
     $template1 = QuestionTemplateCommands::updateTemplate($testProjectId, array(
         'id' => '',

--- a/test/php/model/shared/commands/ActivityCommandsTest.php
+++ b/test/php/model/shared/commands/ActivityCommandsTest.php
@@ -96,9 +96,9 @@ class ActivityCommandsTest extends TestCase
 
         // We create a text, a question, and an answer, with two comments. Then we update the answer and the first comment.
         // All activity-log entries are also captured so that calling code can check them.
-        list($text, $textId, $a1) = $this->createSampleText($project, "Text 1", "text content");
+        list($text, $textId, $a1) = $this->createSampleText($project, "Text 1", "text content", $user1Id);
 
-        list($question, $questionId, $a5) = $this->createSampleQuestion($project, $textId, "the question", "question description");
+        list($question, $questionId, $a5) = $this->createSampleQuestion($project, $textId, "the question", "question description", $user1Id);
         list($answer, $answerId, $a6) = $this->createSampleAnswer($project, $user3Id, $question, $questionId, "first answer", "text highlight");
         list($comment1, $comment1Id, $a7) = $this->addComment($project, $user1Id, $questionId, $answerId, "first comment");
         list($comment2, $comment2Id, $a8) = $this->addComment($project, $user2Id, $questionId, $answerId, "second comment");
@@ -138,13 +138,13 @@ class ActivityCommandsTest extends TestCase
         ];
     }
 
-    private function createSampleText($project, $title, $content): array
+    private function createSampleText($project, $title, $content, $userId): array
     {
         $text = new TextModel($project);
         $text->title = $title;
         $text->content = $content;
         $textId = $text->write();
-        $a1 = ActivityCommands::addText($project, $textId, $text);
+        $a1 = ActivityCommands::addText($project, $textId, $text, $userId);
         return [$text, $textId, $a1];
     }
 
@@ -166,14 +166,14 @@ class ActivityCommandsTest extends TestCase
         return [$user1Id, $user2Id, $user3Id, $a2, $a3, $a4];
     }
 
-    private function createSampleQuestion($project, $textId, $title, $description): array
+    private function createSampleQuestion($project, $textId, $title, $description, $userId): array
     {
         $question = new QuestionModel($project);
         $question->title = $title;
         $question->description = $description;
         $question->textRef->id = $textId;
         $questionId = $question->write();
-        $a5 = ActivityCommands::addQuestion($project, $questionId, $question);
+        $a5 = ActivityCommands::addQuestion($project, $questionId, $question, $userId);
         return [$question, $questionId, $a5];
     }
 

--- a/test/php/model/shared/dto/ActivityListDtoTest.php
+++ b/test/php/model/shared/dto/ActivityListDtoTest.php
@@ -23,9 +23,8 @@ class ActivityListDtoTest extends TestCase
         $text->title = "Text 1";
         $text->content = "text content";
         $textId = $text->write();
-        ActivityCommands::addText($project, $textId, $text);
-
         $userId = $environ->createUser("user1", "user1", "user1@email.com");
+        ActivityCommands::addText($project, $textId, $text, $userId);
         ActivityCommands::addUserToProject($project, $userId);
 
         // Workflow is first to create a question
@@ -34,7 +33,7 @@ class ActivityListDtoTest extends TestCase
         $question->description = "question description";
         $question->textRef->id = $textId;
         $questionId = $question->write();
-        ActivityCommands::addQuestion($project, $questionId, $question);
+        ActivityCommands::addQuestion($project, $questionId, $question, $userId);
 
         // Then to add an answer to a question
         $answer = new AnswerModel();
@@ -86,13 +85,13 @@ class ActivityListDtoTest extends TestCase
         $text1->title = "Text 1";
         $text1->content = "text content";
         $text1Id = $text1->write();
-        $a1 = ActivityCommands::addText($project1, $text1Id, $text1);
+        $a1 = ActivityCommands::addText($project1, $text1Id, $text1, $userId);
 
         $text2 = new TextModel($project2);
         $text2->title = "Text 2";
         $text2->content = "text content";
         $text2Id = $text2->write();
-        $a2 = ActivityCommands::addText($project2, $text2Id, $text2);
+        $a2 = ActivityCommands::addText($project2, $text2Id, $text2, $userId);
 
         $dto = ActivityListDto::getActivityForUser($project1->siteName, $userId);
         $dto = $dto['activity'];
@@ -141,13 +140,13 @@ class ActivityListDtoTest extends TestCase
         $text->title = "Text 1";
         $text->content = "text content";
         $textId = $text->write();
-        $a1 = ActivityCommands::addText($project1, $textId, $text);
+        $a1 = ActivityCommands::addText($project1, $textId, $text, $userId);
 
         $text = new TextModel($project2);
         $text->title = "Text 2";
         $text->content = "text content";
         $textId = $text->write();
-        $a2 = ActivityCommands::addText($project2, $textId, $text);
+        $a2 = ActivityCommands::addText($project2, $textId, $text, $userId);
 
         $dto = ActivityListDto::getActivityForUser($project1->siteName, $userId);
 
@@ -180,13 +179,13 @@ class ActivityListDtoTest extends TestCase
         $text->title = "Text 1";
         $text->content = "text content";
         $textId = $text->write();
-        ActivityCommands::addText($project1, $textId, $text);
+        ActivityCommands::addText($project1, $textId, $text, $userId);
 
         $text = new TextModel($project2);
         $text->title = "Text 2";
         $text->content = "text content";
         $textId = $text->write();
-        ActivityCommands::addText($project2, $textId, $text);
+        ActivityCommands::addText($project2, $textId, $text, $userId);
 
         $dto = ActivityListDto::getActivityForUser($project1->siteName, $userId);
 
@@ -204,11 +203,10 @@ class ActivityListDtoTest extends TestCase
         $text->title = "Text 1";
         $text->content = "text content";
         $textId = $text->write();
-        $a1 = ActivityCommands::addText($project, $textId, $text);
-
         $user1Id = $environ->createUser("user1", "user1", "user1@email.com");
         $user2Id = $environ->createUser("user2", "user2", "user2@email.com");
         $user3Id = $environ->createUser("user3", "user3", "user3@email.com");
+        $a1 = ActivityCommands::addText($project, $textId, $text, $user1Id);
         $a2 = ActivityCommands::addUserToProject($project, $user1Id);
         $a3 = ActivityCommands::addUserToProject($project, $user2Id);
         $a4 = ActivityCommands::addUserToProject($project, $user3Id);
@@ -219,7 +217,7 @@ class ActivityListDtoTest extends TestCase
         $question->description = "question description";
         $question->textRef->id = $textId;
         $questionId = $question->write();
-        $a5 = ActivityCommands::addQuestion($project, $questionId, $question);
+        $a5 = ActivityCommands::addQuestion($project, $questionId, $question, $user1Id);
 
         // Then to add an answer to a question
         $answer = new AnswerModel();

--- a/test/php/service/ApiCrudTest.php
+++ b/test/php/service/ApiCrudTest.php
@@ -40,18 +40,18 @@ class ApiCrudTestEnvironment extends MongoTestEnvironment
         return UserCommands::updateUser($params, $this->website);
     }
 
-    public function makeText($projectId, $textName)
+    public function makeText($projectId, $textName, $userId)
     {
         $model = array('id' => '', 'title' => $textName);
 
-        return TextCommands::updateText($projectId, $model);
+        return TextCommands::updateText($projectId, $model, $userId);
     }
 
-    public function makeQuestion($projectId)
+    public function makeQuestion($projectId, $userId)
     {
         $model = array('id' => '');
 
-        return QuestionCommands::updateQuestion($projectId, $model);
+        return QuestionCommands::updateQuestion($projectId, $model, $userId);
     }
 
     public function getProjectMember($projectId, $userName)
@@ -112,7 +112,7 @@ class ApiCrudTest extends TestCase
         $userId = self::$environ->getProjectMember($projectId, 'user1');
 
         // create text
-        $textId = self::$environ->makeText($projectId, "test text 1");
+        $textId = self::$environ->makeText($projectId, "test text 1", $userId);
 
         // List
         $dto = self::$environ->fixJson(QuestionListDto::encode($projectId, $textId, $userId));
@@ -125,7 +125,7 @@ class ApiCrudTest extends TestCase
             'description' =>'SomeDescription',
             'textRef' => $textId
         );
-        $questionId = QuestionCommands::updateQuestion($projectId, $model);
+        $questionId = QuestionCommands::updateQuestion($projectId, $model, $userId);
         $this->assertNotNull($questionId);
         $this->assertEquals(24, strlen($questionId));
 
@@ -136,7 +136,7 @@ class ApiCrudTest extends TestCase
 
         // Update
         $result['title'] = 'OtherQuestion';
-        $id = QuestionCommands::updateQuestion($projectId, $result);
+        $id = QuestionCommands::updateQuestion($projectId, $result, $userId);
         $this->assertNotNull($id);
         $this->assertEquals($result['id'], $id);
 
@@ -221,7 +221,7 @@ class ApiCrudTest extends TestCase
             'id' => '',
             'title' =>'SomeText'
         );
-        $id = TextCommands::updateText($projectId, $model);
+        $id = TextCommands::updateText($projectId, $model, $userId);
         $this->assertNotNull($id);
         $this->assertEquals(24, strlen($id));
 
@@ -232,7 +232,7 @@ class ApiCrudTest extends TestCase
 
         // Update
         $result['title'] = 'OtherText';
-        $id = TextCommands::updateText($projectId, $result);
+        $id = TextCommands::updateText($projectId, $result, $userId);
         $this->assertNotNull($id);
         $this->assertEquals($result['id'], $id);
 


### PR DESCRIPTION
Have updated all SF E2E tests for the new activity feed layout.
All tests are passing for SF & LF (except for the usual 3).
There were two activities that were not tracking the `userRef`. I've added in the `userRef` based on how I saw it being used in other parts of the API - this will need to be reviewed in case there is a more official way of doing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/255)
<!-- Reviewable:end -->
