### PR TITLE
Activity log DTO sends easier-to-parse content to frontend

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
@@ -45,8 +45,8 @@ class LexEntryCommands
         // So "newValue.lexeme.en" will set $result for the "lexeme" field but not for "en", since that's not a field
         $result = '';
         foreach ($parts as $part) {
-            // Strip away anything after a # character
-            $fieldName = explode('#', $part, 2)[0];
+            // Strip away anything after a @ character
+            $fieldName = explode('@', $part, 2)[0];
             if (array_key_exists($fieldName, $currentList->fields)) {
                 /** @var LexConfig $fieldConfig */
                 $fieldConfig = $currentList->fields[$fieldName];

--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -280,36 +280,43 @@ class LexEntryModel extends MapperModel
             /** @var LexSense $thisSense */
             $seenGuids[] = $guid;
             $thisPosition  = $thisPositions[$guid];
+            $thisSenseId = "senses@" . $thisPosition . "#" . $guid;
             if (isset($otherPositions[$guid])) {
                 $otherPosition = $otherPositions[$guid];
                 if ($otherPosition !== $thisPosition) {
-                    $differences["movedFrom.senses#" . $guid] = (string)$thisPosition;
-                    $differences["movedTo.senses#" . $guid] = (string)$otherPosition;
+                    // The `moved` difference has the *old* position in the field ID and the *new* position in the value.
+                    // This ensures that if a value is edited *and* moved in the same update, the field IDs for the edit
+                    // and for the move will be identical.
+                    $differences["moved." . $thisSenseId] = (string)$otherPosition;
                 }
             }
             if (array_key_exists($guid, $otherSensesByGuid)) {
                 /** @var LexSense $otherSense */
                 $otherSense = $otherSensesByGuid[$guid];
-                $senseDifferences = $thisSense->differences($otherSense);
+                $otherPosition = $otherPositions[$guid] ?? 0;  // Default to 0 just in case, though this *should* never be necessary
+                $otherSenseId = "senses@" . $otherPosition . "#" . $guid;
+                $senseDifferences = $thisSense->differences($otherSense, $thisSenseId, $otherSenseId);
                 foreach ($senseDifferences as $key => $senseDifference) {
                     if (substr($key, 0, 5) === "this.") {
-                        $newKey = str_replace("this.",  "oldValue.senses#" . $guid . ".", $key);
+                        $newKey = str_replace("this.",  "oldValue." . $thisSenseId . ".", $key);
                     } elseif (substr($key, 0, 6) === "other.") {
-                        $newKey = str_replace("other.", "newValue.senses#" . $guid . ".", $key);
+                        $newKey = str_replace("other.", "newValue." . $thisSenseId . ".", $key);
                     } else {
                         $newKey = $key;
                     }
                     $differences[$newKey] = $senseDifference;
                 }
             } else {
-                $differences["deleted.senses#" . $guid] = $thisSense->nameForActivityLog();
+                $differences["deleted." . $thisSenseId] = $thisSense->nameForActivityLog();
             }
         }
         $addedGuids = array_diff($otherGuids, $seenGuids);
         foreach ($addedGuids as $guid) {
             /** @var LexSense $otherSense */
             $otherSense = $otherSensesByGuid[$guid];
-            $differences["added.senses#" . $guid] = $otherSense->nameForActivityLog();
+            $otherPosition  = $otherPositions[$guid];
+            $otherSenseId = "senses@" . $otherPosition . "#" . $guid;
+            $differences["added." . $otherSenseId] = $otherSense->nameForActivityLog();
         }
 
         return $differences;

--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -185,11 +185,11 @@ class LexEntryModel extends MapperModel
     {
         switch ($name) {
             case 'senses':
-                return "ArrayOf(LexSense)";
+                return 'ArrayOf(LexSense)';
             case 'customFields':
-                return "MapOf(CustomField)";
+                return 'MapOf(CustomField)';
             case 'authorInfo':
-                return "LexAuthorInfo";
+                return 'LexAuthorInfo';
 
             case 'lexeme':
             case 'citationForm':
@@ -205,14 +205,14 @@ class LexEntryModel extends MapperModel
             case 'literalMeaning':
             case 'note':  // TODO Notes need to be an array, and more capable than a multi-text. Notes have types. CP 2014-10
             case 'summaryDefinition':
-                return "LexMultiText";
+                return 'LexMultiText';
             case 'environments':
-                return "LexMultiValue";
+                return 'LexMultiValue';
             case 'location':
-                return "LexValue";
+                return 'LexValue';
             case 'morphologyType':
             default:
-                return "string";
+                return 'string';
         }
     }
 
@@ -235,12 +235,12 @@ class LexEntryModel extends MapperModel
     protected function convertLexMultiTextDifferences(array $differences, string $propertyName)
     {
         // The LexMultiText->differences() function returns differences as an array looking like:
-        // [ ["inputSystem" => $key, "this" => $thisValue, "other" => $otherValue], ... ]
+        // [ ['inputSystem' => $key, 'this' => $thisValue, 'other' => $otherValue], ... ]
         $result = [];
         foreach ($differences as $difference) {
-            $inputSystem = $difference["inputSystem"];
-            $result["oldValue." . $propertyName . "." . $inputSystem] = $difference["this"];
-            $result["newValue." . $propertyName . "." . $inputSystem] = $difference["other"];
+            $inputSystem = $difference['inputSystem'];
+            $result['oldValue.' . $propertyName . '.' . $inputSystem] = $difference['this'];
+            $result['newValue.' . $propertyName . '.' . $inputSystem] = $difference['other'];
         }
         return $result;
     }
@@ -250,8 +250,8 @@ class LexEntryModel extends MapperModel
         if (empty($difference)) {
             return [];
         }
-        return [ "oldValue." . $propertyName => $difference["this"],
-                 "newValue." . $propertyName => $difference["other"] ];
+        return [ 'oldValue.' . $propertyName => $difference['this'],
+                 'newValue.' . $propertyName => $difference['other'] ];
     }
 
     protected function getSenseDifferences($thisSenses, $otherSenses)
