### PR TITLE
Remove spaces in Mongo repository string

### DIFF
--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -36,7 +36,7 @@
     - name: add Mongo 3.6 repository
       # TODO: use ansible system variable instead of hardcoding "xenial" in repo line -- except that it can only be from a restricted list of distros (e.g. xenial & bionic only)
       apt_repository:
-        repo: "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse"
+        repo: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse"
         filename: mongodb-org-3.6
         update_cache: yes
     - name: Remove PHP5 for Trusty
@@ -313,7 +313,7 @@
     - name: enable languageforge-web-api service
       service: name=languageforge-web-api enabled=yes
       when: is_build_agent is defined and is_build_agent == true
-      
+
   handlers:
     - name: restart mongod
       service: name=mongod state=restarted


### PR DESCRIPTION
When I run Ansible via a Vagrant provisioning script this task keeps adding lines to `/etc/apt/sources.list.d/mongodb-org-3.6.list`. Generally it looks something like this:
```
deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse
deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse
deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse
```
These extra lines cause apt to print warnings, e.g.:
```
Target Packages (multiverse/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/mongodb-org-3.6.list:1 and /etc/apt/sources.list.d/mongodb-org-3.6.list:2
```
With every run it adds another line (generally without spaces within the brackets) and the warnings grow larger. This only happens when Vagrant is running Ansible though. If I manually SSH into the box and run the exact same command in the same CWD as the same user (vagrant) this does not happen.

When the spaces are removed the behavior is as expected; no lines are added if the repo is already in `mongodb-org-3.6.list`. I don't have a good explanation for why this works the way it does. My best guess would be that it is looking in the file for the version with spaces, not finding it, and then writing the version without spaces, or something of that sort. That doesn't explain though why it only exhibits this problem when run via Vagrant's provision script.

@rmunn As the original author of this task, do you know anything that might explain the odd behavior?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/298)
<!-- Reviewable:end -->
