### PR TITLE
Stop duplicating translations of example sentences

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/LexExample.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexExample.php
@@ -12,8 +12,6 @@ class LexExample extends ObjectForEncoding
 
     public function __construct($liftId = '', $guid = '')
     {
-        $this->setPrivateProp('liftId');
-        $this->setReadOnlyProp('translationGuid');
         $this->setReadOnlyProp('authorInfo');
         if ($liftId) $this->liftId = $liftId;
         $this->guid = Guid::makeValid($guid);

--- a/src/Api/Model/Languageforge/Lexicon/LexSense.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexSense.php
@@ -24,7 +24,6 @@ class LexSense extends ObjectForEncoding
 
     public function __construct($liftId = '', $guid = '')
     {
-        $this->setPrivateProp('liftId');
         $this->setReadOnlyProp('authorInfo');
         $this->setRearrangeableProp('examples');
         $this->setRearrangeableProp('pictures');

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -1109,7 +1109,7 @@ export class LexiconEditorController implements angular.IController {
 
   private prepEntryForUpdate(entry: LexEntry): LexEntry {
     const entryForUpdate: LexEntry = this.recursiveRemoveProperties(angular.copy(entry),
-      ['guid', 'mercurialSha', 'authorInfo', 'dateCreated', 'dateModified', 'liftId', '$$hashKey']);
+      ['mercurialSha', 'authorInfo', 'dateCreated', 'dateModified', '$$hashKey']);
     return this.prepCustomFieldsForUpdate(entryForUpdate);
   }
 


### PR DESCRIPTION
Send/Receive needs to track the translation GUID all the way from the frontend to the FW project and back, so it needs to no longer be a read-only property in LexExample objects (so that it can be updated when the frontend reports a rearranged list of examples or senses). The `liftId` property is in a similar situation, and also needs to track with its parent sense or example if the parent is moved.