### PR TITLE
fix SF user profile list settings not persisting

### DIFF
--- a/src/Api/Model/Shared/ProjectModel.php
+++ b/src/Api/Model/Shared/ProjectModel.php
@@ -53,7 +53,6 @@ class ProjectModel extends MapperModel
         $this->setReadOnlyProp('projectCode');
         $this->setReadOnlyProp('siteName');
         $this->setReadOnlyProp('appName');
-        $this->setReadOnlyProp('userProperties');
 
         // There's separate API calls to get/set $userJoinRequests
         // TODO: Add API calls for $usersRequestingAccess DDW 2016-09

--- a/src/angular-app/bellows/directive/picklist-editor.html
+++ b/src/angular-app/bellows/directive/picklist-editor.html
@@ -9,9 +9,11 @@
     <div class="row">
         <div class="col-12 clearfix">
             <div class="input-group">
-               <input class="form-control" data-ng-model="newValue" data-on-enter="pickAddItem()" name="newValue" type="text" placeholder="new value" no-dirty-check>
+               <input class="form-control" data-ng-model="newValue" data-on-enter="pickAddItem()" name="newValue"
+                      type="text" placeholder="new value" no-dirty-check>
                 <span class="input-group-btn">
-                    <button class="btn btn-primary add-item-to-list" data-ng-click="pickAddItem()"><i class="fa fa-plus iconPadding" aria-hidden="true"></i>Add to List</button>
+                    <a class="btn btn-primary add-item-to-list" href data-ng-click="pickAddItem()">
+                        <i class="fa fa-plus iconPadding" aria-hidden="true"></i>Add to List</a>
                 </span>
             </div>
         </div>
@@ -19,6 +21,7 @@
     <br>
     <div class="row clearfix">
         <div sv-root sv-part="items" sv-on-sort="onSort($indexFrom, $indexTo)">
+            <!--suppress JSUnusedLocalSymbols -->
             <div data-ng-repeat="item in items" class="picklist-group" sv-element>
                 <a data-ng-show="showRemove($index)" data-ng-click="pickRemoveItem($index)"><i class="fa fa-trash"></i></a>
                 <span data-ng-hide="showRemove($index)" style="padding-left: 17px"></span>

--- a/test/app/scriptureforge/sfchecks/question.e2e-spec.ts
+++ b/test/app/scriptureforge/sfchecks/question.e2e-spec.ts
@@ -1,7 +1,8 @@
-import {browser, by, element, ExpectedConditions} from 'protractor';
+import {browser, ExpectedConditions} from 'protractor';
 
 import {BellowsLoginPage} from '../../bellows/shared/login.page';
 import {ProjectsPage} from '../../bellows/shared/projects.page';
+import {Utils} from '../../bellows/shared/utils';
 import {SfProjectPage} from './shared/project.page';
 import {SfQuestionPage} from './shared/question.page';
 import {SfTextSettingsPage} from './shared/text-settings.page';