@@ -280,34 +280,34 @@ class LexEntryModel extends MapperModel
             /** @var LexSense $thisSense */
             $seenGuids[] = $guid;
             $thisPosition  = $thisPositions[$guid];
-            $thisSenseId = "senses@" . $thisPosition . "#" . $guid;
+            $thisSenseId = 'senses@' . $thisPosition . '#' . $guid;
             if (isset($otherPositions[$guid])) {
                 $otherPosition = $otherPositions[$guid];
                 if ($otherPosition !== $thisPosition) {
                     // The `moved` difference has the *old* position in the field ID and the *new* position in the value.
                     // This ensures that if a value is edited *and* moved in the same update, the field IDs for the edit
                     // and for the move will be identical.
-                    $differences["moved." . $thisSenseId] = (string)$otherPosition;
+                    $differences['moved.' . $thisSenseId] = (string)$otherPosition;
                 }
             }
             if (array_key_exists($guid, $otherSensesByGuid)) {
                 /** @var LexSense $otherSense */
                 $otherSense = $otherSensesByGuid[$guid];
                 $otherPosition = $otherPositions[$guid] ?? 0;  // Default to 0 just in case, though this *should* never be necessary
-                $otherSenseId = "senses@" . $otherPosition . "#" . $guid;
+                $otherSenseId = 'senses@' . $otherPosition . '#' . $guid;
                 $senseDifferences = $thisSense->differences($otherSense, $thisSenseId, $otherSenseId);
                 foreach ($senseDifferences as $key => $senseDifference) {
-                    if (substr($key, 0, 5) === "this.") {
-                        $newKey = str_replace("this.",  "oldValue." . $thisSenseId . ".", $key);
-                    } elseif (substr($key, 0, 6) === "other.") {
-                        $newKey = str_replace("other.", "newValue." . $thisSenseId . ".", $key);
+                    if (substr($key, 0, 5) === 'this.') {
+                        $newKey = str_replace('this.',  'oldValue.' . $thisSenseId . '.', $key);
+                    } elseif (substr($key, 0, 6) === 'other.') {
+                        $newKey = str_replace('other.', 'newValue.' . $thisSenseId . '.', $key);
                     } else {
                         $newKey = $key;
                     }
                     $differences[$newKey] = $senseDifference;
                 }
             } else {
-                $differences["deleted." . $thisSenseId] = $thisSense->nameForActivityLog();
+                $differences['deleted.' . $thisSenseId] = $thisSense->nameForActivityLog();
             }
         }
         $addedGuids = array_diff($otherGuids, $seenGuids);
@@ -315,8 +315,8 @@ class LexEntryModel extends MapperModel
             /** @var LexSense $otherSense */
             $otherSense = $otherSensesByGuid[$guid];
             $otherPosition  = $otherPositions[$guid];
