### PR TITLE
Change references to FLEx to FieldWorks

### DIFF
--- a/docs/webdesign/LanguageForgeV2/learn.html
+++ b/docs/webdesign/LanguageForgeV2/learn.html
@@ -113,16 +113,16 @@
             <p>Language Forge has fine-grained configuration options. You can choose which fields you want to see and which fields use which input systems. Add new languages to any field in the Input Systems area. Support for complex scripts and right-to-left languages is built-in. Customize the behavior of each field in the <i>“Fields”</i> section. Specify who can see what fields in the <i>“View Settings”</i>. Choose what role each member of your project will have: <b>Observer</b>, <b>Commenter</b>, <b>Contributor or Manager</b>.</p>
             <p>It’s easy to add members to your project. <b>Search by name</b> for existing Language Forge users or invite colleagues to your Language Forge project via email. You choose with whom you share your data and to what extent.</p>
             <p>Not only can you share your data, but you can invite others to give feedback on all aspects of your lexical data. Commenters can have detailed discussions about any entry and any field in the lexicon. Field context can optionally be attached to any comment, showing what the value of a field was at the time the comment was made. Commenters can reply to existing comments inline, or add their own responses. Managers can organize and search comments. Comments can be marked <b>TODO</b> or marked as <b>RESOLVED</b> to close a discussion.</p>
-            <p>Send/Receive support with other programs such as <b>FLEX</b> and <b>WeSay</b> is not yet available but is coming soon. Accessing your data offline is also planned for a future release.</p>
+            <p>Send/Receive support with other programs such as <b>FieldWorks Language Explorer</b> and <b>WeSay</b> is not yet available but is coming soon. Accessing your data offline is also planned for a future release.</p>
             <p>Language Forge can help you share your data online in the way you want to, with the people you want to, using just a web browser. <b>Give it a try!</b></p>
-            
+
             <h2>Beta Preview Features</h2>
             <ul class="list">
-                <li>Import your WeSay or FLEx data <i>(LIFT format)</i></li>
+                <li>Import your WeSay or FieldWorks data <i>(LIFT format)</i></li>
                 <li>View or Edit the dictionary online</li>
                 <li>Invite others to <b>view</b>, <b>collaborate</b>, <b>edit and comment</b> on your lexicon data</li>
                 <li>Dictionary configuration editor: <b>customize input systems</b>, <b>lexicon fields</b> and <b>tasks</b></li>
-                <li>Supports most FLEx fields</li>
+                <li>Supports most FieldWorks fields</li>
                 <li>Assign project members one of several roles: <b>Observer</b>, <b>Commenter</b>, <b>Collaborator and Manager</b></li>
                 <li>Customize what each member sees down to the field level</li>
                 <li>Custom field support</li>

--- a/src/Site/views/languageforge/theme/default/page/home/index.html.twig
+++ b/src/Site/views/languageforge/theme/default/page/home/index.html.twig
@@ -33,7 +33,7 @@
     <!-- Banner -->
     <section id="banner">
         <h2>Language Forge</h2>
-        <p>Collaborative web-based dictionary building that syncs with FLEx</p>
+        <p>Collaborative web-based dictionary building that syncs with FieldWorks</p>
         <ul class="actions">
             <li><a href="/public/signup" class="button special">Sign Up</a></li>
             <li><a href="/auth/login" class="button">Login</a></li>
@@ -58,9 +58,9 @@
             <div class="features-row">
                 <section>
                     <span class="icon major fa-refresh accent2"></span>
-                    <h3>Sync with FLEx</h3>
-                    <p>Collaborate on Language Forge then sync those changes back into Fieldworks Language Explorer
-                        (FLEx). Make further refinements in FLEx and then Send/Receive those back to Language Forge</p>
+                    <h3>Sync with FieldWorks</h3>
+                    <p>Collaborate on Language Forge then sync those changes back into Fieldworks Language Explorer.
+                      Make further refinements in FieldWorks and then Send/Receive those back to Language Forge</p>
                 </section>
                 <section>
                     <span class="icon major fa-user accent3"></span>
@@ -107,7 +107,7 @@
                     <h3>Real-Time Collaboration</h3>
                     <p>Members of the project will see entries updated as it happens by others in the same project.
                         Language Forge has dozens of additional features including LIFT import, custom field support,
-                        right-to-left script support, and support for many FLEx fields.</p>
+                        right-to-left script support, and support for many FieldWorks fields.</p>
                 </section>
 
             </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.component.ts
