### PR TITLE
Create a working Vagrant install from the taylor-2017 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,21 +136,24 @@ After Ubuntu Xenial Bash has finished installing, close the Windows Command Prom
 
 ### Vagrant VM Setup <a id="VagrantSetup"></a> ###
 
-Clone this repository to your host machine and `vagrant up` the Xenial box. We intentionally postpone provisioning on initial boot so the `Virtualbox guest additions` updates don't interfere with the provisioning process.
+- Download the file https://github.com/sillsdev/web-languageforge/blob/master/deploy/xenial/Vagrantfile and save it as Vagrantfile.
+- Open the command line to the directory where the Vagrantfile is and run `vagrantup --no-provision` (this delays provisioning so the VirtualBox guest additions updates don't interfere with the provisioning process.)
+- Shut down the box with `vagrant halt`
+- Run `vagrant up --provision`
 
 ``` bash
-git clone https://github.com/sillsdev/web-languageforge web-languageforge --recurse-submodules
-cd deploy/xenial
+wget https://raw.githubusercontent.com/sillsdev/web-languageforge/master/deploy/xenial/Vagrantfile
 vagrant up --no-provision
-```
-
-Once the shell notifies the Virtualbox guest additions have been updated, power down the Xenial box.
-
-Now, vagrant up with provision to install and deploy
-
-``` bash
+vagrant halt
 vagrant up --provision
 ```
+
+Edit your hosts file (On Linux, `/etc/hosts`, on Windows, `C:\windows\system32\drivers\etc\hosts`. You will have to use sudo on Linux and edit as Administrator on Windows). Add the following lines:
+```
+192.168.33.10     languageforge.local
+192.168.33.10     scriptureforge.local
+```
+Then open languageforge.local and scriptureforge.local ensure they load correctly.
 
 Proceed to [Language Forge Configuration File](#LFConfig) and follow the rest of the steps in this README.
 

--- a/deploy/code.yml
+++ b/deploy/code.yml
@@ -20,6 +20,9 @@
       when: inventory_hostname == "localhost"
       with_items: "{{lf_path}}"
 
+    - name: 'generate website definitions'
+      shell: gulp build-createWebsiteDefs
+
     - name: factory reset mongodb to empty with admin user
       shell: php FactoryReset.php run
       become: true

--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -256,24 +256,18 @@
 
     - name: update the mongo config file
       lineinfile:
-        dest: /etc/mongodb.conf
+        dest: /etc/mongod.conf
         regexp: '^(\s*dbPath: ).*$'
         line: '\1{{mongo_path}}'
         backrefs: yes
-      notify: restart mongodb
+      notify: restart mongod
     - name: ensure mongod service is running (and enable it at boot)
+
       # Note that the mongodb-org packages install a service named "mongod", not "mongodb"
       service:
-        name: "{{item.name}}"
-        state: "{{item.state}}"
-        enabled: "{{item.enabled}}"
-      with_items:
-        - name: mongodb
-          state: stopped
-          enabled: no
-        - name: mongod
-          state: started
-          enabled: yes
+        name: mongod
+        state: started
+        enabled: yes
 
     - name: 'Add GeoLite2 configuration'
       copy:
@@ -319,13 +313,9 @@
     - name: enable languageforge-web-api service
       service: name=languageforge-web-api enabled=yes
       when: is_build_agent is defined and is_build_agent == true
-
-    - name: 'create generated files'
-      shell: gulp build-createWebsiteDefs
-
-
+      
   handlers:
-    - name: restart mongodb
+    - name: restart mongod
       service: name=mongod state=restarted
 
     - name: restart postfix

--- a/deploy/xenial/Vagrantfile
+++ b/deploy/xenial/Vagrantfile
@@ -5,70 +5,75 @@
 VAGRANTFILE_API_VERSION = "2"
 
 $script = <<SCRIPT
-if [ ! -d "/home/vagrant/src" ]; then
-  mkdir /home/vagrant/src
-fi
-cd /home/vagrant/src
+
+set -eux
+
+apt-get update
+apt-get -y install software-properties-common python-software-properties apt-transport-https
 add-apt-repository ppa:ansible/ansible
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 # TODO move this to Ansible
 apt-get update
 apt-get -y install git ansible
-if [ ! -d "/home/vagrant/src/ops-devbox" ]; then
-  git clone --recurse-submodules https://github.com/sillsdev/ops-devbox
-  cd ops-devbox
-  ansible-playbook -i hosts dev.yml
-fi
-if [ ! -d "/home/vagrant/src/xForge" ]; then
-  mkdir /home/vagrant/src/xForge
-fi
-cd /home/vagrant/src/xForge
+
+echo Install NodeJS 8.X and latest npm
+wget -O- https://deb.nodesource.com/setup_8.x | sudo -E bash -
+apt-get install -y nodejs || exit
+
+# Runs the rest of the script as vagrant
+sudo -i -u vagrant bash << VAGRANT_USER
+
+set -eux
+
+cd ~/src
 if [ ! -d "web-languageforge" ]; then
-  git clone --recurse-submodules https://github.com/sillsdev/web-languageforge 
+  git clone --depth 100 --recurse-submodules https://github.com/sillsdev/web-languageforge.git
 else
-  cd web-languageforge; git pull --ff-only --recurse-submodules 
+  cd web-languageforge
+  # commented out because it crashes the script if git user.email and user.name are not set, and it is non-critical
+  # git pull --ff-only --recurse-submodules
 fi
-cd /home/vagrant/src/xForge
-if [ ! -d "web-scriptureforge" ]; then
-  ln -s /home/vagrant/src/xForge/web-languageforge /home/vagrant/src/xForge/web-scriptureforge
-fi
-#cd /home/vagrant/src/xForge
-#if [ ! -d "web-scriptureforge" ]; then
-#  git clone https://github.com/sillsdev/web-scriptureforge.git /home/vagrant/src/xForge/web-scriptureforge --recursive
-#else
-#  cd web-scriptureforge; git pull --ff-only --recurse-submodules origin
-#fi
-cd /home/vagrant/src/xForge/web-languageforge/deploy/; git checkout master; ansible-playbook -i hosts playbook_create_config.yml; chown vagrant.vagrant ansible.cfg; ansible-playbook -i hosts playbook_xenial_vagrant.yml
+
+cd ~/src/web-languageforge/deploy/
+git checkout master
+
+echo '***You may be asked for a password. The password is vagrant***'
+ansible-playbook -i hosts playbook_create_config.yml --limit localhost
+chown vagrant.vagrant ansible.cfg # TODO: what is this here for?
+ansible-playbook -i hosts playbook_xenial_server_vagrant.yml --limit localhost
+
+cd ~/src/web-languageforge
+git fetch --unshallow || true # This will fail if run on a complete repo
+
+VAGRANT_USER
 
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "xenial-unity-amd64"
+  config.vm.box = "kaorimatz/ubuntu-16.04-amd64"
+  # Less secure but will work on NTFS which doesn't understand permissions / owner very well
+  config.ssh.insert_key = false
 
-  config.vm.box_url = "http://downloads.sil.org/vagrant/xenial-unity-amd64.box"
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "https://atlas.hashicorp.com/kaorimatz/ubuntu-16.04-amd64"
 
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # config.vm.network :forwarded_port, guest: 80, host: 8080
+  config.vm.define "xenial_server"
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network :private_network, ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network :public_network
-
-  # If true, then any SSH connections made will enable agent forwarding.
-  # Default value: false
-  # config.ssh.forward_agent = true
+  config.vm.network "private_network", ip: "192.168.33.10"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/home/vagrant/src",
+    id: "vagrant-root",
+    owner: "vagrant",
+    group: "www-data",
+    mount_options: ["dmode=775,fmode=664"]
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -77,7 +82,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |vb|
     # Don't boot with headless mode
     vb.gui = true
-  
+
     # Use VBoxManage to customize the VM. For example to change memory:
     vb.customize ["modifyvm", :id, "--memory", "4096"]
     vb.customize ["modifyvm", :id, "--vram", 64]
@@ -86,13 +91,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # configure Vagrant's ssh shell to be a non-login one (avoids error "stdin: is not a tty error")
   config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
-
   config.vm.provision "shell", inline: $script
-  
-  #config.vm.provision :ansible do |ansible|
-  #  ansible.playbook = '../playbook_lxde.yml'
-  #  ansible.extra_vars = { ansible_ssh_user: 'vagrant', vagrant: true }
-  # 
-  #  ansible.verbose = 'v'
-  #end
+
+#  config.vm.provision :ansible do |ansible|
+#    ansible.playbook = '../playbook_debian.yml'
+#    ansible.extra_vars = { ansible_ssh_user: 'vagrant', vagrant: true }
+#    ansible.verbose = 'v'
+#  end
+
 end


### PR DESCRIPTION
This PR updates the Vagrant install to a usable condition. The original Vagrantfile was not very helpful, so I used the Taylor-2017 Vagrantfile as a starting point. This also involved some changes to two Ansible files (dependencies.yml and code.yml).

Most of the changes should be relatively straight forward:
- Changing references to a mongodb service to mongod
- Generate website definitions *after* `npm install` has been run, not before (local Gulp does not exist until then)

Intended usage is as follows:
- Download deploy/xenial/Vagrantfile and save it as Vagrantfile
- Run `vagrant up --no-provision`
- Run `vagrant up --provision`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/275)
<!-- Reviewable:end -->
