### PR TITLE
Fix: SF-79 "Email Address" label should not move along with password 

### DIFF
--- a/src/SIL.XForge.Identity/Controllers/Account/RegisterViewModel.cs
+++ b/src/SIL.XForge.Identity/Controllers/Account/RegisterViewModel.cs
@@ -5,13 +5,13 @@ namespace SIL.XForge.Identity.Controllers.Account
     public class RegisterViewModel
     {
         [Required]
-        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 7)]
         [DataType(DataType.Text)]
         [Display(Name = "Full Name")]
         public string Fullname { get; set; }
 
         [Required]
-        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 7)]
         [DataType(DataType.Password)]
         [Display(Name = "Password")]
         public string Password { get; set; }

--- a/src/SIL.XForge.Identity/Views/Account/ForgotPassword.cshtml
+++ b/src/SIL.XForge.Identity/Views/Account/ForgotPassword.cshtml
@@ -1,31 +1,29 @@
 @using SIL.XForge.Identity.Controllers.Account
 @model ForgotPasswordViewModel
 
-<div align="center" class="forgot-password-content">
-    <div>
-        <div>
-            <h1>Forgot Password</h1>
-            <p>Please enter your <b>email or username</b> and we will send you an email to reset your password.</p>
-            @if (Model.EnableErrorMessage)
-            {
-            <div class="alert-error">
-                <div > User not found. </div>
-            </div>
-            }
-        </div>
-
-        <form asp-action="ForgotPassword" accept-charset="utf-8" id="forgot-password-form" name="forgotPasswordForm">
-            <fieldset>
-                <div>
-                    <span class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                        <input class="mdl-textfield__input" type="text" asp-for="EmailOrUsername" autofocus>
-                        <label class="mdl-textfield__label">Email or username</label>
-                    </span>
-                    <button class="mdl-button mdl-js-button mdl-button--raised">
-                        Submit
-                    </button>
-                </div>
-            </fieldset>
-        </form>
+<div class="mdl-layout-spacer"></div>
+<div class="mdl-cell mdl-cell--4-col">
+    <h3 class="mdl-color-text--primary-dark">Forgot Password</h3>
+    <p>Please enter your <b>email or username</b> and we will send you an email to reset your password.</p>
+    @if (Model.EnableErrorMessage)
+    {
+    <div class="alert-error">
+        <div > User not found. </div>
     </div>
+    }
+
+    <form asp-action="ForgotPassword" accept-charset="utf-8" id="forgot-password-form" name="forgotPasswordForm">
+        <fieldset>
+            <div>
+                <span class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                    <input class="mdl-textfield__input" type="text" asp-for="EmailOrUsername" autofocus>
+                    <label class="mdl-textfield__label">Email or username</label>
+                </span>
+                <button class="mdl-button mdl-js-button mdl-button--raised">
+                    Submit
+                </button>
+            </div>
+        </fieldset>
+    </form>
 </div>
+<div class="mdl-layout-spacer"></div>

--- a/src/SIL.XForge.Identity/Views/Account/Register.cshtml
+++ b/src/SIL.XForge.Identity/Views/Account/Register.cshtml
@@ -1,55 +1,46 @@
 @using SIL.XForge.Identity.Controllers.Account
 @model RegisterViewModel
-@section css {
-    <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.css" />
-}
 @{
     ViewData["Title"] = "Register";
 }
-<div class="register-page">
-    <div class="page-header">
-        <h1>Register</h1>
-    </div>
+<div class="mdl-layout-spacer"></div>
+<div class="mdl-cell mdl-cell--4-col">
+    <h3 class="mdl-color-text--primary-dark">Register</h3>
+    <h4 class="mdl-form_title">Create an account</h4>
+    <form asp-controller="Account" asp-action="Register" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" autocomplete="off">
+        <fieldset>
+            <div class="validationsummary">
+                @Html.Partial("_ValidationSummary")
+            </div>
+            <div class="mdl-form_content register-form">
+                <span class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                    <input asp-for="Fullname" id="name" placeholder="Full Name" class="mdl-textfield__input" autofocus required="username"/>
+                    <label asp-for="Fullname" for="name" class="mdl-textfield__label" ></label>
+                </span>
+                <span class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                    <label asp-for="Password" for="Password" class="mdl-textfield__label" ></label>
+                    <input asp-for="Password" id="Password" placeholder="Password" class="mdl-textfield__input" required="password" />
+                    <div id="StrengthProgressBar" class="progress-bar"></div>
+                </span>
+                <span class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                    <label asp-for="Email" for="email" class="mdl-textfield__label" ></label>
+                    <input asp-for="Email" id="email" placeholder="Email Address" class="mdl-textfield__input" required="" />
 