@@ -65,7 +65,7 @@ export class FieldPictureController implements angular.IController {
       picture.fileName +
       ') and therefore cannot be synchronized. ' +
       'To see the picture, link it to an internally referenced file. ' +
-      'Replace the file here or in FLEx, move or copy the file to the Linked Files folder.';
+      'Replace the file here or in FieldWorks, move or copy the file to the Linked Files folder.';
   }
 
   deletePicture(index: number): void {

--- a/src/angular-app/languageforge/lexicon/new-project/views/new-project-initial-data.html
+++ b/src/angular-app/languageforge/lexicon/new-project/views/new-project-initial-data.html
@@ -26,7 +26,7 @@
                         <div class="col-12">
                             <a id="flex-help-link" data-ng-click="$ctrl.show.flexHelp = !$ctrl.show.flexHelp">
                                 <i class="fa fa-question-circle text-info"></i>
-                                How to export a project from FLEx
+                                How to export a project from FieldWorks
                             </a>
                             <div uib-collapse="!$ctrl.show.flexHelp">In FLEx v8 (SIL FieldWorks Language Explorer)
                                 <ol>

--- a/src/angular-app/languageforge/lexicon/new-project/views/new-project-name.html
+++ b/src/angular-app/languageforge/lexicon/new-project/views/new-project-name.html
@@ -5,7 +5,7 @@
                 <h3 class="no-space-break">Choose a project name</h3>
                 <div class="alert alert-danger" role="alert">
                     Creating a non-send/receive project in Language Forge is no longer recommended because of the lack of an export path.
-                    Instead, create a new project from Language Depot to enable Send/Receive with FLEx. Data can then be exported through FLEx.
+                    Instead, create a new project from Language Depot to enable Send/Receive with FieldWorks. Data can then be exported through FieldWorks.
                 </div>
             </div>
             <div class="card card-default">

--- a/src/angular-app/languageforge/semdomtrans/new-project/app-management/ng-app.html
+++ b/src/angular-app/languageforge/semdomtrans/new-project/app-management/ng-app.html
@@ -7,7 +7,7 @@
     <tabset ng-show="dtoLoaded">
         <tab heading="Export">
             <div ng-show="languages.length > 0">
-                <p>Export the following semantic domain language lists in FLEx XML format</p>
+                <p>Export the following semantic domain language lists in FieldWorks XML format</p>
                 <button ng-click="doExport()" class="btn btn-primary">Export <span class="notranslate">{{languages.length}}</span> languages</button>
                 <span style="font-weight: bold" ng-repeat="language in languages"><a ng-href="/app/semdomtrans/{{language.id}}">{{language.name}}</a>  </span>
             </div>

--- a/src/help/Concepts/FieldWorks_Language_Explorer.htm
+++ b/src/help/Concepts/FieldWorks_Language_Explorer.htm
@@ -17,7 +17,7 @@ if ((parseInt(navigator.appVersion) == 4) && (navigator.appName == "Netscape")) 
 	origHeight = innerHeight;
 	onresize = reDo;
 }
-onerror = null; 
+onerror = null;
 //]]>
 </script>
 <style type="text/css">
@@ -56,13 +56,13 @@ gTopicId = "";
 <script type="text/javascript" src="../ehlpdhtm.js" language="JavaScript1.2"></script>
 
 <h1>FieldWorks Language Explorer</h1>
-<p class="BodyText">FieldWorks Language Explorer (FLEx) is a software tool 
- that is used for language and cultural data. It runs in Windows and Linux 
+<p class="BodyText">FieldWorks Language Explorer is a software tool 
+ that is used for language and cultural data. It runs in Windows and Linux
  operating systems. </p>
 <h4>Related Topics</h4>
 <p class="BodyText"><a href="Concepts_overview.htm">Concepts overview</a></p>
 <h4>Related Internet Sites</h4>
-<p class="BodyText"><a title="http://fieldworks.sil.org/" href="http://fieldworks.sil.org/" 
+<p class="BodyText"><a title="http://fieldworks.sil.org/" href="http://fieldworks.sil.org/"
 						 target="_blank">http://fieldworks.sil.org/</a></p>
 </body>
 </html>


### PR DESCRIPTION
The most prominent change is in `index.html.twig`.

The flie `FieldWorks_Language_Explorer.htm` had mixed line endings. Most of them were CRLF, so that's what I changed them all to. The diff doesn't show this very clearly.

This is not changing every reference. I tried not to get carried away and left alone some references, especially where it was clarified that FLEx refers to FieldWorks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/295)
<!-- Reviewable:end -->
