### PR TITLE
Comments now have labels in activity log DTO

### DIFF
--- a/src/Api/Model/Shared/ActivityModel.php
+++ b/src/Api/Model/Shared/ActivityModel.php
@@ -40,6 +40,8 @@ class ActivityModel extends MapperModel
     const COMMENT = 'comment';
     const LEX_COMMENT = 'lexComment';
     const LEX_COMMENT_CONTEXT = 'lexCommentContext';
+    const LEX_COMMENT_LABEL = 'lexCommentLabel';
+    const LEX_COMMENT_FIELD_VALUE = 'lexCommentFieldValue';
     const LEX_COMMENT_STATUS = 'lexCommentStatus';
     const LEX_COMMENT_INCREASE_SCORE = 'lexCommentIncreaseScore';
     const LEX_COMMENT_DECREASE_SCORE = 'lexCommentDecreaseScore';

--- a/src/Api/Model/Shared/Command/ActivityCommands.php
+++ b/src/Api/Model/Shared/Command/ActivityCommands.php
@@ -2,10 +2,13 @@
 
 namespace Api\Model\Shared\Command;
 
+use Api\Library\Shared\Palaso\StringUtil;
 use Api\Model\Languageforge\Lexicon\Command\LexEntryCommands;
 use Api\Model\Languageforge\Lexicon\LexCommentModel;
 use Api\Model\Languageforge\Lexicon\LexCommentReply;
 use Api\Model\Languageforge\Lexicon\LexEntryModel;
+use Api\Model\Languageforge\Lexicon\LexExample;
+use Api\Model\Languageforge\Lexicon\LexSense;
 use Api\Model\Scriptureforge\Sfchecks\AnswerModel;
 use Api\Model\Scriptureforge\Sfchecks\QuestionModel;
 use Api\Model\Scriptureforge\Sfchecks\TextModel;
@@ -301,54 +304,6 @@ class ActivityCommands
     }
 
     /**
-     * @param string $contextGuid The "context GUID" as recorded by the frontend comment code
-     * @param string $fieldLabel The human-readable label of the field commented on
-     * @param LexEntryModel $entry
-     * @return string
-     *
-     * Return a string like "sense@1|example@2|Translation" for putting into the activity log as a field label
-     * Indexes in this one will be 1-based since there's no need for them to be 0-based: we're only ever using this for human display
-     */
-    public static function prepareActivityLabel($contextGuid, $fieldLabel, LexEntryModel $entry)
-    {
-        if (empty($contextGuid) || empty($fieldLabel)) {
-            return $fieldLabel ?? '';
-        }
-        $senseGuid = '';
-        $exampleGuid = '';
-        $parts = explode(' ', trim($contextGuid));
-        $resultParts = [];
-        foreach ($parts as $part) {
-            if (substr($part, 0, 6) === 'sense#') {
-                $senseGuid = substr($part, 6);
-            } else if (substr($part, 0, 8) === 'example#') {
-                $exampleGuid = substr($part, 8);
-            }
-        }
-        // Find 1-based position of sense and example, if needed for this field
-        if (! empty($senseGuid)) {
-            $sensePosition = 0;
-            foreach ($entry->senses as $sense) {
-                /** LexSense $sense */
-                $sensePosition++;
-                if ($sense->guid === $senseGuid) {
-                    $resultParts[] = "sense@$sensePosition";
-                    $examplePosition = 0;
-                    foreach ($sense->examples as $example) {
-                        /** LexExample $example */
-                        $examplePosition++;
-                        if ($example->guid === $exampleGuid) {
-                            $resultParts[] = "example@$examplePosition";
-                        }
-                    }
-                }
-            }
-        }
-        $resultParts[] = $fieldLabel;
-        return implode('|', $resultParts);
-    }
-
-    /**
      * @param ProjectModel $projectModel
      * @param string $entryId
      * @param LexCommentModel $commentModel
@@ -472,5 +427,53 @@ class ActivityCommands
     public static function addReplyToEntryComment($projectModel, $entryId, $commentModel, $replyModel)
     {
         return ActivityCommands::updateReplyToEntryComment($projectModel, $entryId, $commentModel, $replyModel, "add");
+    }
+
+    /**
+     * @param string $contextGuid The "context GUID" as recorded by the frontend comment code
+     * @param string $fieldLabel The human-readable label of the field commented on
+     * @param LexEntryModel $entry
+     * @return string
+     *
+     * Return a string like "sense@1|example@2|Translation" for putting into the activity log as a field label
+     * Indexes in this one will be 1-based since there's no need for them to be 0-based: we're only ever using this for human display
+     */
+    private static function prepareActivityLabel($contextGuid, $fieldLabel, LexEntryModel $entry)
+    {
+        if (empty($contextGuid) || empty($fieldLabel)) {
+            return $fieldLabel ?? '';
+        }
+        $senseGuid = '';
+        $exampleGuid = '';
+        $parts = explode(' ', trim($contextGuid));
+        $resultParts = [];
+        foreach ($parts as $part) {
+            if (StringUtil::startsWith($part, 'sense#')) {
+                $senseGuid = substr($part, strlen('sense#'));
+            } else if (StringUtil::startsWith($part, 'example#')) {
+                $exampleGuid = substr($part, strlen('example#'));
+            }
+        }
+        // Find 1-based position of sense and example, if needed for this field
+        if (! empty($senseGuid)) {
+            $sensePosition = 0;
+            foreach ($entry->senses as $sense) {
+                /** @var LexSense $sense */
+                $sensePosition++;
+                if ($sense->guid === $senseGuid) {
+                    $resultParts[] = "sense@$sensePosition";
+                    $examplePosition = 0;
+                    foreach ($sense->examples as $example) {
+                        /** @var LexExample $example */
+                        $examplePosition++;
+                        if ($example->guid === $exampleGuid) {
+                            $resultParts[] = "example@$examplePosition";
+                        }
+                    }
+                }
+            }
+        }
+        $resultParts[] = $fieldLabel;
+        return implode('|', $resultParts);
     }
 }

