### PR TITLE
Transifex language picker working for Bellows apps

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Dto/LexBaseViewDto.php
+++ b/src/Api/Model/Languageforge/Lexicon/Dto/LexBaseViewDto.php
@@ -27,7 +27,7 @@ class LexBaseViewDto
 
         $interfaceLanguageCode = $project->interfaceLanguageCode;
         $isUserLanguageCode = false;
-        if ($user->interfaceLanguageCode) {
+        if ($user->interfaceLanguageCode && $user->interfaceLanguageCode != $project->interfaceLanguageCode) {
             $interfaceLanguageCode = $user->interfaceLanguageCode;
             $isUserLanguageCode = true;
         }
@@ -59,7 +59,7 @@ class LexBaseViewDto
                 'id' => ['name' => 'Bahasa Indonesia', 'option' => 'Bahasa Indonesia - semantic domain only', 'hasSemanticDomain' => true],
                 'my' => ['name' => 'Burmese', 'option' => 'Burmese - semantic domain only', 'hasSemanticDomain' => true],
                 'km' => ['name' => 'Central Khmer', 'option' => 'Central Khmer - semantic domain only', 'hasSemanticDomain' => true],
-                'en' => ['name' => 'English', 'option' => 'English - semantic domain only', 'hasSemanticDomain' => true],
+                'en' => ['name' => 'English', 'option' => 'English', 'hasSemanticDomain' => true],
                 'ko' => ['name' => 'Korean', 'option' => 'Korean - semantic domain only', 'hasSemanticDomain' => true],
                 'ms' => ['name' => 'Malay', 'option' => 'Malay (macrolanguage) - semantic domain only', 'hasSemanticDomain' => true],
                 'ne' => ['name' => 'Nepali', 'option' => 'Nepali (macrolanguage) - semantic domain only', 'hasSemanticDomain' => true],

--- a/src/Api/Model/Shared/Command/SessionCommands.php
+++ b/src/Api/Model/Shared/Command/SessionCommands.php
@@ -13,11 +13,11 @@ class SessionCommands
      * @param string $projectId
      * @param string $userId
      * @param Website $website
-     * @param string $appName - refers to the application being used by the user
      * @param string $mockFilename
      * @return array
+     * @throws \Exception
      */
-    public static function getSessionData($projectId, $userId, $website, $appName = '', $mockFilename = null)
+    public static function getSessionData($projectId, $userId, $website, $mockFilename = null)
     {
         $sessionData = array();
         $sessionData['baseSite'] = $website->base;
@@ -25,6 +25,25 @@ class SessionCommands
         // VERSION is not defined when running tests
         if (defined('VERSION')) {
             $sessionData['version'] = VERSION;
+        }
+
+        // ensure interfaceConfig if user is not logged in
+        // (LF only at this stage, SF using Transifex default language picker) - IJH 2018-06
+        if ($website->base == Website::LANGUAGEFORGE) {
+            $sessionData['projectSettings'] = [
+                'interfaceConfig' => [
+                    'languageCode' => 'en',
+                    'selectLanguages' => [
+                        'options' => [
+                            'en' => [
+                                'name' => 'English',
+                                'option' => 'English'
+                            ]
+                        ],
+                        'optionsOrder' => ['en']
+                    ]
+                ]
+            ];
         }
 
         if ($userId) {
@@ -49,6 +68,7 @@ class SessionCommands
                 $sessionData['project']['userIsProjectOwner'] = $project->isOwner($userId);
                 $sessionData['project']['slug'] = $project->databaseName();
                 $sessionData['project']['isArchived'] = $project->isArchived;
+                $sessionData['project']['interfaceLanguageCode'] = $project->interfaceLanguageCode;
                 $sessionData['userProjectRights'] = $project->getRightsArray($userId);
                 $sessionData['projectSettings'] = $project->getPublicSettings($userId);
             }

--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -64,15 +64,10 @@
                         </div>
                     </li>
                     {% verbatim %}
-                    <li class="nav-item notranslate" uib-dropdown>
-                        <a class="nav-link" uib-dropdown-toggle href id="languageDropdownButton" aria-haspopup="true" aria-expanded="false" data-ng-model="$ctrl.interfaceConfig.languageCode">
-                            <i class="fa fa-language"></i> <span>{{ $ctrl.interfaceConfig.selectLanguages.options[$ctrl.interfaceConfig.languageCode].name }}</span></a>
-                        <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu id="languageDropdownMenu" aria-labelledby="languageDropdown">
-                            <a class="dropdown-item" data-ng-repeat="languageCode in $ctrl.interfaceConfig.selectLanguages.optionsOrder"
-                               target="_blank" href data-ng-click="$ctrl.interfaceConfig.languageCode = languageCode"
-                               data-ng-class="{ selected: $ctrl.interfaceConfig.languageCode === languageCode }">
-                                {{ $ctrl.interfaceConfig.selectLanguages.options[languageCode].option }}</a>
-                        </div>
+                    <li class="nav-item notranslate">
+                        <pui-interface-language pui-interface-config="$ctrl.interfaceConfig"
+                                                pui-on-update="$ctrl.onUpdate($event)">
+                        </pui-interface-language>
                     </li>
                     {% endverbatim %}
                 </ul>
@@ -119,7 +114,7 @@
         </div>
 
     {% else %}
-        <div id="primary-navigation" class="logged-out">
+        <div id="primary-navigation" class="logged-out" data-ng-cloak data-ng-controller="navbarController as $ctrl">
             <nav class="fixed-nav-bar navbar navbar-expand navbar-dark align-items-stretch logged-out">
                 <span class="navbar-brand d-md-inline-block mr-auto">
                     <img class="navbar-logo" src="/Site/views/languageforge/theme/default/image/lf_logo_medium.png">
@@ -132,6 +127,13 @@
                     <li class="nav-item header-button-rounded">
                         <a class="nav-link" href="/auth/login">Login</a>
                     </li>
+                    {% verbatim %}
+                    <li class="nav-item notranslate">
+                        <pui-interface-language pui-interface-config="$ctrl.interfaceConfig"
+                                                pui-on-update="$ctrl.onUpdate($event)">
+                        </pui-interface-language>
+                    </li>
+                    {% endverbatim %}
                 </ul>
             </nav>
         </div>

--- a/src/Site/views/languageforge/theme/default/sass/_global.scss
+++ b/src/Site/views/languageforge/theme/default/sass/_global.scss
@@ -126,26 +126,31 @@
         font-weight: bold;
       }
     }
