### PR TITLE
Fix SF header background color, broken in 724a2db

### DIFF
--- a/src/Site/views/scriptureforge/theme/default/sass/_global.scss
+++ b/src/Site/views/scriptureforge/theme/default/sass/_global.scss
@@ -2,6 +2,10 @@
 @import '../../../../../../../node_modules/bootstrap/scss/variables';
 @import '../../../../../../../node_modules/bootstrap/scss/mixins';
 
+.fixed-nav-bar {
+  background-color: $theme-primary;
+}
+
 .breadcrumb {
   background-color: #fff;
   padding: 6px 0 0;


### PR DESCRIPTION
Unfortunately when shuffling the Sass around I dropped the background color on the SF header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/306)
<!-- Reviewable:end -->
