### PR TITLE
Field labels in activity log

### DIFF
--- a/src/Api/Library/Shared/Script/Migration/FixSenseAndExampleLabels.php
+++ b/src/Api/Library/Shared/Script/Migration/FixSenseAndExampleLabels.php
@@ -80,4 +80,9 @@ class FixSenseAndExampleLabels
     }
 }
 
-FixSenseAndExampleLabels::run('test');
+$mode = 'test';
+if (isset($argv[1])) {
+    $mode = $argv[1];
+}
+print "Running in $mode mode\n";
+FixSenseAndExampleLabels::run($mode);

--- a/src/Api/Library/Shared/Script/Migration/FixSenseAndExampleLabels.php
+++ b/src/Api/Library/Shared/Script/Migration/FixSenseAndExampleLabels.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Api\Library\Shared\Script\Migration;
+
+use Api\Model\Languageforge\Lexicon\LexProjectModel;
+use Api\Model\Shared\ProjectListModel;
+use Api\Model\Shared\ProjectModel;
+
+
+(php_sapi_name() == 'cli') or die('this script must be run on the command-line');
+
+require_once('../scriptConfig.php');
+
+/**
+ * Migration script to change configuration labels:
+ * from "meaning" to "definition" and
+ * from "example" to "sentence"
+ * @package Api\Library\Shared\Script\Migration
+ */
+class FixSenseAndExampleLabels
+{
+    public static function run($mode = 'test')
+    {
+        $testMode = ($mode != 'run');
+        print("Assign labels to \"senses\" and \"examples\" fields.\n");
+
+        $projectlist = new ProjectListModel();
+        $projectlist->read();
+        $fixCount = 0;
+        $meaningLabelsUpdated = 0;
+        $exampleLabelsUpdated = 0;
+
+        foreach ($projectlist->entries as $projectParams) { // foreach existing project
+            $projectId = $projectParams['id'];
+            $project = new ProjectModel($projectId);
+            if ($project->appName == 'lexicon') {
+                $project = new LexProjectModel($projectId);
+                $projectChanged = false;
+                $entryFieldsArray = $project->config->entry->fields->getArrayCopy();
+                if (array_key_exists("senses", $entryFieldsArray)) {
+                    $senseFieldsArray = $entryFieldsArray["senses"]->fields->getArrayCopy();
+                    if ($entryFieldsArray["senses"]->label != "Meaning") {
+                        $entryFieldsArray["senses"]->label = "Meaning";
+                        //print "  Fixed \"Meaning\" label\n";
+                        $meaningLabelsUpdated++;
+                        $projectChanged = true;
+                    }
+                    if (array_key_exists("examples", $senseFieldsArray)) {
+                        if ($senseFieldsArray["examples"]->label != "Example") {
+                            $senseFieldsArray["examples"]->label = "Example";
+                            //print "  Fixed \"Example\" label\n";
+                            $exampleLabelsUpdated++;
+                            $projectChanged = true;
+                        }
+                    }
+                }
+                $entryFieldsArray["senses"]->fields->exchangeArray($senseFieldsArray);
+                $project->config->entry->fields->exchangeArray($entryFieldsArray);
+
+                if ($projectChanged) {
+                    $fixCount++;
+                    if (!$testMode) {
+                        print "  Saving changes to project $project->projectName.\n";
+                        $project->write();
+                    }
+                }
+
+                unset($senseFieldsArray);
+                unset($entryFieldsArray);
+            }
+        }
+
+        if ($fixCount > 0) {
+            print "$fixCount projects were fixed\n";
+            print "$meaningLabelsUpdated \"Meaning\" labels assigned to \"senses\" fields\n";
+            print "$exampleLabelsUpdated \"Example\" labels assigned to \"examples\" fields\n";
+        } else {
+            print "No projects needed fixing\n";
+        }
+    }
+}
+
+FixSenseAndExampleLabels::run('test');

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
@@ -55,12 +55,8 @@ class LexEntryCommands
                     $currentList = $fieldConfig;
                 }
             } else {
-                if ($fieldName == LexConfig::SENSES_LIST) {
-                    $result = "Meaning";  // Hack - remove once FixSenseAndExampleLabels data migration has been run
-                } else if ($fieldName == LexConfig::EXAMPLES_LIST) {
-                    $result = "Example";  // Hack - remove once FixSenseAndExampleLabels data migration has been run
-                } else if (empty($result)) {
-                    // If we can't find a label, use the field name as that's better than nothing
+                // If we can't find a label, use the field name as that's better than nothing
+                if (empty($result)) {
                     $result = $fieldName;
                 }
             }

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
@@ -55,8 +55,12 @@ class LexEntryCommands
                     $currentList = $fieldConfig;
                 }
             } else {
-                // If we can't find a label, use the field name as that's better than nothing
-                if (empty($result)) {
+                if ($fieldName == LexConfig::SENSES_LIST) {
+                    $result = "Meaning";  // Hack - remove once FixSenseAndExampleLabels data migration has been run
+                } else if ($fieldName == LexConfig::EXAMPLES_LIST) {
+                    $result = "Example";  // Hack - remove once FixSenseAndExampleLabels data migration has been run
+                } else if (empty($result)) {
+                    // If we can't find a label, use the field name as that's better than nothing
                     $result = $fieldName;
                 }
             }

--- a/src/Api/Model/Languageforge/Lexicon/Config/LexConfiguration.php
+++ b/src/Api/Model/Languageforge/Lexicon/Config/LexConfiguration.php
@@ -90,6 +90,7 @@ class LexConfiguration
         $this->entry->fields[LexConfig::LEXEME]->inputSystems[] = 'th';
 
         $this->entry->fields[LexConfig::SENSES_LIST] = new LexConfigFieldList();
+        $this->entry->fields[LexConfig::SENSES_LIST]->label = 'Meaning';
         $this->entry->fields[LexConfig::SENSES_LIST]->fieldOrder[] = LexConfig::GLOSS;
         $this->entry->fields[LexConfig::SENSES_LIST]->fieldOrder[] = LexConfig::DEFINITION;
         $this->entry->fields[LexConfig::SENSES_LIST]->fieldOrder[] = LexConfig::PICTURES;
@@ -131,6 +132,7 @@ class LexConfiguration
         $this->entry->fields[LexConfig::SENSES_LIST]->fields[LexConfig::SEMDOM]->listCode = $listCode;
 
         $this->entry->fields[LexConfig::SENSES_LIST]->fields[LexConfig::EXAMPLES_LIST] = new LexConfigFieldList();
+        $this->entry->fields[LexConfig::SENSES_LIST]->fields[LexConfig::EXAMPLES_LIST]->label = 'Example';
         $this->entry->fields[LexConfig::SENSES_LIST]->fields[LexConfig::EXAMPLES_LIST]->fieldOrder[] = LexConfig::EXAMPLE_SENTENCE;
         $this->entry->fields[LexConfig::SENSES_LIST]->fields[LexConfig::EXAMPLES_LIST]->fieldOrder[] = LexConfig::EXAMPLE_TRANSLATION;
         $this->entry->fields[LexConfig::SENSES_LIST]->fields[LexConfig::EXAMPLES_LIST]->fieldOrder[] = LexConfig::REFERENCE;

--- a/src/Api/Model/Shared/ActivityModel.php
+++ b/src/Api/Model/Shared/ActivityModel.php
@@ -45,6 +45,7 @@ class ActivityModel extends MapperModel
     const USER = 'user';
     const USER2 = 'user2';
     const ENTRY = 'entry';
+    const FIELD_LABEL = 'fieldLabel';
 
     /**
      * @param ProjectModel $projectModel

--- a/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
@@ -208,6 +208,8 @@ class LexEntryCommandsTest extends TestCase
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['oldValue.lexeme.th' => 'apple', 'newValue.lexeme.th' => 'first edit'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['oldValue.lexeme.th' => 'apple', 'newValue.lexeme.th' => 'first edit', 'fieldLabel.lexeme.th' => 'Word'], $withLabels);
 
         $params['lexeme']['th']['value'] = 'second edit';
         LexEntryCommands::updateEntry($projectId, $params, $userId);
@@ -215,6 +217,8 @@ class LexEntryCommandsTest extends TestCase
         $secondUpdatedEntry = new LexEntryModel($project, $entryId);
         $differences = $updatedEntry->calculateDifferences($secondUpdatedEntry);
         $this->assertEquals(['oldValue.lexeme.th' => 'first edit', 'newValue.lexeme.th' => 'second edit'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['oldValue.lexeme.th' => 'first edit', 'newValue.lexeme.th' => 'second edit', 'fieldLabel.lexeme.th' => 'Word'], $withLabels);
     }
 
     public function testUpdateEntry_UpdateWithNull_DifferencesHasEmptyStringInsteadOfNull()
@@ -236,6 +240,8 @@ class LexEntryCommandsTest extends TestCase
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['oldValue.lexeme.th' => 'apple', 'newValue.lexeme.th' => ''], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['oldValue.lexeme.th' => 'apple', 'newValue.lexeme.th' => '', 'fieldLabel.lexeme.th' => 'Word'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteOnlySense_ProducesOneDifference()
@@ -260,6 +266,8 @@ class LexEntryCommandsTest extends TestCase
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['deleted.senses#' . $sense->guid => 'apple'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['deleted.senses#' . $sense->guid => 'apple', 'fieldLabel.senses#' . $sense->guid => 'Meaning'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteTwoSensesOutOfTwoTotal_ProducesTwoDifferences()
@@ -287,6 +295,8 @@ class LexEntryCommandsTest extends TestCase
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['deleted.senses#' . $sense1->guid => 'apple', 'deleted.senses#' . $sense2->guid => 'also an apple'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['deleted.senses#' . $sense1->guid => 'apple', 'fieldLabel.senses#' . $sense1->guid => 'Meaning', 'deleted.senses#' . $sense2->guid => 'also an apple', 'fieldLabel.senses#' . $sense2->guid => 'Meaning'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteFirstSenseOfTwo_ProducesThreeDifferences()
@@ -316,6 +326,12 @@ class LexEntryCommandsTest extends TestCase
         $this->assertEquals(['deleted.senses#' . $sense1->guid => 'apple',
                              'movedFrom.senses#' . $sense2->guid => 1,
                              'movedTo.senses#' . $sense2->guid => 0], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['deleted.senses#' . $sense1->guid => 'apple',
+                             'fieldLabel.senses#' . $sense1->guid => 'Meaning',
+                             'movedFrom.senses#' . $sense2->guid => 1,
+                             'movedTo.senses#' . $sense2->guid => 0,
+                             'fieldLabel.senses#' . $sense2->guid => 'Meaning'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteSecondSenseOfTwo_ProducesOneDifference()
@@ -343,6 +359,8 @@ class LexEntryCommandsTest extends TestCase
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['deleted.senses#' . $sense2->guid => 'also an apple'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['deleted.senses#' . $sense2->guid => 'also an apple', 'fieldLabel.senses#' . $sense2->guid => 'Meaning'], $withLabels);
     }
 
     // marker
@@ -372,6 +390,9 @@ class LexEntryCommandsTest extends TestCase
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example->guid => 'eat an apple'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example->guid => 'eat an apple',
+                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example->guid => 'Example'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteTwoExamplesOutOfTwoTotal_ProducesTwoDifferences()
@@ -402,6 +423,11 @@ class LexEntryCommandsTest extends TestCase
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example1->guid => 'eat an apple', 'deleted.senses#' . $sense->guid . ".examples#" . $example2->guid => 'manger une pomme'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example1->guid => 'eat an apple',
+                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example1->guid => 'Example',
+                             'deleted.senses#' . $sense->guid . ".examples#" . $example2->guid => 'manger une pomme',
+                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example2->guid => 'Example'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteFirstExampleOfTwo_ProducesThreeDifferences()
@@ -432,8 +458,14 @@ class LexEntryCommandsTest extends TestCase
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example1->guid => 'eat an apple',
-            'movedFrom.senses#' . $sense->guid . '.examples#' . $example2->guid => '1',
-            'movedTo.senses#' . $sense->guid . '.examples#' . $example2->guid => '0'], $differences);
+                             'movedFrom.senses#' . $sense->guid . '.examples#' . $example2->guid => '1',
+                             'movedTo.senses#' . $sense->guid . '.examples#' . $example2->guid => '0'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example1->guid => 'eat an apple',
+                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example1->guid => 'Example',
+                             'movedFrom.senses#' . $sense->guid . '.examples#' . $example2->guid => '1',
+                             'movedTo.senses#' . $sense->guid . '.examples#' . $example2->guid => '0',
+                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example2->guid => 'Example'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteSecondExampleOfTwo_ProducesOneDifference()
@@ -464,6 +496,8 @@ class LexEntryCommandsTest extends TestCase
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example2->guid => 'manger une pomme'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example2->guid => 'manger une pomme', 'fieldLabel.senses#' . $sense->guid . '.examples#' . $example2->guid => 'Example'], $withLabels);
     }
 
     public function testUpdateEntry_UpdateFirstExampleOfTwo_ProducesOneDifference()
@@ -495,6 +529,10 @@ class LexEntryCommandsTest extends TestCase
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['oldValue.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
                              'newValue.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['oldValue.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
+                             'newValue.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
+                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'Sentence'], $withLabels);
     }
 
     public function testUpdateEntry_UpdateSecondExampleOfTwo_ProducesOneDifference()
@@ -526,6 +564,10 @@ class LexEntryCommandsTest extends TestCase
         $differences = $entry->calculateDifferences($updatedEntry);
         $this->assertEquals(['oldValue.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
                              'newValue.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'also eat an apple'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['oldValue.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
+                             'newValue.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'also eat an apple',
+                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'Sentence'], $withLabels);
     }
 
     public function testUpdateEntry_UpdateTwoExamplesInTwoSenses_DifferenceHasCorrectSenseGuids()
@@ -563,6 +605,13 @@ class LexEntryCommandsTest extends TestCase
                              'newValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
                              'oldValue.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
                              'newValue.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'aussi manger une pomme'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['oldValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
+                             'newValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
+                             'fieldLabel.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'Sentence',
+                             'oldValue.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
+                             'newValue.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'aussi manger une pomme',
+                             'fieldLabel.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'Sentence'], $withLabels);
     }
 
     public function testUpdateEntry_UpdateExamplesInOneSenseAndDeleteExampleInTheOther_DifferenceHasCorrectSenseGuids()
@@ -599,6 +648,12 @@ class LexEntryCommandsTest extends TestCase
         $this->assertEquals(['oldValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
                              'newValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
                              'deleted.senses#' . $sense2->guid . '.examples#' . $example2->guid => 'manger une pomme'], $differences);
+        $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
+        $this->assertEquals(['oldValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
+                             'newValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
+                             'fieldLabel.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'Sentence',
+                             'deleted.senses#' . $sense2->guid . '.examples#' . $example2->guid => 'manger une pomme',
+                             'fieldLabel.senses#' . $sense2->guid . '.examples#' . $example2->guid => 'Example'], $withLabels);
     }
 
     /* Ignore test for send receive v1.1 since dirtySR counter is not being incremented on edit. IJH 2015-02


### PR DESCRIPTION
Now when a lexical entry is updated, the activity log will contain not just the differences, but also the human-readable field labels for those differences. This will enable the activity log frontend to generate a complete activity-log entry without needing a second server round-trip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/265)
<!-- Reviewable:end -->
