### PR TITLE
Fix timeout in WaitForFileExist

### DIFF
--- a/test/php/model/languageforge/lexicon/command/SendReceiveCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/SendReceiveCommandsTest.php
@@ -294,8 +294,9 @@ class SendReceiveCommandsTest extends TestCase
     private function WaitForFileExist($file, $timeoutSeconds)
     {
         $tenMicroSeconds = 10;
+        $timeoutMicroSeconds = $timeoutSeconds * 1000000;
         for ($waitMicroSeconds = 0;
-             $waitMicroSeconds < $timeoutSeconds * 1000;
+             $waitMicroSeconds < $timeoutMicroSeconds;
              $waitMicroSeconds += $tenMicroSeconds) {
             if (file_exists($file)) {
                 break;


### PR DESCRIPTION
A second is a million microseconds, not a thousand.

Also updated the code so it won't have to do the multiplication more than once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/345)
<!-- Reviewable:end -->
