### PR TITLE
Activity feed tweaks

### DIFF
--- a/src/angular-app/bellows/apps/activity/activity-container.component.html
+++ b/src/angular-app/bellows/apps/activity/activity-container.component.html
@@ -70,7 +70,7 @@
                                     <div class="meta-time">
                                         {{userGroup.date | date:activityGroup.dateFormat}}
                                     </div>
-                                    <span class="activity-username">{{userGroup.user.username}}</span> <span class="activity-summary">{{userGroup.getSummaryDescription()}}</span>
+                                    <span class="activity-username">{{userGroup.user.username}}</span> <span class="activity-summary">{{userGroup.getSummaryDescription($ctrl.entryId)}}</span>
                                     <span class="activity-unread" ng-show="userGroup.unread > 0"> - {{userGroup.unread}} new activit{{userGroup.unread > 1 ? 'ies' : 'y'}}</span>
                                 </div>
                                 <div class="meta-toggle">

--- a/src/angular-app/bellows/apps/activity/activity-container.compontent.ts
+++ b/src/angular-app/bellows/apps/activity/activity-container.compontent.ts
@@ -165,7 +165,7 @@ class ActivityUserGroup {
     this.date = activity.date;
   }
 
-  getSummaryDescription() {
+  getSummaryDescription(entryId: string) {
     let summary = '';
     let totalActivityTypes = 0;
     const entryActivities = {};
@@ -188,7 +188,7 @@ class ActivityUserGroup {
         summaryTypes[activity.action].total++;
       }
     }
-    if (entryActivities) {
+    if (Object.keys(entryActivities).length) {
       let entryActivityCount = 0;
       let entryActivityItems = 0;
       for (const entryRef of Object.keys(entryActivities)) {
@@ -196,16 +196,18 @@ class ActivityUserGroup {
         entryActivityCount++;
       }
       summary += 'updated ' + entryActivityItems + ' field' + (entryActivityItems !== 1 ? 's' : '');
-      if (entryActivityCount === 1) {
-        summary += ' in ' + entryActivityCount + ' entry';
-      } else {
-        summary += ' across ' + entryActivityCount + ' entries';
+      if (entryId == null) {
+        if (entryActivityCount === 1) {
+          summary += ' in ' + entryActivityCount + ' entry';
+        } else {
+          summary += ' across ' + entryActivityCount + ' entries';
+        }
       }
       if (totalActivityTypes === 1) {
-          summary += ' and ';
-        } else if (totalActivityTypes > 1) {
-          summary += ', ';
-        }
+        summary += ' and ';
+      } else if (totalActivityTypes > 1) {
+        summary += ', ';
+      }
     }
     let count = 1;
     for (const activityAction in summaryTypes) {


### PR DESCRIPTION
PR (NEW) addresses the following:

Updated activity summary to not include how many entries were updated when viewing activities from a specific entry
Fixed a bug where it showed entries even if there were no updates made

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/331)
<!-- Reviewable:end -->
