### PR TITLE
Fix .localhost and allow insecure

### DIFF
--- a/src/SIL.XForge.Identity/XFIdentityServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Identity/XFIdentityServiceCollectionExtensions.cs
@@ -28,8 +28,9 @@ namespace SIL.XForge.Identity
             }
         };
 
-        private static Client XFClient(string domain)
+        private static Client XFClient(string domain, bool insecureProtocol = false)
         {
+            string protocol = insecureProtocol ? "http" : "https";
             return new Client
             {
                 ClientId = "xForge",
@@ -40,12 +41,12 @@ namespace SIL.XForge.Identity
                 RequireConsent = false,
                 RedirectUris =
                 {
-                    $"https://{domain}/home",
-                    $"https://{domain}/silent-refresh.html"
+                    $"{protocol}://{domain}/home",
+                    $"{protocol}://{domain}/silent-refresh.html"
                 },
                 PostLogoutRedirectUris =
                 {
-                    $"https://{domain}/"
+                    $"{protocol}://{domain}/"
                 },
                 AllowedScopes =
                 {
@@ -58,7 +59,7 @@ namespace SIL.XForge.Identity
         }
 
         public static IServiceCollection AddXFIdentityServer(this IServiceCollection services,
-            IConfiguration configuration)
+            IConfiguration configuration, bool insecureProtocol = false)
         {
             services.AddOptions<GoogleCaptchaOptions>(configuration);
 
@@ -70,7 +71,7 @@ namespace SIL.XForge.Identity
                 .AddValidationKeys()
                 .AddInMemoryIdentityResources(IdentityResources)
                 .AddInMemoryApiResources(ApiResources)
-                .AddInMemoryClients(new[] { XFClient(siteOptions.Domain) })
+                .AddInMemoryClients(new[] { XFClient(siteOptions.Domain, insecureProtocol) })
                 .AddProfileService<UserProfileService>()
                 .AddResourceOwnerValidator<UserResourceOwnerPasswordValidator>()
                 .AddOperationalStore(options =>

--- a/src/SIL.XForge.Scripture/ClientApp/e2e/protractor.conf.js
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/protractor.conf.js
@@ -12,7 +12,7 @@ exports.config = {
     browserName: 'chrome'
   },
   directConnect: true,
-  baseUrl: 'https://beta.scriptureforge.local/',
+  baseUrl: 'http://beta.scriptureforge.localhost/',
   framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,
@@ -22,7 +22,7 @@ exports.config = {
   SELENIUM_PROMISE_MANAGER: false,
   onPrepare() {
     browser.driver.manage().window().maximize();
-    
+
     require('ts-node').register({
       project: 'e2e/tsconfig.e2e.json'
     });

--- a/src/SIL.XForge.Scripture/ClientApp/e2e/src/app.po.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/src/app.po.ts
@@ -9,7 +9,7 @@ export class AppPage {
   };
 
   static navigateTo(): promise.Promise<any> {
-    return browser.get('https://beta.scriptureforge.local/');
+    return browser.get('http://beta.scriptureforge.localhost/');
   }
 
   static getMainHeading(): promise.Promise<string> {

--- a/src/SIL.XForge.Scripture/ClientApp/e2e/src/change-password.po.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/src/change-password.po.ts
@@ -1,7 +1,7 @@
 import { browser, by, element, ExpectedConditions } from 'protractor';
 
 export class ChangePasswordPage {
-  private static readonly baseUrl = 'https://beta.scriptureforge.local';
+  private static readonly baseUrl = 'http://beta.scriptureforge.localhost';
   private readonly constants = require('../testConstants.json');
 
   changePasswordButton = element(by.id('btnChangePassword'));

--- a/src/SIL.XForge.Scripture/ClientApp/e2e/src/login.po.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/src/login.po.ts
@@ -3,7 +3,7 @@ import { browser, by, element, ExpectedConditions, promise } from 'protractor';
 import { AppPage } from './app.po';
 
 export class LoginPage {
-  private static readonly baseUrl = 'https://beta.scriptureforge.local';
+  private static readonly baseUrl = 'http://beta.scriptureforge.localhost';
 
   private readonly constants = require('../testConstants.json');
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { AuthConfig, JwksValidationHandler, OAuthService } from 'angular-oauth2-oidc';
 
 import { JSONAPIService } from '@xforge-common/jsonapi.service';
+import { environment } from '../environments/environment';
 
 @Component({
   selector: 'app-root',
@@ -15,7 +16,8 @@ export class AppComponent {
     clientId: 'xForge',
     scope: 'openid profile email api',
     postLogoutRedirectUri: window.location.origin + '/',
-    silentRefreshRedirectUri: window.location.origin + '/silent-refresh.html'
+    silentRefreshRedirectUri: window.location.origin + '/silent-refresh.html',
+    requireHttps: environment.production
   };
 
   title = 'Scripture Forge';

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
@@ -5,5 +5,5 @@
 
 export const environment = {
   production: false,
-  issueEmail: 'issues@beta.scriptureforge.local'
+  issueEmail: 'issues@beta.scriptureforge.localhost'
 };

--- a/src/SIL.XForge.Scripture/Properties/launchSettings.json
+++ b/src/SIL.XForge.Scripture/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "SIL.XForge.Scripture": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "https://beta.scriptureforge.local",
+      "launchUrl": "http://beta.scriptureforge.localhost",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -49,22 +49,26 @@ namespace SIL.XForge.Scripture
 
             services.AddExceptionLogging();
 
-            services.AddXFIdentityServer(Configuration);
+            services.AddXFIdentityServer(Configuration,
+                Environment.IsDevelopment() || Environment.IsEnvironment("Testing"));
 
             var siteOptions = Configuration.GetOptions<SiteOptions>();
             var paratextOptions = Configuration.GetOptions<ParatextOptions>();
             services.AddAuthentication()
                 .AddJwtBearer(options =>
                     {
+                        string protocol = "https";
                         if (Environment.IsDevelopment() || Environment.IsEnvironment("Testing"))
                         {
+                            protocol = "http";
+                            options.RequireHttpsMetadata = false;
                             options.BackchannelHttpHandler = new HttpClientHandler
                             {
                                 ServerCertificateCustomValidationCallback
                                     = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
                             };
                         }
-                        options.Authority = $"https://{siteOptions.Domain}";
+                        options.Authority = $"{protocol}://{siteOptions.Domain}";
                         options.Audience = "api";
                     })
                 .AddParatext(options =>

--- a/src/SIL.XForge.Scripture/appsettings.Development.json
+++ b/src/SIL.XForge.Scripture/appsettings.Development.json
@@ -8,7 +8,7 @@
     }
   },
   "Site": {
-    "Domain": "beta.scriptureforge.local",
+    "Domain": "beta.scriptureforge.localhost",
     "SendEmail": "false"
   },
   "Security": {

--- a/src/SIL.XForge.Scripture/appsettings.Testing.json
+++ b/src/SIL.XForge.Scripture/appsettings.Testing.json
@@ -7,7 +7,7 @@
     }
   },
   "Site": {
-    "Domain": "beta.scriptureforge.local",
+    "Domain": "beta.scriptureforge.localhost",
     "SendEmail": "false"
   },
   "Security": {


### PR DESCRIPTION
- finish changing .local to .localhost
- allow insecure protocol in Development and Testing environments

Must run insecure (`http` not `https`) with `.localhost` to test PWA features, i.e. http://beta.scriptureforge.localhost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/429)
<!-- Reviewable:end -->
