### PR TITLE
 Fix RTL in compact list view (LF-184)

### DIFF
--- a/src/Api/Model/Shared/Command/UserCommands.php
+++ b/src/Api/Model/Shared/Command/UserCommands.php
@@ -491,7 +491,7 @@ class UserCommands
 
     public static function getCaptchaData(Session $session)
     {
-        srand(microtime() * 100);
+        srand(microtime(True) * 100);
         $captchaData = [
             'items' => [
                 [

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -352,6 +352,7 @@ dc-entry .card {
     cursor: pointer;
   }
   .listItemPrimary {
+    text-align: initial;
     z-index: 2;
     font-size: 1.0em;
   }

--- a/src/angular-app/languageforge/semdomtrans/views/edit.css
+++ b/src/angular-app/languageforge/semdomtrans/views/edit.css
@@ -3,6 +3,7 @@
 }
 
 .listItemPrimary {
+    text-align: initial;
     z-index:2;
     padding-right: 3px;
     font-size: 1.0em;


### PR DESCRIPTION
Display RTL scripts on the right hand side of the compact list view.

This supersedes PR #372

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/381)
<!-- Reviewable:end -->
