### PR TITLE
Add activity log for more comment activity

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexCommentCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexCommentCommands.php
@@ -149,6 +149,11 @@ class LexCommentCommands
                 throw new \Exception("No permission to delete other people's comments!");
             }
         }
+        $entryRef = '';
+        if (! is_null($comment->entryRef)) {
+            $entryRef = $comment->entryRef->asString();
+        }
+        ActivityCommands::deleteCommentOnEntry($project, $entryRef, $comment, $userId);
         return LexCommentModel::remove($project, $commentId);
     }
 
@@ -176,6 +181,11 @@ class LexCommentCommands
                 throw new \Exception("No permission to delete other people's comment replies!");
             }
         }
+        $entryRef = '';
+        if (! is_null($comment->entryRef)) {
+            $entryRef = $comment->entryRef->asString();
+        }
+        ActivityCommands::deleteReplyToEntryComment($project, $entryRef, $comment, $reply, $userId);
         $comment->deleteReply($replyId);
         return $comment->write();
     }

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
@@ -135,7 +135,7 @@ class LexEntryCommands
             $differences = $oldEntry->calculateDifferences($entry);
             $differences = static::addFieldLabelsToDifferences($project->config, $differences);
         } else {
-            $differences = null;
+            $differences = null; // TODO: Do we want differences even on a brand-new, added, entry?
         }
 
         $entry->write();

--- a/src/Api/Model/Shared/ActivityModel.php
+++ b/src/Api/Model/Shared/ActivityModel.php
@@ -28,9 +28,11 @@ class ActivityModel extends MapperModel
     const DELETE_ENTRY = 'delete_entry';
     const ADD_LEX_COMMENT = 'add_lex_comment';
     const UPDATE_LEX_COMMENT = 'update_lex_comment';
+    const DELETE_LEX_COMMENT = 'delete_lex_comment';
     const UPDATE_LEX_COMMENT_STATUS = 'update_lex_comment_status';
     const ADD_LEX_REPLY = 'add_lex_reply';
     const UPDATE_LEX_REPLY = 'update_lex_reply';
+    const DELETE_LEX_REPLY = 'delete_lex_reply';
 
     // content types for use with the addContent method
     const PROJECT = 'project';
@@ -46,6 +48,9 @@ class ActivityModel extends MapperModel
     const LEX_COMMENT_INCREASE_SCORE = 'lexCommentIncreaseScore';
     const LEX_COMMENT_DECREASE_SCORE = 'lexCommentDecreaseScore';
     const LEX_REPLY = 'lexReply';
+    // USER and USER2 usage: USER is the one doing the current activity. USER2, if present, is the one whose previous activity is being acted on.
+    // E.g., when replying to someone else's comment on a lexical entry, USER2 is the one who made the original comment, and USER is the one making the reply.
+    // TODO: Fix this in ActivityCommands::updateReplyToEntryComment, then remove this TODO line
     const USER = 'user';
     const USER2 = 'user2';
     const ENTRY = 'entry';