-            $otherSenseId = "senses@" . $otherPosition . "#" . $guid;
-            $differences["added." . $otherSenseId] = $otherSense->nameForActivityLog();
+            $otherSenseId = 'senses@' . $otherPosition . '#' . $guid;
+            $differences['added.' . $otherSenseId] = $otherSense->nameForActivityLog();
         }
 
         return $differences;
@@ -342,44 +342,44 @@ class LexEntryModel extends MapperModel
                 }
             }
         }
-        return "";
+        return '';
     }
 
     public function getPropertyDifference(LexEntryModel $otherModel, string $propertyName)
     {
         $type = $this->getPropertyType($propertyName);
         switch ($type) {
-            case "LexMultiText":
+            case 'LexMultiText':
                 /** @var LexMultiText $multiText */
                 $multiText = $this->$propertyName;
                 $difference = $multiText->differences($otherModel->$propertyName);
                 return $this->convertLexMultiTextDifferences($difference, $propertyName);
-            case "LexMultiValue":
+            case 'LexMultiValue':
                 /** @var LexMultiValue $multiValue */
                 $multiValue = $this->$propertyName;
                 $difference = $multiValue->differences($otherModel->$propertyName);
                 return $this->convertDifferences($difference, $propertyName);
-            case "LexMultiParagraph":
+            case 'LexMultiParagraph':
                 /** @var LexMultiParagraph $multiParagraph */
                 $multiParagraph = $this->$propertyName;
                 $difference = $multiParagraph->differences($otherModel->$propertyName);
                 return $this->convertDifferences($difference, $propertyName);
-            case "LexValue":
-                $thisValue  = is_null($this->$propertyName) || is_null($this->$propertyName->value) ? "" : (string)$this->$propertyName;
-                $otherValue = is_null($otherModel->$propertyName) || is_null($otherModel->$propertyName->value) ? "" : (string)$otherModel->$propertyName;
+            case 'LexValue':
+                $thisValue  = is_null($this->$propertyName) || is_null($this->$propertyName->value) ? '' : (string)$this->$propertyName;
+                $otherValue = is_null($otherModel->$propertyName) || is_null($otherModel->$propertyName->value) ? '' : (string)$otherModel->$propertyName;
 
                 if ($thisValue === $otherValue) {
                     return [];
                 } else {
-                    return ["oldValue." . $propertyName => $thisValue, "newValue." . $propertyName => $otherValue];
+                    return ['oldValue.' . $propertyName => $thisValue, 'newValue.' . $propertyName => $otherValue];
                 }
-            case "string":
+            case 'string':
                 $thisValue  = $this->$propertyName;
                 $otherValue = $otherModel->$propertyName;
                 if ($thisValue === $otherValue) {
                     return [];
                 } else {
-                    return ["oldValue." . $propertyName => $thisValue, "newValue." . $propertyName => $otherValue];
+                    return ['oldValue.' . $propertyName => $thisValue, 'newValue.' . $propertyName => $otherValue];
                 }
             case 'ArrayOf(LexSense)':
                 $thisSenses  = $this->$propertyName;

--- a/src/Api/Model/Shared/Dto/ActivityListDto.php
+++ b/src/Api/Model/Shared/Dto/ActivityListDto.php
@@ -297,12 +297,12 @@ class ActivityListDto
                 continue;
             }
             switch ($parts[0]) {
-                case "oldValue":
-                case "newValue":
-                case "added":
-                case "moved":
-                case "deleted":
-                case "fieldLabel":
+                case 'oldValue':
+                case 'newValue':
+                case 'added':
+                case 'moved':
+                case 'deleted':
+                case 'fieldLabel':
                     // Collect change records keyed by field identifier (e.g., "senses@1#GUID.definition.en")
                     if (!array_key_exists($parts[1], $changesInInput)) {
                         $changesInInput[$parts[1]] = [];
@@ -320,15 +320,15 @@ class ActivityListDto
 
         foreach ($changesInInput as $fieldId => $change) {
             $changeType = '';
-            if (array_key_exists("oldValue", $change)) {
+            if (array_key_exists('oldValue', $change)) {
                 $changeType = ActivityListDto::EDITED_FIELD;
-            } else if (array_key_exists("newValue", $change)) {
+            } else if (array_key_exists('newValue', $change)) {
                 $changeType = ActivityListDto::EDITED_FIELD;
-            } else if (array_key_exists("added", $change)) {
+            } else if (array_key_exists('added', $change)) {
                 $changeType = ActivityListDto::ADDED_FIELD;
-            } else if (array_key_exists("moved", $change)) {
+            } else if (array_key_exists('moved', $change)) {
                 $changeType = ActivityListDto::MOVED_FIELD;
-            } else if (array_key_exists("deleted", $change)) {
+            } else if (array_key_exists('deleted', $change)) {
                 $changeType = ActivityListDto::DELETED_FIELD;
             }
 
@@ -343,7 +343,7 @@ class ActivityListDto
             $sensePosition = null;
             $examplePosition = null;
 
-            $mostRecentName = "";
+            $mostRecentName = '';
             $mostRecentPosition = 0;
             $fieldWs = "";
             foreach ($fieldIdParts as $part) {

--- a/src/Api/Model/Shared/Dto/ActivityListDto.php
+++ b/src/Api/Model/Shared/Dto/ActivityListDto.php
@@ -276,7 +276,7 @@ class ActivityListDto
 //  newValue: "Example translation edited"
 //  changeType: "edited_field"
 //  fieldName: "translation"
-//  fieldWs: "en"
+//  inputSystemTag: "en"
 //  sense: 1
 //  example: 2
 //  fieldLabel: "Translation"
@@ -345,7 +345,7 @@ class ActivityListDto
 
             $mostRecentName = '';
             $mostRecentPosition = 0;
-            $fieldWs = "";
+            $inputSystemTag = '';
             foreach ($fieldIdParts as $part) {
                 list ($name, $position, $guid) = self::splitFieldIdPart($part);
                 $position = $position + 1;  // Mongo stores 0-based indices, but DTO wants 1-based
@@ -363,7 +363,7 @@ class ActivityListDto
                         $currentConfig = $currentConfig->fields[$name];
                     }
                 } else {
-                    $fieldWs = $name;  // There will only be one
+                    $inputSystemTag = $name;  // There will only be one
                 }
             }
 
@@ -382,8 +382,8 @@ class ActivityListDto
             if ($examplePosition !== null) {
                 $changeForDto['fieldLabel']['example'] = $examplePosition;
             }
-            if (! empty($fieldWs)) {
-                $changeForDto['fieldWs'] = $fieldWs;
+            if (! empty($inputSystemTag)) {
+                $changeForDto['inputSystemTag'] = $inputSystemTag;
             }
             switch ($changeType) {
                 case ActivityListDto::EDITED_FIELD:

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -421,13 +421,13 @@ class Sf
 
     public function activity_list_dto_for_current_project($filterParams = [])
     {
-        $projectModel = new ProjectModel($this->projectId);
+        $projectModel = ProjectModel::getById($this->projectId);
         return ActivityListDto::getActivityForOneProject($projectModel, $this->userId, $filterParams);
     }
 
     public function activity_list_dto_for_lexical_entry($entryId, $filterParams = [])
     {
-        $projectModel = new ProjectModel($this->projectId);
+        $projectModel = ProjectModel::getById($this->projectId);
         return ActivityListDto::getActivityForOneLexEntry($projectModel, $entryId, $filterParams);
     }
 

--- a/test/php/model/languageforge/lexicon/LexEntryModelTest.php
+++ b/test/php/model/languageforge/lexicon/LexEntryModelTest.php
@@ -85,8 +85,8 @@ class LexEntryModelTest extends TestCase
 
         $differences = $entry->calculateDifferences($entry2);
         $this->assertEquals([
-            "oldValue.senses#$guid.definition.en" => 'hello',
-            "newValue.senses#$guid.definition.en" => 'hi there'], $differences);
+            "oldValue.senses@0#$guid.definition.en" => 'hello',
+            "newValue.senses@0#$guid.definition.en" => 'hi there'], $differences);
     }
 
     public function testGetDifferences_NullField_DoesNotThrowException()
@@ -104,8 +104,8 @@ class LexEntryModelTest extends TestCase
 
         $differences = $entry->calculateDifferences($entry2);
         $this->assertEquals([
-            "oldValue.senses#$guid.definition.en" => 'hello',
-            "newValue.senses#$guid.definition.en" => 'hi there'], $differences);
+            "oldValue.senses@0#$guid.definition.en" => 'hello',
+            "newValue.senses@0#$guid.definition.en" => 'hi there'], $differences);
     }
 
     public function testGetDifferences_TwoFieldsChanged_ContainsBothChanges()
