### PR TITLE
Interface language: handle no-recent-project case

### DIFF
--- a/src/angular-app/bellows/core/navbar.controller.ts
+++ b/src/angular-app/bellows/core/navbar.controller.ts
@@ -27,7 +27,7 @@ export class NavbarController implements angular.IController {
     this.projectTypesBySite = this.projectService.data.projectTypesBySite;
     this.header = this.applicationHeaderService.data;
     this.sessionService.getSession().then(session => {
-      this.interfaceConfig = session.projectSettings<LexiconProjectSettings>().interfaceConfig ||
+      var defaultInterfaceConfig =
         {
           direction: 'ltr',
           pullNormal: 'float-left',
@@ -41,6 +41,12 @@ export class NavbarController implements angular.IController {
             options: { en: { name: 'English', option: 'English' } }
           }
         } as InterfaceConfig;
+      var projectSettings = session.projectSettings<LexiconProjectSettings>();
+      if (projectSettings == null || projectSettings.interfaceConfig == null) {
+        this.interfaceConfig = defaultInterfaceConfig;
+      } else {
+        this.interfaceConfig = projectSettings.interfaceConfig;
+      }
       this.rights.canCreateProject =
         session.hasSiteRight(this.sessionService.domain.PROJECTS, this.sessionService.operation.CREATE);
       this.siteName = session.baseSite();

--- a/src/angular-app/bellows/core/navbar.controller.ts
+++ b/src/angular-app/bellows/core/navbar.controller.ts
@@ -27,7 +27,7 @@ export class NavbarController implements angular.IController {
     this.projectTypesBySite = this.projectService.data.projectTypesBySite;
     this.header = this.applicationHeaderService.data;
     this.sessionService.getSession().then(session => {
-      var defaultInterfaceConfig =
+      const defaultInterfaceConfig =
         {
           direction: 'ltr',
           pullNormal: 'float-left',
@@ -41,7 +41,7 @@ export class NavbarController implements angular.IController {
             options: { en: { name: 'English', option: 'English' } }
           }
         } as InterfaceConfig;
-      var projectSettings = session.projectSettings<LexiconProjectSettings>();
+      const projectSettings = session.projectSettings<LexiconProjectSettings>();
       if (projectSettings == null || projectSettings.interfaceConfig == null) {
         this.interfaceConfig = defaultInterfaceConfig;
       } else {

--- a/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
@@ -157,13 +157,12 @@ export class LexiconAppController implements angular.IController {
 
   private onFetchTransifexLanguages = (languages: TransifexLanguage[]) => {
     for (const language of languages) {
-      if (language.code in this.interfaceConfig.selectLanguages.options) {
-        this.interfaceConfig.selectLanguages.options[language.code].name = language.name;
-      } else {
-        this.interfaceConfig.selectLanguages.options[language.code].name = language.name;
-        this.interfaceConfig.selectLanguages.options[language.code].option = language.name;
+      if (!(language.code in this.interfaceConfig.selectLanguages.options)) {
         this.interfaceConfig.selectLanguages.optionsOrder.push(language.code);
       }
+
+      this.interfaceConfig.selectLanguages.options[language.code].name = language.name;
+      this.interfaceConfig.selectLanguages.options[language.code].option = language.name;
     }
   }
 


### PR DESCRIPTION
If the session doesn't contain a `.projectSettings` property, we should still present a languages menu, even if it's just a default one.

All E2E tests that were passing before this PR are still passing. (8 tests are failing on master as of when I'm submitting this, and this PR doesn't fix them).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/307)
<!-- Reviewable:end -->
