### PR TITLE
Fix hostname of Vagrant creation box and formatting of instructions

### DIFF
--- a/deploy/virtualbox_xenial_gui_creation/Vagrantfile
+++ b/deploy/virtualbox_xenial_gui_creation/Vagrantfile
@@ -8,7 +8,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "chrisvire/xenial64"
   config.ssh.insert_key = false
-  config.vm.hostname = "vag-u1604-xf-creation"
+  config.vm.hostname = "vag-u1604-xf"
 
   config.vm.provider "virtualbox" do |v|
     v.name="vag-u1604-xf-creation"

--- a/deploy/virtualbox_xenial_gui_creation/instructions.md
+++ b/deploy/virtualbox_xenial_gui_creation/instructions.md
@@ -12,15 +12,18 @@ Don't halt the vagrant box too quickly after it finishes provisioning, so the ze
 
 After making the base box, you can do the following smoke test. Note that you should not publish the box that you did the smoke test in, since it won't be cleaned up from the original provision (such as deleting ssh host keys).
 
+```
 cd ~/src/web-languageforge
 ./refreshDeps.sh
 gulp test-php
 gulp webpack-sf
 cd ~/src/web-languageforge/src/SIL.XForge.Scripture
 dotnet run &
+```
 
 A longer test could be:
 
+```
 #!/bin/bash
 set -e -o pipefail
 cd ~/src/web-languageforge
@@ -34,3 +37,4 @@ gulp webpack-sf
 ./rune2e.sh sf
 cd ~/src/web-languageforge/src/SIL.XForge.Scripture
 dotnet run &
+```


### PR DESCRIPTION
This fixes two issues:
- Code in the instructions file was run together (see [the previous version rendered](https://github.com/sillsdev/web-languageforge/blob/b9295dd5db7b0d159dae8dbc02b1e5ff24b57d57/deploy/virtualbox_xenial_gui_creation/instructions.md)).
- The hostname of the creation box being `vag-u1604-xf-creation` caused issues because later the box hostname would be `vag-u1604-xf`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/395)
<!-- Reviewable:end -->
