### PR TITLE
Delete project when trying to s/r empty project

### DIFF
--- a/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.component.ts
+++ b/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.component.ts
@@ -216,6 +216,7 @@ export class LexiconNewProjectController implements angular.IController {
     switch (status.SRState) {
       case SendReceiveState.Error:
         switch (status.ErrorCode) {
+          case SendReceiveErrorCodes.EmptyProject:
           case SendReceiveErrorCodes.NoFlexProject:
           case SendReceiveErrorCodes.Unauthorized:
             this.projectService.deleteProject([this.newProject.id]);


### PR DESCRIPTION
When the user tries to create a project that doesn't have any data
on LanguageDepot yet, we display an error message. We also have to
remove the project from the mongo database again so that when there
is data on LD the project gets created with the correct writing
systems and settings. Otherwise we will end up with a mismatch
between LD and LF.

This change adds the "delete from mongo" part.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/339)
<!-- Reviewable:end -->
