### PR TITLE
Fix z-index of telephone input

### DIFF
--- a/src/angular-app/bellows/apps/userprofile/userprofile.scss
+++ b/src/angular-app/bellows/apps/userprofile/userprofile.scss
@@ -20,6 +20,9 @@
 
   .intl-tel-input {
     width: 100%;
+    ul.country-list {
+      z-index: 3; // Necessary to keep email & SMS buttons from covering the dropdown
+    }
   }
 }
 


### PR DESCRIPTION
The SMS and email settings buttons have had the problem of appearing on top of the telephone input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/296)
<!-- Reviewable:end -->
