### PR TITLE
Fix: SF-85 UI is collapse on Change Password page at mobile view port

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/change-password/change-password.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/change-password/change-password.component.scss
@@ -8,7 +8,7 @@ label
   font-weight: 400;
   line-height: 1.125;
   font-family: Roboto,"Helvetica Neue",sans-serif;
-  width: 440px;
+  width: 100%;
 }
 
 .changepassword-title {


### PR DESCRIPTION
* Changed CSS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/438)
<!-- Reviewable:end -->
