### PR TITLE
SF-68 Reset password page should accept only 7+ character passwords and maximum limit needs to be removed

### DIFF
--- a/src/SIL.XForge.Identity/Controllers/Account/ResetPasswordViewModel.cs
+++ b/src/SIL.XForge.Identity/Controllers/Account/ResetPasswordViewModel.cs
@@ -5,13 +5,13 @@ namespace SIL.XForge.Identity.Controllers.Account
     public class ResetPasswordViewModel
     {
         [Required]
-        [StringLength(12, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+        [MinLength(7, ErrorMessage = "{0} must be at least {1} characters ")]
         [DataType(DataType.Password)]
         [Display(Name = "Password")]
         public string Password { get; set; }
 
         [Required]
-        [StringLength(12, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+        [MinLength(7, ErrorMessage = "{0} must be at least {1} characters ")]
         [DataType(DataType.Password)]
         [Display(Name = "Confirm Password")]
         public string ConfirmPassword { get; set; }


### PR DESCRIPTION
Fixed the issue by removing maximum length and setting minimum length 7 characters for Password and Conform Password.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/417)
<!-- Reviewable:end -->
