### PR TITLE
Retaining new empty entry while refresh in screen

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -29,7 +29,7 @@
                                                search="$ctrl.typeahead.searchEntries" select="$ctrl.typeahead.searchSelect">
                                     <ul data-ng-if="$ctrl.typeahead.searchResults.length > 0" class="list-group">
                                         <li data-typeahead-item="e" class="typeahead-item list-group-item"
-                                            data-ng-repeat="e in $ctrl.typeahead.searchResults | limitTo: $ctrl.typeahead.limit">
+                                            data-ng-repeat="e in $ctrl.typeahead.searchResults track by $index | limitTo: $ctrl.typeahead.limit">
                                             <div class="listItemPrimary" data-ng-bind-html="$ctrl.getPrimaryListItemForDisplay($ctrl.lecConfig, e)"></div>
                                             <small class="listItemSecondary" data-ng-bind-html="$ctrl.getMeaningForDisplay(e)"></small>
                                         </li>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -218,6 +218,11 @@ export class LexiconEditorController implements angular.IController {
               }
             }
             this.cancelAutoSaveTimer();
+            if (this.currentEntryIsDirty()) {
+              if (newValue.lexeme.en.value) {
+                this.startAutoSaveTimer();
+              }
+            }
           }
         }, true);
       }

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -1,5 +1,6 @@
 import * as angular from 'angular';
 
+import {Object} from 'core-js';
 import {ActivityService} from '../../../bellows/core/api/activity.service';
 import {ApplicationHeaderService} from '../../../bellows/core/application-header.service';
 import {ModalService} from '../../../bellows/core/modal/modal.service';
@@ -219,9 +220,10 @@ export class LexiconEditorController implements angular.IController {
             }
             this.cancelAutoSaveTimer();
             if (this.currentEntryIsDirty()) {
-              if (newValue.lexeme.en.value) {
-                this.startAutoSaveTimer();
-              }
+              let lexemeValue = Object.values(newValue.lexeme);
+              if (lexemeValue[0].value !== '') {
+                  this.startAutoSaveTimer();
+               }
             }
           }
         }, true);


### PR DESCRIPTION
In Editor Entry Screen, When New Entry is not saved, Data is retaining while refreshing the browser.

Restricted the duplicate new entry.

Data is retaining in local storage, once it is saved local storage will be cleared.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/308)
<!-- Reviewable:end -->
