### PR TITLE
SF-67: reset password loopholes

### DIFF
--- a/src/SIL.XForge.Identity/Controllers/Account/ResetPasswordViewModel.cs
+++ b/src/SIL.XForge.Identity/Controllers/Account/ResetPasswordViewModel.cs
@@ -15,6 +15,9 @@ namespace SIL.XForge.Identity.Controllers.Account
         [DataType(DataType.Password)]
         [Display(Name = "Confirm Password")]
         public string ConfirmPassword { get; set; }
-        public string Username {get; set;}
+
+        public string Username { get; set; }
+
+        public string ResetToken { get; set; }
     }
 }

--- a/src/SIL.XForge.Identity/Views/Account/ResetPassword.cshtml
+++ b/src/SIL.XForge.Identity/Views/Account/ResetPassword.cshtml
@@ -20,7 +20,15 @@
             <div class="form-group password">
                 <span class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
                     <label class="mdl-textfield__label">Confirm Password</label>
-                    <input class="mdl-textfield__input"  asp-for="ConfirmPassword" autofocus>
+                    <input class="mdl-textfield__input"  asp-for="ConfirmPassword">
+                </span>
+            </div>
+        </fieldset>
+        <fieldset>
+            <div class="form-group password">
+                <span class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                    <input type="hidden" asp-for="Username">
+                    <input type="hidden" asp-for="ResetToken">
                 </span>
             </div>
         </fieldset>

--- a/test/SIL.XForge.Identity.Tests/Controllers/Account/AccountControllerTests.cs
+++ b/test/SIL.XForge.Identity.Tests/Controllers/Account/AccountControllerTests.cs
@@ -31,9 +31,10 @@ namespace SIL.XForge.Identity.Controllers.Account
         private const string TestUserId = "user01";
         private const string TestUsername = "user";
         private const string TestPassword = "pa$$w0rd";
-        private const string TestResetPasswordKey = "jGc6Qe4i1kgM+aA4LVczTJwfHx2YuDR/";
+        private const string TestResetPasswordKey = "jGc6Qe4i1kgM+aA4LVczTJwfHx2YuDR9";
         private const string TestUserEmail = "abc@fakegmail.com";
-        private const string TestReturnUrl = "https://beta.scriptureforge.local/home";
+        private const string TestReturnUrl = "http://beta.scriptureforge.local/home";
+        private const string ShowMessageKey = "showMessage";
 
         [Test]
         public async Task Login_CorrectPassword()
@@ -56,6 +57,8 @@ namespace SIL.XForge.Identity.Controllers.Account
                 CookieAuthenticationDefaults.AuthenticationScheme,
                 Arg.Is<ClaimsPrincipal>(u => u.GetSubjectId() == TestUserId),
                 Arg.Any<AuthenticationProperties>());
+            Assert.Less(env.Users.Query().First(u => u.Username == TestUsername).ResetPasswordExpirationDate, DateTime.UtcNow,
+                "successful login should invalidate pasword reset");
         }
 
         [Test]
@@ -74,13 +77,15 @@ namespace SIL.XForge.Identity.Controllers.Account
             Assert.That(result, Is.TypeOf<ViewResult>());
             Assert.That(env.Controller.ModelState.ErrorCount, Is.EqualTo(1));
             await env.Events.Received().RaiseAsync(Arg.Any<UserLoginFailureEvent>());
