### PR TITLE
Fix: SF-69

### DIFF
--- a/src/SIL.XForge.Identity/Controllers/Account/AccountController.cs
+++ b/src/SIL.XForge.Identity/Controllers/Account/AccountController.cs
@@ -223,14 +223,14 @@ namespace SIL.XForge.Identity.Controllers.Account
                 else
                 {
                     LoginViewModel vm = await BuildLoginViewModelAsync("");
-                    vm.ShowMessage = "The password reset request has expired. Please request another reset.";
-                    return Redirect("Login");
+                    TempData["showMessage"] = "The password reset request has expired. Please request another reset.";
+                    return RedirectToAction("Login", "Account");
                 }
             }
             else
             {
                 LoginViewModel vm = await BuildLoginViewModelAsync("");
-                return Redirect("Login");
+                return RedirectToAction("Login", "Account");
             }
         }
 
@@ -296,8 +296,8 @@ namespace SIL.XForge.Identity.Controllers.Account
                         .Set(u => u.Password, BCrypt.Net.BCrypt.HashPassword(model.Password, 7))
                         .Set(u => u.ResetPasswordExpirationDate, DateTime.Now.AddYears(-42)));
                     LoginViewModel vm = await BuildLoginViewModelAsync("");
-                    vm.ShowMessage = "Your password has been reset. Please login.";
-                    return Redirect("Login");
+                    TempData["showMessage"] = "Your password has been reset. Please login.";
+                    return RedirectToAction("Login", "Account");
                 }
             }
             return View(model);

--- a/test/SIL.XForge.Identity.Tests/Controllers/Account/AccountControllerTests.cs
+++ b/test/SIL.XForge.Identity.Tests/Controllers/Account/AccountControllerTests.cs
@@ -137,10 +137,12 @@ namespace SIL.XForge.Identity.Controllers.Account
             const string resetPasswordKey = "not" + TestResetPasswordKey;
             var env = new TestEnvironment();
 
-            var result = await env.Controller.ResetPassword(resetPasswordKey);
-            Assert.That(result, Is.TypeOf<RedirectResult>(), "shouldn't accept incorrect key");
-            var redirectResult = result as RedirectResult;
-            Assert.That(redirectResult.Url, Is.EqualTo("Login"), "bad link should redirect to login");
+            var result = (RedirectToActionResult) await env.Controller.ResetPassword(resetPasswordKey);
+            Assert.AreEqual("Account", result.ControllerName);
+            Assert.AreEqual("Login", result.ActionName);
+            Assert.That(result, Is.TypeOf<RedirectToActionResult>(), "shouldn't accept incorrect key");
+            var redirectResult = result as RedirectToActionResult;
+            Assert.That(redirectResult.ActionName, Is.EqualTo("Login"), "bad link should redirect to login");
         }
 
         [Test]
@@ -149,10 +151,12 @@ namespace SIL.XForge.Identity.Controllers.Account
             const string resetPasswordKey = TestResetPasswordKey;
             var env = new TestEnvironment(isResetLinkExpired: true);
 
-            var result = await env.Controller.ResetPassword(resetPasswordKey);
-            Assert.That(result, Is.TypeOf<RedirectResult>(), "shouldn't accept expired key");
-            var redirectResult = result as RedirectResult;
-            Assert.That(redirectResult.Url, Is.EqualTo("Login"), "bad link should redirect to login");
+            var result = (RedirectToActionResult) await env.Controller.ResetPassword(resetPasswordKey);
+            Assert.AreEqual("Account", result.ControllerName);
+            Assert.AreEqual("Login", result.ActionName);
+            Assert.That(result, Is.TypeOf<RedirectToActionResult>(), "shouldn't accept expired key");
+            var redirectResult = result as RedirectToActionResult;
+            Assert.That(redirectResult.ActionName, Is.EqualTo("Login"), "bad link should redirect to login");
         }
 
         [Test]
@@ -166,9 +170,12 @@ namespace SIL.XForge.Identity.Controllers.Account
                 ConfirmPassword = "NewPassword"
             };
             var beforeSave = await env.Users.Query().SingleOrDefaultAsync();
-            var result = await env.Controller.ResetPassword(model);
-            Assert.That(result, Is.TypeOf<RedirectResult>(), "bad username should redirect to login");
-            Assert.That(((RedirectResult)result).Url, Is.EqualTo("Login"), "bad username should redirect to login");
+            var result = (RedirectToActionResult) await env.Controller.ResetPassword(model);
+            Assert.AreEqual("Account", result.ControllerName);
+            Assert.AreEqual("Login", result.ActionName);
+            Assert.That(result, Is.TypeOf<RedirectToActionResult>(), "bad username should redirect to login");
+            var redirectResult = result as RedirectToActionResult;
+            Assert.That(redirectResult.ActionName, Is.EqualTo("Login"), "bad username should redirect to login");
             var afterSave = await env.Users.Query().SingleOrDefaultAsync();
             Assert.That(afterSave.Password, Is.EqualTo(beforeSave.Password));
         }
@@ -205,7 +212,7 @@ namespace SIL.XForge.Identity.Controllers.Account
             };
             var beforeSave = await env.Users.Query().SingleOrDefaultAsync();
             var result = await env.Controller.ResetPassword(model);
-            Assert.That(result, Is.TypeOf<RedirectResult>());
+            Assert.That(result, Is.TypeOf<RedirectToActionResult>());
             var afterSave = await env.Users.Query().SingleOrDefaultAsync();
             Assert.That(afterSave.Password, Is.Not.EqualTo(beforeSave.Password));
         }
@@ -222,14 +229,16 @@ namespace SIL.XForge.Identity.Controllers.Account
                 ConfirmPassword = "NewPassword"
             };
             var beforeSave = await env.Users.Query().SingleOrDefaultAsync();
-            var result = await env.Controller.ResetPassword(model);
-            Assert.That(result, Is.TypeOf<RedirectResult>());
+            var result = (RedirectToActionResult) await env.Controller.ResetPassword(model);
+            Assert.That(result, Is.TypeOf<RedirectToActionResult>());
             var afterSave = await env.Users.Query().SingleOrDefaultAsync();
             Assert.True(beforeSave.Password != afterSave.Password);
-            result = await env.Controller.ResetPassword(TestResetPasswordKey);
-            Assert.That(result, Is.TypeOf<RedirectResult>(), "link should work only once");
-            var redirectResult = result as RedirectResult;
-            Assert.That(redirectResult.Url, Is.EqualTo("Login"), "bad link should redirect to login");
+            result = (RedirectToActionResult) await env.Controller.ResetPassword(TestResetPasswordKey);
+            Assert.AreEqual("Account", result.ControllerName);
+            Assert.AreEqual("Login", result.ActionName);
+            Assert.That(result, Is.TypeOf<RedirectToActionResult>(), "link should work only once");
+            var redirectResult = result as RedirectToActionResult;
+            Assert.That(redirectResult.ActionName, Is.EqualTo("Login"), "bad link should redirect to login");
         }
 
         [Test]


### PR DESCRIPTION
FIX: SF -69 Reset password page does not returns with information message pop up.

Once Reset password been updated, alert message be thrown to login page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/419)
<!-- Reviewable:end -->
