### PR TITLE
Upgrade test pausing to work with new debugger in Node 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,16 @@ will run the the *lexicon-new-project.e2e-spec.ts* tests on **languageforge**.
 
 To add more verbosity during E2E tests, add a parameter `--verbosity true`
 
+To debug the tests:
+- Place breakpoints in your code (`debugger;` statements).
+- Open Chrome to `chrome://inspect/#devices`.
+- Run `./debuge2e.sh`. It will wait for a Protractor process to appear so it can signal the process.
+- Start the e2e tests. The `./debuge2e.sh` script will exit and the debugger should start listening (The e2e tests will say `Debugger listening on <some url>`).
+- Go back the the Chrome window. It should list under "Remote Target" the Node process that is running the tests.
+- Click inspect. When a breakpoint is reached the process will pause and you can step through it in the Chrome developer tools (This does not work very well though because of the asynchronous nature of Webdriver).
+
+Alternatively, to pause the debugger on the first test failure, go to `test/app/protractorConf.js` and uncomment the line that adds the `pauseOnFailure` reporter. All the debugging steps above are still necessary, except for adding breakpoints to your code.
+
 ## Get a copy of the live database ##
 
 (For installation of npm see https://github.com/nodesource/distributions)

--- a/debuge2e.sh
+++ b/debuge2e.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Searches for the Node process running Protractor tests, then signals for it to attach the debugger
+# You can run this script before starting the e2e tests and it will send the signal once the process is found.
+
+set -eu
+
+echo "Waiting for a Protractor process to appear so the debugger can be attached..."
+
+PID=""
+while [ "$PID" = "" ]; do
+  PID=$(pgrep -f protractor/built/cli.js) || true
+  sleep 0.25;
+done
+
+# Send SIGUSR1 to the Node process so it will attach to the debugger
+# See https://nodejs.org/en/docs/guides/debugging-getting-started/
+kill -s SIGUSR1 "$PID"

--- a/test/app/protractorConf.js
+++ b/test/app/protractorConf.js
@@ -68,7 +68,7 @@ exports.config = {
       var pauseOnFailure = {
         specDone: function (spec) {
           if (spec.status === 'failed') {
-            browser.pause();
+            debugger;
           }
         }
       };


### PR DESCRIPTION
At present it is not possible to pause the tests while running because `browser.pause()` is broken as of Node 8.x. The old debugger has been replaced with one that works with the Chrome devtools.

This adds a script that signals the Node process running the tests to tell it to enable its debugger and start listening. Also adds usage instructions to the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/282)
<!-- Reviewable:end -->
