### PR TITLE
Ensure activity log DTO always processes difference data

### DIFF
--- a/src/Api/Model/Shared/Dto/ActivityListDto.php
+++ b/src/Api/Model/Shared/Dto/ActivityListDto.php
@@ -243,14 +243,15 @@ class ActivityListDto
         return ((new \DateTime($a['date'])) < (new \DateTime($b['date']))) ? 1 : -1;
     }
 
-    private static function prepareDto(&$dto, $projectModel)
+    private static function prepareDto(&$dto, ProjectModel $projectModel)
     {
         foreach ($dto['entries'] as &$item) {
             $item['content'] = $item['actionContent'];
             $item['type'] = 'project';  // FIXME: Should this always be "project"? Should it sometimes be "entry"? 2018-02 RM
             unset($item['actionContent']);
-            if ($item['action'] === ActivityModel::UPDATE_ENTRY && $projectModel instanceof LexProjectModel) {
-                $item['content'] = static::prepareActivityContentForEntryDifferences($item, $projectModel);
+            if ($item['action'] === ActivityModel::UPDATE_ENTRY && $projectModel->appName === 'lexicon') {
+                $lexProjectModel = new LexProjectModel($projectModel->id->asString());
+                $item['content'] = static::prepareActivityContentForEntryDifferences($item, $lexProjectModel);
             }
         }
     }

--- a/src/Api/Model/Shared/Dto/ActivityListDto.php
+++ b/src/Api/Model/Shared/Dto/ActivityListDto.php
@@ -249,7 +249,7 @@ class ActivityListDto
             $item['content'] = $item['actionContent'];
             $item['type'] = 'project';  // FIXME: Should this always be "project"? Should it sometimes be "entry"? 2018-02 RM
             unset($item['actionContent']);
-            if ($item['action'] === ActivityModel::UPDATE_ENTRY && $projectModel->appName === 'lexicon') {
+            if ($item['action'] === ActivityModel::UPDATE_ENTRY && $projectModel->appName === LfProjectModel::LEXICON_APP) {
                 $lexProjectModel = new LexProjectModel($projectModel->id->asString());
                 $item['content'] = static::prepareActivityContentForEntryDifferences($item, $lexProjectModel);
             }


### PR DESCRIPTION
The `instanceof` logic in `prepareDto` assumes that the project model instance received is always the most specific instance possible (e.g., was created by `ProjectModel::getById`). But there are some code paths (for example, `ActivityListDto::getActivityForUser`) where `new ProjectModel($id)` is called, which creates a base ProjectModel instance instead of a more specific instance like LexProjectModel. The simplest fix is to rely on the `appName` field, rather than the PHP class instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/287)
<!-- Reviewable:end -->
