### PR TITLE
Remove Username from Reset Password model

### DIFF
--- a/src/SIL.XForge.Identity/Controllers/Account/AccountController.cs
+++ b/src/SIL.XForge.Identity/Controllers/Account/AccountController.cs
@@ -286,8 +286,7 @@ namespace SIL.XForge.Identity.Controllers.Account
                 ModelState.AddModelError(string.Empty, "Both Passwords do not match");
                 return View(model);
             }
-            var updatedUserEntity = await _users.UpdateAsync(u => u.Username == model.Username
-                                                               && u.ResetPasswordKey == model.ResetToken
+            var updatedUserEntity = await _users.UpdateAsync(u => u.ResetPasswordKey == model.ResetToken
                                                                && u.ResetPasswordExpirationDate > DateTime.UtcNow,
                 update => update
                     .Set(u => u.Password, BCrypt.Net.BCrypt.HashPassword(model.Password, 7))
@@ -304,7 +303,6 @@ namespace SIL.XForge.Identity.Controllers.Account
             {
                 Password = "",
                 ConfirmPassword = "",
-                Username = user.Username,
                 ResetToken = user.ResetPasswordKey
             };
         }

--- a/src/SIL.XForge.Identity/Controllers/Account/ResetPasswordViewModel.cs
+++ b/src/SIL.XForge.Identity/Controllers/Account/ResetPasswordViewModel.cs
@@ -16,8 +16,6 @@ namespace SIL.XForge.Identity.Controllers.Account
         [Display(Name = "Confirm Password")]
         public string ConfirmPassword { get; set; }
 
-        public string Username { get; set; }
-
         public string ResetToken { get; set; }
     }
 }

--- a/src/SIL.XForge.Identity/Views/Account/ResetPassword.cshtml
+++ b/src/SIL.XForge.Identity/Views/Account/ResetPassword.cshtml
@@ -27,7 +27,6 @@
         <fieldset>
             <div class="form-group password">
                 <span class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                    <input type="hidden" asp-for="Username">
                     <input type="hidden" asp-for="ResetToken">
                 </span>
             </div>


### PR DESCRIPTION
- not all users have a username (email is key)
- prevents discovering usernames through an alphabet attack on reset keys

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/448)
<!-- Reviewable:end -->