-    .nav-item.dropdown {
-      a {
+    a.nav-link.dropdown-toggle {
+      i {
+        display: none;
+      }
+      @include media-breakpoint-down(sm) {
         i {
+          display: block;
+          font-size: 20px;
+        }
+        &:after, span {
           display: none;
         }
-        @include media-breakpoint-down(sm) {
-          i {
-            display: block;
-            font-size: 20px;
-          }
-          &:after, span {
-            display: none;
-          }
+      }
+      &#helpDropdown {
+        i {
+          display: inline-block !important;
+          font-size: 16px;
+          margin-top: 2px;
         }
-        &#helpDropdown {
-          i {
-            display: inline-block !important;
-            font-size: 16px;
-            margin-top: 2px;
-          }
+      }
+      &#languageDropdownButton {
+        i {
+          display: inline-block !important;
+          font-size: 16px;
+          margin-top: 2px;
         }
       }
     }

--- a/src/angular-app/bellows/apps/public/forgot_password/forgot-password-app.module.ts
+++ b/src/angular-app/bellows/apps/public/forgot_password/forgot-password-app.module.ts
@@ -1,6 +1,11 @@
 import * as angular from 'angular';
 
+import {CoreModule} from '../../../core/core.module';
+
 export const ForgotPasswordAppModule = angular
-  .module('forgot_password', ['ui.bootstrap'])
+  .module('forgot_password', [
+    'ui.bootstrap',
+    CoreModule
+  ])
   .controller('ForgotPasswordCtrl', () => {})
   .name;

--- a/src/angular-app/bellows/apps/public/link_oauth_account/link-oauth-account-app.module.ts
+++ b/src/angular-app/bellows/apps/public/link_oauth_account/link-oauth-account-app.module.ts
@@ -1,5 +1,10 @@
 import * as angular from 'angular';
 
+import {CoreModule} from '../../../core/core.module';
+
 export const LinkOAuthAccountAppModule = angular
-  .module('link_oauth_account', ['ui.bootstrap'])
+  .module('link_oauth_account', [
+    'ui.bootstrap',
+    CoreModule
+  ])
   .name;

--- a/src/angular-app/bellows/apps/public/login/login-app.module.ts
+++ b/src/angular-app/bellows/apps/public/login/login-app.module.ts
@@ -1,6 +1,11 @@
 import * as angular from 'angular';
 
+import {CoreModule} from '../../../core/core.module';
+
 export const LoginAppModule = angular
-  .module('login', ['ui.bootstrap'])
+  .module('login', [
+    'ui.bootstrap',
+    CoreModule
+  ])
   .controller('LoginCtrl', () => {})
   .name;

--- a/src/angular-app/bellows/core/core.module.ts
+++ b/src/angular-app/bellows/core/core.module.ts
@@ -1,5 +1,6 @@
 import * as angular from 'angular';
 
+import {InterfaceLanguageModule} from '../shared/interface-language.component';
 import {ActivityService} from './api/activity.service';
 import {ApiService} from './api/api.service';
 import {JsonRpcModule} from './api/json-rpc.service';
@@ -8,8 +9,8 @@ import {RestApiService} from './api/rest-api.service';
 import {UserRestApiService} from './api/user-rest-api.service';
 import {UserService} from './api/user.service';
 import {ApplicationHeaderService} from './application-header.service';
-import {BytesFilter, EncodeURIFilter, RelativeTimeFilter} from './filters';
 import {ExceptionOverrideModule} from './exception-handling.service';
+import {BytesFilter, EncodeURIFilter, RelativeTimeFilter} from './filters';
 import {LinkService} from './link.service';
 import {ModalService} from './modal/modal.service';
 import {NavbarController} from './navbar.controller';
@@ -19,7 +20,12 @@ import {SessionService} from './session.service';
 import {UtilityService} from './utility.service';
 
 export const CoreModule = angular
-  .module('coreModule', [JsonRpcModule, OfflineModule, ExceptionOverrideModule])
+  .module('coreModule', [
+    JsonRpcModule,
+    OfflineModule,
+    ExceptionOverrideModule,
+    InterfaceLanguageModule
+  ])
   .service('projectService', ProjectService)
   .service('userService', UserService)
   .service('activityService', ActivityService)

--- a/src/angular-app/bellows/core/navbar.controller.ts
+++ b/src/angular-app/bellows/core/navbar.controller.ts
@@ -1,7 +1,7 @@
 import * as angular from 'angular';
 
-import {LexiconProjectSettings} from '../../languageforge/lexicon/shared/model/lexicon-project-settings.model';
 import {InterfaceConfig} from '../shared/model/interface-config.model';
+import {ProjectSettings} from '../shared/model/project-settings.model';
 import {ProjectService, ProjectTypeNames} from './api/project.service';
 import {ApplicationHeaderService, HeaderData} from './application-header.service';
 import {SessionService} from './session.service';
@@ -18,9 +18,10 @@ export class NavbarController implements angular.IController {
   projectTypeNames: ProjectTypeNames;
   siteName: string;
 
-  static $inject = ['projectService', 'sessionService', 'applicationHeaderService'];
-  constructor(private projectService: ProjectService, private sessionService: SessionService,
-              private applicationHeaderService: ApplicationHeaderService) { }
+  static $inject = ['projectService', 'sessionService',
+    'applicationHeaderService'];
+  constructor(private readonly projectService: ProjectService, private readonly sessionService: SessionService,
+              private readonly applicationHeaderService: ApplicationHeaderService) { }
 
   $onInit() {
     this.projectTypeNames = this.projectService.data.projectTypeNames;
@@ -41,7 +42,7 @@ export class NavbarController implements angular.IController {
             options: { en: { name: 'English', option: 'English' } }
           }
         } as InterfaceConfig;
-      const projectSettings = session.projectSettings<LexiconProjectSettings>();
+      const projectSettings = session.projectSettings<ProjectSettings>();
       if (projectSettings == null || projectSettings.interfaceConfig == null) {
         this.interfaceConfig = defaultInterfaceConfig;
       } else {
@@ -51,6 +52,12 @@ export class NavbarController implements angular.IController {
         session.hasSiteRight(this.sessionService.domain.PROJECTS, this.sessionService.operation.CREATE);
       this.siteName = session.baseSite();
     });
+  }
+
+  onUpdate = ($event: { interfaceConfig: InterfaceConfig}) => {
+    if ($event.interfaceConfig) {
+      this.interfaceConfig = $event.interfaceConfig;
+    }
   }
 
 }