@@ -123,10 +123,10 @@ class LexEntryModelTest extends TestCase
 
         $differences = $entry->calculateDifferences($entry2);
         $this->assertEquals([
-            "oldValue.senses#$guid.definition.en" => 'hello',
-            "newValue.senses#$guid.definition.en" => 'hi there',
-            "oldValue.senses#$guid.gloss.en" => 'hello',
-            "newValue.senses#$guid.gloss.en" => 'hi'], $differences);
+            "oldValue.senses@0#$guid.definition.en" => 'hello',
+            "newValue.senses@0#$guid.definition.en" => 'hi there',
+            "oldValue.senses@0#$guid.gloss.en" => 'hello',
+            "newValue.senses@0#$guid.gloss.en" => 'hi'], $differences);
     }
 
     public function testGetDifferences_TwoFieldsChangedButOneChangedToTheOriginalValue_ContainsOnlyOneChange()
@@ -144,8 +144,8 @@ class LexEntryModelTest extends TestCase
 
         $differences = $entry->calculateDifferences($entry2);
         $this->assertEquals([
-            "oldValue.senses#$guid.definition.en" => 'hello',
-            "newValue.senses#$guid.definition.en" => 'hi there'], $differences);
+            "oldValue.senses@0#$guid.definition.en" => 'hello',
+            "newValue.senses@0#$guid.definition.en" => 'hi there'], $differences);
     }
 
     public function testGetDifferences_DeletingSecondSense_DifferencesIncludeOnlyTheDeletionAsASingleChange()
