### PR TITLE
Unsticky footer on mobile

### DIFF
--- a/src/Site/views/languageforge/theme/default/sass/_global.scss
+++ b/src/Site/views/languageforge/theme/default/sass/_global.scss
@@ -14,9 +14,15 @@ html {
 
 body {
   background: white;
-  height: 100%;
+  min-height: 100%;
   display: flex;
   flex-direction: column;
+}
+
+@include media-breakpoint-up(lg) {
+  body {
+    height: 100%;
+  }
 }
 
 h1.mobile-title {

--- a/src/Site/views/scriptureforge/theme/default/sass/_global.scss
+++ b/src/Site/views/scriptureforge/theme/default/sass/_global.scss
@@ -14,9 +14,15 @@ html {
 
 body {
   background: white;
-  height: 100%;
+  min-height: 100%;
   display: flex;
   flex-direction: column;
+}
+
+@include media-breakpoint-up(lg) {
+  body {
+    height: 100%;
+  }
 }
 
 h1.mobile-title {


### PR DESCRIPTION
Currently the xForge footer is sticky. I can understand the purpose of a sticky header, but the footer seems unnecessary (looking at commit history, there's a possibility it may have even been changed by accident). On mobile this is especially problematic, especially when typing causes half the screen to be taken by the keyboard.

Surprisingly, this small change to the CSS breaks the e2e tests. Frequently buttons are hidden behind the sticky header and we have to scroll to the top before clicking them. Tests are passing as well as they do on master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/292)
<!-- Reviewable:end -->