--- a/src/Api/Model/Shared/Command/ActivityCommands.php
+++ b/src/Api/Model/Shared/Command/ActivityCommands.php
@@ -369,6 +369,7 @@ class ActivityCommands
         $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
         $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
         $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $activity->addContent(ActivityModel::LEX_COMMENT_FIELD_VALUE, $commentModel->regarding->fieldValue);
         $activity->addContent(ActivityModel::LEX_COMMENT_STATUS, $commentModel->status);
         $label = self::prepareActivityLabel($commentModel->contextGuid, $commentModel->regarding->fieldNameForDisplay, $entry);
         if (! empty($label)) {
@@ -403,6 +404,7 @@ class ActivityCommands
         $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
         $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
         $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $activity->addContent(ActivityModel::LEX_COMMENT_FIELD_VALUE, $commentModel->regarding->fieldValue);
         $label = self::prepareActivityLabel($commentModel->contextGuid, $commentModel->regarding->fieldNameForDisplay, $entry);
         if (! empty($label)) {
             $activity->addContent(ActivityModel::LEX_COMMENT_LABEL, $label);
@@ -450,6 +452,7 @@ class ActivityCommands
         $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
         $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
         $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $activity->addContent(ActivityModel::LEX_COMMENT_FIELD_VALUE, $commentModel->regarding->fieldValue);
         $activity->addContent(ActivityModel::LEX_REPLY, $replyModel->content);
         $label = self::prepareActivityLabel($commentModel->contextGuid, $commentModel->regarding->fieldNameForDisplay, $entry);
         if (! empty($label)) {
@@ -489,6 +492,7 @@ class ActivityCommands
         $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
         $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
         $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $activity->addContent(ActivityModel::LEX_COMMENT_FIELD_VALUE, $commentModel->regarding->fieldValue);
         $activity->addContent(ActivityModel::LEX_REPLY, $replyModel->content);
         $label = self::prepareActivityLabel($commentModel->contextGuid, $commentModel->regarding->fieldNameForDisplay, $entry);
         if (! empty($label)) {

--- a/src/Api/Model/Shared/Command/ActivityCommands.php
+++ b/src/Api/Model/Shared/Command/ActivityCommands.php
@@ -307,6 +307,41 @@ class ActivityCommands
      * @param ProjectModel $projectModel
      * @param string $entryId
      * @param LexCommentModel $commentModel
+     * @param string $userId The user who deleted the comment (usually the author, but could be project manager)
+     * @return string activity id
+     * @throws \Exception
+     */
+    public static function deleteCommentOnEntry($projectModel, $entryId, $commentModel, $userId)
+    {
+        $activity = new ActivityModel($projectModel);
+        $entry = new LexEntryModel($projectModel, $entryId);
+        $userId2 = $commentModel->authorInfo->createdByUserRef->asString();
+        $user = new UserModel($userId);
+        $user2 = new UserModel($userId2);
+        $activity->action = ActivityModel::DELETE_LEX_COMMENT;
+        $activity->userRef->id = $userId;
+        $activity->entryRef->id = $entryId;
+        $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
+        $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
+        $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $activity->addContent(ActivityModel::LEX_COMMENT_FIELD_VALUE, $commentModel->regarding->fieldValue);
+        $label = self::prepareActivityLabel($commentModel->contextGuid, $commentModel->regarding->fieldNameForDisplay, $entry);
+        if (! empty($label)) {
+            $activity->addContent(ActivityModel::LEX_COMMENT_LABEL, $label);
+        }
+        $activity->addContent(ActivityModel::USER, $user->username);
+        $activity->addContent(ActivityModel::USER2, $user2->username);
+        $activityId = $activity->write();
+        UnreadActivityModel::markUnreadForProjectMembers($activityId, $projectModel);
+        UnreadLexCommentModel::markUnreadForProjectMembers($commentModel->id->asString(), $projectModel, $entryId, $userId);
+
+        return $activityId;
+    }
+
+    /**
+     * @param ProjectModel $projectModel
+     * @param string $entryId
+     * @param LexCommentModel $commentModel
      * @return string activity id
      * @throws \Exception
      */
@@ -335,6 +370,10 @@ class ActivityCommands
         $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
         $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
         $activity->addContent(ActivityModel::LEX_COMMENT_STATUS, $commentModel->status);
+        $label = self::prepareActivityLabel($commentModel->contextGuid, $commentModel->regarding->fieldNameForDisplay, $entry);
+        if (! empty($label)) {
+            $activity->addContent(ActivityModel::LEX_COMMENT_LABEL, $label);
+        }
         $activity->addContent(ActivityModel::USER, $user->username);
         $activityId = $activity->write();
         UnreadActivityModel::markUnreadForProjectMembers($activityId, $projectModel);
@@ -364,6 +403,10 @@ class ActivityCommands
         $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
         $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
         $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $label = self::prepareActivityLabel($commentModel->contextGuid, $commentModel->regarding->fieldNameForDisplay, $entry);
+        if (! empty($label)) {
+            $activity->addContent(ActivityModel::LEX_COMMENT_LABEL, $label);
+        }
         $activity->addContent(ActivityModel::USER, $user->username);
         $activityId = $activity->write();
         UnreadActivityModel::markUnreadForProjectMembers($activityId, $projectModel);
@@ -393,6 +436,9 @@ class ActivityCommands
         } else {
             $user2Id = $replyModel->authorInfo->createdByUserRef->asString();
         }
+        // TODO: Swap "user" and "user2" here (will need a migration).
+        // "User" should always be the one doing the current activity, and "user2" the one whose previous activity is being responded to.
+
         $user = new UserModel($userId);
         $user2 = new UserModel($user2Id);
         $activity = new ActivityModel($projectModel);
@@ -405,6 +451,49 @@ class ActivityCommands
         $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
         $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
         $activity->addContent(ActivityModel::LEX_REPLY, $replyModel->content);
+        $label = self::prepareActivityLabel($commentModel->contextGuid, $commentModel->regarding->fieldNameForDisplay, $entry);
+        if (! empty($label)) {
+            $activity->addContent(ActivityModel::LEX_COMMENT_LABEL, $label);
+        }
+        $activity->addContent(ActivityModel::USER, $user->username);
+        $activity->addContent(ActivityModel::USER2, $user2->username);
+        $activityId = $activity->write();
+        UnreadActivityModel::markUnreadForProjectMembers($activityId, $projectModel);
+        // Disabling the "mark replies as unread" feature until "unread items" system is revamped. - RM 2018-03
+        // (Can't mark things unread unless they have a MongoID, and LexCommentReplies just have a PHP "uniqid". But changing that would have knock-on effects in LfMerge.)
+        // UnreadLexReplyModel::markUnreadForProjectMembers($replyModel->id, $projectModel, $entryId, $userId);
+
+        return $activityId;
+    }
+
+    /**
+     * @param ProjectModel $projectModel
+     * @param string $entryId
+     * @param LexCommentModel $commentModel
+     * @param LexCommentReply $replyModel
+     * @param string $userId The user who deleted the reply (usually the author, but could be project manager)
+     * @return string activity id
+     * @throws \Exception
+     */
+    public static function deleteReplyToEntryComment($projectModel, $entryId, $commentModel, $replyModel, $userId)
+    {
+        $user2Id = $commentModel->authorInfo->createdByUserRef->asString();
+        $user = new UserModel($userId);
+        $user2 = new UserModel($user2Id);
+        $activity = new ActivityModel($projectModel);
+        $activity->action = ActivityModel::DELETE_LEX_REPLY;
+        $activity->userRef->id = $userId;
+        $activity->userRef2->id = $user2Id;
+        $activity->entryRef->id = $entryId;
+        $entry = new LexEntryModel($projectModel, $entryId);
+        $activity->addContent(ActivityModel::ENTRY, $entry->nameForActivityLog());
+        $activity->addContent(ActivityModel::LEX_COMMENT, $commentModel->content);
+        $activity->addContent(ActivityModel::LEX_COMMENT_CONTEXT, $commentModel->contextGuid);
+        $activity->addContent(ActivityModel::LEX_REPLY, $replyModel->content);
+        $label = self::prepareActivityLabel($commentModel->contextGuid, $commentModel->regarding->fieldNameForDisplay, $entry);
+        if (! empty($label)) {
+            $activity->addContent(ActivityModel::LEX_COMMENT_LABEL, $label);
+        }
         $activity->addContent(ActivityModel::USER, $user->username);
         $activity->addContent(ActivityModel::USER2, $user2->username);
         $activityId = $activity->write();

--- a/src/Api/Model/Shared/Dto/ActivityListDto.php
+++ b/src/Api/Model/Shared/Dto/ActivityListDto.php
@@ -258,10 +258,18 @@ class ActivityListDto
             $item['type'] = 'project';  // FIXME: Should this always be "project"? Should it sometimes be "entry"? 2018-02 RM
             unset($item['actionContent']);
             if ($projectModel->appName === LfProjectModel::LEXICON_APP) {
-                if ($item['action'] === ActivityModel::UPDATE_ENTRY) {
+                if ($item['action'] === ActivityModel::UPDATE_ENTRY || $item['action'] === ActivityModel::ADD_ENTRY) {
                     $lexProjectModel = new LexProjectModel($projectModel->id->asString());
                     $item['content'] = static::prepareActivityContentForEntryDifferences($item, $lexProjectModel);
-                } else if ($item['action'] === ActivityModel::ADD_LEX_COMMENT || $item['action'] === ActivityModel::UPDATE_LEX_COMMENT) {
+                } else if ($item['action'] === ActivityModel::ADD_LEX_COMMENT ||
+                           $item['action'] === ActivityModel::UPDATE_LEX_COMMENT ||
+                           $item['action'] === ActivityModel::DELETE_LEX_COMMENT ||
+                           $item['action'] === ActivityModel::UPDATE_LEX_COMMENT_STATUS ||
+                           $item['action'] === ActivityModel::LEX_COMMENT_INCREASE_SCORE ||
+                           $item['action'] === ActivityModel::LEX_COMMENT_DECREASE_SCORE ||
+                           $item['action'] === ActivityModel::ADD_LEX_REPLY ||
+                           $item['action'] === ActivityModel::UPDATE_LEX_REPLY ||
+                           $item['action'] === ActivityModel::DELETE_LEX_REPLY) {
                     $labelFromMongo = $item['content'][ActivityModel::LEX_COMMENT_LABEL] ?? '';
                     unset($item['content'][ActivityModel::LEX_COMMENT_LABEL]);
                     if (! empty($labelFromMongo)) {

--- a/test/php/model/shared/commands/ActivityCommandsTest.php
+++ b/test/php/model/shared/commands/ActivityCommandsTest.php
@@ -1,9 +1,15 @@
 <?php
 
+use Api\Model\Languageforge\Lexicon\Command\LexCommentCommands;
+use Api\Model\Languageforge\Lexicon\Command\LexEntryCommands;
+use Api\Model\Languageforge\Lexicon\LexEntryModel;
+use Api\Model\Languageforge\Lexicon\LexExample;
+use Api\Model\Languageforge\Lexicon\LexSense;
 use Api\Model\Scriptureforge\Sfchecks\AnswerModel;
 use Api\Model\Scriptureforge\Sfchecks\QuestionModel;
 use Api\Model\Scriptureforge\Sfchecks\SfchecksProjectModel;
 use Api\Model\Scriptureforge\Sfchecks\TextModel;
+use Api\Model\Shared\ActivityModel;
 use Api\Model\Shared\Command\ActivityCommands;
 use Api\Model\Shared\CommentModel;
 use Api\Model\Shared\Dto\ActivityListDto;

--- a/test/php/model/shared/commands/ActivityCommandsTest.php
+++ b/test/php/model/shared/commands/ActivityCommandsTest.php
@@ -1,15 +1,9 @@
 <?php
 
-use Api\Model\Languageforge\Lexicon\Command\LexCommentCommands;
-use Api\Model\Languageforge\Lexicon\Command\LexEntryCommands;
-use Api\Model\Languageforge\Lexicon\LexEntryModel;
-use Api\Model\Languageforge\Lexicon\LexExample;
-use Api\Model\Languageforge\Lexicon\LexSense;
 use Api\Model\Scriptureforge\Sfchecks\AnswerModel;
 use Api\Model\Scriptureforge\Sfchecks\QuestionModel;
 use Api\Model\Scriptureforge\Sfchecks\SfchecksProjectModel;
 use Api\Model\Scriptureforge\Sfchecks\TextModel;
-use Api\Model\Shared\ActivityModel;
 use Api\Model\Shared\Command\ActivityCommands;
 use Api\Model\Shared\CommentModel;
 use Api\Model\Shared\Dto\ActivityListDto;

--- a/test/php/model/shared/dto/ActivityListDtoTest.php
+++ b/test/php/model/shared/dto/ActivityListDtoTest.php
@@ -660,13 +660,14 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals(ActivityModel::ADD_LEX_COMMENT, $activityRecord['action']);
         // "Content" field should contain human-readable strings for use in activity log
         $this->assertArrayHasKey('content', $activityRecord);
-        $content = $activityRecord['content'];
-        $this->assertEquals(SF_TESTPROJECT, $content['project']);
-        $this->assertEquals('user1', $content['user']);
-        $this->assertEquals($data['content'], $content[ActivityModel::LEX_COMMENT]);
-        $this->assertEquals($data['contextGuid'], $content[ActivityModel::LEX_COMMENT_CONTEXT]);
-        $this->assertEquals($data['regarding']['fieldValue'], $content[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
-        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $content['fieldLabel']);
+        $actual = $activityRecord['content'];
+        $expected = $data;
+        $this->assertEquals(SF_TESTPROJECT, $actual['project']);
+        $this->assertEquals('user1', $actual['user']);
+        $this->assertEquals($expected['content'], $actual[ActivityModel::LEX_COMMENT]);
+        $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
+        $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
+        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
         $environ->clean();
     }
 
@@ -735,13 +736,14 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($entryId, $activityRecord['entryRef']);
         // "Content" field should contain human-readable strings for use in activity log
         $this->assertArrayHasKey('content', $activityRecord);
-        $content = $activityRecord['content'];
-        $this->assertEquals(SF_TESTPROJECT, $content['project']);
-        $this->assertEquals('user1', $content['user']);
-        $this->assertEquals($data['content'], $content[ActivityModel::LEX_COMMENT]);
-        $this->assertEquals($data['contextGuid'], $content[ActivityModel::LEX_COMMENT_CONTEXT]);
-        $this->assertEquals($data['regarding']['fieldValue'], $content[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
-        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $content['fieldLabel']);
+        $actual = $activityRecord['content'];
+        $expected = $data;
+        $this->assertEquals(SF_TESTPROJECT, $actual['project']);
+        $this->assertEquals('user1', $actual['user']);
+        $this->assertEquals($expected['content'], $actual[ActivityModel::LEX_COMMENT]);
+        $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
+        $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
+        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
         $environ->clean();
     }
 
@@ -810,14 +812,15 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($entryId, $activityRecord['entryRef']);
         // "Content" field should contain human-readable strings for use in activity log
         $this->assertArrayHasKey('content', $activityRecord);
-        $content = $activityRecord['content'];
-        $this->assertEquals(SF_TESTPROJECT, $content['project']);
-        $this->assertEquals('user1', $content['user']);
-        $this->assertEquals($data['content'], $content[ActivityModel::LEX_COMMENT]);
-        $this->assertEquals($data['contextGuid'], $content[ActivityModel::LEX_COMMENT_CONTEXT]);
-        $this->assertEquals(LexCommentModel::STATUS_TODO, $content[ActivityModel::LEX_COMMENT_STATUS]);
-        $this->assertEquals($data['regarding']['fieldValue'], $content[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
-        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $content['fieldLabel']);
+        $actual = $activityRecord['content'];
+        $expected = $data;
+        $this->assertEquals(SF_TESTPROJECT, $actual['project']);
+        $this->assertEquals('user1', $actual['user']);
+        $this->assertEquals($expected['content'], $actual[ActivityModel::LEX_COMMENT]);
+        $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
+        $this->assertEquals(LexCommentModel::STATUS_TODO, $actual[ActivityModel::LEX_COMMENT_STATUS]);
+        $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
+        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
         $environ->clean();
     }
 
@@ -886,13 +889,14 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($entryId, $activityRecord['entryRef']);
         // "Content" field should contain human-readable strings for use in activity log
         $this->assertArrayHasKey('content', $activityRecord);
-        $content = $activityRecord['content'];
-        $this->assertEquals(SF_TESTPROJECT, $content['project']);
-        $this->assertEquals('user1', $content['user']);
-        $this->assertEquals($data['content'], $content[ActivityModel::LEX_COMMENT]);
-        $this->assertEquals($data['contextGuid'], $content[ActivityModel::LEX_COMMENT_CONTEXT]);
-        $this->assertEquals($data['regarding']['fieldValue'], $content[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
-        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $content['fieldLabel']);
+        $actual = $activityRecord['content'];
+        $expected = $data;
+        $this->assertEquals(SF_TESTPROJECT, $actual['project']);
+        $this->assertEquals('user1', $actual['user']);
+        $this->assertEquals($expected['content'], $actual[ActivityModel::LEX_COMMENT]);
+        $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
+        $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
+        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
         $environ->clean();
     }
 
@@ -966,14 +970,16 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($entryId, $activityRecord['entryRef']);
         // "Content" field should contain human-readable strings for use in activity log
         $this->assertArrayHasKey('content', $activityRecord);
-        $content = $activityRecord['content'];
-        $this->assertEquals(SF_TESTPROJECT, $content['project']);
-        $this->assertEquals('user1', $content['user']);
-        $this->assertEquals($data['content'], $content[ActivityModel::LEX_COMMENT]);
-        $this->assertEquals($replyData['content'], $content[ActivityModel::LEX_REPLY]);
-        $this->assertEquals($data['contextGuid'], $content[ActivityModel::LEX_COMMENT_CONTEXT]);
-        $this->assertEquals($data['regarding']['fieldValue'], $content[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
-        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $content['fieldLabel']);
+        $actual = $activityRecord['content'];
+        $expected = $data;
+        $expected['replyContent'] = $replyData['content'];
+        $this->assertEquals(SF_TESTPROJECT, $actual['project']);
+        $this->assertEquals('user1', $actual['user']);
+        $this->assertEquals($expected['content'], $actual[ActivityModel::LEX_COMMENT]);
+        $this->assertEquals($expected['replyContent'], $actual[ActivityModel::LEX_REPLY]);
+        $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
+        $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
+        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
         $environ->clean();
     }
 
@@ -1054,14 +1060,16 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($entryId, $activityRecord['entryRef']);
         // "Content" field should contain human-readable strings for use in activity log
         $this->assertArrayHasKey('content', $activityRecord);
-        $content = $activityRecord['content'];
-        $this->assertEquals(SF_TESTPROJECT, $content['project']);
-        $this->assertEquals('user1', $content['user']);
-        $this->assertEquals($data['content'], $content[ActivityModel::LEX_COMMENT]);
-        $this->assertEquals($updatedReplyData['content'], $content[ActivityModel::LEX_REPLY]);
-        $this->assertEquals($data['contextGuid'], $content[ActivityModel::LEX_COMMENT_CONTEXT]);
-        $this->assertEquals($data['regarding']['fieldValue'], $content[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
-        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $content['fieldLabel']);
+        $actual = $activityRecord['content'];
+        $expected = $data;
+        $expected['replyContent'] = $updatedReplyData['content'];
+        $this->assertEquals(SF_TESTPROJECT, $actual['project']);
+        $this->assertEquals('user1', $actual['user']);
+        $this->assertEquals($expected['content'], $actual[ActivityModel::LEX_COMMENT]);
+        $this->assertEquals($expected['replyContent'], $actual[ActivityModel::LEX_REPLY]);
+        $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
+        $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
+        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
         $environ->clean();
     }
 
@@ -1136,13 +1144,15 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($entryId, $activityRecord['entryRef']);
         // "Content" field should contain human-readable strings for use in activity log
         $this->assertArrayHasKey('content', $activityRecord);
-        $content = $activityRecord['content'];
-        $this->assertEquals(SF_TESTPROJECT, $content['project']);
-        $this->assertEquals('user1', $content['user']);
-        $this->assertEquals($data['content'], $content[ActivityModel::LEX_COMMENT]);
-        $this->assertEquals($replyData['content'], $content[ActivityModel::LEX_REPLY]);
-        $this->assertEquals($data['contextGuid'], $content[ActivityModel::LEX_COMMENT_CONTEXT]);
-        $this->assertEquals($data['regarding']['fieldValue'], $content[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
-        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $content['fieldLabel']);
+        $actual = $activityRecord['content'];
+        $expected = $data;
+        $expected['replyContent'] = $replyData['content'];
+        $this->assertEquals(SF_TESTPROJECT, $actual['project']);
+        $this->assertEquals('user1', $actual['user']);
+        $this->assertEquals($expected['content'], $actual[ActivityModel::LEX_COMMENT]);
+        $this->assertEquals($expected['replyContent'], $actual[ActivityModel::LEX_REPLY]);
+        $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
+        $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
+        $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
     }
 }

--- a/test/php/model/shared/dto/ActivityListDtoTest.php
+++ b/test/php/model/shared/dto/ActivityListDtoTest.php
@@ -652,7 +652,7 @@ class ActivityListDtoTest extends TestCase
 
         $dto = ActivityListDto::getActivityForUser($project->siteName, $userId);
         $activity = $dto['activity'];
-        $this->assertEquals(1, count($activity));
+        $this->assertCount(1, $activity);
         $activityRecord = array_shift($activity);
         $this->assertEquals($projectId, $activityRecord['projectRef']['id']);
         $this->assertEquals(LfProjectModel::LEXICON_APP, $activityRecord['projectRef']['type']);
@@ -668,7 +668,6 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
         $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
         $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
-        $environ->clean();
     }
 
     public function testGetActivityForUser_PlusOneEntryComment_DtoAsExpected()
@@ -744,7 +743,6 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
         $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
         $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
-        $environ->clean();
     }
 
     public function testGetActivityForUser_UpdateEntryCommentStatus_DtoAsExpected()
@@ -821,7 +819,6 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals(LexCommentModel::STATUS_TODO, $actual[ActivityModel::LEX_COMMENT_STATUS]);
         $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
         $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
-        $environ->clean();
     }
 
     public function testGetActivityForUser_DeleteEntryComment_DtoAsExpected()
@@ -897,7 +894,6 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
         $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
         $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
-        $environ->clean();
     }
 
     public function testGetActivityForUser_AddReplyToEntryComment_DtoAsExpected()
@@ -980,7 +976,6 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
         $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
         $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
-        $environ->clean();
     }
 
     public function testGetActivityForUser_UpdateReplyToEntryComment_DtoAsExpected()
@@ -1070,7 +1065,6 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($expected['contextGuid'], $actual[ActivityModel::LEX_COMMENT_CONTEXT]);
         $this->assertEquals($expected['regarding']['fieldValue'], $actual[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
         $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $actual['fieldLabel']);
-        $environ->clean();
     }
 
     public function testGetActivityForUser_DeleteReplyToEntryComment_DtoAsExpected()

--- a/test/php/model/shared/dto/ActivityListDtoTest.php
+++ b/test/php/model/shared/dto/ActivityListDtoTest.php
@@ -121,8 +121,6 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($project2->projectName, $dto[$a2]['content']['project']);
         $this->assertEquals($text2Id, $dto[$a2]['textRef']);
         $this->assertEquals($text2->title, $dto[$a2]['content']['text']);
-
-        $environ->clean();
     }
 
     public function testGetActivityForUser_TwoProjectsTwoDomains_DtoHasOneProject()