@@ -164,7 +164,7 @@ class LexEntryModelTest extends TestCase
         $entry2->senses->append($sense1);
 
         $differences = $entry->calculateDifferences($entry2);
-        $this->assertEquals(["deleted.senses#$guid2" => 'hi'], $differences);
+        $this->assertEquals(["deleted.senses@1#$guid2" => 'hi'], $differences);
     }
 
     public function testGetDifferences_DeletingFirstSense_DifferencesIncludeTheDeletionAndPositionChanges()
@@ -184,9 +184,8 @@ class LexEntryModelTest extends TestCase
 
         $differences = $entry->calculateDifferences($entry2);
         $this->assertEquals([
-            "deleted.senses#$guid1" => 'hello',
-            "movedFrom.senses#$guid2" => 1,
-            "movedTo.senses#$guid2" => 0], $differences);
+            "deleted.senses@0#$guid1" => 'hello',
+            "moved.senses@1#$guid2" => 0], $differences);
     }
 
     public function testGetDifferences_DeletingBothSenses_DifferencesIncludeOnlyTheTwoDeletions()
@@ -205,7 +204,7 @@ class LexEntryModelTest extends TestCase
 
         $differences = $entry->calculateDifferences($entry2);
         $this->assertEquals([
-            "deleted.senses#$guid1" => 'hello',
-            "deleted.senses#$guid2" => 'hi'], $differences);
+            "deleted.senses@0#$guid1" => 'hello',
+            "deleted.senses@1#$guid2" => 'hi'], $differences);
     }
 }

