### PR TITLE
Fix unsupported filter exception on e-mail check

### DIFF
--- a/src/SIL.XForge.Identity/Controllers/Account/AccountController.cs
+++ b/src/SIL.XForge.Identity/Controllers/Account/AccountController.cs
@@ -382,7 +382,7 @@ namespace SIL.XForge.Identity.Controllers.Account
             ViewData["ReturnUrl"] = returnUrl;
             if (ModelState.IsValid)
             {
-                bool emailExists = await _users.Query().AnyAsync(u => String.Equals(u.Email, model.Email, StringComparison.OrdinalIgnoreCase));
+                bool emailExists = await _users.Query().AnyAsync(u => u.Email.ToLowerInvariant() == model.Email.ToLowerInvariant());
                 if (emailExists)
                 {
                     ModelState.AddModelError(string.Empty,


### PR DESCRIPTION
* String.Equals isn't supported by the LINQ Translator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/436)
<!-- Reviewable:end -->