@@ -199,7 +197,7 @@ class ActivityListDtoTest extends TestCase
 
         $dto = ActivityListDto::getActivityForUser($project1->siteName, $userId);
 
-        $this->assertEquals(1, count($dto['unread']));
+        $this->assertCount(1, $dto['unread']);
     }
 
     public function testGetActivityForProject_ProjectWithTextQuestionAnswerAndComments_DtoAsExpected()
@@ -431,7 +429,7 @@ class ActivityListDtoTest extends TestCase
 
         $dto = ActivityListDto::getActivityForUser($project->siteName, $userId);
         $activity = $dto['activity'];
-        $this->assertEquals(1, count($activity));
+        $this->assertCount(1, $activity);
         $activityRecord = array_shift($activity);
         $this->assertEquals($projectId, $activityRecord['projectRef']['id']);
         $this->assertEquals(LfProjectModel::LEXICON_APP, $activityRecord['projectRef']['type']);
@@ -472,8 +470,6 @@ class ActivityListDtoTest extends TestCase
             'oldValue' => '',
             'newValue' => '',
         ], $changes);
-
-        $environ->clean();
     }
 
     public function testGetActivityForUser_AddExample_DtoAsExpected()
@@ -513,7 +509,7 @@ class ActivityListDtoTest extends TestCase
 
         $dto = ActivityListDto::getActivityForUser($project->siteName, $userId);
         $activity = $dto['activity'];
