### PR TITLE
Add Vagrant GUI install method and update local Linux setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,35 +170,33 @@ Proceed to [Language Forge Configuration File](#LFConfig) and follow the rest of
 
 ### Local Linux Development Setup <a id="LocalSetup"></a> ###
 
-Start with the Ansible-assisted setup [described here](https://github.com/sillsdev/ops-devbox) to install and configure a basic development environment.
+Start by installing Git and Ansible:
+``` shell
+sudo add-apt-repository ppa:ansible/ansible
+sudo apt-get update
+sudo apt-get install -y git ansible
+```
 
-#### Installation and Deployment ####
-
-After creating your Ansible-assisted setup, clone this repository from your *home* folder...
-
-```` bash
-mkdir src
-cd src
-mkdir xForge
-cd xForge
-git clone https://github.com/sillsdev/web-languageforge web-languageforge --recurse-submodules
-````
+Now create a directory for installation and clone the repo:
+``` shell
+mkdir -p src/xForge
+cd src/xForge
+git clone https://github.com/sillsdev/web-languageforge --recurse-submodules
+```
 
 The `--recurse-submodules` is used to fetch many of the Ansible roles used by the Ansible playbooks in the deploy folder. If you've already cloned the repo without `--recurse-submodules`, run `git submodule update --init --recursive` to pull and initialize them.
 
-If you want to run an independant repo for scriptureforge, clone its repo also...
-
+If you want to run an independent repo for Scripture Forge, clone its repo also:
 ``` bash
-git clone https://github.com/sillsdev/web-scriptureforge web-scriptureforge --recurse-submodules
+git clone https://github.com/sillsdev/web-scriptureforge --recurse-submodules
 ```
 
-Otherwise just create a symbolic link between languageforge and scriptureforge...
-
+Otherwise just create a symbolic link between languageforge and scriptureforge:
 ``` bash
 ln -s web-languageforge web-scriptureforge
 ```
 
-Change the variable *mongo_path: /var/lib/mongodb* in `deploy/vars_palaso.yml`. Set it to a location where MongoDB should store its databases.
+Change the variable `mongo_path: /var/lib/mongodb` in `deploy/vars_palaso.yml`. Set it to a location where MongoDB should store its databases.
 
 - **Vagrant VM Setup**: uncomment line 6 and comment line 5
 - **Local Linux Development Setup**: uncomment line 5 and comment line 6 (or whatever is appropriate on your system, its best to have Mongo store databases on your HDD rather than SSD). Make sure the `mongodb` user has permission to read and write to the path you specify.
@@ -211,22 +209,17 @@ ansible-playbook -i hosts playbook_create_config.yml --limit localhost -K
 ansible-playbook playbook_xenial.yml --limit localhost -K
 ````
 
-If you run into an error on the `ssl_config : LetsEncrypt: Install packages` task, run the playbook again and that task should succeed the second time it is run.
+To build the JavaScript and CSS, run `refreshDeps.sh lf` if you are working on Language Forge, or `refreshDeps.sh sf` if you are working on Scripture Forge. Running `refreshDeps.sh` without arguments defaults to Language Forge.
 
-Install dependencies used to build Sass files and run E2E tests
+That's it; you should now be able to open your browser to languageforge.local and scriptureforge.local and log in with the credentials "admin" and "password".
 
-``` bash
-cd web-languageforge
-npm install
-gulp sass
-gulp webpack-lf
-```
+#### Building TypeScript and Sass
 
-or use `gulp webpack-sf` if you are working in **Scripture Forge**.
+`refreshDeps.sh` builds the TypeScript and Sass, but it does a lot of other things as well.
 
-To watch Sass files for changes, run `gulp sass:watch`. The output will also be in a more readable format (rather than compressed as it is with `gulp sass`). You can also pass the `--debug` flag to enable source comments and source maps in comments in the output files.
+To build Sass, run `gulp sass`. To watch the Sass for changes, run `gulp sass:watch`. Pass the `--debug` flag to enable sourcemaps and source comments.
 
-To watch TypeScript files for changes, run `gulp webpack-lf:watch` or `gulp webpack-sf:watch`. This includes a live reload server to refresh the browser on TypeScript changes (browser setup [here](#LiveReloadInstall)).
+To build TypeScript, run `gulp webpack-lf` or `gulp webpack-sf` to build for Language Forge or Scripture Forge respectively. To watch the files for changes, run `gulp webpack-lf:watch` or `gulp webpack-sf:watch`. This includes a live reload server to refresh the browser on TypeScript changes (browser setup [here](#LiveReloadInstall)).
 
 #### Language Forge Configuration File <a id="LFConfig"></a> ####
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # web-languageforge / web-scriptureforge #
 
-[Language Forge](https://github.com/sillsdev/web-languageforge) and [Scripture Forge](https://github.com/sillsdev/web-scriptureforge) represent different websites, but have the same code base stored in seperate repositories for the purpose of  version control and issue tracking. Since they are related repos it is easy to merge from one to the other.
+[Language Forge](https://github.com/sillsdev/web-languageforge) and [Scripture Forge](https://github.com/sillsdev/web-scriptureforge) represent different websites, but have the same code base stored in separate repositories for the purpose of version control. Since they are related repos it is easy to merge from one to the other.
 
 ## Users ##
 
@@ -12,7 +12,7 @@ To use **Scripture Forge** go to [scriptureforge.org](https://scriptureforge.org
 
 To report an user issue with the **Language Forge** application, email "issues @ languageforge dot org".
 
-To report an user issue with the **Scripture Forge** application email "issues @ scriptureforge dot org".
+To report an user issue with the **Scripture Forge** application, email "issues @ scriptureforge dot org".
 
 ## Special Thanks To ##
 
@@ -89,7 +89,11 @@ The below sections go into detail on how to manually set up the developer enviro
 
 ### Linux Ubuntu Gnome ###
 
-Our recommended development environment for web development is Linux Ubuntu GNOME.  Choose either the [Vagrant VM Setup](#VagrantSetup) or the [Local Linux Development Setup](#LocalSetup).  Even though the Vagrant VM Setup is definitely easier because it always installs from a clean slate on a new virtual box, we recommend doing development on your local development machine.  This approach will make your page loads approximately 50 times faster.  In my tests 100 ms (local) vs 5000 ms (Vagrant / Virtualbox).  The reason for this is that Virtualbox gives access to the php files via the VirtualBox shared folder feature.  This is notoriously slow.
+Our recommended development environment for web development is Linux Ubuntu GNOME.
+There are three main installation methods:
+- [Local Linux Development Setup](#local-linux-development-setup). Everything is installed directly on your machine, which needs to be running Ubuntu 16.04. This is the best method because everything runs at full speed.
+- [Vagrant GUI setup](#vagrant-gui-setup). This is the simplest setup method. A Vagrant box with xForge already installed is downloaded and set up on your machine. The main drawback is speed. In some tests the e2e tests took approximately 10 minutes, rather than the 5 minutes they normally take.
+- [Vagrant headless setup](#vagrant-headless-setup). A small base box is downloaded and xForge is then installed into it. The source code is kept in a shared folder between the host and guest operating systems. This has a number of drawbacks, one of which is that page loads are much slower (50 times slower in some tests; 5000 ms rather than 100 ms). The reason for this is that Virtualbox gives access to the PHP files via the VirtualBox shared folder feature.  This is notoriously slow.
 
 ### Ubuntu Xenial on Windows 10 WSL ###
 
@@ -134,11 +138,17 @@ After Ubuntu Xenial Bash has finished installing, close the Windows Command Prom
 
 -------------------------------
 
-### Vagrant VM Setup <a id="VagrantSetup"></a> ###
+### Vagrant GUI Setup ###
+
+Install [VirtualBox](https://www.virtualbox.org/) and [Vagrant](https://www.vagrantup.com/). Make sure virtualization is enabled in your BIOS.
+
+Create a directory for the installation, such as `src/xForge`. Download the file [deploy/vagrant_xenial_gui/Vagrantfile](https://raw.githubusercontent.com/sillsdev/web-languageforge/master/deploy/vagrant_xenial_gui/Vagrantfile) to the directory where you want to install. Then open the command line to that directory and run `vagrant up`. This will download a box (it's about 5GB, so expect it to take a while) and run a few setup steps. When it is complete the virtual machine should be open. Launch the web browser and try navigating to languageforge.local or scriptureforge.local. The default login credentials are "admin" and "password".
+
+### Vagrant Headless Setup ###
 
 If you are on Windows, begin by giving your user account permission to create symlinks. This is necessary or `npm install` will not run properly.
 
-- Run `secpol.msc`. This ([reportendly](https://www.virtualbox.org/ticket/10085#comment:32)) does not exist on some versions of Windows and you will have to use [a workaround](https://stackoverflow.com/questions/815472/how-do-i-grant-secreatesymboliclink-on-windows-vista-home-edition).
+- Run `secpol.msc`. This ([reportedly](https://www.virtualbox.org/ticket/10085#comment:32)) does not exist on some versions of Windows and you will have to use [a workaround](https://stackoverflow.com/questions/815472/how-do-i-grant-secreatesymboliclink-on-windows-vista-home-edition).
 - Go to Local Policies -> User Rights Assignment -> Create symbolic links -> Add User or Group...
 - Type your username in the text field and click "Check Names".
 - Click OK, then click OK, and close the Local Security Policy window.
@@ -168,7 +178,7 @@ Proceed to [Language Forge Configuration File](#LFConfig) and follow the rest of
 
 -------------------------------
 
-### Local Linux Development Setup <a id="LocalSetup"></a> ###
+### Local Linux Development Setup ###
 
 Start by installing Git and Ansible:
 ``` shell

--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -56,7 +56,7 @@
         - geoipupdate
         - libapache2-mod-php
         - mongodb-org
-        - nodejs
+        - npm
         - p7zip-full
         - php7.0-cli
         - php7.0-curl

--- a/deploy/vagrant_xenial_gui/Vagrantfile
+++ b/deploy/vagrant_xenial_gui/Vagrantfile
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "NathanielPaulus/xenial64-xforge"
+  config.ssh.insert_key = false
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.memory = "2048"
+  end
+
+  config.vm.provision "shell", privileged: false, inline: <<~SHELL
+    set -eux
+
+    git config --global user.email "#{`git config --get user.email`.strip}"
+    git config --global user.name "#{`git config --get user.name`.strip}"
+
+    cd ~/src/web-languageforge
+    git pull --ff-only --recurse-submodules
+    ./refreshDeps.sh
+
+    SHELL
+end
+

--- a/deploy/virtualbox_xenial_gui_creation/Vagrantfile
+++ b/deploy/virtualbox_xenial_gui_creation/Vagrantfile
@@ -1,0 +1,103 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# This Vagrantfile is for the creation of a VirtualBox image where xForge is installed
+# Currently the result is hosted as NathanielPaulus/xenial64-xforge
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "chrisvire/xenial64"
+  config.ssh.insert_key = false
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.memory = "2048"
+  end
+
+  config.vm.provision "ubuntu-setup", type: "shell", privileged: false, inline: <<~SHELL
+    set -eux
+
+    # Disable automatic updates
+    sudo sed -i 's/APT::Periodic::Update-Package-Lists "1";/APT::Periodic::Update-Package-Lists "0";/g' /etc/apt/apt.conf.d/10periodic
+    sudo apt-get purge -y unattended-upgrades
+
+    CODENAME="$(lsb_release -cs)"
+    MIRRORS="deb mirror://mirrors.ubuntu.com/mirrors.txt $CODENAME main restricted universe multiverse
+    deb mirror://mirrors.ubuntu.com/mirrors.txt $CODENAME-updates main restricted universe multiverse
+    deb mirror://mirrors.ubuntu.com/mirrors.txt $CODENAME-backports main restricted universe multiverse
+    deb mirror://mirrors.ubuntu.com/mirrors.txt $CODENAME-security main restricted universe multiverse
+    "
+
+    # Add sources to the top of sources.list if they're not already there
+    grep --fixed-strings --silent 'deb mirror://mirrors.ubuntu.com/mirrors.txt' /etc/apt/sources.list || { { echo "$MIRRORS" && cat /etc/apt/sources.list; } > sources.list.tmp && sudo mv sources.list.tmp /etc/apt/sources.list; }
+
+    sudo apt-get update
+    sudo apt-get -y upgrade
+
+    # In order to run gsettings over SSH we have to set DBUS_SESSION_BUS_ADDRESS. See https://askubuntu.com/a/457023
+    export DBUS_SESSION_BUS_ADDRESS="$(sudo cat /proc/$(pidof -s pulseaudio)/environ | tr '\\0' '\\n' | grep --text DBUS_SESSION_BUS_ADDRESS | cut -d '=' -f 2-)"
+    if [ "$DBUS_SESSION_BUS_ADDRESS" != "" ]; then
+      gsettings set org.gnome.desktop.screensaver lock-enabled false
+      gsettings set org.gnome.desktop.session idle-delay 0
+      gsettings set com.canonical.Unity.Lenses remote-content-search none
+      gsettings set com.canonical.Unity.Launcher favorites "['application://org.gnome.Nautilus.desktop', 'application://firefox.desktop', 'application://unity-control-center.desktop', 'unity://running-apps', 'application://gnome-terminal.desktop', 'unity://expo-icon', 'unity://devices']"
+    else
+      echo ***COULD NOT MODIFY GSETTINGS***
+    fi
+
+    # Enable automatic login
+    echo $'[SeatDefaults]\nautologin-user=vagrant' | sudo tee /etc/lightdm/lightdm.conf.d/12-autologin.conf > /dev/null
+
+    # remove some of the packages suggested by ubuntu-desktop
+    sudo apt-get -y purge update-manager update-notifier aisleriot cheese deja-dup example-content fwupd fwupdate fwupdate-signed gnome-accessibility-themes gnome-calendar gnome-font-viewer gnome-mahjongg gnome-mines gnome-orca gnome-screensaver gnome-sudoku libreoffice* remmina rhythmbox shotwell simple-scan thunderbird* totem transmission-gtk usb-creator-gtk
+    [ -f ~/examples.desktop ] && rm ~/examples.desktop
+
+    sudo apt-get -y autoremove
+    sudo apt-get clean
+  SHELL
+
+  config.vm.provision "xforge-setup", type: "shell", privileged: false, inline: <<~SHELL
+    set -eux
+
+    sudo add-apt-repository ppa:ansible/ansible
+    # Add mongo public key
+    sudo apt-get update
+    sudo apt-get -y install ansible git
+    mkdir -p ~/src
+    cd ~/src
+
+    if [ ! -d "web-languageforge" ]; then
+      git clone --depth 1 --recurse-submodules https://github.com/sillsdev/web-languageforge.git
+    else
+      cd web-languageforge
+      git pull --ff-only --recurse-submodules
+    fi
+
+    cd ~/src
+    [ -d web-scriptureforge ] || ln -s web-languageforge web-scriptureforge
+
+    cd ~/src/web-languageforge/deploy/
+    ansible-playbook -i hosts playbook_create_config.yml --limit localhost
+    ansible-playbook -i hosts playbook_xenial_server_vagrant.yml --limit localhost
+
+    cd ~/src/web-languageforge
+    ./refreshDeps.sh
+
+    cd
+    if ! command -v code >> /dev/null ; then
+      wget -O vscode.deb https://az764295.vo.msecnd.net/stable/24f62626b222e9a8313213fb64b10d741a326288/code_1.24.1-1528912196_amd64.deb
+      sudo apt-get install ./vscode.deb
+      rm vscode.deb
+    fi
+
+    sudo apt-get -y autoremove
+    sudo apt-get clean
+
+    cd ~/src/web-languageforge
+    # Fix fetch issues caused by cloning with --depth
+    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    # if it's still a shallow repo
+    [ -f .git/shallow ] && git fetch --unshallow
+
+    echo Install complete
+  SHELL
+end


### PR DESCRIPTION
I've created a Vagrant install method where everything is inside the box, including development tools. I initially thought this would be too slow, but Mark does all his development in VirtualBox and says it is not a problem. It's not ideal, but it's likely faster than using VirtualBox shared folders. At the very least it avoids the numerous problems with having the source code on the host and the application in the box.

The Vagrant GUI install method downloads a box with xForge already installed. This box is generated using `deploy/virtualbox_xenial_gui_creation/Vagrantfile` and should be updated whenever our installation method changes. Currently it's hosted on my Vagrant Cloud account at [NathanielPaulus/xenial64-xforge](https://app.vagrantup.com/NathanielPaulus/boxes/xenial64-xforge). I asked Jason about it and was told for now just host it there and it can be changed in the future if necessary (it would be a simple matter up building the box, uploading it elsewhere, and updating `deploy/vagrant_xenial_gui/Vagrantfile` to point to the new location). So far I am the only person to have tried it out.

The Ansible setup has been changed to install the npm package instead of the nodejs package. This is because npm depends on nodejs, but nodejs does not depend on npm (I believe npm used to be included in the nodejs package). What we really need to install is npm, because we intend to use it to install n, which in turn will install Node.js.

I've also updated the local Linux setup instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/303)
<!-- Reviewable:end -->
