### PR TITLE
Fix E2E after GH-155 fix to swap order of Definition and Gloss

### DIFF
--- a/test/app/languageforge/lexicon/settings/config-unified.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/config-unified.e2e-spec.ts
@@ -162,14 +162,14 @@ describe('Lexicon E2E Configuration Fields', () => {
     });
 
     it('can reorder Sense rows', () => {
-      expect<any>(configPage.unifiedPane.sense.rowLabel(0).getText()).toEqual('Definition');
-      expect<any>(configPage.unifiedPane.sense.rowLabel(1).getText()).toEqual('Gloss');
+      expect<any>(configPage.unifiedPane.sense.rowLabel(0).getText()).toEqual('Gloss');
+      expect<any>(configPage.unifiedPane.sense.rowLabel(1).getText()).toEqual('Definition');
       expect<any>(configPage.unifiedPane.sense.rowLabel(2).getText()).toEqual('Pictures');
       browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.sense.rows().get(2).getWebElement(),
         configPage.unifiedPane.sense.rows().get(0).getWebElement());
-      expect<any>(configPage.unifiedPane.sense.rowLabel(0).getText()).toEqual('Definition');
+      expect<any>(configPage.unifiedPane.sense.rowLabel(0).getText()).toEqual('Gloss');
       expect<any>(configPage.unifiedPane.sense.rowLabel(1).getText()).toEqual('Pictures');
-      expect<any>(configPage.unifiedPane.sense.rowLabel(2).getText()).toEqual('Gloss');
+      expect<any>(configPage.unifiedPane.sense.rowLabel(2).getText()).toEqual('Definition');
     });
 
     it('can reorder Example rows', () => {

--- a/test/app/languageforge/lexicon/shared/editor.page.ts
+++ b/test/app/languageforge/lexicon/shared/editor.page.ts
@@ -309,7 +309,7 @@ export class EditorPage {
 
     bubbles: {
       first: element.all(by.css('.dc-entry .commentBubble')).get(1),
-      second: element.all(by.css('.dc-entry .dc-sense .commentBubble')).get(0)
+      second: element.all(by.css('.dc-entry .dc-sense .commentBubble')).get(1)
     },
 
     // Top-row UI elements


### PR DESCRIPTION
A recent PHP change broke the E2E tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/258)
<!-- Reviewable:end -->
