### PR TITLE
Fix blank entry in SF reports select tag

### DIFF
--- a/src/angular-app/bellows/directive/pui-run-report.js
+++ b/src/angular-app/bellows/directive/pui-run-report.js
@@ -10,7 +10,7 @@ angular.module('palaso.ui.runReport', ['coreModule'])
         function ($scope, projectService) {
           $scope.report = {
             output: '',
-            currentId: ''
+            currentId: null
           };
           $scope.reportOutput = '';
 


### PR DESCRIPTION
This is somewhat unintuitive. The original code looks more "correct." However, it appears that AngularJS maps null/undefined in the model to an empty string value in the select tag. I'm guessing this is because it needs a concept of the selection value being null. 

This isn't clearly documented, but the examples in [the documentation](https://docs.angularjs.org/api/ng/directive/ngOptions) don't define the property in the scope, making it undefined by default.

Before | After
---------|-------
![sf_select_before](https://user-images.githubusercontent.com/6140710/41927742-aac1a3ea-7938-11e8-902d-35c4579cbcc8.png) | ![sf_select_after](https://user-images.githubusercontent.com/6140710/41927780-c193fb7c-7938-11e8-94c9-42d8c4094796.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/311)
<!-- Reviewable:end -->