@@ -88,13 +89,8 @@ describe('SFChecks E2E the question page', () => {
     describe('paratext export of flagged answer', () => {
 
       it('setup: back to Text, click settings, click on tab', () => {
-
-        // click on breadcrumb text title to go back one
-        element(by.linkText(constants.testText1Title)).click();
-
-        // click on text settings
+        Utils.clickBreadcrumb(constants.testText1Title);
         SfTextPage.clickTextSettingsButton();
-
         textSettingsPage.tabs.paratextExport.click();
       });
 
@@ -106,7 +102,7 @@ describe('SFChecks E2E the question page', () => {
         expect<any>(textSettingsPage.paratextExportTab.downloadPT8Button.isPresent()).toBe(true);
         textSettingsPage.paratextExportTab.downloadPT7Button.click();
         browser.wait(ExpectedConditions.visibilityOf(textSettingsPage.paratextExportTab.answerCount),
-          constants.conditionTimeout);
+          Utils.conditionTimeout);
         expect<any>(textSettingsPage.paratextExportTab.answerCount.isDisplayed()).toBe(true);
         expect<any>(textSettingsPage.paratextExportTab.answerCount.getText()).toEqual('1');
         expect<any>(textSettingsPage.paratextExportTab.commentCount.isDisplayed()).toBe(false);
@@ -116,7 +112,7 @@ describe('SFChecks E2E the question page', () => {
         textSettingsPage.paratextExportTab.exportComments.click();
         textSettingsPage.paratextExportTab.downloadPT7Button.click();
         browser.wait(ExpectedConditions.visibilityOf(textSettingsPage.paratextExportTab.answerCount),
-          constants.conditionTimeout);
+          Utils.conditionTimeout);
         expect<any>(textSettingsPage.paratextExportTab.answerCount.isDisplayed()).toBe(true);
         expect<any>(textSettingsPage.paratextExportTab.answerCount.getText()).toEqual('1');
         expect<any>(textSettingsPage.paratextExportTab.commentCount.isDisplayed()).toBe(true);

--- a/test/app/scriptureforge/sfchecks/shared/project-settings.page.ts
+++ b/test/app/scriptureforge/sfchecks/shared/project-settings.page.ts
@@ -1,11 +1,13 @@
 import {browser, by, element, ExpectedConditions} from 'protractor';
 
 import {ProjectsPage} from '../../../bellows/shared/projects.page';
+import {Utils} from '../../../bellows/shared/utils';
 
 export class SfProjectSettingsPage {
   private readonly projectsPage = new ProjectsPage();
+  private readonly utils = new Utils();
 
-  conditionTimeout = 3000;
+  conditionTimeout = Utils.conditionTimeout;
   settingsMenuLink = element(by.id('settings-dropdown-button'));
   projectSettingsLink = element(by.id('dropdown-project-settings'));
 
@@ -14,14 +16,16 @@ export class SfProjectSettingsPage {
     this.projectsPage.get();
     this.projectsPage.clickOnProject(projectName);
     browser.wait(ExpectedConditions.visibilityOf(this.settingsMenuLink), this.conditionTimeout);
-    this.settingsMenuLink.click();
-    this.projectSettingsLink.click();
+    this.clickOnSettingsLink();
   }
 
   clickOnSettingsLink() {
     this.settingsMenuLink.click();
     this.projectSettingsLink.click();
   }
+
+  noticeList = element.all(by.repeater('notice in $ctrl.notices()'));
+  lastNoticeCloseButton = this.noticeList.last().element(by.partialButtonText('×'));
 
   tabs = {
     members: element(by.linkText('Members')),
@@ -67,15 +71,7 @@ export class SfProjectSettingsPage {
     allowAudioDownload: element(by.model('project.allowAudioDownload')),
     usersSeeEachOthersResponses: element(by.model('project.usersSeeEachOthersResponses')),
     saveButton: element(by.id('project-properties-save-button')),
-    // Set a checkbox to either true or false no matter what its current value is
-    // TODO: Move this function to a general utilities library somewhere
-    setCheckbox(checkboxElement: any, value: any) {
-      checkboxElement.isSelected().then((selected: any) => {
-        if (value !== selected) {
-          checkboxElement.click();
-        }
-      });
-    }
+    setCheckbox: this.utils.setCheckbox
   };
 
   optionlistsTab = {
@@ -84,6 +80,7 @@ export class SfProjectSettingsPage {
       .all(by.repeater('(listId, list) in project.userProperties.userProfilePickLists')),
     editList: element(by.id('editListValuesFieldset'))
       .all(by.repeater('(listId, list) in project.userProperties.userProfilePickLists')),
+    editContentsLabel: element(by.id('picklistEditorFieldset')).element(by.tagName('legend')),
     editContentsList: element(by.id('picklistEditorFieldset')).all(by.repeater('item in items')),
     defaultValue: element(by.id('picklistEditorFieldset')).element(by.model('defaultKey')),
     addInput: element(by.id('picklistEditorFieldset')).element(by.model('newValue')),
@@ -94,7 +91,7 @@ export class SfProjectSettingsPage {
       // Given a single repeater row in the picklist, return the delete button for that row
       return repeaterRow.element(by.css('a:first-of-type'));
     }
-  }; // NYI - wait for refactor
+  };
 
   communicationTab = {
     sms: {
@@ -111,10 +108,7 @@ export class SfProjectSettingsPage {
 }
 
 class MembersTab {
-  sfProjectSettingsPage: any;
-  constructor(sfProjectSettingsPage: any) {
-    this.sfProjectSettingsPage = sfProjectSettingsPage;
-  }
+  constructor(private sfProjectSettingsPage: SfProjectSettingsPage) { }
 
   addButton = element(by.id('addMembersButton'));
   removeButton = element(by.id('remove-members-button'));
@@ -131,11 +125,10 @@ class MembersTab {
   addNewMember(name: string) {
     this.sfProjectSettingsPage.tabs.members.click();
     this.addButton.click();
-    browser.wait(ExpectedConditions.visibilityOf(this.newMember.input),
-      this.sfProjectSettingsPage.conditionTimeout);
+    browser.wait(ExpectedConditions.visibilityOf(this.newMember.input), this.sfProjectSettingsPage.conditionTimeout);
     this.newMember.input.sendKeys(name);
-    browser.wait(ExpectedConditions.textToBePresentInElementValue(this.newMember.input,
-      name), this.sfProjectSettingsPage.conditionTimeout);
+    browser.wait(ExpectedConditions.textToBePresentInElementValue(this.newMember.input, name),
+      this.sfProjectSettingsPage.conditionTimeout);
     this.newMember.button.click();
   }
 
@@ -146,4 +139,5 @@ class MembersTab {
       });
     });
   }
+
 }

--- a/test/php/model/languageforge/lexicon/command/LexProjectCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexProjectCommandsTest.php
@@ -101,7 +101,6 @@ class LexProjectCommandsTest extends TestCase
         $params['projectCode'] = $hackedData;
         $params['siteName'] = $hackedData;
         $params['appName'] = $hackedData;
-        $params['userProperties']['userProfilePickLists']['city']['name'] = $hackedData;
 
         LexProjectCommands::updateProject($projectId, $userId, $params);
 
@@ -113,7 +112,6 @@ class LexProjectCommandsTest extends TestCase
         $this->assertNotEquals($hackedData, $updatedProject['projectCode']);
         $this->assertNotEquals($hackedData, $updatedProject['siteName']);
         $this->assertNotEquals($hackedData, $updatedProject['appName']);
-        $this->assertNotEquals($hackedData, $updatedProject['userProperties']['userProfilePickLists']['city']['name']);
     }
 
     public function testCreateCustomFieldsViews_ProjectDoesNotExist_NoAction()


### PR DESCRIPTION
- add regression E2E tests
- remove readonly restriction on 'userProperties'
- fix pick list editor submitting forms (change <button> to <a>)
- some general tidy-up in changed files

Note: `projectSettings.js` changes are all non-functional tidy-up changes.

This is in response to a user reported error: https://community.scripture.software.sil.org/t/how-to-access-and-display-user-profiles/451

SF E2E tests passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/289)
<!-- Reviewable:end -->