--- a/src/Api/Model/Shared/Dto/ActivityListDto.php
+++ b/src/Api/Model/Shared/Dto/ActivityListDto.php
@@ -2,6 +2,7 @@
 
 namespace Api\Model\Shared\Dto;
 
+use Api\Library\Shared\Palaso\StringUtil;
 use Api\Library\Shared\Website;
 use Api\Model\Languageforge\Lexicon\Config\LexConfig;
 use Api\Model\Languageforge\Lexicon\LexEntryModel;
@@ -260,9 +261,7 @@ class ActivityListDto
                 if ($item['action'] === ActivityModel::UPDATE_ENTRY) {
                     $lexProjectModel = new LexProjectModel($projectModel->id->asString());
                     $item['content'] = static::prepareActivityContentForEntryDifferences($item, $lexProjectModel);
-                }
-                if ($item['action'] === ActivityModel::ADD_LEX_COMMENT ||
-                    $item['action'] === ActivityModel::UPDATE_LEX_COMMENT) {
+                } else if ($item['action'] === ActivityModel::ADD_LEX_COMMENT || $item['action'] === ActivityModel::UPDATE_LEX_COMMENT) {
                     $labelFromMongo = $item['content'][ActivityModel::LEX_COMMENT_LABEL] ?? '';
                     unset($item['content'][ActivityModel::LEX_COMMENT_LABEL]);
                     if (! empty($labelFromMongo)) {
@@ -278,11 +277,11 @@ class ActivityListDto
         $result = [];
         $parts = explode('|', $labelFromMongo);
         foreach ($parts as $part) {
-            if (substr($part, 0, 6) === 'sense@') {
-                $pos = substr($part, 6);
+            if (StringUtil::startsWith($part, 'sense#')) {
+                $pos = substr($part, strlen('sense#'));
                 $result['sense'] = intval($pos);
-            } else if (substr($part, 0, 8) === 'example@') {
-                $pos = substr($part, 8);
+            } else if (StringUtil::startsWith($part, 'example#')) {
+                $pos = substr($part, strlen('example#'));
                 $result['example'] = intval($pos);
             } else {
                 $result['label'] = $part;

--- a/src/Api/Model/Shared/Dto/ActivityListDto.php
+++ b/src/Api/Model/Shared/Dto/ActivityListDto.php
@@ -277,11 +277,11 @@ class ActivityListDto
         $result = [];
         $parts = explode('|', $labelFromMongo);
         foreach ($parts as $part) {
-            if (StringUtil::startsWith($part, 'sense#')) {
-                $pos = substr($part, strlen('sense#'));
+            if (StringUtil::startsWith($part, 'sense@')) {
+                $pos = substr($part, strlen('sense@'));
                 $result['sense'] = intval($pos);
-            } else if (StringUtil::startsWith($part, 'example#')) {
-                $pos = substr($part, strlen('example#'));
+            } else if (StringUtil::startsWith($part, 'example@')) {
+                $pos = substr($part, strlen('example@'));
                 $result['example'] = intval($pos);
             } else {
                 $result['label'] = $part;


### PR DESCRIPTION
For "add_lex_comment" and "update_lex_comment" activities, activity log DTO now returns a "fieldLabel" field whose contents look like:

```json
"fieldLabel": { "label": "Translation", "sense": 1, "example": 2 }
```

Or, at a minimum:

```json
"fieldLabel": { "label": "Word" }
```

The "fieldLabel.label" field should always be there, but "fieldLabel.sense" and "fieldLabel.example" are optional (though if "fieldLabel.example" appears, then "fieldLabel.sense" is guaranteed to also be there).

The DTO will also contain a "lexCommentFieldValue" which will contain the value of the field at the time the comment was made; this may be useful for displaying in the activity log.

Feedback requested on naming consistency: should "fieldLabel" be called "fieldLabel", or "lexCommentLabel", or "lexCommentFieldLabel"? The advantage of the "fieldLabel" name is that this is consistent with what's returned in the case of entry updates. The advantage of the "lexCommentLabel" or "lexCommentFieldLabel" names would be more internal consistency within the activity log content for a comment update (or a comment addition). Since I couldn't make up my mind which name to use, I've gone for the shorter name, "fieldLabel", for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/291)
<!-- Reviewable:end -->