+            Assert.Greater(env.Users.Query().First(u => u.Username == TestUsername).ResetPasswordExpirationDate, DateTime.UtcNow,
+                "Unsuccessful login should not invalidate pasword reset");
         }
 
         [Test]
         public async Task ForgotPassword_CorrectEmailOrUsername(
             [Values(TestUsername, TestUserEmail)] string emailOrUsername)
         {
-            var env = new TestEnvironment();
+            var env = new TestEnvironment(isResetLinkExpired: true);
 
             var model = new ForgotPasswordViewModel
             {
@@ -95,12 +100,11 @@ namespace SIL.XForge.Identity.Controllers.Account
             var user = await env.Users.Query().SingleOrDefaultAsync(
                 x => x.Username == model.EmailOrUsername || x.Email == model.EmailOrUsername);
             Assert.That(user.ResetPasswordKey, Is.Not.EqualTo(TestResetPasswordKey), "ResetPasswordKey not updated.");
-            Assert.That(user.ResetPasswordExpirationDate, Is.GreaterThan(DateTime.Now), "ResetPasswordExpirationDate expired very quickly!");
+            Assert.That(user.ResetPasswordExpirationDate, Is.GreaterThan(DateTime.UtcNow), "ResetPasswordExpirationDate expired very quickly!");
 
-            string emailId = TestUserEmail;
-            string subject = "xForge Forgotten Password Verification";
-            // Skip verification for the body, we may change the content
-            await env.EmailService.Received().SendEmailAsync(Arg.Is(emailId), Arg.Is(subject), Arg.Any<string>());
+            const string subject = "xForge Forgotten Password Verification";
+            // Skip verification for the body; we may change the content
+            await env.EmailService.Received().SendEmailAsync(Arg.Is(TestUserEmail), Arg.Is(subject), Arg.Any<string>());
         }
 
         [Test]
@@ -127,8 +131,7 @@ namespace SIL.XForge.Identity.Controllers.Account
 
             var result = await env.Controller.ResetPassword(resetPasswordKey);
             Assert.That(result, Is.TypeOf<ViewResult>());
-            var viewResult = result as ViewResult;
-            Assert.True(viewResult.ViewName == "ResetPassword");
+            Assert.True(((ViewResult)result).ViewName == "ResetPassword", "valid token should allow user to reset password");
         }
 
         [Test]
@@ -139,10 +142,7 @@ namespace SIL.XForge.Identity.Controllers.Account
 
             var result = (RedirectToActionResult) await env.Controller.ResetPassword(resetPasswordKey);
             Assert.AreEqual("Account", result.ControllerName);
-            Assert.AreEqual("Login", result.ActionName);
-            Assert.That(result, Is.TypeOf<RedirectToActionResult>(), "shouldn't accept incorrect key");
-            var redirectResult = result as RedirectToActionResult;
-            Assert.That(redirectResult.ActionName, Is.EqualTo("Login"), "bad link should redirect to login");
+            Assert.AreEqual("Login", result.ActionName, "bad link should redirect to login");
         }
 
         [Test]
@@ -153,10 +153,8 @@ namespace SIL.XForge.Identity.Controllers.Account
 
             var result = (RedirectToActionResult) await env.Controller.ResetPassword(resetPasswordKey);
             Assert.AreEqual("Account", result.ControllerName);
-            Assert.AreEqual("Login", result.ActionName);
-            Assert.That(result, Is.TypeOf<RedirectToActionResult>(), "shouldn't accept expired key");
-            var redirectResult = result as RedirectToActionResult;
-            Assert.That(redirectResult.ActionName, Is.EqualTo("Login"), "bad link should redirect to login");
+            Assert.AreEqual("Login", result.ActionName, "bad link should redirect to login");
+            StringAssert.Contains("expired", env.Controller.TempData[ShowMessageKey].ToString(), "user should be informed that the link is expired");
         }
 
         [Test]
@@ -167,17 +165,15 @@ namespace SIL.XForge.Identity.Controllers.Account
             var model = new ResetPasswordViewModel
             {
                 Password = "NewPassword",
-                ConfirmPassword = "NewPassword"
+                ConfirmPassword = "NewPassword",
+                ResetToken = TestResetPasswordKey
             };
             var beforeSave = await env.Users.Query().SingleOrDefaultAsync();
             var result = (RedirectToActionResult) await env.Controller.ResetPassword(model);
             Assert.AreEqual("Account", result.ControllerName);