--- a/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
@@ -265,9 +265,9 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['deleted.senses#' . $sense->guid => 'apple'], $differences);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid => 'apple'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['deleted.senses#' . $sense->guid => 'apple', 'fieldLabel.senses#' . $sense->guid => 'Meaning'], $withLabels);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid => 'apple', 'fieldLabel.senses@0#' . $sense->guid => 'Meaning'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteTwoSensesOutOfTwoTotal_ProducesTwoDifferences()
@@ -294,9 +294,10 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['deleted.senses#' . $sense1->guid => 'apple', 'deleted.senses#' . $sense2->guid => 'also an apple'], $differences);
+        $this->assertEquals(['deleted.senses@0#' . $sense1->guid => 'apple', 'deleted.senses@1#' . $sense2->guid => 'also an apple'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['deleted.senses#' . $sense1->guid => 'apple', 'fieldLabel.senses#' . $sense1->guid => 'Meaning', 'deleted.senses#' . $sense2->guid => 'also an apple', 'fieldLabel.senses#' . $sense2->guid => 'Meaning'], $withLabels);
+        $this->assertEquals(['deleted.senses@0#' . $sense1->guid => 'apple', 'fieldLabel.senses@0#' . $sense1->guid => 'Meaning',
+                             'deleted.senses@1#' . $sense2->guid => 'also an apple', 'fieldLabel.senses@1#' . $sense2->guid => 'Meaning'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteFirstSenseOfTwo_ProducesThreeDifferences()
@@ -323,15 +324,13 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['deleted.senses#' . $sense1->guid => 'apple',
-                             'movedFrom.senses#' . $sense2->guid => 1,
-                             'movedTo.senses#' . $sense2->guid => 0], $differences);
+        $this->assertEquals(['deleted.senses@0#' . $sense1->guid => 'apple',
+                             'moved.senses@1#' . $sense2->guid => 0], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['deleted.senses#' . $sense1->guid => 'apple',
-                             'fieldLabel.senses#' . $sense1->guid => 'Meaning',
-                             'movedFrom.senses#' . $sense2->guid => 1,
-                             'movedTo.senses#' . $sense2->guid => 0,
-                             'fieldLabel.senses#' . $sense2->guid => 'Meaning'], $withLabels);
+        $this->assertEquals(['deleted.senses@0#' . $sense1->guid => 'apple',
+                             'fieldLabel.senses@0#' . $sense1->guid => 'Meaning',
+                             'moved.senses@1#' . $sense2->guid => 0,
+                             'fieldLabel.senses@1#' . $sense2->guid => 'Meaning'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteSecondSenseOfTwo_ProducesOneDifference()
@@ -358,9 +357,9 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['deleted.senses#' . $sense2->guid => 'also an apple'], $differences);
+        $this->assertEquals(['deleted.senses@1#' . $sense2->guid => 'also an apple'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['deleted.senses#' . $sense2->guid => 'also an apple', 'fieldLabel.senses#' . $sense2->guid => 'Meaning'], $withLabels);
+        $this->assertEquals(['deleted.senses@1#' . $sense2->guid => 'also an apple', 'fieldLabel.senses@1#' . $sense2->guid => 'Meaning'], $withLabels);
     }
 
     // marker
@@ -389,10 +388,10 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example->guid => 'eat an apple'], $differences);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid . '.examples@0#' . $example->guid => 'eat an apple'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example->guid => 'eat an apple',
-                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example->guid => 'Example'], $withLabels);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid . '.examples@0#' . $example->guid => 'eat an apple',
+                             'fieldLabel.senses@0#' . $sense->guid . '.examples@0#' . $example->guid => 'Example'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteTwoExamplesOutOfTwoTotal_ProducesTwoDifferences()
@@ -422,12 +421,13 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example1->guid => 'eat an apple', 'deleted.senses#' . $sense->guid . ".examples#" . $example2->guid => 'manger une pomme'], $differences);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid . '.examples@0#' . $example1->guid => 'eat an apple',
+                             'deleted.senses@0#' . $sense->guid . '.examples@1#' . $example2->guid => 'manger une pomme'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example1->guid => 'eat an apple',
-                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example1->guid => 'Example',
-                             'deleted.senses#' . $sense->guid . ".examples#" . $example2->guid => 'manger une pomme',
-                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example2->guid => 'Example'], $withLabels);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid . '.examples@0#' . $example1->guid => 'eat an apple',
+                             'fieldLabel.senses@0#' . $sense->guid . '.examples@0#' . $example1->guid => 'Example',
+                             'deleted.senses@0#' . $sense->guid . ".examples@1#" . $example2->guid => 'manger une pomme',
+                             'fieldLabel.senses@0#' . $sense->guid . '.examples@1#' . $example2->guid => 'Example'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteFirstExampleOfTwo_ProducesThreeDifferences()
@@ -457,15 +457,13 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example1->guid => 'eat an apple',
-                             'movedFrom.senses#' . $sense->guid . '.examples#' . $example2->guid => '1',
-                             'movedTo.senses#' . $sense->guid . '.examples#' . $example2->guid => '0'], $differences);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid . '.examples@0#' . $example1->guid => 'eat an apple',
+                             'moved.senses@0#' . $sense->guid . '.examples@1#' . $example2->guid => '0'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example1->guid => 'eat an apple',
-                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example1->guid => 'Example',
-                             'movedFrom.senses#' . $sense->guid . '.examples#' . $example2->guid => '1',
-                             'movedTo.senses#' . $sense->guid . '.examples#' . $example2->guid => '0',
-                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example2->guid => 'Example'], $withLabels);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid . '.examples@0#' . $example1->guid => 'eat an apple',
+                             'fieldLabel.senses@0#' . $sense->guid . '.examples@0#' . $example1->guid => 'Example',
+                             'moved.senses@0#' . $sense->guid . '.examples@1#' . $example2->guid => '0',
+                             'fieldLabel.senses@0#' . $sense->guid . '.examples@1#' . $example2->guid => 'Example'], $withLabels);
     }
 
     public function testUpdateEntry_DeleteSecondExampleOfTwo_ProducesOneDifference()
