### PR TITLE
fix E2E LF traversal failure on slower machines

### DIFF
--- a/test/app/languageforge/lexicon-traversal.e2e-spec.ts
+++ b/test/app/languageforge/lexicon-traversal.e2e-spec.ts
@@ -24,33 +24,27 @@ describe('Lexicon E2E Page Traversal', () => {
       configurationPage.tabs.unified.click();
       configurationPage.unifiedPane.inputSystem.addGroupButton.click();
       browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(
-        ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.inputSystem.addInputSystemButton),
-        constants.conditionTimeout);
+      browser.wait(ExpectedConditions.invisibilityOf(configurationPage.modal.modalBodyDiv), constants.conditionTimeout);
       configurationPage.unifiedPane.inputSystem.addInputSystemButton.click();
       browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.tabs.unified), constants.conditionTimeout);
+      browser.wait(ExpectedConditions.invisibilityOf(configurationPage.modal.modalBodyDiv), constants.conditionTimeout);
       configurationPage.tabs.unified.click();
       configurationPage.unifiedPane.entry.addGroupButton.click();
       browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.entry.addCustomEntryButton),
-        constants.conditionTimeout);
+      browser.wait(ExpectedConditions.invisibilityOf(configurationPage.modal.modalBodyDiv), constants.conditionTimeout);
       configurationPage.unifiedPane.entry.addCustomEntryButton.click();
       browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.sense.addGroupButton),
-        constants.conditionTimeout);
+      browser.wait(ExpectedConditions.invisibilityOf(configurationPage.modal.modalBodyDiv), constants.conditionTimeout);
       configurationPage.unifiedPane.hiddenIfEmptyCheckbox('Citation Form').click();
       configurationPage.unifiedPane.fieldSpecificButton('Citation Form').click();
       configurationPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox('Citation Form', 1).click();
       configurationPage.unifiedPane.fieldSpecificButton('Citation Form').click();
       configurationPage.unifiedPane.sense.addGroupButton.click();
       browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.sense.addCustomSenseButton),
-        constants.conditionTimeout);
+      browser.wait(ExpectedConditions.invisibilityOf(configurationPage.modal.modalBodyDiv), constants.conditionTimeout);
       configurationPage.unifiedPane.sense.addCustomSenseButton.click();
       browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.example.addGroupButton),
-        constants.conditionTimeout);
+      browser.wait(ExpectedConditions.invisibilityOf(configurationPage.modal.modalBodyDiv), constants.conditionTimeout);
       configurationPage.unifiedPane.hiddenIfEmptyCheckbox('Pictures').click();
       configurationPage.unifiedPane.fieldSpecificButton('Pictures').click();
       configurationPage.unifiedPane.sense.fieldSpecificInputSystemCheckbox('Pictures', 1).click();
@@ -58,12 +52,10 @@ describe('Lexicon E2E Page Traversal', () => {
       configurationPage.unifiedPane.fieldSpecificButton('Pictures').click();
       configurationPage.unifiedPane.example.addGroupButton.click();
       browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(
-        ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.example.addCustomExampleButton),
-        constants.conditionTimeout);
+      browser.wait(ExpectedConditions.invisibilityOf(configurationPage.modal.modalBodyDiv), constants.conditionTimeout);
       configurationPage.unifiedPane.example.addCustomExampleButton.click();
       browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.tabs.unified), constants.conditionTimeout);
+      browser.wait(ExpectedConditions.invisibilityOf(configurationPage.modal.modalBodyDiv), constants.conditionTimeout);
       configurationPage.unifiedPane.hiddenIfEmptyCheckbox('Translation').click();
       configurationPage.unifiedPane.fieldSpecificButton('Translation').click();
       configurationPage.unifiedPane.example.fieldSpecificInputSystemCheckbox('Translation', 0).click();

--- a/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
@@ -10,6 +10,8 @@ describe('Lexicon E2E Editor Comments', () => {
   const projectsPage = new ProjectsPage();
   const editorPage = new EditorPage();
 
+  const originalDefinition = constants.testEntry1.senses[0].definition.en.value;
+
   it('setup: login, click on test project', () => {
     loginPage.loginAsManager();
     projectsPage.get();
@@ -18,8 +20,8 @@ describe('Lexicon E2E Editor Comments', () => {
 
   it('browse page has correct word count', () => {
     // flaky assertion, also test/app/languageforge/lexicon/editor/e2e/editor-entry.spec.js:20
-    expect<any>(editorPage.browse.entriesList.count()).toEqual(editorPage.browse.getEntryCount());
     expect<any>(editorPage.browse.getEntryCount()).toBe(3);
+    expect<any>(editorPage.browse.entriesList.count()).toEqual(editorPage.browse.getEntryCount());
   });
 
   it('click on first word', () => {
@@ -48,9 +50,8 @@ describe('Lexicon E2E Editor Comments', () => {
   it('comments panel: add comment to another part of the entry', () => {
     const definitionField = editorPage.edit.getMultiTextInputs('Definition').first();
     definitionField.clear();
-    definitionField.sendKeys(
-      constants.testEntry1.senses[0].definition.en.value
-    );
+    definitionField.sendKeys(originalDefinition);
+    expect<any>(definitionField.getAttribute('value')).toEqual(originalDefinition);
     editorPage.comment.bubbles.second.click();
     editorPage.comment.newComment.textarea.clear();
     editorPage.comment.newComment.textarea.sendKeys('Second comment.');
@@ -70,20 +71,21 @@ describe('Lexicon E2E Editor Comments', () => {
 
   it('comments panel: check regarding value is hidden when the field value matches', () => {
     const comment = editorPage.comment.getComment(-1);
+    const definitionField = editorPage.edit.getMultiTextInputs('Definition').first();
 
     // Make sure it is hidden
     expect<any>(comment.regarding.container.isDisplayed()).toBe(false);
 
     // Change the field value and then make sure it appears
-    editorPage.edit.getMultiTextInputs('Definition').first().sendKeys('update - ');
+    definitionField.sendKeys('update - ');
     expect<any>(comment.regarding.container.isDisplayed()).toBe(true);
 
     // Make sure the regarding value matches what was originally there
-    const word    = constants.testEntry1.senses[0].definition.en.value;
-    expect<any>(comment.regarding.fieldValue.getText()).toEqual(word);
+    expect<any>(comment.regarding.fieldValue.getText()).toEqual(originalDefinition);
 
-    // old stuff
-    // This comment should have a "regarding" section
+    definitionField.clear();
+    definitionField.sendKeys(originalDefinition);
+    expect<any>(definitionField.getAttribute('value')).toEqual(originalDefinition);
   });
 
   it('comments panel: click +1 button on first comment', () => {
@@ -94,7 +96,7 @@ describe('Lexicon E2E Editor Comments', () => {
     expect(comment.plusOneActive.getAttribute('data-ng-click')).not.toBe(null);
     comment.plusOneActive.click();
     expect<any>(comment.score.getText()).toEqual('1 Like');
-    });
+  });
 
   it('comments panel: +1 button disabled after clicking', () => {
     const comment = editorPage.comment.getComment(0);
@@ -133,4 +135,5 @@ describe('Lexicon E2E Editor Comments', () => {
     browser.wait(ExpectedConditions.invisibilityOf(editorPage.commentDiv), constants.conditionTimeout);
     expect<any>(editorPage.commentDiv.getAttribute('class')).not.toContain('panel-visible');
   });
+
 });


### PR DESCRIPTION
 - add check to catch another bug when `editor-entry` is run after `editor-comments` on slower machines

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/283)
<!-- Reviewable:end -->