-            Assert.AreEqual("Login", result.ActionName);
-            Assert.That(result, Is.TypeOf<RedirectToActionResult>(), "bad username should redirect to login");
-            var redirectResult = result as RedirectToActionResult;
-            Assert.That(redirectResult.ActionName, Is.EqualTo("Login"), "bad username should redirect to login");
+            Assert.AreEqual("Login", result.ActionName, "bad username should redirect to login");
             var afterSave = await env.Users.Query().SingleOrDefaultAsync();
-            Assert.That(afterSave.Password, Is.EqualTo(beforeSave.Password));
+            Assert.That(afterSave.Password, Is.EqualTo(beforeSave.Password), "Password should not have changed");
         }
 
         [Test]
@@ -189,32 +185,72 @@ namespace SIL.XForge.Identity.Controllers.Account
             {
                 Username = TestUsername,
                 Password = "NewPassword",
-                ConfirmPassword = "NewPassword1"
+                ConfirmPassword = "NewPassword1",
+                ResetToken = TestResetPasswordKey
             };
             var beforeSave = await env.Users.Query().SingleOrDefaultAsync();
             var result = await env.Controller.ResetPassword(model);
-            Assert.That(result, Is.TypeOf<ViewResult>());
+            Assert.That(result, Is.TypeOf<ViewResult>(), "User should have a chance to try again");
             var afterSave = await env.Users.Query().SingleOrDefaultAsync();
-            Assert.That(afterSave.Password, Is.EqualTo(beforeSave.Password));
+            Assert.That(afterSave.Password, Is.EqualTo(beforeSave.Password), "Password should not have changed");
+        }
+
+        [Test]
+        public async Task ResetPassword_IncorrectResetKey_PasswordNotSaved()
+        {
+            var env = new TestEnvironment();
+
+            var model = new ResetPasswordViewModel
+            {
+                Username = TestUsername,
+                Password = "NewPassword",
+                ConfirmPassword = "NewPassword",
+                ResetToken = TestResetPasswordKey + "bad"
+            };
+            var beforeSave = await env.Users.Query().SingleOrDefaultAsync();
+            var result = await env.Controller.ResetPassword(model);
+            Assert.That(result, Is.TypeOf<RedirectToActionResult>());
+            var afterSave = await env.Users.Query().SingleOrDefaultAsync();
+            Assert.That(afterSave.Password, Is.EqualTo(beforeSave.Password), "Password should not have changed");
+        }
+
+        [Test]
+        public async Task ResetPassword_ExpiredResetKey_PasswordNotSaved()
+        {
+            var env = new TestEnvironment(isResetLinkExpired: true);
+
+            var model = new ResetPasswordViewModel
+            {
+                Username = TestUsername,
+                Password = "NewPassword",
+                ConfirmPassword = "NewPassword",
+                ResetToken = TestResetPasswordKey
+            };
+            var beforeSave = await env.Users.Query().SingleOrDefaultAsync();
+            var result = await env.Controller.ResetPassword(model);
+            Assert.That(result, Is.TypeOf<RedirectToActionResult>());
+            var afterSave = await env.Users.Query().SingleOrDefaultAsync();
+            Assert.That(afterSave.Password, Is.EqualTo(beforeSave.Password), "Password should not have changed");
         }
 
         [Test]
         public async Task ResetPassword_PasswordSaved()
         {
             var env = new TestEnvironment();
-            const string NewPassword = "N3wP@ssword";
+            const string newPassword = "N3wP@ssword";
 
             var model = new ResetPasswordViewModel
             {
                 Username = TestUsername,
-                Password = NewPassword,
-                ConfirmPassword = NewPassword
+                Password = newPassword,
+                ConfirmPassword = newPassword,
+                ResetToken = TestResetPasswordKey
             };
             var beforeSave = await env.Users.Query().SingleOrDefaultAsync();
             var result = await env.Controller.ResetPassword(model);
             Assert.That(result, Is.TypeOf<RedirectToActionResult>());
             var afterSave = await env.Users.Query().SingleOrDefaultAsync();
-            Assert.That(afterSave.Password, Is.Not.EqualTo(beforeSave.Password));
+            Assert.That(afterSave.Password, Is.Not.EqualTo(beforeSave.Password), "Password should have been updated");
         }
 
         [Test]