-        $this->assertEquals(1, count($activity));
+        $this->assertCount(1, $activity);
         $activityRecord = array_shift($activity);
         $this->assertEquals($projectId, $activityRecord['projectRef']['id']);
         $this->assertEquals(LfProjectModel::LEXICON_APP, $activityRecord['projectRef']['type']);
@@ -527,7 +523,7 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals('user1', $content['user']);
         $this->assertArrayHasKey('changes', $content);
         $changes = $content['changes'];
-        $this->assertEquals(2, count($changes));
+        $this->assertCount(2, $changes);
         $change = $changes[0];
 
         $this->assertEquals(ActivityListDto::ADDED_FIELD, $change['changeType']);
@@ -538,8 +534,6 @@ class ActivityListDtoTest extends TestCase
         $this->assertArrayNotHasKey('inputSystemTag', $change);
         $this->assertEquals('', $change['oldValue']);
         $this->assertEquals('', $change['newValue']);
-
-        $environ->clean();
     }
 
     public function testGetActivityForUser_AddExampleSentence_DtoAsExpected()
@@ -580,7 +574,7 @@ class ActivityListDtoTest extends TestCase
 
         $dto = ActivityListDto::getActivityForUser($project->siteName, $userId);
         $activity = $dto['activity'];
-        $this->assertEquals(1, count($activity));
+        $this->assertCount(1, $activity);
         $activityRecord = array_shift($activity);
         $this->assertEquals($projectId, $activityRecord['projectRef']['id']);
         $this->assertEquals(LfProjectModel::LEXICON_APP, $activityRecord['projectRef']['type']);
