### PR TITLE
SF-86: Duplicate eMail is accepting on Sign up

### DIFF
--- a/src/SIL.XForge.Identity/Controllers/Account/AccountController.cs
+++ b/src/SIL.XForge.Identity/Controllers/Account/AccountController.cs
@@ -148,7 +148,7 @@ namespace SIL.XForge.Identity.Controllers.Account
             if (ModelState.IsValid)
             {
                 UserEntity user = await _users.Query().SingleOrDefaultAsync(u => u.Username == model.EmailOrUsername
-                    || u.Email == model.EmailOrUsername);
+                    || u.CanonicalEmail == UserEntity.CanonicalizeEmail(model.EmailOrUsername));
                 // validate username/password against in-memory store
                 if (user != null && user.VerifyPassword(model.Password))
                 {
@@ -227,7 +227,8 @@ namespace SIL.XForge.Identity.Controllers.Account
         public async Task<IActionResult> ForgotPassword(ForgotPasswordViewModel model)
         {
             UserEntity user = await _users.UpdateAsync(
-                u => u.Username == model.EmailOrUsername || u.Email == model.EmailOrUsername,
+                u => u.Username == model.EmailOrUsername
+                    || u.CanonicalEmail == UserEntity.CanonicalizeEmail(model.EmailOrUsername),
                 update => update
                     .Set(u => u.ResetPasswordKey, GenerateValidationKey())
                     .Set(u => u.ResetPasswordExpirationDate, DateTime.UtcNow.AddDays(PasswordResetPeriodDays)));
@@ -388,6 +389,7 @@ namespace SIL.XForge.Identity.Controllers.Account
                 {
                     Name = model.Fullname,
                     Email = model.Email,
+                    CanonicalEmail = UserEntity.CanonicalizeEmail(model.Email),
                     EmailVerified = false,
                     Password = BCrypt.Net.BCrypt.HashPassword(model.Password, 7),
                     Role = SystemRoles.User,

--- a/src/SIL.XForge.Identity/Controllers/IdentityController.cs
+++ b/src/SIL.XForge.Identity/Controllers/IdentityController.cs
@@ -51,7 +51,7 @@ namespace SIL.XForge.Identity.Controllers
         public async Task<ActionResult<LogInResult>> LogIn(LogInParams parameters)
         {
             UserEntity user = await _users.Query().SingleOrDefaultAsync(u => u.Username == parameters.User
-                || u.Email == parameters.User);
+                || u.CanonicalEmail == UserEntity.CanonicalizeEmail(parameters.User));
             // validate username/password
             if (user != null && user.VerifyPassword(parameters.Password))
             {
@@ -122,7 +122,7 @@ namespace SIL.XForge.Identity.Controllers
         public async Task<ActionResult<IdentityResult>> ForgotPassword(ForgotPasswordParams parameters)
         {
             UserEntity user = await _users.UpdateAsync(
-                u => u.Username == parameters.User || u.Email == parameters.User,
+                u => u.Username == parameters.User || u.CanonicalEmail == UserEntity.CanonicalizeEmail(parameters.User),
                 update => update
                     .Set(u => u.ResetPasswordKey, GenerateKey())
                     .Set(u => u.ResetPasswordExpirationDate, DateTime.UtcNow.AddDays(PasswordResetPeriodDays)));
@@ -169,6 +169,7 @@ namespace SIL.XForge.Identity.Controllers
             {
                 Name = parameters.Name,
                 Email = parameters.Email,
+                CanonicalEmail = UserEntity.CanonicalizeEmail(parameters.Email),
                 EmailVerified = false,
                 Password = BCrypt.Net.BCrypt.HashPassword(parameters.Password, 7),
                 Role = SystemRoles.User,

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/user.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/user.ts
@@ -6,6 +6,7 @@ export abstract class User extends Resource {
   username?: string;
   name?: string;
   email?: string;
+  canonicalEmail?: string;
   password?: string;
   paratextId?: string;
 

--- a/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
@@ -59,12 +59,8 @@ namespace SIL.XForge.DataAccess
                     IndexKeysDefinitionBuilder<UserEntity> builder = Builders<UserEntity>.IndexKeys;
                     var models = new[]
                     {
-                        new CreateIndexModel<UserEntity>(builder.Ascending(u => u.Email),
-                            new CreateIndexOptions
-                            {
-                                Unique = true,
-                                Collation = new Collation("en", strength: CollationStrength.Secondary)
-                            }),
+                        new CreateIndexModel<UserEntity>(builder.Ascending(u => u.CanonicalEmail),
+                            new CreateIndexOptions { Unique = true }),
                         new CreateIndexModel<UserEntity>(builder.Ascending(u => u.Username),
                             new CreateIndexOptions { Unique = true })
                     };

--- a/src/SIL.XForge/Models/UserEntity.cs
+++ b/src/SIL.XForge/Models/UserEntity.cs
@@ -10,6 +10,7 @@ namespace SIL.XForge.Models
         public string Username { get; set; }
         public string Name { get; set; }
         public string Email { get; set; }
+        public string CanonicalEmail { get; set; }
         public bool EmailVerified { get; set; }
         public string ValidationKey { get; set; }
         public DateTime ValidationExpirationDate { get; set; }
@@ -40,6 +41,11 @@ namespace SIL.XForge.Models
         public bool VerifyPassword(string password)
         {
             return BCrypt.Net.BCrypt.Verify(password, Password);
+        }
+
+        public static string CanonicalizeEmail(string email)
+        {
+            return email?.ToLowerInvariant();
         }
     }
 }

--- a/src/SIL.XForge/Models/UserResource.cs
+++ b/src/SIL.XForge/Models/UserResource.cs
@@ -10,6 +10,8 @@ namespace SIL.XForge.Models
         public string Name { get; set; }
         [Attr("email")]
         public string Email { get; set; }
+        [Attr("canonical-email", isImmutable: true)]
+        public string CanonicalEmail { get; set; }
         [Attr("password")]
         public string Password { get; set; }
         [Attr("paratext-id")]

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -17,11 +17,19 @@ namespace SIL.XForge.Services
         {
         }
 
+        protected override Task<UserEntity> InsertEntityAsync(UserEntity entity)
+        {
+            entity.CanonicalEmail = UserEntity.CanonicalizeEmail(entity.Email);
+            return base.InsertEntityAsync(entity);
+        }
+
         protected override Task<UserEntity> UpdateEntityAsync(string id, IDictionary<string, object> attrs,
             IDictionary<string, string> relationships)
         {
-            if (attrs.TryGetValue(nameof(UserResource.Password), out object value))
-                attrs[nameof(UserResource.Password)] = BCrypt.Net.BCrypt.HashPassword((string) value, 7);
+            if (attrs.TryGetValue(nameof(UserEntity.Password), out object password))
+                attrs[nameof(UserEntity.Password)] = BCrypt.Net.BCrypt.HashPassword((string) password, 7);
+            if (attrs.TryGetValue(nameof(UserEntity.Email), out object email))
+                attrs[nameof(UserEntity.CanonicalEmail)] = UserEntity.CanonicalizeEmail((string) email);
             return base.UpdateEntityAsync(id, attrs, relationships);
         }
 

--- a/test/SIL.XForge.Identity.Tests/Controllers/Account/AccountControllerTests.cs
+++ b/test/SIL.XForge.Identity.Tests/Controllers/Account/AccountControllerTests.cs
@@ -348,7 +348,8 @@ namespace SIL.XForge.Identity.Controllers.Account
                             ResetPasswordExpirationDate = isResetLinkExpired
                                 ? DateTime.UtcNow.AddTicks(-1)
                                 : DateTime.UtcNow.AddMinutes(2),
-                            Email = TestUserEmail
+                            Email = TestUserEmail,
+                            CanonicalEmail = UserEntity.CanonicalizeEmail(TestUserEmail)
                         }
                     });
                 AuthService = Substitute.For<IAuthenticationService>();

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -48,6 +48,24 @@ namespace SIL.XForge.Services
         }
 
         [Test]
+        public async Task CreateAsync_Email()
+        {
+            var env = new TestEnvironment();
+            env.SetUser("user01", SystemRoles.SystemAdmin);
+
+            var userResource = new UserResource
+            {
+                Id = "usernew",
+                Email = "UserNew@gmail.com"
+            };
+            UserResource newResource = await env.Service.CreateAsync(userResource);
+
+            Assert.That(newResource, Is.Not.Null);
+            Assert.That(newResource.Email, Is.EqualTo("UserNew@gmail.com"));
+            Assert.That(newResource.CanonicalEmail, Is.EqualTo("usernew@gmail.com"));
+        }
+
+        [Test]
         public async Task UpdateAsync_UserRole()
         {
             var env = new TestEnvironment();
@@ -101,6 +119,29 @@ namespace SIL.XForge.Services
         }
 
         [Test]
+        public async Task UpdateAsync_Email()
+        {
+            var env = new TestEnvironment();
+            env.SetUser("user01", SystemRoles.SystemAdmin);
+            env.JsonApiContext.AttributesToUpdate.Returns(new Dictionary<AttrAttribute, object>
+                {
+                    { env.GetAttribute("email"), "New@gmail.com" }
+                });
+            env.JsonApiContext.RelationshipsToUpdate.Returns(new Dictionary<RelationshipAttribute, object>());
+
+            var resource = new UserResource
+            {
+                Id = "user01",
+                Email = "New@gmail.com"
+            };
+            UserResource updatedResource = await env.Service.UpdateAsync(resource.Id, resource);
+
+            Assert.That(updatedResource, Is.Not.Null);
+            Assert.That(updatedResource.Email, Is.EqualTo("New@gmail.com"));
+            Assert.That(updatedResource.CanonicalEmail, Is.EqualTo("new@gmail.com"));
+        }
+
+        [Test]
         public async Task GetAsync_UserRole()
         {
             var env = new TestEnvironment();
@@ -140,9 +181,27 @@ namespace SIL.XForge.Services
             {
                 return new[]
                 {
-                    new UserEntity { Id = "user01", Username = "user01" },
-                    new UserEntity { Id = "user02", Username = "user02" },
-                    new UserEntity { Id = "user03", Username = "user03" }
+                    new UserEntity
+                    {
+                        Id = "user01",
+                        Username = "user01",
+                        Email = "user01@gmail.com",
+                        CanonicalEmail = "user01@gmail.com"
+                    },
+                    new UserEntity
+                    {
+                        Id = "user02",
+                        Username = "user02",
+                        Email = "user02@gmail.com",
+                        CanonicalEmail = "user02@gmail.com"
+                    },
+                    new UserEntity
+                    {
+                        Id = "user03",
+                        Username = "user03",
+                        Email = "user03@gmail.com",
+                        CanonicalEmail = "user03@gmail.com"
+                    },
                 };
             }
         }


### PR DESCRIPTION
- add a canonical email property to user
- use canonical email for querying
- use normal email for display and sending emails

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/447)
<!-- Reviewable:end -->