@@ -226,19 +262,16 @@ namespace SIL.XForge.Identity.Controllers.Account
             {
                 Username = TestUsername,
                 Password = "NewPassword",
-                ConfirmPassword = "NewPassword"
+                ConfirmPassword = "NewPassword",
+                ResetToken = TestResetPasswordKey
             };
             var beforeSave = await env.Users.Query().SingleOrDefaultAsync();
-            var result = (RedirectToActionResult) await env.Controller.ResetPassword(model);
-            Assert.That(result, Is.TypeOf<RedirectToActionResult>());
+            await env.Controller.ResetPassword(model);
             var afterSave = await env.Users.Query().SingleOrDefaultAsync();
-            Assert.True(beforeSave.Password != afterSave.Password);
-            result = (RedirectToActionResult) await env.Controller.ResetPassword(TestResetPasswordKey);
+            Assert.That(beforeSave.Password, Is.Not.EqualTo(afterSave.Password), "first reset should work");
+            var result = (RedirectToActionResult) await env.Controller.ResetPassword(TestResetPasswordKey);
             Assert.AreEqual("Account", result.ControllerName);
-            Assert.AreEqual("Login", result.ActionName);
-            Assert.That(result, Is.TypeOf<RedirectToActionResult>(), "link should work only once");
-            var redirectResult = result as RedirectToActionResult;
-            Assert.That(redirectResult.ActionName, Is.EqualTo("Login"), "bad link should redirect to login");
+            Assert.AreEqual("Login", result.ActionName, "bad link should redirect to login");
         }
 
         [Test]
@@ -248,7 +281,7 @@ namespace SIL.XForge.Identity.Controllers.Account
 
             var model = new RegisterViewModel
             {
-                Fullname = "testsamplename",
+                Fullname = "Test Sample Name",
                 Password = "password1234",
                 Email = "testeremail@gmail.com"
             };
@@ -299,7 +332,7 @@ namespace SIL.XForge.Identity.Controllers.Account
             Assert.That(env.Controller.ModelState.ErrorCount, Is.EqualTo(1));
         }
 
-        class TestEnvironment
+        private class TestEnvironment
         {
             public TestEnvironment(bool isResetLinkExpired = false)
             {
@@ -325,8 +358,8 @@ namespace SIL.XForge.Identity.Controllers.Account
                             Password = BCrypt.Net.BCrypt.HashPassword(TestPassword, 7),
                             ResetPasswordKey =  TestResetPasswordKey,
                             ResetPasswordExpirationDate = isResetLinkExpired
-                                ? DateTime.Now.AddTicks(-1)
-                                : DateTime.Now.AddMinutes(2),
+                                ? DateTime.UtcNow.AddTicks(-1)
+                                : DateTime.UtcNow.AddMinutes(2),
                             Email = TestUserEmail
                         }
                     });
@@ -377,8 +410,8 @@ namespace SIL.XForge.Identity.Controllers.Account
             public IAuthenticationService AuthService { get; }
             public IEventService Events { get; }
             public AccountController Controller { get; }
-            public MemoryRepository<UserEntity> Users { get; set; }
-            public IEmailService EmailService { get; set; }
+            public MemoryRepository<UserEntity> Users { get; }
+            public IEmailService EmailService { get; }
 
         }
     }


### PR DESCRIPTION
- check token and expiry before honoring the the final reset request
- invalidate the reset token following a successful login (the user obviously remembers the forgotten password)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/428)
<!-- Reviewable:end -->