--- a/src/angular-app/bellows/shared/interface-language.component.html
+++ b/src/angular-app/bellows/shared/interface-language.component.html
@@ -1,0 +1,12 @@
+<div uib-dropdown>
+    <a class="nav-link" uib-dropdown-toggle href id="languageDropdownButton" aria-haspopup="true" aria-expanded="false"
+       data-ng-model="$ctrl.interfaceConfig.languageCode">
+        <i class="fa fa-language"></i>
+        <span>{{ $ctrl.interfaceConfig.selectLanguages.options[$ctrl.interfaceConfig.languageCode].name }}</span></a>
+    <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu id="languageDropdownMenu" aria-labelledby="languageDropdown">
+        <a class="dropdown-item" data-ng-repeat="languageCode in $ctrl.interfaceConfig.selectLanguages.optionsOrder"
+           target="_blank" href data-ng-click="$ctrl.onCodeChange(languageCode)"
+           data-ng-class="{ selected: $ctrl.interfaceConfig.languageCode === languageCode }">
+            {{ $ctrl.interfaceConfig.selectLanguages.options[languageCode].option }}</a>
+    </div>
+</div>

--- a/src/angular-app/bellows/shared/interface-language.component.ts
+++ b/src/angular-app/bellows/shared/interface-language.component.ts
@@ -1,0 +1,95 @@
+import * as angular from 'angular';
+
+import {TransifexLanguage, TransifexLive} from '../../../../typings/transifex';
+import {InputSystemsService} from '../core/input-systems/input-systems.service';
+import {InterfaceConfig} from './model/interface-config.model';
+
+interface WindowService extends angular.IWindowService {
+  Transifex?: {
+    live: TransifexLive
+  };
+}
+
+export class InterfaceLanguageController implements angular.IController {
+  puiInterfaceConfig: InterfaceConfig;
+  puiOnUpdate: (params: { $event: { interfaceConfig: InterfaceConfig } }) => void;
+
+  private transifexLanguageCodes: string[] = [];
+  private interfaceConfig: InterfaceConfig;
+
+  static $inject = ['$window'];
+  constructor(private readonly $window: WindowService) { }
+
+  $onInit() {
+    if (this.$window.Transifex != null) {
+      this.$window.Transifex.live.onFetchLanguages(this.onFetchTransifexLanguages);
+    }
+  }
+
+  $onChanges(changes: any): void {
+    const interfaceConfigChange = changes.puiInterfaceConfig as angular.IChangesObject<InterfaceConfig>;
+    if (interfaceConfigChange != null && interfaceConfigChange.currentValue != null) {
+      this.interfaceConfig = this.puiInterfaceConfig;
+      this.changeInterfaceLanguage(this.interfaceConfig.languageCode);
+    }
+  }
+
+  onCodeChange(languageCode: string) {
+    if (this.interfaceConfig.languageCode !== languageCode) {
+      this.changeInterfaceLanguage(languageCode);
+    }
+  }
+
+  private changeInterfaceLanguage(code: string): void {
+    this.interfaceConfig.languageCode = code;
+    if (InputSystemsService.isRightToLeft(code)) {
+      this.interfaceConfig.direction = 'rtl';
+      this.interfaceConfig.pullToSide = 'float-left';
+      this.interfaceConfig.pullNormal = 'float-right';
+      this.interfaceConfig.placementToSide = 'right';
+      this.interfaceConfig.placementNormal = 'left';
+    } else {
+      this.interfaceConfig.direction = 'ltr';
+      this.interfaceConfig.pullToSide = 'float-right';
+      this.interfaceConfig.pullNormal = 'float-left';
+      this.interfaceConfig.placementToSide = 'left';
+      this.interfaceConfig.placementNormal = 'right';
+    }
+
+    if (this.$window.Transifex != null && this.transifexLanguageCodes.includes(code)) {
+      this.$window.Transifex.live.translateTo(code);
+    }
+
+    this.puiOnUpdate({ $event: { interfaceConfig: this.interfaceConfig } });
+  }
+
+  private onFetchTransifexLanguages = (languages: TransifexLanguage[]) => {
+    this.transifexLanguageCodes = [];
+    for (const language of languages) {
+      if (!(language.code in this.interfaceConfig.selectLanguages.options)) {
+        this.interfaceConfig.selectLanguages.optionsOrder.push(language.code);
+      }
+
+      this.interfaceConfig.selectLanguages.options[language.code].name = language.name;
+      this.interfaceConfig.selectLanguages.options[language.code].option = language.name;
+      this.transifexLanguageCodes.push(language.code);
+    }
+
+    this.changeInterfaceLanguage(this.interfaceConfig.languageCode);
+  }
+
+}
+
+export const InterfaceLanguageComponent: angular.IComponentOptions = {
+  bindings: {
+    puiInterfaceConfig: '<',
+    puiOnUpdate: '&'
+  },
+  controller: InterfaceLanguageController,
+  templateUrl: '/angular-app/bellows/shared/interface-language.component.html'
+};
+
+export const InterfaceLanguageModule = angular
+  .module('interfaceLanguageModule', [])
+  .component('puiInterfaceLanguage', InterfaceLanguageComponent)
+  .name;