-    <div class="row">
-        <div class="col-sm-6">
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h3 class="panel-title">Create an account</h3>
+                </span>
+                <span class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                    <div class="g-recaptcha" data-size="normal" data-sitekey="@ViewData["ReCaptchaKey"]"></div>
+                </span>
+                <div>
+                    <button type="submit" class="mdl-button mdl-js-button mdl-button--raised">Register</button>
                 </div>
-                <div class="panel-body">
-                    <form asp-controller="Account" asp-action="Register" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" autocomplete="off">
-                        @Html.Partial("_ValidationSummary")
-                        <fieldset>
-                        <div class="form-group">
-                                <label asp-for="Fullname" ></label>
-                                <input asp-for="Fullname" placeholder="Full Name" class="form-control" autofocus/>
-                            </div>
-                            <div class="form-group password">
-                                <label asp-for="Password" ></label>
-                                <input asp-for="Password" placeholder="Password" class="form-control" />
-                                <div id="StrengthProgressBar" class="progress-bar"></div>
-                            </div>
-                            <div class="form-group">
-                                <label asp-for="Email" ></label>
-                                <input asp-for="Email" placeholder="Email Address" class="form-control" />
-                            </div>
-                            <div class="form-group">
-                                <div class="g-recaptcha" data-size="normal" data-sitekey="@ViewData["ReCaptchaKey"]"></div>
-                            </div>
-                            <div class="form-group">
-                                <button type="submit" class="btn btn-default">Register</button>
-                            </div>
-                            <div class="form-group">
-                                <span style="color: green;">@ViewBag.StatusMessage</span>
-                            </div>
-                        </fieldset>
-                    </form>
-                    </div>
+                <div class="mdl-textfield">
+                    <span style="color: green;">@ViewBag.StatusMessage</span>
                 </div>
             </div>
-    </div>
+        </fieldset>
+    </form>
 </div>
+<div class="mdl-layout-spacer"></div>
 @section Scripts {
     <script src="~/lib/bootstrap/js/bootstrap.js"></script>
     <script src='https://www.google.com/recaptcha/api.js'></script>

--- a/src/SIL.XForge.Identity/Views/Account/ResetPassword.cshtml
+++ b/src/SIL.XForge.Identity/Views/Account/ResetPassword.cshtml
@@ -1,8 +1,9 @@
 @using SIL.XForge.Identity.Controllers.Account
 @model ResetPasswordViewModel
 
-<div align="center" class="reset-password-content">
-    <h1>Reset Password</h1>
+<div class="mdl-layout-spacer"></div>
+<div class="mdl-cell mdl-cell--4-col">
+    <h3 class="mdl-color-text--primary-dark">Reset Password</h3>
 
     @Html.Partial("_ValidationSummary")
     <form asp-action="ResetPassword" method="post">
@@ -27,4 +28,4 @@
         </fieldset>
     </form>
 </div>
-
+<div class="mdl-layout-spacer"></div>

--- a/src/SIL.XForge.Identity/wwwroot/css/site.css
+++ b/src/SIL.XForge.Identity/wwwroot/css/site.css
@@ -148,6 +148,18 @@
   }
 }
 
-.reset-password-content {
-  margin-top:125px;
+.login-page {
+  width:100%;
+}
+
+.register-form {
+  clear: both;
+  max-width     : 400px;
+  margin-bottom : 24px;
+}
+
+.validationsummary
+{
+  width: 400px;
+  text-align: left;
 }

--- a/src/SIL.XForge.Scripture/Views/Shared/_Layout.cshtml
+++ b/src/SIL.XForge.Scripture/Views/Shared/_Layout.cshtml
@@ -20,7 +20,7 @@
     @RenderSection("css", required: false)
 </head>
 <body>
-    <div class="mdl-layout__content container body-content">
+    <div class="mdl-grid container body-content">
         @RenderBody()
     </div>
     <script src="~/lib/jquery/jquery.js"></script>


### PR DESCRIPTION
Fix: SF-79 "Email Address" label should not move along with password strength

 * Fixed the problem - moving the email label control.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/421)
<!-- Reviewable:end -->