@@ -495,9 +493,10 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example2->guid => 'manger une pomme'], $differences);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid . '.examples@1#' . $example2->guid => 'manger une pomme'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['deleted.senses#' . $sense->guid . '.examples#' . $example2->guid => 'manger une pomme', 'fieldLabel.senses#' . $sense->guid . '.examples#' . $example2->guid => 'Example'], $withLabels);
+        $this->assertEquals(['deleted.senses@0#' . $sense->guid . '.examples@1#' . $example2->guid => 'manger une pomme',
+                             'fieldLabel.senses@0#' . $sense->guid . '.examples@1#' . $example2->guid => 'Example'], $withLabels);
     }
 
     public function testUpdateEntry_UpdateFirstExampleOfTwo_ProducesOneDifference()
@@ -527,12 +526,12 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['oldValue.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
-                             'newValue.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple'], $differences);
+        $this->assertEquals(['oldValue.senses@0#'   . $sense->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'eat an apple',
+                             'newValue.senses@0#'   . $sense->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'also eat an apple'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['oldValue.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
-                             'newValue.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
-                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example1->guid . '.sentence.en' => 'Sentence'], $withLabels);
+        $this->assertEquals(['oldValue.senses@0#'   . $sense->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'eat an apple',
+                             'newValue.senses@0#'   . $sense->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'also eat an apple',
+                             'fieldLabel.senses@0#' . $sense->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'Sentence'], $withLabels);
     }
 
     public function testUpdateEntry_UpdateSecondExampleOfTwo_ProducesOneDifference()