--- a/src/angular-app/bellows/shared/model/project-settings.model.ts
+++ b/src/angular-app/bellows/shared/model/project-settings.model.ts
@@ -1,4 +1,7 @@
+import {InterfaceConfig} from './interface-config.model';
+
 export class ProjectSettings {
   allowInviteAFriend: boolean;
   hasSendReceive: boolean;
+  interfaceConfig?: InterfaceConfig;
 }

--- a/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
@@ -1,7 +1,5 @@
 import * as angular from 'angular';
-import {TransifexLanguage, TransifexLive} from '../../../../typings/transifex';
 
-import {InputSystemsService} from '../../bellows/core/input-systems/input-systems.service';
 import {NoticeService} from '../../bellows/core/notice/notice.service';
 import {InterfaceConfig} from '../../bellows/shared/model/interface-config.model';
 import {User} from '../../bellows/shared/model/user.model';
@@ -15,12 +13,6 @@ import {LexiconProjectSettings} from './shared/model/lexicon-project-settings.mo
 import {LexiconProject} from './shared/model/lexicon-project.model';
 import {LexOptionList} from './shared/model/option-list.model';
 
-interface WindowService extends angular.IWindowService {
-  Transifex?: {
-    live: TransifexLive
-  };
-}
-
 export class LexiconAppController implements angular.IController {
   finishedLoading: boolean = false;
   config: LexiconConfig;
@@ -31,20 +23,18 @@ export class LexiconAppController implements angular.IController {
   rights: Rights;
   users: { [userId: string]: User };
 
-  private transifexLanguageCodes: string[] = [];
   private online: boolean;
   private pristineLanguageCode: string;
 
   static $inject = ['$scope', '$location',
-    '$q', '$window',
+    '$q',
     'silNoticeService', 'lexConfigService',
     'lexProjectService',
     'lexEditorDataService',
     'lexRightsService',
-    'lexSendReceive'
-  ];
+    'lexSendReceive'];
   constructor(private readonly $scope: angular.IScope, private readonly $location: angular.ILocationService,
-              private readonly $q: angular.IQService, private readonly $window: WindowService,
+              private readonly $q: angular.IQService,
               private readonly notice: NoticeService, private readonly configService: LexiconConfigService,
               private readonly lexProjectService: LexiconProjectService,
               private readonly editorService: LexiconEditorDataService,
@@ -77,23 +67,13 @@ export class LexiconAppController implements angular.IController {
         this.config = rights.session.projectSettings<LexiconProjectSettings>().config;
         this.optionLists = rights.session.projectSettings<LexiconProjectSettings>().optionlists;
         this.interfaceConfig = rights.session.projectSettings<LexiconProjectSettings>().interfaceConfig;
+        this.pristineLanguageCode = this.interfaceConfig.languageCode;
         this.rights = rights;
-        this.changeInterfaceLanguage(this.interfaceConfig.languageCode);
-        if (this.$window.Transifex != null) {
-          this.$window.Transifex.live.onFetchLanguages(this.onFetchTransifexLanguages);
-        }
 
         this.$scope.$watch(() => this.interfaceConfig.languageCode, (newVal: string) => {
-          if (newVal && newVal !== this.pristineLanguageCode) {
-            const user = { interfaceLanguageCode: newVal };
-            if (newVal === this.project.interfaceLanguageCode) {
-              user.interfaceLanguageCode = null;
-              this.interfaceConfig.isUserLanguageCode = false;
-            } else {
-              this.interfaceConfig.isUserLanguageCode = true;
-            }
-            this.lexProjectService.updateUserProfile(user);
-            this.changeInterfaceLanguage(newVal);
+          if (newVal && this.pristineLanguageCode && newVal !== this.pristineLanguageCode) {
+            this.updateUserProfile(newVal);
+            this.pristineLanguageCode = newVal;
           }
         });
       }
@@ -116,7 +96,9 @@ export class LexiconAppController implements angular.IController {
     if ($event.project) {
       this.project = $event.project;
       if (!this.interfaceConfig.isUserLanguageCode) {
-        this.interfaceConfig.languageCode = angular.copy(this.project.interfaceLanguageCode);
+        this.interfaceConfig.languageCode = this.project.interfaceLanguageCode;
+      } else if (this.interfaceConfig.languageCode === this.project.interfaceLanguageCode) {
+        this.updateUserProfile(this.interfaceConfig.languageCode);
       }
     }
 
@@ -135,40 +117,15 @@ export class LexiconAppController implements angular.IController {
     }
   }
 
-  private changeInterfaceLanguage(code: string): void {
-    this.pristineLanguageCode = angular.copy(code);
-    if (this.$window.Transifex != null && this.transifexLanguageCodes.includes(code)) {
-      this.$window.Transifex.live.translateTo(code);
-    }
-
-    if (InputSystemsService.isRightToLeft(code)) {
-      this.interfaceConfig.direction = 'rtl';
-      this.interfaceConfig.pullToSide = 'float-left';
-      this.interfaceConfig.pullNormal = 'float-right';
-      this.interfaceConfig.placementToSide = 'right';
-      this.interfaceConfig.placementNormal = 'left';
+  private updateUserProfile(languageCode: string): void {
+    const user = { interfaceLanguageCode: languageCode };
+    if (languageCode === this.project.interfaceLanguageCode) {
+      user.interfaceLanguageCode = null;
+      this.interfaceConfig.isUserLanguageCode = false;
     } else {
-      this.interfaceConfig.direction = 'ltr';
-      this.interfaceConfig.pullToSide = 'float-right';
-      this.interfaceConfig.pullNormal = 'float-left';
-      this.interfaceConfig.placementToSide = 'left';
-      this.interfaceConfig.placementNormal = 'right';
+      this.interfaceConfig.isUserLanguageCode = true;
     }
-  }
-
-  private onFetchTransifexLanguages = (languages: TransifexLanguage[]) => {
-    this.transifexLanguageCodes = [];
-    for (const language of languages) {
-      if (!(language.code in this.interfaceConfig.selectLanguages.options)) {
-        this.interfaceConfig.selectLanguages.optionsOrder.push(language.code);
-      }
-
-      this.interfaceConfig.selectLanguages.options[language.code].name = language.name;
-      this.interfaceConfig.selectLanguages.options[language.code].option = language.name;
-      this.transifexLanguageCodes.push(language.code);
-    }
-
-    this.changeInterfaceLanguage(this.interfaceConfig.languageCode);
+    this.lexProjectService.updateUserProfile(user);
   }
 
   private setupOffline(): void {

--- a/src/angular-app/languageforge/lexicon/shared/model/lexicon-project-settings.model.ts
+++ b/src/angular-app/languageforge/lexicon/shared/model/lexicon-project-settings.model.ts
@@ -1,4 +1,3 @@
-import {InterfaceConfig} from '../../../../bellows/shared/model/interface-config.model';
 import {ProjectSettings} from '../../../../bellows/shared/model/project-settings.model';
 import {LexiconConfig} from './lexicon-config.model';
 import {LexOptionList} from './option-list.model';
@@ -8,7 +7,6 @@ export class LexiconProjectSettings extends ProjectSettings {
   config: LexiconConfig;
   currentUserRole: string;
   hasSendReceive: boolean;
-  interfaceConfig: InterfaceConfig;
   lastSyncedDate: string;
   optionlists: LexOptionList[];
   sendReceive?: { status: SendReceiveStatus };

--- a/test/app/languageforge/lexicon/settings/semantic-domains.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/semantic-domains.e2e-spec.ts
@@ -37,6 +37,7 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
     projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
     projectSettingsPage.projectTab.saveButton.click();
     expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    expect<any>(header.language.button.getText()).toEqual('ภาษาไทย');
   });
 
   it('should be using Thai Semantic Domain', () => {
@@ -51,6 +52,7 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
     projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('English');
     projectSettingsPage.projectTab.saveButton.click();
     expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    expect<any>(header.language.button.getText()).toEqual('English');
   });
 
   it('should be using English Semantic Domain', () => {
@@ -78,10 +80,10 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
   });
 
   it('can change user interface language', () => {
-    expect<any>(header.language.button.getText()).toContain('ภาษาไทย');
+    expect<any>(header.language.button.getText()).toEqual('ภาษาไทย');
     header.language.button.click();
-    header.language.findItem('English - semantic domain only').click();
-    expect<any>(header.language.button.getText()).toContain('English');
+    header.language.findItem('English').click();
+    expect<any>(header.language.button.getText()).toEqual('English');
   });
 
   it('should still have Thai for Project default language', () => {
@@ -105,6 +107,25 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
   it('should still have Thai for Project default language', () => {
     projectSettingsPage.getByLink();
     expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+  });
+
+  it('can change user interface language to English', () => {
+    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    header.language.button.click();
+    header.language.findItem('English').click();
+    expect<any>(header.language.button.getText()).toEqual('English');
+  });
+
+  it('can change Project default language to match interface language twice', () => {
+    projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('English');
+    projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    expect<any>(header.language.button.getText()).toEqual('English');
+
+    projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
+    projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    expect<any>(header.language.button.getText()).toEqual('ภาษาไทย');
   });
 
 });

--- a/test/php/model/languageforge/lexicon/dto/LexBaseViewDtoTest.php
+++ b/test/php/model/languageforge/lexicon/dto/LexBaseViewDtoTest.php
@@ -38,6 +38,6 @@ class LexBaseViewDtoTest extends TestCase
         $this->assertTrue($dto['config']['roleViews']['contributor']['fields']['lexeme']['show']);
         $this->assertTrue($dto['config']['roleViews']['contributor']['showTasks']['dbe']);
         $this->assertEquals('th', $dto['interfaceConfig']['languageCode']);
-        $this->assertEquals('English - semantic domain only', $dto['interfaceConfig']['selectLanguages']['options']['en']['option']);
+        $this->assertEquals('English', $dto['interfaceConfig']['selectLanguages']['options']['en']['option']);
     }
 }

--- a/test/php/model/shared/commands/SessionCommandsTest.php
+++ b/test/php/model/shared/commands/SessionCommandsTest.php
@@ -29,19 +29,33 @@ class SessionTestEnvironment
 
     public function create()
     {
-        $environ = new MongoTestEnvironment();
+        $environ = $this->getEnviron();
         $environ->clean();
         $this->website = $environ->website;
 
         $this->project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
-        $this->project->appName = 'sfchecks';
-        $this->project->write();
         $this->question = new QuestionModel($this->project);
         $this->question->write();
 
         $this->userId = $environ->createUser('test_user', 'Test User', 'test_user@example.com');
         $this->projectId = $this->project->id->asString();
         $this->questionId = $this->question->id->asString();
+    }
+
+    /**
+     * @return MongoTestEnvironment
+     */
+    protected function getEnviron(): MongoTestEnvironment
+    {
+        return new MongoTestEnvironment();
+    }
+
+}
+
+class LfSessionTestEnvironment extends SessionTestEnvironment {
+    protected function getEnviron(): MongoTestEnvironment
+    {
+        return new LexiconMongoTestEnvironment();
     }
 }
 
@@ -52,6 +66,9 @@ class SessionCommandsTest extends TestCase
         @unlink(SessionCommands::getSessionFilePath('mockSessionFile'));
     }
 
+    /**
+     * @throws Exception
+     */
     public function testSessionData_userIsNotPartOfProject()
     {
         $environ = new SessionTestEnvironment();
@@ -85,6 +102,50 @@ class SessionCommandsTest extends TestCase
         $this->assertArrayNotHasKey('userProjectRights', $data);
     }
 
+    /**
+     * @throws Exception
+     */
+    public function testSessionData_userIsNotPartOfProjectInLf()
+    {
+        $environ = new LfSessionTestEnvironment();
+        $environ->create();
+        $data = SessionCommands::getSessionData($environ->projectId, $environ->userId, $environ->website);
+
+        // Session data should contain a userId but not a projectId
+        $this->assertArrayHasKey('userId', $data);
+        $this->assertTrue(is_string($data['userId']));
+        $this->assertEquals($environ->userId, $data['userId']);
+
+        // Session data should also contain "site", a string...
+        $this->assertArrayHasKey('baseSite', $data);
+        $this->assertTrue(is_string($data['baseSite']));
+        // ... and "fileSizeMax", an integer
+        $this->assertArrayHasKey('fileSizeMax', $data);
+        $this->assertTrue(is_integer($data['fileSizeMax']));
+
+        // Session data should contain projectSettings, an array with only interFaceConfig
+        $this->assertArrayHasKey('projectSettings', $data);
+        $this->assertTrue(is_array($data['projectSettings']));
+        $this->assertCount(1, $data['projectSettings']);
+        $this->assertArrayHasKey('interfaceConfig', $data['projectSettings']);
+
+        // Session data should not contain project, an associative array
+        $this->assertArrayNotHasKey('project', $data);
+
+        // Session data should contain user site rights, an array of integers
+        $this->assertArrayHasKey('userSiteRights', $data);
+        $this->assertTrue(is_array($data['userSiteRights']));
+        // ... which should not be empty
+        $this->assertFalse(empty($data['userSiteRights']));
+        $this->assertTrue(is_integer($data['userSiteRights'][0]));
+
+        // Session data should contain user project rights, an array of integers
+        $this->assertArrayNotHasKey('userProjectRights', $data);
+    }
+
+    /**
+     * @throws Exception
+     */
     public function testSessionData_userIsPartOfProject()
     {
         $environ = new SessionTestEnvironment();
@@ -100,6 +161,9 @@ class SessionCommandsTest extends TestCase
         $this->assertTrue(is_integer($data['userProjectRights'][0]));
     }
 
+    /**
+     * @throws Exception
+     */
     public function testGetSessionData_sessionFileExists_dataInFile()
     {
         $environ = new SessionTestEnvironment();
@@ -108,9 +172,10 @@ class SessionCommandsTest extends TestCase
         
         $this->assertFalse(file_exists(SessionCommands::getSessionFilePath('mockSessionFile')));
 
-        $data = SessionCommands::getSessionData($environ->projectId, $environ->userId, $environ->website, '', 'mockSessionFile');
+        $data = SessionCommands::getSessionData($environ->projectId, $environ->userId, $environ->website, 'mockSessionFile');
         
         $this->assertTrue(file_exists(SessionCommands::getSessionFilePath('mockSessionFile')));
         $this->assertJsonStringEqualsJsonFile(SessionCommands::getSessionFilePath('mockSessionFile'), json_encode($data));
     }
+
 }


### PR DESCRIPTION
- refactor for better separation-of-concerns for the interface language picker
- enable interface language picker in bellows apps

SF and LF E2E tests both passing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/320)
<!-- Reviewable:end -->
