### PR TITLE
Fix audio recording issue on Safari

### DIFF
--- a/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
+++ b/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
@@ -1,6 +1,10 @@
 import * as angular from 'angular';
 import * as lamejs from 'lamejs';
 
+declare var webkitAudioContext: {
+  new(): AudioContext;
+};
+
 export class AudioRecorderController implements angular.IController {
 
   static $inject = ['$interval', '$scope'];
@@ -32,7 +36,8 @@ export class AudioRecorderController implements angular.IController {
   }
 
   recordingSupported() {
-    return navigator.mediaDevices && navigator.mediaDevices.enumerateDevices && navigator.mediaDevices.getUserMedia;
+    return navigator.mediaDevices && navigator.mediaDevices.enumerateDevices && navigator.mediaDevices.getUserMedia &&
+      ((window as any).AudioContext || (window as any).webkitAudioContext);
   }
 
   $onDestroy() {
@@ -51,7 +56,8 @@ export class AudioRecorderController implements angular.IController {
       });
 
       const recordingStartTime = new Date();
-      const context = new AudioContext();
+      // webkit prefix required for Safari
+      const context = (window as any).AudioContext ? new AudioContext() : new webkitAudioContext();
       const bufferSize = 0;
       const channels = 1;
       const processor = context.createScriptProcessor(bufferSize, channels, channels);


### PR DESCRIPTION
Safari does not support `AudioContext` without vendor prefixing. This PR adds the user of the Webkit vendor prefix.

Audio recording is now supported in Safari 11+. Safari <=10 does not support `getUserMedia()`.

I tested this on BrowserStack and it appeared to work. Sound recording is, however, silent when done through BrowserStack. If anyone has an opportunity to test this in Safari 11+ that would be even better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/371)
<!-- Reviewable:end -->