@@ -562,12 +561,12 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['oldValue.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
-                             'newValue.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'also eat an apple'], $differences);
+        $this->assertEquals(['oldValue.senses@0#'   . $sense->guid . '.examples@1#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
+                             'newValue.senses@0#'   . $sense->guid . '.examples@1#' . $example2->guid . '.sentence.fr' => 'also eat an apple'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['oldValue.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
-                             'newValue.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'also eat an apple',
-                             'fieldLabel.senses#' . $sense->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'Sentence'], $withLabels);
+        $this->assertEquals(['oldValue.senses@0#'   . $sense->guid . '.examples@1#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
+                             'newValue.senses@0#'   . $sense->guid . '.examples@1#' . $example2->guid . '.sentence.fr' => 'also eat an apple',
+                             'fieldLabel.senses@0#' . $sense->guid . '.examples@1#' . $example2->guid . '.sentence.fr' => 'Sentence'], $withLabels);
     }
 
     public function testUpdateEntry_UpdateTwoExamplesInTwoSenses_DifferenceHasCorrectSenseGuids()
@@ -601,17 +600,17 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['oldValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
-                             'newValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
-                             'oldValue.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
-                             'newValue.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'aussi manger une pomme'], $differences);
+        $this->assertEquals(['oldValue.senses@0#'   . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'eat an apple',
+                             'newValue.senses@0#'   . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'also eat an apple',
+                             'oldValue.senses@1#'   . $sense2->guid . '.examples@0#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
+                             'newValue.senses@1#'   . $sense2->guid . '.examples@0#' . $example2->guid . '.sentence.fr' => 'aussi manger une pomme'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['oldValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
-                             'newValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
-                             'fieldLabel.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'Sentence',
-                             'oldValue.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
-                             'newValue.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'aussi manger une pomme',
-                             'fieldLabel.senses#' . $sense2->guid . '.examples#' . $example2->guid . '.sentence.fr' => 'Sentence'], $withLabels);
+        $this->assertEquals(['oldValue.senses@0#'   . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'eat an apple',
+                             'newValue.senses@0#'   . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'also eat an apple',
+                             'fieldLabel.senses@0#' . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'Sentence',
+                             'oldValue.senses@1#'   . $sense2->guid . '.examples@0#' . $example2->guid . '.sentence.fr' => 'manger une pomme',
+                             'newValue.senses@1#'   . $sense2->guid . '.examples@0#' . $example2->guid . '.sentence.fr' => 'aussi manger une pomme',
+                             'fieldLabel.senses@1#' . $sense2->guid . '.examples@0#' . $example2->guid . '.sentence.fr' => 'Sentence'], $withLabels);
     }
 
     public function testUpdateEntry_UpdateExamplesInOneSenseAndDeleteExampleInTheOther_DifferenceHasCorrectSenseGuids()
@@ -645,15 +644,15 @@ class LexEntryCommandsTest extends TestCase
 
         $updatedEntry = new LexEntryModel($project, $entryId);
         $differences = $entry->calculateDifferences($updatedEntry);
-        $this->assertEquals(['oldValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
-                             'newValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
-                             'deleted.senses#' . $sense2->guid . '.examples#' . $example2->guid => 'manger une pomme'], $differences);
+        $this->assertEquals(['oldValue.senses@0#'   . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'eat an apple',
+                             'newValue.senses@0#'   . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'also eat an apple',
+                             'deleted.senses@1#'    . $sense2->guid . '.examples@0#' . $example2->guid => 'manger une pomme'], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
-        $this->assertEquals(['oldValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'eat an apple',
-                             'newValue.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'also eat an apple',
-                             'fieldLabel.senses#' . $sense1->guid . '.examples#' . $example1->guid . '.sentence.en' => 'Sentence',
-                             'deleted.senses#' . $sense2->guid . '.examples#' . $example2->guid => 'manger une pomme',
-                             'fieldLabel.senses#' . $sense2->guid . '.examples#' . $example2->guid => 'Example'], $withLabels);
+        $this->assertEquals(['oldValue.senses@0#'   . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'eat an apple',
+                             'newValue.senses@0#'   . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'also eat an apple',
+                             'fieldLabel.senses@0#' . $sense1->guid . '.examples@0#' . $example1->guid . '.sentence.en' => 'Sentence',
+                             'deleted.senses@1#'    . $sense2->guid . '.examples@0#' . $example2->guid => 'manger une pomme',
+                             'fieldLabel.senses@1#' . $sense2->guid . '.examples@0#' . $example2->guid => 'Example'], $withLabels);
     }
 
     /* Ignore test for send receive v1.1 since dirtySR counter is not being incremented on edit. IJH 2015-02


### PR DESCRIPTION
Activity list in Mongo stores `actionContent` as a map of string keys to string values, so storing the old and new values of fields required some complicated key names to uniquely identify the fields. For the activity log frontend code, however, we can simplify those key names and turn the changes into a much simpler `changes` array, where each change is a record with the following keys:

- `changeType`: one of `edited_field`, `added_field`, `deleted_field`, or later on `moved_field` (once https://github.com/sillsdev/web-languageforge/pull/209 is implemented)
- `fieldName`: the name of the field in MongoDB (not localized)
- `fieldLabel`: an object representing the field label (localized) to display in the activity log. This object will always contain a `label` key (value is a string) and may contain a `sense` and/or `example` key, whose value(s) will be integer(s): the 1-based indices of the sense or example that this field belongs to.
- `fieldWs`: present for multitext fields, absent for fields that don't have writing systems (e.g., optionlists). The input system abbreviation of the data that was changed in the field.
- `oldValue` and `newValue`: present for updated, added or deleted fields (in the latter two cases either `oldValue` or `newValue` will be an empty string). For moved fields, these keys will be `movedFrom` and `movedTo` instead.

An example of what the DTO now produces can be seen below:

```json
{
  "jsonrpc": "2.0",
  "id": 6,
  "result": {
    "activity": {
      "5b1d35a726cd8306b713b023": {
        ...
        "content": {
          "project": "Robin Test FR 05",
          "entry": "blarg",
          "user": "rmunn",
          "oldValue.senses@0#ff626f8e-241b-4d82-b00c-d6b6e844d8c7.examples@0#86210e77-4d05-46c4-ab2c-5d383bcdf2e6.translation.en": "New example",
          "newValue.senses@0#ff626f8e-241b-4d82-b00c-d6b6e844d8c7.examples@0#86210e77-4d05-46c4-ab2c-5d383bcdf2e6.translation.en": "New example edited",
          "fieldLabel.senses@0#ff626f8e-241b-4d82-b00c-d6b6e844d8c7.examples@0#86210e77-4d05-46c4-ab2c-5d383bcdf2e6.translation.en": "Translation",
          "changes": [
            {
              "changeType": "edited_field",
              "fieldName": "translation",
              "fieldLabel": {
                "label": "Translation",
                "sense": 1,
                "example": 1
              },
              "fieldWs": "en",
              "oldValue": "New example",
              "newValue": "New example edited"
            }
          ]
        },
        "type": "project"
      },
      "5b1d32cd26cd833bc12d1ed2": {
        ...
      }
    }
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/284)
<!-- Reviewable:end -->
