### PR TITLE
Mongo mapper can now rearrange items

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -55,7 +55,7 @@ class LexEntryModel extends MapperModel
         $this->setPrivateProp('dirtySR');
         $this->setPrivateProp('mercurialSha');
         $this->setReadOnlyProp('authorInfo');
-        $this->setSensitiveProp('senses');
+        $this->setRearrangeableProp('senses');
 
         $this->initLazyProperties([
             'lexeme',

--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -55,6 +55,7 @@ class LexEntryModel extends MapperModel
         $this->setPrivateProp('dirtySR');
         $this->setPrivateProp('mercurialSha');
         $this->setReadOnlyProp('authorInfo');
+        $this->setSensitiveProp('senses');
 
         $this->initLazyProperties([
             'lexeme',

--- a/src/Api/Model/Languageforge/Lexicon/LexExample.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexExample.php
@@ -13,7 +13,6 @@ class LexExample extends ObjectForEncoding
     public function __construct($liftId = '', $guid = '')
     {
         $this->setPrivateProp('liftId');
-//        $this->setReadOnlyProp('guid');  // No longer readonly - 2018-07 RM
         $this->setReadOnlyProp('translationGuid');
         $this->setReadOnlyProp('authorInfo');
         if ($liftId) $this->liftId = $liftId;

--- a/src/Api/Model/Languageforge/Lexicon/LexExample.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexExample.php
@@ -13,7 +13,7 @@ class LexExample extends ObjectForEncoding
     public function __construct($liftId = '', $guid = '')
     {
         $this->setPrivateProp('liftId');
-        $this->setReadOnlyProp('guid');
+//        $this->setReadOnlyProp('guid');  // No longer readonly - 2018-07 RM
         $this->setReadOnlyProp('translationGuid');
         $this->setReadOnlyProp('authorInfo');
         if ($liftId) $this->liftId = $liftId;

--- a/src/Api/Model/Languageforge/Lexicon/LexPicture.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexPicture.php
@@ -10,7 +10,7 @@ class LexPicture extends ObjectForEncoding
     {
         $this->fileName = $fileName;
         $this->caption = new LexMultiText();
-        $this->setReadOnlyProp('guid');
+//        $this->setReadOnlyProp('guid');  // No longer readonly - 2018-07 RM
         $this->guid = Guid::makeValid($guid);
     }
 

--- a/src/Api/Model/Languageforge/Lexicon/LexPicture.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexPicture.php
@@ -10,7 +10,6 @@ class LexPicture extends ObjectForEncoding
     {
         $this->fileName = $fileName;
         $this->caption = new LexMultiText();
-//        $this->setReadOnlyProp('guid');  // No longer readonly - 2018-07 RM
         $this->guid = Guid::makeValid($guid);
     }
 

--- a/src/Api/Model/Languageforge/Lexicon/LexSense.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexSense.php
@@ -25,10 +25,9 @@ class LexSense extends ObjectForEncoding
     public function __construct($liftId = '', $guid = '')
     {
         $this->setPrivateProp('liftId');
-//        $this->setReadOnlyProp('guid');  // No longer readonly - 2018-07 RM
         $this->setReadOnlyProp('authorInfo');
-        $this->setSensitiveProp('examples');
-        $this->setSensitiveProp('pictures');
+        $this->setRearrangeableProp('examples');
+        $this->setRearrangeableProp('pictures');
         if ($liftId) $this->liftId = $liftId;
         $this->guid = Guid::makeValid($guid);
 

--- a/src/Api/Model/Languageforge/Lexicon/LexSense.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexSense.php
@@ -25,8 +25,10 @@ class LexSense extends ObjectForEncoding
     public function __construct($liftId = '', $guid = '')
     {
         $this->setPrivateProp('liftId');
-        $this->setReadOnlyProp('guid');
+//        $this->setReadOnlyProp('guid');  // No longer readonly - 2018-07 RM
         $this->setReadOnlyProp('authorInfo');
+        $this->setSensitiveProp('examples');
+        $this->setSensitiveProp('pictures');
         if ($liftId) $this->liftId = $liftId;
         $this->guid = Guid::makeValid($guid);
 

--- a/src/Api/Model/Scriptureforge/Sfchecks/QuestionModel.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/QuestionModel.php
@@ -96,6 +96,8 @@ class QuestionModel extends MapperModel
         $this->_mapper->write(
             $answerToWrite,
             $id,
+            [],
+            [],
             MongoMapper::ID_IN_KEY,
             $this->id->asString(),
             'answers'
@@ -157,6 +159,8 @@ class QuestionModel extends MapperModel
         $mapper->write(
             $comment,
             $id,
+            [],
+            [],
             MongoMapper::ID_IN_KEY,
             $questionId,
             "answers.$answerId.comments"

--- a/src/Api/Model/Shared/Mapper/MapperModel.php
+++ b/src/Api/Model/Shared/Mapper/MapperModel.php
@@ -95,24 +95,24 @@ class MapperModel extends ObjectForEncoding
         if (Id::isEmpty($this->id)) {
             $this->dateCreated = $now;
         }
-        $sensitiveProperties = $this->getSensitiveProperties();
-        $sensitiveSubproperties = [];
-        foreach ($sensitiveProperties as $property) {
+        $rearrangeableProperties = $this->getRearrangeableProperties();
+        $rearrangeableSubproperties = [];
+        foreach ($rearrangeableProperties as $property) {
             $value = $this->$property;
             if (is_a($value, 'Api\Model\Shared\Mapper\ArrayOf')) {
                 foreach ($value as $item) {
                     if (is_a($item, 'Api\Model\Shared\Mapper\ObjectForEncoding')) {
-                        foreach ($item->getSensitiveProperties() as $subProperty) {
-                            if (! array_key_exists($property, $sensitiveSubproperties)) {
-                                $sensitiveSubproperties[$property] = [];
+                        foreach ($item->getRearrangeableProperties() as $subProperty) {
+                            if (! array_key_exists($property, $rearrangeableSubproperties)) {
+                                $rearrangeableSubproperties[$property] = [];
                             }
-                            $sensitiveSubproperties[$property][] = $subProperty;
+                            $rearrangeableSubproperties[$property][] = $subProperty;
                         }
                     }
                 }
             }
         }
-        $this->id->id = $this->_mapper->write($this, $this->id->id, $sensitiveProperties, $sensitiveSubproperties);
+        $this->id->id = $this->_mapper->write($this, $this->id->id, $rearrangeableProperties, $rearrangeableSubproperties);
 
         return $this->id->id;
     }

--- a/src/Api/Model/Shared/Mapper/MapperUtils.php
+++ b/src/Api/Model/Shared/Mapper/MapperUtils.php
@@ -19,60 +19,6 @@ class MapperUtils
         MongoStore::dropAllCollections($databaseName);
     }
 
-    /** Figure out if subdocuments have moved
-     * Structure expected for oldData and newData: array of documents that have a unique key
-     * Returns a keyed array (dict) with keys being ID values, and values being ["oldPos" => int, "newPos" => int].
-     * Only the key is examined; the other parts of the data are not compared
-     * E.g., if the input is as follows:
-     * $oldData = [ ["id" => "abc", "data" => "foo"], ["id" => "def", "data" => "bar"] ]
-     * $newData = [ ["id" => "def", "data" => "bar"], ["id" => "abc", "data" => "new foo"] ]
-     * $key = "id"
-     * then the result will be:
-     * [ "abc" => [ "oldPos" => 0, "newPos" => 1 ], "def" => [ "oldPos" => 1, "newPos" => 0 ] ]
-     * If any ID has appeared or disappeared, the oldPos or newPos for that ID will be null.
-     * E.g., ["oldPos" => 0, "newPos" => null] means that the item was deleted.
-     *
-     * WARNING: if keys are duplicated, this function's behavior will be undefined
-     *
-     * @param array $oldData
-     * @param array $newData
-     * @param string $keyName
-     * @return array
-     */
-    public static function detectMoved($oldData, $newData, $keyName)
-    {
-        $oldPositionsById = [];
-        $newPositionsById = [];
-        foreach ($oldData as $pos => $value) {
-            if (is_array($value) && array_key_exists($keyName, $value)) {
-                $oldPositionsById[$value[$keyName]] = $pos;
-            }
-        }
-        foreach ($newData as $pos => $value) {
-            if (is_array($value) && array_key_exists($keyName, $value)) {
-                $newPositionsById[$value[$keyName]] = $pos;
-            }
-        }
-
-        // Most of the time there will be no motion, so check that first
-        if ($oldPositionsById === $newPositionsById) {
-            return [];
-        }
-
-        $result = [];
-        foreach ($oldPositionsById as $id => $oldPos) {
-            $newPos = $newPositionsById[$id] ?? null;  // Without the "?? null", we'd get an error if the ID didn't exist
-            $result[$id] = ["oldPos" => $oldPos, "newPos" => $newPos];
-            // Keep track of which keys we've handled
-            unset($newPositionsById[$id]);
-        }
-        // Any remaining IDs in newData are items that were added
-        foreach ($newPositionsById as $id => $newPos) {
-            $result[$id] = ["oldPos" => null, "newPos" => $newPos];
-        }
-        return $result;
-    }
-
     // Returns an array with three keys:
     // [ 'added' => [ 'new1', 'new2' ], 'removed' => [ 'old1', 'old2' ], 'moved' => [ 0 => 1, 1 => 0 ] ]
     // The indices in "moved" are calculated after removing all the old keys, and then adding all the new keys *at the end*

--- a/src/Api/Model/Shared/Mapper/MapperUtils.php
+++ b/src/Api/Model/Shared/Mapper/MapperUtils.php
@@ -18,4 +18,92 @@ class MapperUtils
     public static function dropAllCollections($databaseName) {
         MongoStore::dropAllCollections($databaseName);
     }
+
+    /** Figure out if subdocuments have moved
+     * Structure expected for oldData and newData: array of documents that have a unique key
+     * Returns a keyed array (dict) with keys being ID values, and values being ["oldPos" => int, "newPos" => int].
+     * Only the key is examined; the other parts of the data are not compared
+     * E.g., if the input is as follows:
+     * $oldData = [ ["id" => "abc", "data" => "foo"], ["id" => "def", "data" => "bar"] ]
+     * $newData = [ ["id" => "def", "data" => "bar"], ["id" => "abc", "data" => "new foo"] ]
+     * $key = "id"
+     * then the result will be:
+     * [ "abc" => [ "oldPos" => 0, "newPos" => 1 ], "def" => [ "oldPos" => 1, "newPos" => 0 ] ]
+     * If any ID has appeared or disappeared, the oldPos or newPos for that ID will be null.
+     * E.g., ["oldPos" => 0, "newPos" => null] means that the item was deleted.
+     *
+     * WARNING: if keys are duplicated, this function's behavior will be undefined
+     *
+     * @param array $oldData
+     * @param array $newData
+     * @param string $keyName
+     * @return array
+     */
+    public static function detectMoved($oldData, $newData, $keyName)
+    {
+        $oldPositionsById = [];
+        $newPositionsById = [];
+        foreach ($oldData as $pos => $value) {
+            if (is_array($value) && array_key_exists($keyName, $value)) {
+                $oldPositionsById[$value[$keyName]] = $pos;
+            }
+        }
+        foreach ($newData as $pos => $value) {
+            if (is_array($value) && array_key_exists($keyName, $value)) {
+                $newPositionsById[$value[$keyName]] = $pos;
+            }
+        }
+
+        // Most of the time there will be no motion, so check that first
+        if ($oldPositionsById === $newPositionsById) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($oldPositionsById as $id => $oldPos) {
+            $newPos = $newPositionsById[$id] ?? null;  // Without the "?? null", we'd get an error if the ID didn't exist
+            $result[$id] = ["oldPos" => $oldPos, "newPos" => $newPos];
+            // Keep track of which keys we've handled
+            unset($newPositionsById[$id]);
+        }
+        // Any remaining IDs in newData are items that were added
+        foreach ($newPositionsById as $id => $newPos) {
+            $result[$id] = ["oldPos" => null, "newPos" => $newPos];
+        }
+        return $result;
+    }
+
+    // Returns an array with three keys:
+    // [ 'added' => [ 'new1', 'new2' ], 'removed' => [ 'old1', 'old2' ], 'moved' => [ 0 => 1, 1 => 0 ] ]
+    // The indices in "moved" are calculated after removing all the old keys, and then adding all the new keys *at the end*
+    // So to apply these changes (e.g., in Mongo), you do the same sequence: remove first, then add, then rearrange
+    public static function calculateChanges($oldKeys, $newKeys)
+    {
+        // Most of the time there will be no motion, so check that first.
+        if ($oldKeys === $newKeys) {
+            return [];
+        }
+
+        // array_values() call needed because array_diff(['a', 'b', 'c'], ['a']) produces [ 1 => 'b', 2 => 'c' ]
+        // but the index-based logic further down needs [ 0 => 'b', 1 => 'c' ]
+        $added = array_values(array_diff($newKeys, $oldKeys));
+        $removed = array_values(array_diff($oldKeys, $newKeys));
+
+        $remaining = array_values(array_diff($oldKeys, $removed));
+        foreach ($added as $item) {
+            $remaining[] = $item;
+        }
+
+        $oldIndicesByKey = array_flip($remaining);
+        $newIndicesByKey = array_flip($newKeys);
+
+        $moved = [];
+        if ($oldIndicesByKey != $newIndicesByKey) {
+            foreach ($oldIndicesByKey as $id => $oldPos) {
+                $newPos = $newIndicesByKey[$id];
+                $moved[$oldPos] = $newPos;
+            }
+        }
+        return [ 'added' => $added, 'removed' => $removed, 'moved' => $moved ];
+    }
 }

--- a/src/Api/Model/Shared/Mapper/MongoMapper.php
+++ b/src/Api/Model/Shared/Mapper/MongoMapper.php
@@ -10,11 +10,12 @@
  * PHP MongoDB Client Library API Generated Docs       http://mongodb.github.io/mongo-php-library/api/
  * PHP MongoDB Client Library API Reference            http://mongodb.github.io/mongo-php-library/
  * MongoDB Documentation                               https://docs.mongodb.org/manual/reference/
- * 
+ *
  */
 
 namespace Api\Model\Shared\Mapper;
 
+use MongoDB\UpdateResult;
 use Palaso\Utilities\CodeGuard;
 
 class MongoMapper
@@ -309,7 +310,7 @@ class MongoMapper
      * @return string
      * @throws \Exception
      */
-    public function write($model, $id, $keyStyle = MongoMapper::ID_IN_KEY, $rootId = '', $property = '')
+    public function write($model, $id, $sensitiveProperties = [], $sensitiveSubproperties = [], $keyStyle = MongoMapper::ID_IN_KEY, $rootId = '', $property = '')
     {
         CodeGuard::checkTypeAndThrow($rootId, 'string');
         CodeGuard::checkTypeAndThrow($property, 'string');
@@ -317,10 +318,12 @@ class MongoMapper
         $data = MongoEncoder::encode($model); // TODO Take into account key style for stripping key out of the model if needs be
         if (empty($rootId)) {
             // We're doing a root level update, only $model, $id are relevant
+            $this->rearrangeIfNeeded($data, $id, $sensitiveProperties, $sensitiveSubproperties, self::ID_IN_KEY, '', '');
             $id = $this->update($data, $id, self::ID_IN_KEY, '', '');
         } else {
             if ($keyStyle == self::ID_IN_KEY) {
                 CodeGuard::checkNullAndThrow($id, 'id');
+                $this->rearrangeIfNeeded($model, $id, $sensitiveProperties, $sensitiveSubproperties, self::ID_IN_KEY, $rootId, $property);
                 $id = $this->update($data, $id, self::ID_IN_KEY, $rootId, $property);
             } else {
                 if (empty($id)) {
@@ -328,6 +331,7 @@ class MongoMapper
                     throw new \Exception("Method appendSubDocument() is not implemented");
                     //$this->appendSubDocument($data, $rootId, $property);
                 } else {
+                    $this->rearrangeIfNeeded($model, $id, $sensitiveProperties, $sensitiveSubproperties, self::ID_IN_DOC, $rootId, $property);
                     $id = $this->update($data, $id, self::ID_IN_DOC, $rootId, $property);
                 }
             }
@@ -395,6 +399,7 @@ class MongoMapper
 
     public static function shouldKeepKey(string $key) {
         // Some keys shouldn't be removed even if empty, at least as long as our code is still making assumptions that these keys exist
+        // TODO: Transfer this knowledge to the ObjectForEncoding base class, so that it can pass down a list of keys to keep on a per-model basis. That will avoid this hardcoded list.
         return ($key === "guid" || $key === "translation" || $key === "description" || $key === "answers" || $key == "paragraphs");
     }
 
@@ -468,5 +473,183 @@ class MongoMapper
             $this->_collection->updateOne($filter, $updateCommand);
         }
         return $id;
+    }
+
+    protected function rearrangeIfNeeded($data, $id, $sensitiveProperties = [], $sensitiveSubproperties = [], $keyStyle = MongoMapper::ID_IN_KEY, $rootId = '', $property = '')
+    {
+        if (empty($sensitiveProperties) && empty($sensitiveSubproperties)) {
+            // Most models don't need this, so exit early in most scenarios
+            return;
+        }
+
+        $filter = array('_id' => self::mongoID($id));
+        $oldMongoData = $this->_collection->find($filter)->toArray();
+
+        foreach ($sensitiveProperties as $property) {
+            if (!array_key_exists($property, $data)) {
+                // No rearranging needed if we're deleting the entire property
+                continue;
+            }
+            if (!array_key_exists($property, $oldMongoData)) {
+                // No rearranging needed if the property didn't exist before
+                continue;
+            }
+            $this->rearrangeOne($oldMongoData, $data, $id, $property);
+        }
+
+        // Re-read data now that first-level property arrays have been rearranged, so that indices will match up when rearranging subproperties
+        $oldMongoData = $this->_collection->find($filter)->toArray();
+
+        foreach ($sensitiveSubproperties as $property => $subProperties) {
+            foreach ($data[$property] as $index => $propData) {
+                foreach ($subProperties as $subProperty) {
+                    if (array_key_exists($property, $oldMongoData)) {
+                        // We can now count on the indices matching up
+                        $oldPropData = $oldMongoData[$property][$index];
+                    } else {
+                        // No need to rearrange an empty array
+                        continue;
+                    }
+                    $this->rearrangeOne($oldPropData, $propData, $id, $property, $index, $subProperty);
+                }
+            }
+        }
+    }
+
+    protected function rearrangeOne($oldData, $newData, $rootId, $property, $subIndex = 0, $subProperty = '', $idFieldName = 'guid')
+    {
+        // First get the old data
+        $filter = array('_id' => self::mongoID($rootId));
+        if (empty($subProperty)) {
+            // Property rearranging: data is entire object.
+            $newItems = $newData[$property];
+            $oldItems = $oldData[$property];
+        } else {
+            // Subproperty rearranging: data is one item in the root property
+            // E.g., if $property = 'senses' and $subProperty = 'examples', then data is *one* sense, not the whole array of senses
+            $newItems = $newData[$subProperty];
+            $oldItems = $oldData[$subProperty];
+        }
+        $oldGuids = [];
+        foreach ($oldItems as $item) {
+            $oldGuids[] = $item[$idFieldName];
+        }
+        $newGuids = [];
+        $newItemsByGuid = [];
+        foreach ($newItems as $item) {
+            $newGuids[] = $item[$idFieldName];
+            $newItemsByGuid[$item[$idFieldName]] = $item;
+        }
+        $changes = MapperUtils::calculateChanges($oldGuids, $newGuids);
+        if (empty($changes)) {
+            return; // Nothing to do!
+        }
+        $dataToAdd = [];
+        foreach ($changes['added'] as $changeGuid) {
+            $dataToAdd[] = $newItemsByGuid[$changeGuid];
+        }
+        $this->addAndRemoveInProperty($dataToAdd, $changes['removed'], $rootId, $property, $subIndex, $subProperty, $idFieldName);
+        $this->reorderInPseudoTransaction($filter, $changes['moved'], $property, $subIndex, $subProperty);
+    }
+
+    /**
+     * @param array $dataToAdd - An array of "objects" to add (if you're only adding one item, call as [$itemToAdd])
+     * @param string[] $guidsToRemove
+     * @param string $rootId
+     * @param string $property
+     * @return string
+     */
+    protected function addAndRemoveInProperty($dataToAdd, $guidsToRemove, $rootId, $property, $subIndex = 0, $subProperty = '', $idFieldName = 'guid') {
+        // Besides the update() parameters, we also need to take one more: the order mapping.
+        // This will be an array from old to new: [0 => 1, 1 => 2, 2 => 0] means to rearrange ABC into CAB.
+
+        // This needs to handle two cases:
+        // 1. "senses", where it's a property of the root object and we're replacing that property
+        // 2. "senses.examples", where it's a sub-property and the property we're replacing is something like "senses.0.examples"
+        // This should probably build the update, but the root one does the update.
+        $filter = array('_id' => self::mongoID($rootId));
+        if (empty($subProperty)) {
+            $key = $property;
+        } else {
+            $key = $property . '.' . $subIndex . '.' . $subProperty;
+        }
+        $removeUpdateCommand = $this->createRemoveUpdate($key, $guidsToRemove, $idFieldName);
+        $addUpdateCommand = $this->createAddUpdate($key, $dataToAdd);
+        $this->_collection->updateOne($filter, $removeUpdateCommand);
+        $this->_collection->updateOne($filter, $addUpdateCommand);
+    }
+
+    protected function createRemoveUpdate($key, $guidsToRemove, $idFieldname = 'guid')
+    {
+        // db.samples.update({'guid': '456'}, {'$pull': {'senses.0.examples': {'guid': {'$in': ['A1']}}}})
+        return [
+            '$pull' => [
+                $key => [
+                    $idFieldname => [
+                        '$in' => $guidsToRemove
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    protected function createAddUpdate($key, $dataToAdd)
+    {
+        // E.g., db.collection.update({'guid': '456'}, {'$push': {'senses.0.examples': {'$each': [{'guid': 'A3', 'sentence': 'Ex-A3'}]}}})
+        // NOTE: $dataToAdd needs to be an array, even if there's just one item
+        return [
+            '$push' => [
+                $key => [
+                    '$each' => $dataToAdd
+                ]
+            ]
+        ];
+    }
+
+    protected function reorderInPseudoTransaction($baseFilter, $orderMapping, $property, $subIndex = 0, $subProperty = '', $timeoutInSeconds = 0.5) {
+        $startTime = microtime(true);
+        $filter = $baseFilter;
+        while (true) {
+            $data = $this->_collection->find($baseFilter)->toArray();
+            if (empty($data)) {
+                return true;
+            }
+            if (empty($subProperty)) {
+                $dataBeforeReordering = $data[$property];
+                $key = $property;
+            } else {
+                $dataBeforeReordering = $data[$property][$subIndex][$subProperty];
+                $key = $property . '.' . $subIndex . '.' . $subProperty;
+            }
+            $filter[$key] = $dataBeforeReordering;
+            $reorderedData = $this->reorderData($orderMapping, $dataBeforeReordering);
+            /** @var UpdateResult $result */
+            $update = [
+                '$set' => [ $key => $reorderedData ]
+            ];
+            $result = $this->_collection->updateOne($filter, $update);
+            if ($result->isAcknowledged() && $result->getModifiedCount() > 0) {
+                return true;
+            }
+            $now = microtime(true);
+            if (($now - $startTime) > $timeoutInSeconds) {
+                return false;
+            }
+        }
+    }
+
+    protected function reorderData($orderMapping, $data) {
+        if (count($orderMapping) != count($data)) {
+            // TODO: Move this check to where it belongs, or delete it if we can guarantee that it won't be needed (I think we can guarantee that)
+            throw new \LengthException("Each index in data needs to be mapped");
+        }
+
+        // Ensure that indices will be returned in order
+        $result = array_fill(0, count($orderMapping), null);
+
+        foreach ($orderMapping as $oldIndex => $newIndex) {
+            $result[$newIndex] = $data($oldIndex);
+        }
+        return $result;
     }
 }

--- a/src/Api/Model/Shared/Mapper/ObjectForEncoding.php
+++ b/src/Api/Model/Shared/Mapper/ObjectForEncoding.php
@@ -11,7 +11,7 @@ class ObjectForEncoding
     private $_readOnlyProperties;
 
     /** @var array */
-    protected $_sensitiveProperties;  // E.g., "senses" for a LexEntry, and "pictures" or "examples" for a LexSense
+    protected $_rearrangeableProperties;  // E.g., "senses" for a LexEntry, and "pictures" or "examples" for a LexSense
     // TODO: would a name like "guidKeyedProperties" be better? - 2018-07-13 RM
 
     protected function setReadOnlyProp($propertyName)
@@ -23,6 +23,7 @@ class ObjectForEncoding
             $this->_readOnlyProperties[] = $propertyName;
         }
     }
+
     protected function setPrivateProp($propertyName)
     {
         if (!is_array($this->_privateProperties)) {
@@ -32,13 +33,14 @@ class ObjectForEncoding
             $this->_privateProperties[] = $propertyName;
         }
     }
-    protected function setSensitiveProp($propertyName)
+
+    protected function setRearrangeableProp($propertyName)
     {
-        if (!is_array($this->_sensitiveProperties)) {
-            $this->_sensitiveProperties = [];
+        if (!is_array($this->_rearrangeableProperties)) {
+            $this->_rearrangeableProperties = [];
         }
-        if (!in_array($propertyName, $this->_sensitiveProperties)) {
-            $this->_sensitiveProperties[] = $propertyName;
+        if (!in_array($propertyName, $this->_rearrangeableProperties)) {
+            $this->_rearrangeableProperties[] = $propertyName;
         }
     }
 
@@ -51,11 +53,12 @@ class ObjectForEncoding
     {
         return $this->_privateProperties;
     }
-    public function getSensitiveProperties()
+
+    public function getRearrangeableProperties()
     {
-        if (!is_array($this->_sensitiveProperties)) {
-            $this->_sensitiveProperties = [];
+        if (!is_array($this->_rearrangeableProperties)) {
+            $this->_rearrangeableProperties = [];
         }
-        return $this->_sensitiveProperties;
+        return $this->_rearrangeableProperties;
     }
 }

--- a/src/Api/Model/Shared/Mapper/ObjectForEncoding.php
+++ b/src/Api/Model/Shared/Mapper/ObjectForEncoding.php
@@ -10,10 +10,14 @@ class ObjectForEncoding
     /** @var array */
     private $_readOnlyProperties;
 
+    /** @var array */
+    protected $_sensitiveProperties;  // E.g., "senses" for a LexEntry, and "pictures" or "examples" for a LexSense
+    // TODO: would a name like "guidKeyedProperties" be better? - 2018-07-13 RM
+
     protected function setReadOnlyProp($propertyName)
     {
         if (!is_array($this->_readOnlyProperties)) {
-            $this->_readOnlyProperties = array();
+            $this->_readOnlyProperties = [];
         }
         if (!in_array($propertyName, $this->_readOnlyProperties)) {
             $this->_readOnlyProperties[] = $propertyName;
@@ -22,10 +26,19 @@ class ObjectForEncoding
     protected function setPrivateProp($propertyName)
     {
         if (!is_array($this->_privateProperties)) {
-            $this->_privateProperties = array();
+            $this->_privateProperties = [];
         }
         if (!in_array($propertyName, $this->_privateProperties)) {
             $this->_privateProperties[] = $propertyName;
+        }
+    }
+    protected function setSensitiveProp($propertyName)
+    {
+        if (!is_array($this->_sensitiveProperties)) {
+            $this->_sensitiveProperties = [];
+        }
+        if (!in_array($propertyName, $this->_sensitiveProperties)) {
+            $this->_sensitiveProperties[] = $propertyName;
         }
     }
 
@@ -37,5 +50,12 @@ class ObjectForEncoding
     public function getPrivateProperties()
     {
         return $this->_privateProperties;
+    }
+    public function getSensitiveProperties()
+    {
+        if (!is_array($this->_sensitiveProperties)) {
+            $this->_sensitiveProperties = [];
+        }
+        return $this->_sensitiveProperties;
     }
 }

--- a/test/php/model/shared/mapper/MapperUtilsTest.php
+++ b/test/php/model/shared/mapper/MapperUtilsTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: rmunn
- * Date: 7/12/18
- * Time: 5:06 PM
- */
 
 use Api\Model\Shared\Mapper\MapperUtils;
 use PHPUnit\Framework\TestCase;

--- a/test/php/model/shared/mapper/MapperUtilsTest.php
+++ b/test/php/model/shared/mapper/MapperUtilsTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: rmunn
+ * Date: 7/12/18
+ * Time: 5:06 PM
+ */
+
+use Api\Model\Shared\Mapper\MapperUtils;
+use PHPUnit\Framework\TestCase;
+
+class MapperUtilsTest extends TestCase
+{
+    public function doit($old, $new, $expected)
+    {
+        $changes = MapperUtils::calculateChanges($old, $new);
+        if (empty($expected)) {
+            $this->assertEmpty($changes);
+        } else {
+            $this->assertEquals($expected['added'], $changes['added']);
+            $this->assertEquals($expected['removed'], $changes['removed']);
+            $this->assertEquals($expected['moved'], $changes['moved']);
+        }
+    }
+
+    public function testCalculateChanges_EmptyInputs_NoChange()
+    {
+        $this->doit([], [], []);
+    }
+
+    public function testCalculateChanges_SameInputs_NoChange()
+    {
+        $this->doit(['a', 'b', 'c'], ['a', 'b', 'c'], []);
+    }
+
+    public function testCalculateChanges_FirstItemDeleted_NoMoves()
+    {
+        $this->doit(['a', 'b', 'c'], ['b', 'c'], ['added' => [], 'removed' => ['a'], 'moved' => []]);
+    }
+
+    public function testCalculateChanges_MiddleItemDeleted_NoMoves()
+    {
+        $this->doit(['a', 'b', 'c'], ['a', 'c'], ['added' => [], 'removed' => ['b'], 'moved' => []]);
+    }
+
+    public function testCalculateChanges_LastItemDeleted_NoMoves()
+    {
+        $this->doit(['a', 'b', 'c'], ['a', 'b'], ['added' => [], 'removed' => ['c'], 'moved' => []]);
+    }
+
+    public function testCalculateChanges_ItemAppended_NoMoves()
+    {
+        $this->doit(['a', 'b', 'c'], ['a', 'b', 'c', 'd'], ['added' => ['d'], 'removed' => [], 'moved' => []]);
+    }
+
+    public function testCalculateChanges_ItemAddedInFirstPosition_CreatesMoves()
+    {
+        $this->doit(['a', 'b', 'c'], ['d', 'a', 'b', 'c'], ['added' => ['d'], 'removed' => [], 'moved' => [0 => 1, 1 => 2, 2 => 3, 3 => 0]]);
+    }
+
+    public function testCalculateChanges_ItemAddedInSecondPosition_CreatesMoves()
+    {
+        $this->doit(['a', 'b', 'c'], ['a', 'd', 'b', 'c'], ['added' => ['d'], 'removed' => [], 'moved' => [0 => 0, 1 => 2, 2 => 3, 3 => 1]]);
+    }
+
+    public function testCalculateChanges_LotsOfChanges_RightOutput()
+    {
+        $this->doit(['a', 'b', 'c'], ['b', 'd', 'a'], ['added' => ['d'], 'removed' => ['c'], 'moved' => [0 => 2, 1 => 0, 2 => 1]]);
+    }
+}


### PR DESCRIPTION
This is the backend code that should enable https://github.com/sillsdev/web-languageforge/pull/209 to work: the Mongo mapper can now be told about some properties and subproperties (properties of properties) that should be treated with special care to match up the "old" values to the "new" values. For any order-sensitive properties, instead of matching the updated data from the frontend by index, it will match by a key contained in the data ("guid" by default), and reorder the data in Mongo before applying the normal update code.

The classic case is a lexical entry whose senses are being edited. Consider an entry with senses A, B and C. The user has created a new sense D, deleted sense B, and re-ordered the senses so that their order is now D, C, A. Furthermore, he has edited the meaning of sense C; we'll call the "new" sense C by the name C2, so what is coming in from the frontend is JSON for senses D, C2, A. (The GUIDs of C and C2 match up). The order of operations that the Mongo mapper now applies is:

* First, remove any items from Mongo that were deleted in the "new" data we've received.
    * Before this step, Mongo contained senses A, B, C
    * After this step, Mongo contained senses A, C
* Next, add any new items at the end of the current list (a "push" operation in Mongo)
    * Before this step, Mongo contained senses A, C
    * After this step, Mongo contained senses A, C, D
* Now match up the existing senses by GUID and rearrange them to match the order of the senses in the update
    * Before this step, Mongo contained senses A, C, D
    * After this step, Mongo contained senses D, C, A
* Now hand off to the existing update code, which applies updates by index
    * Before this step, Mongo contained senses D, C, A
    * After this step, Mongo contained senses D, C2, A

PHP tests are included for rearranging both senses and example sentences; there's one test left to write (where I rearrange senses *and* rearrange example sentences within those senses) but I've left it for later because it will be a bit large, and it's not needed in order to start reviewing this code.

All PHP unit tests pass, and all E2E tests pass for both LF and SF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/333)
<!-- Reviewable:end -->
