### PR TITLE
Refactor comments to Angular components

### DIFF
--- a/src/angular-app/languageforge/lexicon/core/lexicon-rights.service.ts
+++ b/src/angular-app/languageforge/lexicon/core/lexicon-rights.service.ts
@@ -5,9 +5,9 @@ import {
   RightsFunction, Session,
   SessionService
 } from '../../../bellows/core/session.service';
-import { LexiconSendReceiveService } from './lexicon-send-receive.service';
+import {LexiconSendReceiveService} from './lexicon-send-receive.service';
 
-export type ConditionFunction = () => boolean;
+export type ConditionFunction = (userId?: string) => boolean;
 
 export class Rights {
   readonly canRemoveUsers: ConditionFunction;
@@ -19,18 +19,24 @@ export class Rights {
   readonly canEditEntry: ConditionFunction;
   readonly canDeleteEntry: ConditionFunction;
   readonly canComment: ConditionFunction;
+  readonly canDeleteComment: ConditionFunction;
+  readonly canEditComment: ConditionFunction;
+  readonly canUpdateCommentStatus: ConditionFunction;
 
   constructor(private domain: Domains, private operation: Operations,
               private sendReceive: LexiconSendReceiveService, public session?: Session) {
-    this.canRemoveUsers = this.isPermitted(true, domain.USERS, operation.DELETE);
-    this.canCreateUsers = this.isPermitted(true, domain.USERS, operation.CREATE);
-    this.canEditUsers = this.isPermitted(false, domain.USERS, operation.EDIT);
-    this.canArchiveProject = this.isPermitted(true, domain.PROJECTS, operation.ARCHIVE, true);
-    this.canDeleteProject = this.isPermitted(true, domain.PROJECTS, operation.DELETE, true);
-    this.canEditProject = this.isPermitted(false, domain.PROJECTS, operation.EDIT);
-    this.canEditEntry = this.isPermitted(false, domain.ENTRIES, operation.EDIT);
-    this.canDeleteEntry = this.isPermitted(false, domain.ENTRIES, operation.DELETE);
-    this.canComment = this.isPermitted(false, domain.COMMENTS, operation.CREATE);
+    this.canRemoveUsers = this.isPermitted(true, false, domain.USERS, operation.DELETE);
+    this.canCreateUsers = this.isPermitted(true, false, domain.USERS, operation.CREATE);
+    this.canEditUsers = this.isPermitted(false, false, domain.USERS, operation.EDIT);
+    this.canArchiveProject = this.isPermitted(true, true, domain.PROJECTS, operation.ARCHIVE);
+    this.canDeleteProject = this.isPermitted(true, true, domain.PROJECTS, operation.DELETE);
+    this.canEditProject = this.isPermitted(false, false, domain.PROJECTS, operation.EDIT);
+    this.canEditEntry = this.isPermitted(false, false, domain.ENTRIES, operation.EDIT);
+    this.canDeleteEntry = this.isPermitted(false, false, domain.ENTRIES, operation.DELETE);
+    this.canComment = this.isPermitted(false, false, domain.COMMENTS, operation.CREATE);
+    this.canDeleteComment = this.isPermitted(false, false, domain.COMMENTS, operation.DELETE_OWN, operation.DELETE);
+    this.canEditComment = this.isPermitted(false, false, domain.COMMENTS, operation.EDIT_OWN, false);
+    this.canUpdateCommentStatus = this.isPermitted(false, false, domain.COMMENTS, operation.EDIT);
   }
 
   /**
@@ -38,23 +44,32 @@ export class Rights {
    * operation is permitted.
    * @param {boolean} allowArchived - When false, the resulting function will always return false
    * if the project is archived.
+   * @param {boolean} projectOwnerAllowed - When this is true and the current project is owned by
+   * the current user, the user will be considered to always have permission.
    * @param {RightsFunction} domain - An enum value from sessionService.domain indicating the domain
    * of the operation.
    * @param {RightsFunction} operation - An enum value from sessionService.operation indicating the
    * operation for which the user's permissions should be checked.
-   * @param {boolean} projectOwnerAllowed - When this is true and the current project is owned by
-   * the current user, the user will be considered to always have permission.
+   * @param {RightsFunction|boolean} otherUserOperation use this operation if the supplied userId is not the
+   * current user.
    * @return {Function<boolean>} - A function that will indicate whether the user is
    * allowed to perform the given operation.
    */
-  private isPermitted(allowArchived: boolean, domain: RightsFunction, operation: RightsFunction,
-                      projectOwnerAllowed: boolean = false): ConditionFunction {
-    return () => {
+  private isPermitted(allowArchived: boolean, projectOwnerAllowed: boolean, domain: RightsFunction,
+                      operation: RightsFunction, otherUserOperation?: RightsFunction | boolean): ConditionFunction {
+    return (userId?: string) => {
       if (this.sendReceive.isInProgress()) return false;
       else if (!this.session.project()) return false;
       else if (!allowArchived && this.session.project().isArchived) return false;
       else {
         let hasRight = this.session.hasProjectRight(domain, operation);
+        if (otherUserOperation != null && userId != null && this.session.userId() !== userId) {
+          if (typeof otherUserOperation === 'boolean') {
+            hasRight = otherUserOperation;
+          } else {
+            hasRight = this.session.hasProjectRight(domain, otherUserOperation);
+          }
+        }
 
         // The case where user does not explicitly have a right, but does because user is owner
         if (projectOwnerAllowed) {
@@ -69,10 +84,11 @@ export class Rights {
 }
 
 export class LexiconRightsService {
+  // noinspection TypeScriptFieldCanBeMadeReadonly
   private rights: Rights;
 
   static $inject: string[] = ['sessionService', 'lexSendReceive'];
-  constructor(private sessionService: SessionService, sendReceive: LexiconSendReceiveService) {
+  constructor(private sessionService: SessionService, private sendReceive: LexiconSendReceiveService) {
     this.rights = new Rights(sessionService.domain, sessionService.operation, sendReceive);
   }
 

--- a/src/angular-app/languageforge/lexicon/editor/comment/comment-bubble.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/comment/comment-bubble.component.html
@@ -1,7 +1,8 @@
-<div class="commentBubbleContainer" ng-class="(!active ? 'comment-inactivate' : '')" ng-hide="isCommentingAvailable()">
-    <a ng-click="getComments()" title="{{(active) ? 'Show Comments' : 'Please wait while comments are setup'}}" class="commentBubble" ng-class="(getCountForDisplay() < 1 ? 'noCount' : '')">
-        <i class="fa fa-spinner fa-spin" ng-hide="active"></i>
-        <i class="fa fa-comments" ng-show="active"></i><span class="commentCount" style="">{{getCountForDisplay()}}</span>
-        <span class="commentLabel">Comment{{(getCountForDisplay() !== 1) ? 's' : ''}}</span>
+<div class="commentBubbleContainer" data-ng-class="(!$ctrl.active ? 'comment-inactivate' : '')" data-ng-hide="$ctrl.isCommentingAvailable()">
+    <a class="commentBubble" title="{{($ctrl.active) ? 'Show Comments' : 'Please wait while comments are setup'}}"
+       data-ng-click="$ctrl.getComments()" data-ng-class="($ctrl.getCountForDisplay() < 1 ? 'noCount' : '')">
+        <i class="fa fa-spinner fa-spin" data-ng-hide="$ctrl.active"></i>
+        <i class="fa fa-comments" data-ng-show="$ctrl.active"></i><span class="commentCount">{{$ctrl.getCountForDisplay()}}</span>
+        <span class="commentLabel">Comment{{($ctrl.getCountForDisplay() !== 1) ? 's' : ''}}</span>
     </a>
 </div>

--- a/src/angular-app/languageforge/lexicon/editor/comment/comment.module.ts
+++ b/src/angular-app/languageforge/lexicon/editor/comment/comment.module.ts
@@ -9,10 +9,10 @@ import {RegardingFieldComponent} from './regarding-field.component';
 
 export const EditorCommentsModule = angular
   .module('lexCommentsModule', [])
-  .directive('commentBubble', CommentBubbleComponent)
-  .directive('commentsRightPanel', CommentsRightPanelComponent)
-  .directive('currentEntryCommentCount', CurrentEntryCommentCountComponent)
-  .directive('dcComment', CommentComponent)
-  .directive('lexCommentsView', LexCommentsViewComponent)
-  .directive('regardingField', RegardingFieldComponent)
+  .component('commentBubble', CommentBubbleComponent)
+  .component('commentsRightPanel', CommentsRightPanelComponent)
+  .component('currentEntryCommentCount', CurrentEntryCommentCountComponent)
+  .component('dcComment', CommentComponent)
+  .component('lexCommentsView', LexCommentsViewComponent)
+  .component('regardingField', RegardingFieldComponent)
   .name;

--- a/src/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.html
@@ -1,16 +1,16 @@
-<div class="comments-right-panel-container right-panel-container" ng-class="{'context-mode': commentFilter.contextGuid}">
-    <div ng-hide="commentFilter.contextGuid">
+<div class="comments-right-panel-container right-panel-container" data-ng-class="{'context-mode': $ctrl.commentFilter.contextGuid}">
+    <div data-ng-hide="$ctrl.commentFilter.contextGuid">
         <div class="comments-search-container">
-            <input dir="auto" class="form-control" placeholder="Filter Comments" data-ng-model="commentFilter.text" type="text">
-            <span ng-show="commentFilter.text != ''" title="Clear Filter" ng-click="commentFilter.text = ''">
+            <input dir="auto" class="form-control" placeholder="Filter Comments" data-ng-model="$ctrl.commentFilter.text" type="text">
+            <span data-ng-show="$ctrl.commentFilter.text != ''" title="Clear Filter" data-ng-click="$ctrl.commentFilter.text = ''">
                 <i class="fa fa-times"></i>
             </span>
             <!--suppress HtmlFormInputWithoutLabel -->
-            <select ng-show="rights.canUpdateCommentStatus()" class="form-control custom-select" data-ng-model="commentFilter.status">
+            <select data-ng-show="$ctrl.control.rights.canUpdateCommentStatus()" class="form-control custom-select" data-ng-model="$ctrl.commentFilter.status">
                 <option value="all">Show All</option>
                 <option value="resolved">Resolved</option>
                 <option value="unresolved">Unresolved</option>
-                <option ng-if="rights.canUpdateCommentStatus()" value="todo">Todo</option>
+                <option data-ng-if="$ctrl.control.rights.canUpdateCommentStatus()" value="todo">Todo</option>
             </select>
         </div>
     </div>
@@ -18,24 +18,34 @@
         <div class="commentListView">
             <div class="commentListContainer">
                 <!--suppress JSUnusedLocalSymbols -->
-                <div ng-repeat="comment in currentEntryCommentsFiltered">
-                    <dc-comment></dc-comment>
+                <div data-ng-repeat="comment in $ctrl.currentEntryCommentsFiltered">
+                    <dc-comment comment="comment"
+                                control="$ctrl.control"
+                                can-plus-one-comment="$ctrl.canPlusOneComment(commentId)"
+                                load-comments="$ctrl.loadComments()"
+                                parent-get-sense-label="$ctrl.getSenseLabel(regardingField, contextGuid)"
+                                plus-one-comment="$ctrl.plusOneComment(commentId)"
+                                set-comment-interactive-status="$ctrl.setCommentInteractiveStatus(id, visible)"
+                                toggle-show-new-comment="$ctrl.toggleShowNewComment()"></dc-comment>
                 </div>
             </div>
         </div>
-        <div ng-show="rights.canComment() && newComment.regarding.field && showNewComment && newComment.regarding.field != 'entry'" class="newCommentForm" ng-class="{'show': showNewComment, 'regard': newComment.regarding.field}">
+        <div class="newCommentForm"
+             data-ng-show="$ctrl.control.rights.canComment() && $ctrl.newComment.regarding.field && $ctrl.showNewComment && $ctrl.newComment.regarding.field != 'entry'"
+             data-ng-class="{'show': $ctrl.showNewComment, 'regard': $ctrl.newComment.regarding.field}">
             <div class="card card-default">
-                <div class="card-title" ng-show="currentEntryCommentsFiltered.length === 0">
-                    <span class="sense-label">{{getNewCommentSenseLabel(newComment.regarding.field)}}</span> {{newComment.regarding.fieldNameForDisplay}}{{(newComment.regarding.inputSystemAbbreviation) ? ' - ' + newComment.regarding.inputSystemAbbreviation : ''}}
+                <div class="card-title" data-ng-show="$ctrl.currentEntryCommentsFiltered.length === 0">
+                    <span class="sense-label">{{$ctrl.getNewCommentSenseLabel($ctrl.newComment.regarding.field)}}</span>
+                    {{$ctrl.newComment.regarding.fieldNameForDisplay}}{{($ctrl.newComment.regarding.inputSystemAbbreviation) ? ' - ' + $ctrl.newComment.regarding.inputSystemAbbreviation : ''}}
                 </div>
-                <div class="card-title" ng-show="currentEntryCommentsFiltered.length > 0">
+                <div class="card-title" data-ng-show="$ctrl.currentEntryCommentsFiltered.length > 0">
                     Start a new conversation thread
                 </div>
                 <div class="card-block">
-                    <form ng-submit="postNewComment()">
-                        <textarea required id="comment-panel-textarea" data-ng-model="newComment.content" class="form-control" placeholder="{{getNewCommentPlaceholderText()}}"  ></textarea>
+                    <form data-ng-submit="$ctrl.postNewComment()">
+                        <textarea required id="comment-panel-textarea" data-ng-model="$ctrl.newComment.content" class="form-control" placeholder="{{$ctrl.getNewCommentPlaceholderText()}}"></textarea>
                         <div class="d-flex justify-content-end">
-                            <button id="comment-panel-post-button" type="submit" class="btn btn-sm btn-primary" data-ng-disabled="posting">Post</button>
+                            <button id="comment-panel-post-button" type="submit" class="btn btn-sm btn-primary" data-ng-disabled="$ctrl.isPosting">Post</button>
                         </div>
                     </form>
                 </div>

--- a/src/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.ts
@@ -1,299 +1,275 @@
 import * as angular from 'angular';
 
 import {LexiconCommentService} from '../../../../bellows/core/offline/lexicon-comments.service';
-import {SessionService} from '../../../../bellows/core/session.service';
-import {LexComment} from '../../shared/model/lex-comment.model';
+import {LexiconEditorDataService} from '../../core/lexicon-editor-data.service';
+import {LexComment, LexCommentFieldReference} from '../../shared/model/lex-comment.model';
+import {LexCommentChange} from '../../shared/model/lex-comment.model';
 import {LexEntry} from '../../shared/model/lex-entry.model';
+import {LexConfigFieldList} from '../../shared/model/lexicon-config.model';
+import {FieldControl} from '../field/field-control.model';
 
-export function CommentsRightPanelComponent() {
-  return {
-    restrict: 'E',
-    templateUrl: '/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.html',
-    scope: {
-      entry: '=',
-      control: '=',
-      newComment: '='
-    },
-    controller: ['$scope', 'lexCommentService', 'sessionService',
-    ($scope: any, commentService: LexiconCommentService, sessionService: SessionService) => {
-
-      /*  $scope.newComment has the following initial structure
-       {
-       id: '',
-       content: '',
-       regarding: {}
-       };
-       */
-      $scope.showNewComment = false;
-      $scope.senseLabel = '';
-      $scope.posting = false;
-      $scope.commentInteractiveStatus = {
-        id: '',
-        visible: false
-      };
-
-      $scope.initializeNewComment = function initializeNewComment(): void {
-        if ($scope.showNewComment && $scope.entry.id === $scope.newComment.entryRef) {
-          if ($scope.posting) {
-            $scope.newComment.content = '';
-          }
-        } else {
-          $scope.newComment = {
-            id: '',
-            content: '',
-            entryRef: $scope.entry.id,
-            regarding: {},
-            contextGuid: ''
-          };
-        }
-      };
-
-      $scope.currentEntryCommentsFiltered = commentService.comments.items.currentEntryFiltered;
-
-      $scope.numberOfComments = function numberOfComments(): number {
-        return commentService.comments.counts.currentEntry.total;
-      };
-
-      $scope.commentFilter = {
-        text: '',
-        status: 'all',
-        contextGuid: '',
-        byText: function byText(comment: LexComment): boolean {
-          // Convert entire comment object to a big string and search for filter.
-          // Note: This has a slight side effect of ID and avatar information
-          // matching the filter.
-          return (JSON.stringify(comment).normalize().toLowerCase()
-            .indexOf($scope.commentFilter.text.normalize().toLowerCase()) !== -1);
-        },
-
-        byStatus: function byStatus(comment: LexComment): boolean {
-          if (comment != null) {
-            if ($scope.commentFilter.status === 'all') {
-              return true;
-            } else if ($scope.commentFilter.status === 'todo') {
-              if (comment.status === 'todo') {
-                return true;
-              }
-            } else if ($scope.commentFilter.status === 'resolved') {
-              if (comment.status === 'resolved') {
-                return true;
-              }
-            } else { // show unresolved comments
-              if (comment.status !== 'resolved') {
-                return true;
-              }
-            }
-          }
-
-          return false;
-        },
-
-        byContext: function byContext(comment: LexComment): boolean {
-          if (comment == null) {
-            return false;
-          } else if (!$scope.commentFilter.contextGuid) {
-            // Return true as we're most likely not running a valid context search so return all
-            return true;
-          } else if ($scope.commentFilter.contextGuid) {
-            // All new comments will have a context ID available
-            return (comment.contextGuid === $scope.commentFilter.contextGuid);
-          }
-
-          return false;
-        }
-      };
-
-      sessionService.getSession().then(session => {
-        $scope.rights = {
-          canComment: function canComment(): boolean {
-            if (session.project().isArchived) return false;
-            return session.hasProjectRight(sessionService.domain.COMMENTS,
-              sessionService.operation.CREATE);
-          },
-
-          canDeleteComment: function canDeleteComment(commentAuthorId: string): boolean {
-            if (session.project().isArchived) return false;
-            if (session.userId() === commentAuthorId) {
-              return session.hasProjectRight(sessionService.domain.COMMENTS,
-                sessionService.operation.DELETE_OWN);
-            } else {
-              return session.hasProjectRight(sessionService.domain.COMMENTS,
-                sessionService.operation.DELETE);
-            }
-          },
-
-          canEditComment: function canEditComment(commentAuthorId: string): boolean {
-            if (session.project().isArchived) return false;
-            if (session.userId() === commentAuthorId) {
-              return session.hasProjectRight(sessionService.domain.COMMENTS,
-                sessionService.operation.EDIT_OWN);
-            } else {
-              return false;
-            }
-          },
-
-          canUpdateCommentStatus: function canUpdateCommentStatus(): boolean {
-            if (session.project().isArchived) return false;
-            return session.hasProjectRight(sessionService.domain.COMMENTS,
-              sessionService.operation.EDIT);
-          }
-        };
-      });
-
-      commentService.refreshFilteredComments($scope.commentFilter);
-
-      $scope.loadComments = function loadComments(): void {
-        commentService.loadEntryComments($scope.entry.id).then(() => {
-          commentService.refreshFilteredComments($scope.commentFilter);
-          if ($scope.commentInteractiveStatus.id) {
-            angular.forEach($scope.currentEntryCommentsFiltered, comment => {
-              if (comment.id === $scope.commentInteractiveStatus.id) {
-                comment.showRepliesContainer = $scope.commentInteractiveStatus.visible;
-              }
-            });
-          }
-        });
-      };
-
-      $scope.setCommentInteractiveStatus = function setCommentInteractiveStatus(id: string, visible: boolean): void {
-        $scope.commentInteractiveStatus.id = id;
-        $scope.commentInteractiveStatus.visible = visible;
-      };
-
-      $scope.plusOneComment = function plusOneComment(commentId: string): void {
-        commentService.plusOne(commentId, result => {
-          if (result.ok) {
-            $scope.control.editorService.refreshEditorData().then(() => {
-              $scope.loadComments();
-            });
-          }
-        });
-      };
-
-      $scope.canPlusOneComment = function canPlusOneComment(commentId: string): boolean {
-        return !(commentService.comments.counts.userPlusOne != null &&
-          commentService.comments.counts.userPlusOne[commentId] != null);
-      };
-
-      $scope.getNewCommentPlaceholderText = function getNewCommentPlaceholderText(): string {
-        let label;
-        if ($scope.currentEntryCommentsFiltered.length === 0) {
-          label = 'Your comment goes here.  Be the first to share!';
-        } else if ($scope.currentEntryCommentsFiltered.length > 0) {
-          if ($scope.newComment != null) {
-            label = 'Start a new conversation relating to the ' + $scope.newComment.regarding.fieldNameForDisplay;
-          } else {
-            label = 'Start a new conversation';
-          }
-        } else {
-          label = 'Join the discussion and type your comment here.';
-        }
-
-        return label;
-      };
-
-      $scope.showCommentsInContext = function showCommentsInContext(contextGuid: string): void {
-        $scope.commentFilter.contextGuid = contextGuid;
-        $scope.showNewComment = (contextGuid !== '');
-
-        commentService.refreshFilteredComments($scope.commentFilter);
-      };
-
-      $scope.postNewComment = function postNewComment(): void {
-        // Get the latest value for the field before saving in case it has changed
-        // since the comment panel was first triggered and comment started getting entered
-        const contextParts = $scope.control.getContextParts($scope.newComment.contextGuid);
-        $scope.newComment.regarding.fieldValue = contextParts.value;
-        $scope.posting = true;
-        commentService.update($scope.newComment, result => {
-          if (result.ok) {
-            $scope.control.editorService.refreshEditorData().then(() => {
-              const previousComment = $scope.newComment;
-              $scope.loadComments();
-              $scope.initializeNewComment();
-              $scope.newComment.regarding = previousComment.regarding;
-              $scope.posting = false;
-            });
-          }
-        });
-
-        commentService.refreshFilteredComments($scope.commentFilter); // for instant feedback
-      };
-
-      $scope.getSenseLabel = function getSenseLabel(regardingField: string, contextGuid: string): string {
-        if (regardingField == null) {
-          return '';
-        }
-
-        let index = null;
-        if (contextGuid != null) {
-          const contextParts = $scope.control.getContextParts(contextGuid);
-          if (contextParts.example.index) {
-            index = contextParts.example.index;
-          } else if (contextParts.sense.index) {
-            index = contextParts.sense.index;
-          }
-        }
-
-        let configField = null;
-        const fields = $scope.control.config.entry.fields;
-        if (fields.hasOwnProperty(regardingField)) {
-          configField = fields[regardingField];
-        } else if (fields.senses.fields.hasOwnProperty(regardingField)) {
-          configField = fields.senses.fields[regardingField];
-        } else if (fields.senses.fields.examples.fields.hasOwnProperty(regardingField)) {
-          configField = fields.senses.fields.examples.fields[regardingField];
-        }
-
-        if (configField !== null) {
-          if (configField.hasOwnProperty('senseLabel')) {
-            if (index != null && configField.senseLabel instanceof Array) {
-              return configField.senseLabel[index];
-            } else {
-              return configField.senseLabel;
-            }
-          }
-        }
-
-        return '';
-      };
-
-      $scope.getNewCommentSenseLabel = function getNewCommentSenseLabel(regardingField: string): string {
-        if (regardingField == null) {
-          return '';
-        }
-
-        return $scope.getSenseLabel(regardingField, $scope.newComment.contextGuid);
-      };
-
-      $scope.$watch('entry', (newVal: LexEntry) => {
-        if (newVal && !angular.equals(newVal, {})) {
-          $scope.loadComments();
-          $scope.initializeNewComment();
-        }
-      });
-
-      $scope.$watch('commentFilter.text', (newVal: string, oldVal: string) => {
-        if (newVal !== oldVal) {
-          commentService.refreshFilteredComments($scope.commentFilter);
-        }
-
-      });
-
-      $scope.$watch('commentFilter.status', (newVal: string, oldVal: string) => {
-        if (newVal !== oldVal) {
-          commentService.refreshFilteredComments($scope.commentFilter);
-        }
-
-      });
-
-      $scope.$watch('control.commentContext', (newVal: LexComment, oldVal: LexComment) => {
-        if (newVal !== oldVal) {
-          $scope.showCommentsInContext(newVal.contextGuid);
-        }
-
-      }, true);
-
-    }]
-  };
+class CommentFilter {
+  text: string = '';
+  status: string = 'all';
+  contextGuid: string = '';
+  byText: (comment: LexComment) => boolean;
+  byStatus: (comment: LexComment) => boolean;
+  byContext: (comment: LexComment) => boolean;
 }
+
+export class CommentsRightPanelController implements angular.IController {
+  newComment: LexCommentChange;
+  entry: LexEntry;
+  control: FieldControl;
+
+  currentEntryCommentsFiltered = this.commentService.comments.items.currentEntryFiltered;
+  showNewComment: boolean = false;
+  senseLabel: string = '';
+  isPosting: boolean = false;
+  commentInteractiveStatus = {
+    id: '',
+    visible: false
+  };
+  commentFilter: CommentFilter;
+
+  static $inject = ['$scope', 'lexCommentService',
+    'lexEditorDataService'];
+  constructor(private $scope: angular.IScope, private commentService: LexiconCommentService,
+              private editorService: LexiconEditorDataService) { }
+
+  $onInit(): void {
+    this.commentFilter = {
+      text: '',
+      status: 'all',
+      contextGuid: '',
+      byText: (comment: LexComment): boolean => {
+        if (this.commentFilter.text === '') {
+          return true;
+        }
+
+        // Convert entire comment object to a big string and search for filter.
+        // Note: This has a slight side effect of ID and avatar information
+        // matching the filter.
+        return JSON.stringify(comment).normalize().toLowerCase()
+          .includes(this.commentFilter.text.normalize().toLowerCase());
+      },
+
+      byStatus: (comment: LexComment): boolean => {
+        if (comment != null) {
+          if (this.commentFilter.status === 'all') {
+            return true;
+          } else if (this.commentFilter.status === 'todo') {
+            if (comment.status === 'todo') {
+              return true;
+            }
+          } else if (this.commentFilter.status === 'resolved') {
+            if (comment.status === 'resolved') {
+              return true;
+            }
+          } else { // show unresolved comments
+            if (comment.status !== 'resolved') {
+              return true;
+            }
+          }
+        }
+
+        return false;
+      },
+
+      byContext: (comment: LexComment): boolean => {
+        if (comment == null) {
+          return false;
+        } else if (!this.commentFilter.contextGuid) {
+          // Return true as we're most likely not running a valid context search so return all
+          return true;
+        } else if (this.commentFilter.contextGuid) {
+          // All new comments will have a context ID available
+          return (comment.contextGuid === this.commentFilter.contextGuid);
+        }
+
+        return false;
+      }
+    };
+
+    this.commentService.refreshFilteredComments(this.commentFilter);
+
+    this.$scope.$watch(() => this.entry, (newVal: LexEntry) => {
+      if (newVal && Object.keys(newVal).length !== 0) {
+        this.loadComments();
+        this.initializeNewComment();
+      }
+    });
+
+    this.$scope.$watch(() => this.commentFilter.text, (newVal: string, oldVal: string) => {
+      if (newVal !== oldVal) {
+        this.commentService.refreshFilteredComments(this.commentFilter);
+      }
+    });
+
+    this.$scope.$watch(() => this.commentFilter.status, (newVal: string, oldVal: string) => {
+      if (newVal !== oldVal) {
+        this.commentService.refreshFilteredComments(this.commentFilter);
+      }
+    });
+
+    this.$scope.$watch(() => (this.control != null) ? this.control.commentContext : null,
+      (newVal: LexComment, oldVal: LexComment) => {
+        if (newVal != null && newVal !== oldVal) {
+          this.showCommentsInContext(newVal.contextGuid);
+        }
+      }, true);
+  }
+
+  loadComments = (): void => {
+    this.commentService.loadEntryComments(this.entry.id).then(() => {
+      this.commentService.refreshFilteredComments(this.commentFilter);
+      if (this.commentInteractiveStatus.id) {
+        for (const comment of this.currentEntryCommentsFiltered) {
+          if (comment.id === this.commentInteractiveStatus.id) {
+            (comment as LexCommentChange).showRepliesContainer = this.commentInteractiveStatus.visible;
+          }
+        }
+      }
+    });
+  }
+
+  setCommentInteractiveStatus = (id: string, visible: boolean): void => {
+    this.commentInteractiveStatus.id = id;
+    this.commentInteractiveStatus.visible = visible;
+  }
+
+  plusOneComment = (commentId: string): void => {
+    this.commentService.plusOne(commentId, result => {
+      if (result.ok) {
+        this.editorService.refreshEditorData().then(() => {
+          this.loadComments();
+        });
+      }
+    });
+  }
+
+  canPlusOneComment = (commentId: string): boolean => {
+    return !(this.commentService.comments.counts.userPlusOne != null &&
+      this.commentService.comments.counts.userPlusOne[commentId] != null);
+  }
+
+  toggleShowNewComment = (): void => {
+    this.showNewComment = !this.showNewComment;
+  }
+
+  getSenseLabel = (regardingField: string, contextGuid: string): string => {
+    if (regardingField == null || this.control.config == null) {
+      return '';
+    }
+
+    let index = null;
+    if (contextGuid != null) {
+      const contextParts = this.control.getContextParts(contextGuid);
+      if (contextParts.example.index) {
+        index = contextParts.example.index;
+      } else if (contextParts.sense.index) {
+        index = contextParts.sense.index;
+      }
+    }
+
+    let configField = null;
+    const entryConfig = this.control.config.entry;
+    const sensesConfig = entryConfig.fields.senses as LexConfigFieldList;
+    const examplesConfig = sensesConfig.fields.examples as LexConfigFieldList;
+    if (entryConfig.fields.hasOwnProperty(regardingField)) {
+      configField = entryConfig.fields[regardingField];
+    } else if (sensesConfig.fields.hasOwnProperty(regardingField)) {
+      configField = sensesConfig.fields[regardingField];
+    } else if (examplesConfig.fields.hasOwnProperty(regardingField)) {
+      configField = examplesConfig.fields[regardingField];
+    }
+
+    if (configField !== null) {
+      if (configField.hasOwnProperty('senseLabel')) {
+        if (index != null) {
+          return configField.senseLabel[index];
+        }
+      }
+    }
+
+    return '';
+  }
+
+  getNewCommentSenseLabel(regardingField: string): string {
+    if (regardingField == null) {
+      return '';
+    }
+
+    return this.getSenseLabel(regardingField, this.newComment.contextGuid);
+  }
+
+  getNewCommentPlaceholderText(): string {
+    let label;
+    if (this.currentEntryCommentsFiltered.length === 0) {
+      label = 'Your comment goes here.  Be the first to share!';
+    } else if (this.currentEntryCommentsFiltered.length > 0) {
+      if (this.newComment != null && this.newComment.regarding != null) {
+        label = 'Start a new conversation relating to the ' + this.newComment.regarding.fieldNameForDisplay;
+      } else {
+        label = 'Start a new conversation';
+      }
+    } else {
+      label = 'Join the discussion and type your comment here.';
+    }
+
+    return label;
+  }
+
+  postNewComment(): void {
+    // Get the latest value for the field before saving in case it has changed
+    // since the comment panel was first triggered and comment started getting entered
+    const contextParts = this.control.getContextParts(this.newComment.contextGuid);
+    this.newComment.regarding.fieldValue = contextParts.value;
+    this.isPosting = true;
+    this.commentService.update(this.newComment, result => {
+      if (result.ok) {
+        this.editorService.refreshEditorData().then(() => {
+          const previousComment = angular.copy(this.newComment);
+          this.loadComments();
+          this.initializeNewComment();
+          this.newComment.regarding = previousComment.regarding;
+        }).finally(() => {
+          this.isPosting = false;
+        });
+      }
+    });
+
+    this.commentService.refreshFilteredComments(this.commentFilter); // for instant feedback
+  }
+
+  private initializeNewComment(): void {
+    if (this.showNewComment && this.entry.id === this.newComment.entryRef) {
+      if (this.isPosting) {
+        this.newComment.content = '';
+      }
+    } else {
+      this.newComment.id = '';
+      this.newComment.content = '';
+      this.newComment.entryRef = this.entry.id;
+      this.newComment.regarding = new LexCommentFieldReference();
+      this.newComment.contextGuid = '';
+    }
+  }
+
+  private showCommentsInContext(contextGuid: string): void {
+    this.commentFilter.contextGuid = contextGuid;
+    this.showNewComment = (contextGuid !== '');
+    this.commentService.refreshFilteredComments(this.commentFilter);
+  }
+
+}
+
+export const CommentsRightPanelComponent: angular.IComponentOptions = {
+  bindings: {
+    newComment: '=',
+    entry: '<',
+    control: '<'
+  },
+  controller: CommentsRightPanelController,
+  templateUrl: '/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.html'
+};

--- a/src/angular-app/languageforge/lexicon/editor/comment/current-entry-comment-count.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/comment/current-entry-comment-count.component.html
@@ -1,5 +1,5 @@
 <span>
-    {{count.total}}
-    <span ng-if="count.total !== 1" class="d-none d-md-inline-block">Comments</span>
-    <span ng-if="count.total === 1" class="d-none d-md-inline-block">Comment</span>
+    {{$ctrl.count.total}}
+    <span ng-if="$ctrl.count.total !== 1" class="d-none d-md-inline-block">Comments</span>
+    <span ng-if="$ctrl.count.total === 1" class="d-none d-md-inline-block">Comment</span>
 </span>

--- a/src/angular-app/languageforge/lexicon/editor/comment/current-entry-comment-count.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/comment/current-entry-comment-count.component.ts
@@ -1,11 +1,17 @@
+import * as angular from 'angular';
+
 import {LexiconCommentService} from '../../../../bellows/core/offline/lexicon-comments.service';
 
-export function CurrentEntryCommentCountComponent() {
-  return {
-    restrict: 'E',
-    templateUrl: '/angular-app/languageforge/lexicon/editor/comment/current-entry-comment-count.component.html',
-    controller: ['$scope', 'lexCommentService', ($scope: any, commentService: LexiconCommentService) => {
-      $scope.count = commentService.comments.counts.currentEntry;
-    }]
-  };
+export class CurrentEntryCommentCountController implements angular.IController {
+  count = this.commentService.comments.counts.currentEntry;
+
+  static $inject = ['lexCommentService'];
+  constructor(private commentService: LexiconCommentService) { }
 }
+
+export const CurrentEntryCommentCountComponent: angular.IComponentOptions = {
+  bindings: {
+  },
+  controller: CurrentEntryCommentCountController,
+  templateUrl: '/angular-app/languageforge/lexicon/editor/comment/current-entry-comment-count.component.html'
+};

--- a/src/angular-app/languageforge/lexicon/editor/comment/dc-comment.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/comment/dc-comment.component.html
@@ -1,91 +1,95 @@
 <div class="commentContainer card">
     <div class="card-title">
-        <span class="sense-label">{{getSenseLabel()}}</span> {{comment.regarding.fieldNameForDisplay}}{{(comment.regarding.inputSystemAbbreviation) ? ' - ' + comment.regarding.inputSystemAbbreviation : ''}}
+        <span class="sense-label">{{$ctrl.getSenseLabel()}}</span>
+        {{$ctrl.comment.regarding.fieldNameForDisplay}}{{($ctrl.comment.regarding.inputSystemAbbreviation) ? ' - ' + $ctrl.comment.regarding.inputSystemAbbreviation : ''}}
     </div>
-    <div class="card-block" data-ng-class="{resolvedComment: comment.status == 'resolved'}">
+    <div class="card-block" data-ng-class="{resolvedComment: $ctrl.comment.status === 'resolved'}">
         <div class="commentContentContainer">
-            <div class="ng-hide" data-ng-bind="comment.contextGuid"></div>
+            <div class="ng-hide" data-ng-bind="$ctrl.comment.contextGuid"></div>
             <div class="comment-meta">
                 <div>
                     <img class="rounded-circle"
-                         data-ng-src="{{getAvatarUrl(comment.authorInfo.createdByUserRef.avatar_ref)}}">
+                         data-ng-src="{{$ctrl.getAvatarUrl($ctrl.comment.authorInfo.createdByUserRef.avatar_ref)}}">
                     <div class="data-and-author">
-                        <div class="comment-author">{{comment.authorInfo.createdByUserRef.name}}</div>
-                        <div class="comment-date">{{comment.authorInfo.createdDate | relativetime}}</div>
+                        <div class="comment-author">{{$ctrl.comment.authorInfo.createdByUserRef.name}}</div>
+                        <div class="comment-date">{{$ctrl.comment.authorInfo.createdDate | relativetime}}</div>
                     </div>
                 </div>
-                <div class="dropdown" uib-dropdown data-ng-show="rights.canComment() && rights.canEditComment(comment.authorInfo.createdByUserRef.id) || rights.canDeleteComment(comment.authorInfo.createdByUserRef.id) && !comment.editing">
+                <div class="dropdown" uib-dropdown data-ng-show="$ctrl.control.rights.canComment() && $ctrl.control.rights.canEditComment($ctrl.comment.authorInfo.createdByUserRef.id) || $ctrl.control.rights.canDeleteComment($ctrl.comment.authorInfo.createdByUserRef.id) && !$ctrl.comment.isEditing">
                     <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle type="button"><i
                             class="fa fa-ellipsis-v"></i></button>
                     <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
                         <a href class="dropdown-item"
-                           data-ng-show="rights.canEditComment(comment.authorInfo.createdByUserRef.id)"
-                           data-ng-click="editComment()"><i class="fa fa-pencil"></i> Edit</a>
+                           data-ng-show="$ctrl.control.rights.canEditComment($ctrl.comment.authorInfo.createdByUserRef.id)"
+                           data-ng-click="$ctrl.editComment()"><i class="fa fa-pencil"></i> Edit</a>
                         <a href class="dropdown-item"
-                           data-ng-show="rights.canDeleteComment(comment.authorInfo.createdByUserRef.id) && !comment.editing"
-                           data-ng-click="deleteComment(comment)"><i class="fa fa-trash"></i> Delete</a>
+                           data-ng-show="$ctrl.control.rights.canDeleteComment($ctrl.comment.authorInfo.createdByUserRef.id) && !$ctrl.comment.isEditing"
+                           data-ng-click="$ctrl.deleteComment($ctrl.comment)"><i class="fa fa-trash"></i> Delete</a>
                     </div>
                 </div>
             </div>
             <div class="comment-body">
-                <div class="commentRegarding" data-ng-show="comment.regarding.field && !comment.editing && isOriginalRelevant()">
-                    <regarding-field class="form-control" content="comment.regarding.fieldValue" control="control"
-                         field="comment.regarding.field" field-config="commentRegardingFieldConfig" ng-hide="isCommentRegardingPicture"></regarding-field>
-                    <div data-ng-if="isCommentRegardingPicture">
-                        <img data-ng-src="{{getCommentRegardingPictureSource()}}">
+                <div class="commentRegarding" data-ng-show="$ctrl.comment.regarding.field && !$ctrl.comment.isEditing && $ctrl.isOriginalRelevant()">
+                    <regarding-field class="form-control" ng-hide="$ctrl.isCommentRegardingPicture"
+                                     content="$ctrl.comment.regarding.fieldValue"
+                                     control="$ctrl.control"
+                                     field="$ctrl.comment.regarding.field"
+                                     field-config="$ctrl.commentRegardingFieldConfig"></regarding-field>
+                    <div data-ng-if="$ctrl.isCommentRegardingPicture">
+                        <img data-ng-src="{{$ctrl.getCommentRegardingPictureSource()}}">
                     </div>
                 </div>
-                <div class="commentContent" data-ng-hide="comment.editing" data-ng-bind="comment.content"></div>
-                <div data-ng-show="comment.editing" class="commentEditing">
+                <div class="commentContent" data-ng-hide="$ctrl.comment.isEditing" data-ng-bind="$ctrl.comment.content"></div>
+                <div data-ng-show="$ctrl.comment.isEditing" class="commentEditing">
                     <!--suppress HtmlFormInputWithoutLabel -->
-                    <textarea class="form-control" data-ng-model="editingCommentContent"></textarea>
+                    <textarea class="form-control" data-ng-model="$ctrl.editingCommentContent"></textarea>
                     <div class="d-flex justify-content-end">
-                        <a class="btn btn-sm btn-std" data-ng-click="comment.editing = false">Cancel</a>
-                        <button data-ng-disabled="!comment.content" class="btn btn-sm btn-primary"
-                                data-ng-click="updateComment(comment)">Update
+                        <a class="btn btn-sm btn-std" data-ng-click="$ctrl.comment.isEditing = false">Cancel</a>
+                        <button data-ng-disabled="!$ctrl.comment.content" class="btn btn-sm btn-primary"
+                                data-ng-click="$ctrl.updateComment($ctrl.comment)">Update
                         </button>
                     </div>
                 </div>
             </div>
         </div>
         <div class="comment-interaction">
-            <span class="likes">{{comment.score}} Like{{(comment.score != 1 ? 's' : '')}}</span>
-            <span class="replies">{{comment.replies.length || '0'}} Comment{{(comment.replies.length != 1 ? 's' : '')}}</span>
+            <span class="likes">{{$ctrl.comment.score}} Like{{($ctrl.comment.score !== 1 ? 's' : '')}}</span>
+            <span class="replies">{{$ctrl.comment.replies.length || '0'}} Comment{{($ctrl.comment.replies.length !== 1 ? 's' : '')}}</span>
         </div>
         <div class="comment-actions">
             <div class="btn-like">
-                <div class="can-like btn-action-icon" data-ng-show="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'" data-ng-click="plusOneComment(comment.id)">
+                <div class="can-like btn-action-icon" data-ng-click="$ctrl.plusOneComment({ commentId: $ctrl.comment.id })" data-ng-show="$ctrl.canLike()">
                     <i title="Like comment" class="fa fa-thumbs-o-up"></i>
                     <span>Like</span>
                 </div>
-                <div class="liked btn-action-icon" data-ng-hide="canPlusOneComment(comment.id) && rights.canComment() && comment.status != 'resolved'">
+                <div class="liked btn-action-icon" data-ng-hide="$ctrl.canLike()">
                     <i class="fa fa-thumbs-o-up"></i>
                     <span>Like</span>
                 </div>
             </div>
             <div class="btn-todo">
-                <div ng-show="rights.canUpdateCommentStatus()">
-                    <div class="open-todo btn-action-icon" data-ng-show="comment.status == 'resolved'"
-                       data-ng-click="updateCommentStatus(comment.id, 'open')"><i class="fa fa-pencil-square-o"></i><span>Resolved</span></div>
-                    <div class="resolve-todo btn-action-icon" data-ng-show="comment.status == 'todo'"
-                       data-ng-click="updateCommentStatus(comment.id, 'resolved')"><i class="fa fa-pencil-square-o"></i><span>To do</span></div>
-                    <div class="mark-todo btn-action-icon" data-ng-show="comment.status != 'resolved' && comment.status != 'todo'"
-                       data-ng-click="updateCommentStatus(comment.id, 'todo')"><i class="fa fa-pencil-square-o"></i><span>To do</span></div>
+                <div data-ng-show="$ctrl.control.rights.canUpdateCommentStatus()">
+                    <div class="open-todo btn-action-icon" data-ng-show="$ctrl.comment.status === 'resolved'"
+                       data-ng-click="$ctrl.updateCommentStatus($ctrl.comment.id, 'open')"><i class="fa fa-pencil-square-o"></i><span>Resolved</span></div>
+                    <div class="resolve-todo btn-action-icon" data-ng-show="$ctrl.comment.status === 'todo'"
+                       data-ng-click="$ctrl.updateCommentStatus($ctrl.comment.id, 'resolved')"><i class="fa fa-pencil-square-o"></i><span>To do</span></div>
+                    <div class="mark-todo btn-action-icon" data-ng-show="$ctrl.comment.status !== 'resolved' && $ctrl.comment.status !== 'todo'"
+                       data-ng-click="$ctrl.updateCommentStatus($ctrl.comment.id, 'todo')"><i class="fa fa-pencil-square-o"></i><span>To do</span></div>
                 </div>
-                <div ng-hide="rights.canUpdateCommentStatus()">
-                    <div class="open-todo open-todo-readonly btn-action-icon" data-ng-show="comment.status == 'resolved'">
+                <div data-ng-hide="$ctrl.control.rights.canUpdateCommentStatus()">
+                    <div class="open-todo open-todo-readonly btn-action-icon" data-ng-show="$ctrl.comment.status === 'resolved'">
                         <i class="fa fa-pencil-square-o"></i><span>Resolved</span>
                     </div>
                 </div>
             </div>
-            <div class="btn-comments btn-action-icon" ng-click="showCommentReplies()">
+            <div class="btn-comments btn-action-icon" data-ng-click="$ctrl.showCommentReplies()">
                 <i class="fa fa-comment-o"></i>
                 <span>Comments</span>
             </div>
         </div>
-        <div class="commentRepliesContainer" data-ng-show="comment.showRepliesContainer" ng-class="(comment.showRepliesContainer) ? 'on' : 'off'">
-            <div class="comment-replies" ng-show="comment.replies.length">
-                <div data-ng-repeat="reply in comment.replies" data-ng-mouseenter="reply.isHover = true"
+        <div class="commentRepliesContainer" data-ng-show="$ctrl.comment.showRepliesContainer" data-ng-class="($ctrl.comment.showRepliesContainer) ? 'on' : 'off'">
+            <div class="comment-replies" data-ng-show="$ctrl.comment.replies.length">
+                <div data-ng-repeat="reply in $ctrl.comment.replies" data-ng-mouseenter="reply.isHover = true"
                      data-ng-mouseleave="reply.isHover = false">
                     <div data-ng-hide="reply.isEditing" class="comment-reply">
                         <div class="reply-body">
@@ -95,41 +99,41 @@
                             </div>
                             <span class="reply-content">{{reply.content}}</span>
                         </div>
-                        <div data-ng-show="comment.status != 'resolved' && rights.canComment() && rights.canEditComment(reply.authorInfo.createdByUserRef.id)" class="reply-actions">
+                        <div data-ng-show="$ctrl.comment.status !== 'resolved' && $ctrl.control.rights.canComment() && $ctrl.control.rights.canEditComment(reply.authorInfo.createdByUserRef.id)" class="reply-actions">
                             <div class="dropdown float-right" uib-dropdown>
                                 <button class="btn btn-sm btn-std ellipsis-menu pui-no-caret" uib-dropdown-toggle
                                         type="button"><i class="fa fa-ellipsis-v"></i></button>
                                 <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
                                     <a href class="dropdown-item editReplyLink"
-                                       data-ng-show="rights.canEditComment(reply.authorInfo.createdByUserRef.id)"
-                                       data-ng-click="editReply(reply)">
+                                       data-ng-show="$ctrl.control.rights.canEditComment(reply.authorInfo.createdByUserRef.id)"
+                                       data-ng-click="$ctrl.editReply(reply)">
                                         <i class="fa fa-pencil"></i> Edit</a>
                                     <a href class="dropdown-item deleteReplyLink"
-                                       data-ng-show="rights.canDeleteComment(reply.authorInfo.createdByUserRef.id)"
-                                       data-ng-click="deleteCommentReply(comment.id, reply)">
+                                       data-ng-show="$ctrl.control.rights.canDeleteComment(reply.authorInfo.createdByUserRef.id)"
+                                       data-ng-click="$ctrl.deleteCommentReply($ctrl.comment.id, reply)">
                                         <i class="fa fa-trash"></i> Delete</a>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <form data-ng-show="reply.isEditing && rights.canComment()" data-ng-submit="submitReply(reply)" class="reply-edit-form">
+                    <form data-ng-show="reply.isEditing && $ctrl.control.rights.canComment()" data-ng-submit="$ctrl.submitReply(reply)" class="reply-edit-form">
                         <!--suppress HtmlFormInputWithoutLabel -->
                         <textarea class="form-control" data-ng-model="reply.editingContent"
                                   pui-auto-focus="reply.isAutoFocusEditing"></textarea>
                         <div class="d-flex justify-content-end">
-                            <a href class="btn btn-sm btn-std" data-ng-click="cancelReply(reply)">Cancel</a>
+                            <a href class="btn btn-sm btn-std" data-ng-click="$ctrl.cancelReply(reply)">Cancel</a>
                             <button type="submit" class="btn btn-sm btn-primary">Update</button>
                         </div>
                     </form>
                 </div>
             </div>
-            <form ng-show="showNewReplyForm && comment.status != 'resolved' && rights.canComment()" class="commentNewReplyForm" data-ng-submit="submitReply(newReply)">
+            <form data-ng-show="$ctrl.showNewReplyForm && $ctrl.comment.status !== 'resolved' && $ctrl.control.rights.canComment()" class="commentNewReplyForm" data-ng-submit="$ctrl.submitReply($ctrl.newReply)">
                 <textarea class="form-control" required placeholder="Reply here.  Press Enter when done."
-                          data-ng-model="newReply.editingContent" pui-auto-focus="isAutoFocusNewReply"
-                          ng-keydown="submitReply(newReply, $event)"></textarea>
+                          data-ng-model="$ctrl.newReply.editingContent" pui-auto-focus="$ctrl.isAutoFocusNewReply"
+                          data-ng-keydown="$ctrl.submitReply($ctrl.newReply, $event)"></textarea>
                 <div class="d-flex justify-content-end">
-                    <a href class="btn btn-sm btn-std" data-ng-click="showCommentReplies()">Hide</a>
-                    <button type="submit" class="btn btn-sm btn-primary" data-ng-disabled="posting"><i class="fa fa-reply"></i> Reply</button>
+                    <a href class="btn btn-sm btn-std" data-ng-click="$ctrl.showCommentReplies()">Hide</a>
+                    <button type="submit" class="btn btn-sm btn-primary" data-ng-disabled="$ctrl.isPosting"><i class="fa fa-reply"></i> Reply</button>
                 </div>
             </form>
         </div>

--- a/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.component.html
@@ -1,1 +1,4 @@
-<comments-right-panel entry="entry" control="control" new-comment="newComment" class="comments-right-panel right-panel-container"></comments-right-panel>
+<comments-right-panel class="comments-right-panel right-panel-container"
+                      new-comment="$ctrl.newComment"
+                      entry="$ctrl.entry"
+                      control="$ctrl.control"></comments-right-panel>

--- a/src/angular-app/languageforge/lexicon/editor/comment/regarding-field.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/comment/regarding-field.component.html
@@ -1,4 +1,4 @@
 <span class="uneditable-input regardingFieldValue"
-         data-ng-class="{'dc-multioptionlist-value': (fieldConfig.type == 'multioptionlist')}"
-         data-ng-bind-html="regarding || '&nbsp;'"
-         data-pui-show-overflow></span>
+      data-ng-class="{'dc-multioptionlist-value': ($ctrl.fieldConfig.type === 'multioptionlist')}"
+      data-ng-bind-html="$ctrl.regarding || '&nbsp;'"
+      data-pui-show-overflow></span>

--- a/src/angular-app/languageforge/lexicon/editor/comment/regarding-field.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/comment/regarding-field.component.ts
@@ -1,65 +1,80 @@
 import * as angular from 'angular';
 
-import {LexConfigField} from '../../shared/model/lexicon-config.model';
+import {LexConfigField, LexConfigOptionList} from '../../shared/model/lexicon-config.model';
+import {FieldControl} from '../field/field-control.model';
 
 interface WindowService extends angular.IWindowService {
   semanticDomains_en?: any;
 }
 
-export function RegardingFieldComponent() {
-  return {
-    restrict: 'E',
-    templateUrl: '/angular-app/languageforge/lexicon/editor/comment/regarding-field.component.html',
-    scope: {
-      content: '=',
-      control: '=',
-      field: '=',
-      fieldConfig: '='
-    },
-    controller: ['$scope', '$window', ($scope: any, $window: WindowService) => {
-      $scope.regarding = '';
-      $scope.$watch('fieldConfig', (newContent: LexConfigField) => {
-        if (newContent != null) {
-          $scope.setContent();
-        }
-      });
+export class RegardingFieldController implements angular.IController {
+  content: string;
+  control: FieldControl;
+  field: string;
+  fieldConfig: LexConfigField;
 
-      $scope.setContent = function setContent(): void {
-        if ($scope.fieldConfig != null) {
-          if ($scope.content != null) {
-            if ($scope.fieldConfig.type === 'optionlist' || $scope.fieldConfig.type === 'multioptionlist') {
-              if ($scope.field === 'semanticDomain') {
-                // Semantic domains are in the global scope and appear to be English only
-                // Will need to be updated once the system provides support for other languages
-                for (const i in $window.semanticDomains_en) {
-                  if ($window.semanticDomains_en.hasOwnProperty(i) &&
-                    $window.semanticDomains_en[i].key === $scope.content
+  regarding: string = '';
+
+  static $inject = ['$window'];
+  constructor(private $window: WindowService) { }
+
+  $onInit(): void {
+    this.setContent();
+  }
+
+  $onChanges(changes: any): void {
+    const fieldConfigChange = changes.fieldConfig as angular.IChangesObject<LexConfigField>;
+    if (fieldConfigChange != null && fieldConfigChange.currentValue != null) {
+      this.setContent();
+    }
+  }
+
+  private setContent(): void {
+    if (this.fieldConfig != null) {
+      if (this.content != null) {
+        if (this.fieldConfig.type === 'optionlist' || this.fieldConfig.type === 'multioptionlist') {
+          if (this.field === 'semanticDomain') {
+            // Semantic domains are in the global scope and appear to be English only
+            // Will need to be updated once the system provides support for other languages
+            for (const i in this.$window.semanticDomains_en) {
+              if (this.$window.semanticDomains_en.hasOwnProperty(i) &&
+                this.$window.semanticDomains_en[i].key === this.content
+              ) {
+                this.regarding = this.$window.semanticDomains_en[i].value;
+              }
+            }
+          } else {
+            const optionlists = this.control.config.optionlists;
+            for (const listCode in optionlists) {
+              if (optionlists.hasOwnProperty(listCode) &&
+                listCode === (this.fieldConfig as LexConfigOptionList).listCode
+              ) {
+                for (const i in optionlists[listCode].items) {
+                  if (optionlists[listCode].items.hasOwnProperty(i) &&
+                    optionlists[listCode].items[i].key === this.content
                   ) {
-                    $scope.regarding = $window.semanticDomains_en[i].value;
-                  }
-                }
-              } else {
-                const optionlists = $scope.control.config.optionlists;
-                for (const listCode in optionlists) {
-                  if (optionlists.hasOwnProperty(listCode) && listCode === $scope.fieldConfig.listCode) {
-                    for (const i in optionlists[listCode].items) {
-                      if (optionlists[listCode].items.hasOwnProperty(i) &&
-                        optionlists[listCode].items[i].key === $scope.content
-                      ) {
-                        $scope.regarding = optionlists[listCode].items[i].value;
-                      }
-                    }
+                    this.regarding = optionlists[listCode].items[i].value;
                   }
                 }
               }
-            } else {
-              $scope.regarding = $scope.content;
             }
           }
+        } else {
+          this.regarding = this.content;
         }
-      };
+      }
+    }
+  }
 
-      $scope.setContent();
-    }]
-  };
 }
+
+export const RegardingFieldComponent: angular.IComponentOptions = {
+  bindings: {
+    content: '<',
+    control: '<',
+    field: '<',
+    fieldConfig: '<'
+  },
+  controller: RegardingFieldController,
+  templateUrl: '/angular-app/languageforge/lexicon/editor/comment/regarding-field.component.html'
+};

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.html
@@ -53,28 +53,29 @@
                                     <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
                                     <div class="form-inline">
                                         <select id="sortEntriesBy" class="custom-select sortfilter-control"
-                                                ng-change="sortEntries(true)" ng-model="entryListModifiers.sortBy"
-                                                ng-options="item as item.label for item in entryListModifiers.sortOptions track by item.value">
+                                                data-ng-change="sortEntries(true)" data-ng-model="entryListModifiers.sortBy"
+                                                data-ng-options="item as item.label for item in entryListModifiers.sortOptions track by item.value">
                                         </select>
                                         <label>
-                                            <input type="checkbox" ng-change="sortEntries(true)" ng-model="entryListModifiers.sortReverse"> Reverse
+                                            <input type="checkbox" data-ng-change="sortEntries(true)" data-ng-model="entryListModifiers.sortReverse"> Reverse
                                         </label>
                                     </div>
                                 </div>
                                 <div class="form-group sortfilter-form">
                                     <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
                                     <div class="form-inline">
-                                        <select class="custom-select sortfilter-control" ng-show="entryListModifiers.filterBy"
-                                                ng-change="filterEntries(true)" ng-model="entryListModifiers.filterType">
+                                        <!--suppress HtmlFormInputWithoutLabel -->
+                                        <select class="custom-select sortfilter-control" data-ng-show="entryListModifiers.filterBy"
+                                                data-ng-change="filterEntries(true)" data-ng-model="entryListModifiers.filterType">
                                             <option value="isEmpty">Doesn't have</option>
                                             <option value="isNotEmpty">Has</option>
                                         </select>
                                         <select class="custom-select sortfilter-control" id="filterEntriesFor"
-                                                ng-change="filterEntries(true)" ng-model="entryListModifiers.filterBy"
-                                                ng-options="item as item.label for item in entryListModifiers.filterOptions track by item.key">
+                                                data-ng-change="filterEntries(true)" data-ng-model="entryListModifiers.filterBy"
+                                                data-ng-options="item as item.label for item in entryListModifiers.filterOptions track by item.key">
                                             <option value="">Show All</option>
                                         </select>
-                                        <button ng-click="resetEntryListFilter()" ng-show="entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
+                                        <button data-ng-click="resetEntryListFilter()" data-ng-show="entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
                                     </div>
                                 </div>
                             </div>
@@ -113,13 +114,13 @@
     <div id="lexRightPanels">
         <div class="right-panel-list">
             <div id="lexAppCommentView" class="right-panel">
-                <lex-comments-view entry-config="config.entry" entry="currentEntry" control="control"></lex-comments-view>
+                <lex-comments-view entry="currentEntry" control="control"></lex-comments-view>
             </div>
             <div id="lexAppActivityFeed" class="right-panel">
                 <activity-container entry-id="{{currentEntry.id}}"></activity-container>
             </div>
         </div>
-        <div class="right-panel-backdrop" ng-click="control.hideRightPanel()">
+        <div class="right-panel-backdrop" data-ng-click="control.hideRightPanel()">
             <i class="fa fa-times"></i>
         </div>
     </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor.js
+++ b/src/angular-app/languageforge/lexicon/editor/editor.js
@@ -466,7 +466,7 @@ angular.module('lexicon.editor', [
           commentService.loadEntryComments(id);
           if ($scope.rightPanelVisible === true && $scope.commentContext.contextGuid !== '') {
             $scope.showComments();
-            $scope.setCommentContext('', '');
+            $scope.setCommentContext('');
           }
         }
 
@@ -700,10 +700,10 @@ angular.module('lexicon.editor', [
           $scope.showCommentsPanel();
 
           // Reset the comment context AFTER the panel starts hiding
-          $scope.setCommentContext('', '', '', '', '');
+          $scope.setCommentContext('');
         } else {
           // Reset the comment context BEFORE we start showing the panel
-          $scope.setCommentContext('', '', '', '', '');
+          $scope.setCommentContext('');
           document.querySelector('.comments-right-panel').style.paddingTop = 0;
           if ($scope.rightPanelVisible === false) {
             $scope.showCommentsPanel();
@@ -715,7 +715,7 @@ angular.module('lexicon.editor', [
         $scope.showRightPanel('#lexAppCommentView');
       };
 
-      $scope.showActivityFeed = function showCommentsPanel() {
+      $scope.showActivityFeed = function showActivityFeed() {
         $scope.showRightPanel('#lexAppActivityFeed');
       };
 
@@ -758,7 +758,7 @@ angular.module('lexicon.editor', [
             }
 
             $scope.rightPanelVisible = false;
-            $scope.setCommentContext('', '');
+            $scope.setCommentContext('');
           }, delay);
         }
       };

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.component.html
@@ -24,7 +24,7 @@
                 </div>
             </div>
             <div class="dc-multioptionlist-values-list"
-                 data-ng-show="$ctrl.isAtEditorEntry() && $ctrl.rights.canEditEntry() && $ctrl.isAdding">
+                 data-ng-show="$ctrl.isAtEditorEntry() && $ctrl.control.rights.canEditEntry() && $ctrl.isAdding">
                 <!--suppress HtmlFormInputWithoutLabel -->
                 <select class="form-control custom-select" data-ng-change="$ctrl.addValue()" data-ng-model="$ctrl.newKey"
                         data-ng-options="item.key as item.value for item in $ctrl.items | filter: $ctrl.filterSelectedItems">
@@ -37,9 +37,7 @@
         </div>
     </div>
 </form>
-<div class="addItem"
-     data-ng-show="$ctrl.rights.canEditEntry() && $ctrl.isAtEditorEntry() && $ctrl.showAddButton()">
+<div class="addItem" data-ng-show="$ctrl.showAddButton()">
     <a class="btn btn-sm btn-std" data-ng-click="$ctrl.isAdding = true"><i class="fa fa-plus"></i> Add {{$ctrl.config.label}}</a>
 </div>
-<div class="spacing-after"
-     data-ng-hide="$ctrl.rights.canEditEntry() && $ctrl.isAtEditorEntry() && $ctrl.showAddButton()">&nbsp;</div>
+<div class="spacing-after" data-ng-hide="$ctrl.showAddButton()">&nbsp;</div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multioptionlist.component.ts
@@ -1,11 +1,9 @@
 import * as angular from 'angular';
 
-import {Rights} from '../../core/lexicon-rights.service';
 import {LexMultiValue} from '../../shared/model/lex-multi-value.model';
 import {LexConfigMultiOptionList} from '../../shared/model/lexicon-config.model';
 import {LexOptionListItem} from '../../shared/model/option-list.model';
 import {FieldOptionListController} from './dc-optionlist.component';
-import {FieldControl} from './field-control.model';
 
 export class FieldMultiOptionListController extends FieldOptionListController implements angular.IController {
   model: LexMultiValue;
@@ -14,17 +12,9 @@ export class FieldMultiOptionListController extends FieldOptionListController im
 
   isAdding = false;
   newKey: string;
-  rights: Rights;
-
-  $onChanges(changes: any): void {
-    const controlChange = changes.control as angular.IChangesObject<FieldControl>;
-    if (controlChange != null && controlChange.currentValue && controlChange.currentValue.rights != null) {
-      this.rights = this.control.rights;
-    }
-  }
 
   showDeleteButton(valueToBeDeleted: string, value: string): boolean {
-    if (this.items != null && this.isAtEditorEntry() && this.rights.canEditEntry()) {
+    if (this.items != null && this.isAtEditorEntry() && this.control.rights.canEditEntry()) {
       return valueToBeDeleted === value;
     }
 
@@ -48,7 +38,8 @@ export class FieldMultiOptionListController extends FieldOptionListController im
   }
 
   showAddButton(): boolean {
-    return !this.isAdding && this.items != null && this.model.values.length < this.items.length;
+    return this.control.rights.canEditEntry() && this.isAtEditorEntry() && !this.isAdding && this.model != null &&
+      this.items != null && this.model.values.length < this.items.length;
   }
 
   addValue(): void {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.component.html
@@ -23,7 +23,7 @@
                 </div>
             </div>
             <div class="notranslate dc-semanticdomain-values-list"
-                 data-ng-show="$ctrl.isAtEditorEntry() && $ctrl.rights.canEditEntry() && $ctrl.isAdding">
+                 data-ng-show="$ctrl.isAtEditorEntry() && $ctrl.control.rights.canEditEntry() && $ctrl.isAdding">
                 <!--suppress HtmlFormInputWithoutLabel -->
                 <select class="form-control custom-select" data-ng-change="$ctrl.addValue()" data-ng-model="$ctrl.newKey"
                         data-ng-options="option.key as option.value for option in $ctrl.options | orderBy: 'key' | filter: $ctrl.filterSelectedItems">
@@ -36,9 +36,7 @@
         </div>
     </div>
 </form>
-<div class="addItem"
-     data-ng-show="$ctrl.rights.canEditEntry() && $ctrl.isAtEditorEntry() && $ctrl.showAddButton()">
+<div class="addItem" data-ng-show="$ctrl.showAddButton()">
     <a class="btn btn-sm btn-std" data-ng-click="$ctrl.isAdding = true"><i class="fa fa-plus"></i> Add {{$ctrl.config.label}}</a>
 </div>
-<div class="spacing-after"
-     data-ng-hide="$ctrl.rights.canEditEntry() && $ctrl.isAtEditorEntry() && $ctrl.showAddButton()">&nbsp;</div>
+<div class="spacing-after" data-ng-hide="$ctrl.showAddButton()">&nbsp;</div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-semanticdomain.component.ts
@@ -15,7 +15,7 @@ export class FieldSemanticDomainController extends FieldMultiOptionListControlle
   }
 
   $onInit(): void {
-    super.$onInit();
+    this.contextGuid = this.parentContextGuid;
     this.createOptions();
   }
 
@@ -29,7 +29,7 @@ export class FieldSemanticDomainController extends FieldMultiOptionListControlle
   }
 
   showDeleteButton(valueToBeDeleted: string, value: string): boolean {
-    if (this.$window.semanticDomains_en != null && this.isAtEditorEntry() && this.rights.canEditEntry()) {
+    if (this.$window.semanticDomains_en != null && this.isAtEditorEntry() && this.control.rights.canEditEntry()) {
       return valueToBeDeleted === value;
     }
 
@@ -41,12 +41,9 @@ export class FieldSemanticDomainController extends FieldMultiOptionListControlle
   }
 
   showAddButton(): boolean {
-    if (this.model == null) {
-      return false;
-    }
-
-    return (this.$window.semanticDomains_en != null && !this.isAdding
-      && this.model.values.length < Object.keys(this.$window.semanticDomains_en).length);
+    return this.control.rights.canEditEntry() && this.isAtEditorEntry() && !this.isAdding && this.model != null &&
+      this.$window.semanticDomains_en != null &&
+      this.model.values.length < Object.keys(this.$window.semanticDomains_en).length;
   }
 
   private createOptions(): void {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.ts
@@ -9,7 +9,7 @@ export class FieldTextController implements angular.IController {
   fteDir: string;
 
   fte: any = {};
-  textFieldValue: string;
+  textFieldValue: string = '';
 
   static $inject = ['$scope'];
   constructor(private $scope: angular.IScope) { }
@@ -50,19 +50,11 @@ export class FieldTextController implements angular.IController {
     this.fteModel = FieldTextController.escapeHTML(this.textFieldValue);
   }
 
-  setupTaEditor($element: HTMLElement): void {
-    if (!this.fteMultiline) {
-      $element.onkeydown = (event: KeyboardEvent) => {
-        // ignore the enter key
-        const key = event.which || event.keyCode;
-        if (key === 13) {
-          event.preventDefault();
-        }
-      };
-    }
-  }
-
   private static unescapeHTML(str: string): string {
+    if (str == null) {
+      return '';
+    }
+
     return new DOMParser().parseFromString(str, 'text/html').body.textContent;
   }
 

--- a/src/angular-app/languageforge/lexicon/editor/field/field-control.model.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/field-control.model.ts
@@ -1,6 +1,8 @@
 import {InterfaceConfig} from '../../../../bellows/shared/model/interface-config.model';
 import {Rights} from '../../core/lexicon-rights.service';
+import {LexComment} from '../../shared/model/lex-comment.model';
 import {LexEntry} from '../../shared/model/lex-entry.model';
+import {LexField} from '../../shared/model/lex-field.model';
 import {LexConfig, LexiconConfig} from '../../shared/model/lexicon-config.model';
 import {LexiconProject} from '../../shared/model/lexicon-project.model';
 
@@ -9,15 +11,23 @@ import {LexiconProject} from '../../shared/model/lexicon-project.model';
 // entire editor controller.
 export class FieldControl {
   interfaceConfig: InterfaceConfig;
+  commentContext: { contextGuid: string };
   config: LexiconConfig;
   currentEntry: LexEntry;
   deleteEntry: (currentEntry: LexEntry) => void;
+  getContextParts: (contextGuid: string) => any;
+  getNewComment: () => LexComment;
   hideRightPanel: () => void;
   makeValidModelRecursive: (config: LexConfig, data?: any, stopAtNodes?: string | string[]) => any;
   project: LexiconProject;
   saveCurrentEntry: () => void;
+  selectFieldForComment: (fieldName: string, model: LexField, inputSystemTag: string, multioptionValue: string,
+                          pictureFilePath: string, contextGuid: string) => void;
+  setCommentContext: (contextGuid: string) => void;
   show: {
     emptyFields: boolean
   };
+  showCommentsPanel: () => void;
+  rightPanelVisible: boolean;
   rights: Rights;
 }

--- a/src/angular-app/languageforge/lexicon/shared/model/lex-comment.model.ts
+++ b/src/angular-app/languageforge/lexicon/shared/model/lex-comment.model.ts
@@ -1,16 +1,17 @@
 import {LexAuthorInfo} from './lex-author-info.model';
+import {LexConfigField} from './lexicon-config.model';
 
 export class LexComment {
-  authorInfo: LexAuthorInfo;
-  content: string;
+  authorInfo?: LexAuthorInfo;
+  content?: string;
   contextGuid: string;
   entryRef: string;
   id: string;
-  isDeleted: boolean;
+  isDeleted?: boolean;
   regarding: LexCommentFieldReference;
-  replies: LexCommentReply[];
-  score: number;
-  status: string;
+  replies?: LexCommentReply[];
+  score?: number;
+  status?: string;
 }
 
 export class LexCommentReply {
@@ -18,15 +19,22 @@ export class LexCommentReply {
   content: string;
   guid: string;
   id: string;
-  isDeleted: boolean;
+  isDeleted?: boolean;
 }
 
-class LexCommentFieldReference {
+export class LexCommentFieldReference {
   field: string;
   fieldNameForDisplay: string;
   fieldValue: string;
-  inputSystem: string;
-  inputSystemAbbreviation: string;
+  inputSystem?: string;
+  inputSystemAbbreviation?: string;
   meaning: string;
   word: string;
+}
+
+export class LexCommentChange extends LexComment {
+  isEditing?: boolean;
+  isRegardingPicture?: boolean;
+  showRepliesContainer?: boolean;
+  regardingFieldConfig?: LexConfigField;
 }

--- a/test/app/languageforge/lexicon/shared/editor.page.ts
+++ b/test/app/languageforge/lexicon/shared/editor.page.ts
@@ -315,8 +315,8 @@ export class EditorPage {
     // Top-row UI elements
     renderedDiv: this.commentDiv.element(by.css('dc-rendered')),
     filter: {
-      byTextElem: this.commentDiv.element(by.model('commentFilter.text')),
-      byStatusElem: this.commentDiv.element(by.model('commentFilter.status')),
+      byTextElem: this.commentDiv.element(by.model('$ctrl.commentFilter.text')),
+      byStatusElem: this.commentDiv.element(by.model('$ctrl.commentFilter.status')),
       clearElem: this.commentDiv.element(by.css('[title="Clear Filter] > i.fa-times')),
       byText: (textToFilterBy: string) => {
         this.comment.filter.byTextElem.sendKeys(textToFilterBy);
@@ -333,12 +333,6 @@ export class EditorPage {
       clearByStatus: () => {
         this.comment.filter.byStatus('Show All');
       }
-    },
-    commentCountElem: this.commentDiv.element(by.binding('currentEntryCommentCounts.total')),
-    getCommentCount: () => {
-      return this.comment.commentCountElem.getText().then((s: string) =>
-        parseInt(s, 10)
-      );
     },
 
     // Left half of page: entry (with clickable elements)
@@ -360,7 +354,7 @@ export class EditorPage {
       textarea: element(by.id('comment-panel-textarea')),
       postBtn: element(by.id('comment-panel-post-button'))
     },
-    commentsList: this.commentDiv.all(by.repeater('comment in currentEntryCommentsFiltered')),
+    commentsList: this.commentDiv.all(by.repeater('comment in $ctrl.currentEntryCommentsFiltered')),
     getComment: (commentNum: number) => {
       return EditorPage.getComment(this.comment.commentsList, commentNum);
     }
@@ -398,7 +392,7 @@ export class EditorPage {
   // Usage example:
   // expect(partsOfDcComment(commentDiv).regarding.inputSystem).toBe("th")
   static partsOfComment(div: ElementFinder) {
-    const replies = div.all(by.repeater('reply in model.replies')); // used in
+    const replies = div.all(by.repeater('reply in $ctrl.comment.replies')); // used in
     // getReply()
     // below
     return {
@@ -408,18 +402,18 @@ export class EditorPage {
       // avatar:
       // div.element(by.binding('model.authorInfo.createdByUserRef.avatar_ref')),
       avatar: div.element(by.css('.comment-footer img')),
-      author: div.element(by.binding('comment.authorInfo.createdByUserRef.name')),
-      date: div.element(by.binding('comment.authorInfo.createdDate | relativetime')),
+      author: div.element(by.binding('$ctrl.comment.authorInfo.createdByUserRef.name')),
+      date: div.element(by.binding('$ctrl.comment.authorInfo.createdDate | relativetime')),
       score: div.element(by.css('.comment-interaction .likes')),
       plusOneActive: div.element(by.css('.comment-actions .can-like')),
       plusOneInactive: div.element(by.css('.comment-actions .liked')),
       plusOne: div.element(by.css('.comment-actions i.fa-thumbs-o-up:not(.ng-hide)')),
 
       // Right side content
-      content: div.element(by.binding('comment.content')),
-      contextGuid: div.element(by.binding('comment.contextGuid')),
+      content: div.element(by.binding('$ctrl.comment.content')),
+      contextGuid: div.element(by.binding('$ctrl.comment.contextGuid')),
       edit: {
-        textarea: div.element(by.model('editingCommentContent')),
+        textarea: div.element(by.model('$ctrl.editingCommentContent')),
         updateBtn: div.element(by.buttonText('Update')),
         cancelLink: div.element(by.linkText('Cancel'))
       },
@@ -428,8 +422,6 @@ export class EditorPage {
         // isPresent() before calling expect().
         toggle: div.element(by.css('.comment-body > button')),
         container: div.element(by.css('.commentRegarding')),
-        fieldLabel: div.element(by.binding('comment.regarding.fieldNameForDisplay')),
-        fieldWsid: div.element(by.binding('comment.regarding.inputSystem')),
         fieldValue: div.element(by.css('.regardingFieldValue'))
       },
 


### PR DESCRIPTION
This removes API calls and takes data from component inputs instead. Since Angular components have an isolated scopes inputs were added (esp. `dc-comment` which entirely relied on the parent scope).

 - also simplify multi option lists and semantic domain fields

LF E2E is passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/260)
<!-- Reviewable:end -->
