### PR TITLE
Fix truncated lines in Gulp output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1546,16 +1546,20 @@ function execute(command, options, callback) {
     var process = _execute(command, options, callback || undefined);
 
     process.stdout.on('data', function (data) {
-      gutil.log(data.slice(0, -1)); // remove trailing \n
+      gutil.log(stripTrailingLF(data));
     });
 
     process.stderr.on('data', function (data) {
-      gutil.log(gutil.colors.yellow(data.slice(0, -1))); // remove trailing \n
+      gutil.log(gutil.colors.yellow(stripTrailingLF(data)));
     });
 
   } else {
     callback(null);
   }
+}
+
+function stripTrailingLF (line) {
+  return line[line.length-1] === '\n' ? line.slice(0, -1) : line;
 }
 
 // Determine the path to test/app from a given destination.


### PR DESCRIPTION
I introduced this issue more than a year ago when fixing other issues related to shelling out. It was supposed to trim `\n` characters off the end of each line before logging it, but it operated with the incorrect assumption that every piece of data that came its way ended with a newline character (which may have incidentally been correct at the time). This resulted in lines that said "WAR" instead of "WARN" or "np" instead of "npm". It also appears to have split lines that were not supposed to be split up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/394)
<!-- Reviewable:end -->