@@ -594,7 +588,7 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals('user1', $content['user']);
         $this->assertArrayHasKey('changes', $content);
         $changes = $content['changes'];
-        $this->assertEquals(1, count($changes));
+        $this->assertCount(1, $changes);
         $change = $changes[0];
 
         $this->assertEquals(ActivityListDto::EDITED_FIELD, $change['changeType']);
@@ -605,8 +599,6 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals('fr', $change['inputSystemTag']);
         $this->assertEquals('', $change['oldValue']);
         $this->assertEquals('manger une pomme', $change['newValue']);
-
-        $environ->clean();
     }
 
     public function testGetActivityForUser_AddEntryComment_DtoAsExpected()
@@ -1152,6 +1144,5 @@ class ActivityListDtoTest extends TestCase
         $this->assertEquals($data['contextGuid'], $content[ActivityModel::LEX_COMMENT_CONTEXT]);
         $this->assertEquals($data['regarding']['fieldValue'], $content[ActivityModel::LEX_COMMENT_FIELD_VALUE]);
         $this->assertEquals(['label' => 'Sentence', 'sense' => 2, 'example' => 1], $content['fieldLabel']);
-        $environ->clean();
     }
 }


### PR DESCRIPTION
This adds activity log entries for:
* Comment likes
* Status changes (todo / resolved / open) on comments
* Replies to comments
* Editing comments or replies
* Deleting comments or replies

Also add comments explaining proper usage of USER and USER2 fields in activity log. One activity type will need to be updated (it currently uses USER and USER2 the wrong way around), which will require a data migration once this goes live. This PR intentionally does not include that change or the data migration script, which will be submitted in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/316)
<!-- Reviewable:end -->
