### PR TITLE
SF-31 fixup

### DIFF
--- a/src/SIL.XForge.Identity/Models/SendInviteParams.cs
+++ b/src/SIL.XForge.Identity/Models/SendInviteParams.cs
@@ -1,0 +1,7 @@
+namespace SIL.XForge.Identity.Models
+{
+    public class SendInviteParams
+    {
+        public string Email { get; set; }
+    }
+}

--- a/src/SIL.XForge.Identity/Models/SendInviteResult.cs
+++ b/src/SIL.XForge.Identity/Models/SendInviteResult.cs
@@ -1,0 +1,8 @@
+namespace SIL.XForge.Identity.Models
+{
+    public class SendInviteResult : IdentityResult
+    {
+        public bool IsAlreadyInProject { get; set; }
+        public string EmailTypeSent { get; set; }
+    }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -4,6 +4,8 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ServiceWorkerModule } from '@angular/service-worker';
 
+import { IdentityModule } from '@identity/identity.module';
+import { InviteDialogComponent } from '@xforge-common/email-invite/invite-dialog.component';
 import { DetailSnackBarComponent } from '@xforge-common/notice/detail-snack-bar.component';
 import { UICommonModule } from '@xforge-common/ui-common.module';
 import { XForgeCommonModule } from '@xforge-common/xforge-common.module';
@@ -39,11 +41,12 @@ import { SharedModule } from './shared/shared.module';
     // not ready for production yet - 2018-11 IJH
     ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.pwaTest }), // || environment.production }),
     SharedModule,
+    IdentityModule,
     UICommonModule,
     XForgeCommonModule
   ],
   providers: [],
-  entryComponents: [DetailSnackBarComponent],
+  entryComponents: [DetailSnackBarComponent, InviteDialogComponent],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.prod.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.prod.ts
@@ -3,6 +3,5 @@ export const environment = {
   pwaTest: false,
   issueEmail: 'issues@beta.qa.scriptureforge.org',
   siteName: 'Scripture Forge',
-  siteOrigin: 'https://beta.qa.scriptureforge.org',
   realtimeUrl: '/realtime-api/'
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.pwa-test.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.pwa-test.ts
@@ -3,7 +3,6 @@ export const environment = {
   pwaTest: true,
   issueEmail: 'issues@beta.qa.scriptureforge.org',
   siteName: 'Scripture Forge',
-  siteOrigin: 'http://localhost:5000',
   realtimePort: 5002,
   realtimeUrl: '/'
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
@@ -9,7 +9,6 @@ export const environment = {
   pwaTest: false,
   issueEmail: 'issues@beta.qa.scriptureforge.org',
   siteName: 'Scripture Forge',
-  siteOrigin: 'http://localhost:5000',
   realtimePort: 5002,
   realtimeUrl: '/'
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/identity/identity.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/identity/identity.service.ts
@@ -7,6 +7,8 @@ import { IdentityResult } from './models/identity-result';
 import { LogInParams } from './models/log-in-params';
 import { LogInResult } from './models/log-in-result';
 import { ResetPasswordParams } from './models/reset-password-params';
+import { SendInviteParams } from './models/send-invite-params';
+import { SendInviteResult } from './models/send-invite-result';
 import { SignUpParams } from './models/sign-up-params';
 import { VerifyEmailParams } from './models/verify-email-params';
 
@@ -27,6 +29,10 @@ export class IdentityService {
   async resetPassword(params: ResetPasswordParams): Promise<boolean> {
     const result = await this.callApi('reset-password', params);
     return result.success;
+  }
+
+  async sendInvite(email: string): Promise<SendInviteResult> {
+    return await this.callApi<SendInviteResult>('send-invite', { email } as SendInviteParams);
   }
 
   async signUp(params: SignUpParams): Promise<boolean> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/identity/models/send-invite-params.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/identity/models/send-invite-params.ts
@@ -1,0 +1,3 @@
+export interface SendInviteParams {
+  email: string;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/identity/models/send-invite-result.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/identity/models/send-invite-result.ts
@@ -1,0 +1,6 @@
+import { IdentityResult } from './identity-result';
+
+export interface SendInviteResult extends IdentityResult {
+  isAlreadyInProject: boolean;
+  emailTypeSent: string;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/email-invite.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/email-invite.component.html
@@ -1,33 +1,4 @@
-<div [hidden]="showInviteForm">
-  <ng-template #dialogRef>
-    <form [formGroup]="sendInviteForm" id="send-invite-form">
-      <h3 mat-dialog-title>Invite a friend to {{ siteName }}</h3>
-      <mat-dialog-content>
-        <mat-form-field class="example-full-width">
-          <input matInput placeholder="Email" id="email" name="email" #email formControlName="email">
-          <mat-error *ngIf="sendInviteForm.get('email').hasError('email') && !sendInviteForm.get('email').hasError('required')">
-            Please enter a valid email address, e.g. me@example.com
-          </mat-error>
-          <mat-error *ngIf="sendInviteForm.get('email').hasError('required') && isSubmitted">
-            Email is <strong>required</strong>
-          </mat-error>
-        </mat-form-field>
-        <mat-spinner *ngIf="spinnerDisplay" strokeWidth="3" [diameter]="20"></mat-spinner>
-      </mat-dialog-content>
-      <mat-dialog-actions align="end">
-        <button mat-button (click)="onCancel()" id="invitation-cancel-btn">Cancel</button>
-        <button mat-button cdkfocusinitial [disabled]="disabledSendInviteBtn" (click)="onSubmit()" id="invitation-send-btn">
-          Send Invitation</button>
-      </mat-dialog-actions>
-    </form>
-  </ng-template>
-</div>
-
-<div class="container">
-  <div class="page-header">
-    <span style="float: right;">
-      <button type="button" (click)="openDialog(dialogRef)" color="accent" mat-raised-button id="invite-btn">
-          <mat-icon>email</mat-icon> Invite a Friend</button>
-    </span>
-  </div>
-</div>
+<span style="float: right;">
+  <button mat-raised-button class="mat-primary" (click)="openDialog()" id="invite-btn">
+      <mat-icon>email</mat-icon> Invite a Friend</button>
+</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/email-invite.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/email-invite.component.scss
@@ -1,7 +1,3 @@
-.mat-form-field {
-  width: 350px;
-}
-
 .email-invite-panel {
   float: right;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/email-invite.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/email-invite.component.ts
@@ -1,76 +1,21 @@
-import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MatDialog } from '@angular/material';
+import { Component } from '@angular/core';
+import { MatDialog, MatDialogConfig } from '@angular/material';
 
-import { AuthService } from '@xforge-common/auth.service';
-import { NoticeService } from '@xforge-common/notice.service';
-import { UserService } from '@xforge-common/user.service';
-import { environment } from '../../environments/environment';
-
+import { InviteDialogComponent } from './invite-dialog.component';
 
 @Component({
   selector: 'app-email-invite',
   templateUrl: './email-invite.component.html',
   styleUrls: ['./email-invite.component.scss']
 })
-export class EmailInviteComponent implements OnInit {
-  sendInviteForm: FormGroup;
-  isSubmitted: boolean = false;
-  showInviteForm: boolean = true;
-  spinnerDisplay: boolean = false;
-  disabledSendInviteBtn: boolean = false;
-  siteName = environment.siteName;
+export class EmailInviteComponent {
+  constructor(private dialog: MatDialog) { }
 
-  constructor(private dialog: MatDialog, private readonly formBuilder: FormBuilder,
-    private readonly noticeService: NoticeService, private readonly authService: AuthService,
-    private readonly userService: UserService) { }
-
-  ngOnInit() {
-    this.sendInviteForm = this.formBuilder.group({
-      email: ['', Validators.compose([Validators.required, Validators.email])],
-    });
-  }
-
-  get formControls() {
-    return this.sendInviteForm.controls;
-  }
-
-  get name() {
-    return this.authService.currentUserName;
-  }
-
-  openDialog(dialogRef: any) {
-    this.dialog.open(dialogRef, { disableClose: true });
-  }
-
-  onSubmit() {
-    this.isSubmitted = true;
-    if (this.sendInviteForm.valid) {
-      this.spinnerDisplay = true;
-      this.disabledSendInviteBtn = true;
-      this.userService.sendInvitation(this.name, this.sendInviteForm.value.email)
-        .subscribe(response => {
-          if (response === 'User already has an account!') {
-            this.isSubmitted = false;
-            this.spinnerDisplay = false;
-            this.disabledSendInviteBtn = false;
-            this.noticeService.push(NoticeService.SUCCESS, response);
-          } else {
-            this.isSubmitted = false;
-            this.dialog.closeAll();
-            this.spinnerDisplay = false;
-            this.disabledSendInviteBtn = false;
-            this.noticeService.push(NoticeService.SUCCESS, response);
-            this.sendInviteForm.reset();
-          }
-        });
-    } else {
-      return false;
-    }
-  }
-
-  onCancel() {
-    this.sendInviteForm.reset();
-    this.dialog.closeAll();
+  openDialog() {
+    const dialogConfig = {
+      autoFocus: true,
+      disableClose: true
+    } as MatDialogConfig;
+    this.dialog.open(InviteDialogComponent, dialogConfig);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/invite-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/invite-dialog.component.html
@@ -1,0 +1,18 @@
+<h3 mat-dialog-title>Invite a friend to {{ siteName }}</h3>
+<mat-dialog-content>
+  <mat-form-field [formGroup]="sendInviteForm" id="send-invite-form">
+    <input matInput placeholder="Email" id="email" name="email" formControlName="email">
+    <mat-error *ngIf="email.hasError('email') && !email.hasError('required')">
+      Please enter a valid email address, e.g. me@example.com
+    </mat-error>
+    <mat-error *ngIf="email.hasError('required') && isSubmitted">
+      Email is <strong>required</strong>
+    </mat-error>
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <mat-spinner *ngIf="isSubmitted" strokeWidth="3" diameter="20"></mat-spinner>
+  <button mat-raised-button (click)="onClose()" id="invitation-close-btn">Close</button>
+  <button mat-raised-button class="mat-primary" [disabled]="isSubmitted" (click)="onSubmit()" id="invitation-send-btn">
+    Send Invitation</button>
+</mat-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/invite-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/invite-dialog.component.scss
@@ -1,0 +1,3 @@
+.mat-form-field {
+  width: 350px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/invite-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/invite-dialog.component.spec.ts
@@ -1,8 +1,7 @@
-import { OverlayContainer } from '@angular/cdk/overlay';
-import { CUSTOM_ELEMENTS_SCHEMA, DebugElement, NgModule } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatDialogModule, MatDialogRef } from '@angular/material';
+import { MatDialogRef } from '@angular/material';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
@@ -10,52 +9,52 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { IdentityService } from '@identity/identity.service';
 import { SendInviteResult } from '@identity/models/send-invite-result';
 import { UICommonModule } from '@xforge-common/ui-common.module';
-import { EmailInviteComponent } from './email-invite.component';
 import { InviteDialogComponent } from './invite-dialog.component';
 
-describe('EmailInviteComponent', () => {
+describe('InviteDialogComponent', () => {
 
   it('form should be invalid when empty and pristine', fakeAsync(() => {
     const env = new TestEnvironment();
     env.fixture.detectChanges();
 
-    env.clickElement(env.inviteButton);
-
+    expect(env.component.sendInviteForm.pristine).toBe(true);
+    expect(env.component.sendInviteForm.valid).toBe(false);
+    expect(env.component.email.hasError('email')).toBeFalsy();
     env.clickElement(env.closeButton);
     verify(env.mockedIdentityService.sendInvite(anything())).never();
-    expect().nothing();
-    flush();
   }));
 
   it('form should be invalid when dirty', fakeAsync(() => {
     const env = new TestEnvironment();
     env.fixture.detectChanges();
 
-    env.clickElement(env.inviteButton);
+    expect(env.component.email.hasError('email')).toBeFalsy();
 
     env.clickElement(env.emailInput);
     env.setInputValue(env.emailInput, 'notAnEmailAddress');
 
+    expect(env.component.sendInviteForm.dirty).toBe(true);
+    expect(env.component.sendInviteForm.valid).toBe(false);
+    expect(env.component.email.hasError('email')).toBe(true);
     env.clickElement(env.closeButton);
     verify(env.mockedIdentityService.sendInvite(anything())).never();
-    expect().nothing();
-    flush();
   }));
 
   it('form should be invalid when dirty and empty', fakeAsync(() => {
     const env = new TestEnvironment();
     env.fixture.detectChanges();
 
-    env.clickElement(env.inviteButton);
     env.setInputValue(env.emailInput, 'notAnEmailAddress');
+    expect(env.component.email.hasError('required')).toBeFalsy();
 
     env.clickElement(env.emailInput);
     env.setInputValue(env.emailInput, '');
 
+    expect(env.component.sendInviteForm.dirty).toBe(true);
+    expect(env.component.sendInviteForm.valid).toBe(false);
+    expect(env.component.email.hasError('required')).toBe(true);
     env.clickElement(env.closeButton);
     verify(env.mockedIdentityService.sendInvite(anything())).never();
-    expect().nothing();
-    flush();
   }));
 
   it('should submit when form is valid', fakeAsync(() => {
@@ -63,38 +62,24 @@ describe('EmailInviteComponent', () => {
     const env = new TestEnvironment();
     env.fixture.detectChanges();
 
-    env.clickElement(env.inviteButton);
     env.setInputValue(env.emailInput, emailAddress);
 
+    expect(env.component.sendInviteForm.dirty).toBe(true);
+    expect(env.component.sendInviteForm.valid).toBe(true);
+    expect(env.component.email.hasError('required')).toBeFalsy();
+    expect(env.component.email.hasError('email')).toBeFalsy();
     env.clickElement(env.sendInviteButton);
     verify(env.mockedIdentityService.sendInvite(emailAddress)).once();
-    expect().nothing();
-    flush();
   }));
 
 });
 
-@NgModule({
-  imports: [
-    FormsModule,
-    MatDialogModule,
-    ReactiveFormsModule,
-    NoopAnimationsModule,
-    UICommonModule
-  ],
-  exports: [InviteDialogComponent],
-  declarations: [InviteDialogComponent],
-  entryComponents: [InviteDialogComponent]
-})
-class DialogTestModule { }
-
 class TestEnvironment {
-  component: EmailInviteComponent;
-  fixture: ComponentFixture<EmailInviteComponent>;
+  component: InviteDialogComponent;
+  fixture: ComponentFixture<InviteDialogComponent>;
 
   mockedMatDialogRef: MatDialogRef<InviteDialogComponent>;
   mockedIdentityService: IdentityService;
-  overlayContainer: OverlayContainer;
 
   constructor() {
     this.mockedMatDialogRef = mock(MatDialogRef);
@@ -106,36 +91,32 @@ class TestEnvironment {
     when(this.mockedIdentityService.sendInvite(anything())).thenResolve(sendInviteResult);
 
     TestBed.configureTestingModule({
-      imports: [DialogTestModule],
-      declarations: [EmailInviteComponent],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+        UICommonModule
+      ],
+      declarations: [InviteDialogComponent],
       providers: [
         { provide: MatDialogRef, useFactory: () => instance(this.mockedMatDialogRef) },
         { provide: IdentityService, useFactory: () => instance(this.mockedIdentityService) }
       ]
     });
-    this.fixture = TestBed.createComponent(EmailInviteComponent);
+    this.fixture = TestBed.createComponent(InviteDialogComponent);
     this.component = this.fixture.componentInstance;
-    this.overlayContainer = TestBed.get(OverlayContainer);
   }
 
-  get inviteButton(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#invite-btn'));
+  get sendInviteButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#invitation-send-btn'));
   }
 
-  get sendInviteButton(): HTMLButtonElement {
-    const overlayContainerElement = this.overlayContainer.getContainerElement();
-    return overlayContainerElement.querySelector('#invitation-send-btn');
+  get closeButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#invitation-close-btn'));
   }
 
-  get closeButton(): HTMLButtonElement {
-    const overlayContainerElement = this.overlayContainer.getContainerElement();
-    return overlayContainerElement.querySelector('#invitation-close-btn');
-  }
-
-  get emailInput(): HTMLInputElement {
-    const overlayContainerElement = this.overlayContainer.getContainerElement();
-    return overlayContainerElement.querySelector('#email');
+  get emailInput(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#email'));
   }
 
   clickElement(element: HTMLElement | DebugElement): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/invite-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/email-invite/invite-dialog.component.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material';
+
+import { IdentityService } from '@identity/identity.service';
+import { NoticeService } from '@xforge-common/notice.service';
+import { environment } from 'src/environments/environment';
+
+@Component({
+  templateUrl: './invite-dialog.component.html',
+  styleUrls: ['./invite-dialog.component.scss']
+})
+export class InviteDialogComponent {
+  sendInviteForm: FormGroup = new FormGroup({
+    email: new FormControl('', [Validators.required, Validators.email])
+  });
+  isSubmitted: boolean = false;
+  siteName = environment.siteName;
+
+  constructor(private readonly dialogRef: MatDialogRef<InviteDialogComponent>,
+    private readonly noticeService: NoticeService,
+    private readonly identityService: IdentityService) { }
+
+  get email() {
+    return this.sendInviteForm.get('email');
+  }
+
+  onSubmit() {
+    if (!this.sendInviteForm.valid) {
+      return false;
+    }
+
+    this.isSubmitted = true;
+    this.identityService.sendInvite(this.sendInviteForm.value.email)
+      .then(response => {
+        let message: string = '';
+        this.isSubmitted = false;
+        if (response.success) {
+          if (response.emailTypeSent === 'joined') {
+            message = 'An email has been sent to ' + this.sendInviteForm.value.email +
+              ' adding them to this project';
+            this.noticeService.push(NoticeService.SUCCESS, message);
+            this.sendInviteForm.reset();
+          } else if (response.emailTypeSent === 'invited') {
+            message = 'An invitation email has been sent to ' + this.sendInviteForm.value.email;
+            this.noticeService.push(NoticeService.SUCCESS, message);
+            this.sendInviteForm.reset();
+          } else if (response.isAlreadyInProject) {
+            message = 'A user with email ' + this.sendInviteForm.value.email + ' is already in the project';
+            this.noticeService.push(NoticeService.SUCCESS, message);
+          }
+        }
+      });
+  }
+
+  onClose() {
+    this.sendInviteForm.reset();
+    this.dialogRef.close();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -16,8 +16,7 @@ import {
   MatProgressSpinnerModule,
   MatSelectModule,
   MatSnackBarModule,
-  MatTableModule,
-  MatToolbarModule
+  MatTableModule
 } from '@angular/material';
 import { PasswordStrengthMeterModule } from 'angular-password-strength-meter';
 
@@ -38,10 +37,9 @@ const modules = [
   MatProgressSpinnerModule,
   MatSelectModule,
   MatSnackBarModule,
-  MatToolbarModule,
-  ReactiveFormsModule,
   MatTableModule,
-  PasswordStrengthMeterModule
+  PasswordStrengthMeterModule,
+  ReactiveFormsModule
 ];
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -1,9 +1,5 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
-import { environment } from '../environments/environment';
 import { AuthService } from './auth.service';
 import { JSONAPIService, QueryObservable } from './jsonapi.service';
 import { ProjectUser } from './models/project-user';
@@ -13,10 +9,7 @@ import { nameof } from './utils';
 
 @Injectable()
 export abstract class UserService extends ResourceService {
-
-  constructor(jsonApiService: JSONAPIService, private readonly authService: AuthService,
-    private readonly http: HttpClient
-  ) {
+  constructor(jsonApiService: JSONAPIService, private readonly authService: AuthService) {
     super(User.TYPE, jsonApiService);
   }
 
@@ -31,12 +24,5 @@ export abstract class UserService extends ResourceService {
 
   onlineGetProjects(id: string): QueryObservable<ProjectUser[]> {
     return this.jsonApiService.onlineGetAllRelated(this.identity(id), nameof<User>('projects'));
-  }
-
-  sendInvitation(name: string, email: string): Observable<string> {
-    const headers = new HttpHeaders().set('Content-Type', 'application/json; charset=utf-8');
-    return this.http.post(environment.siteOrigin + '/Account/SendInvitation',
-      JSON.stringify({ name, email }), { headers: headers, responseType: 'text' })
-      .pipe(map(response => response));
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
@@ -2,10 +2,10 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { OAuthModule } from 'angular-oauth2-oidc';
-import { PasswordStrengthMeterModule } from 'angular-password-strength-meter';
 
 import { ChangePasswordComponent } from './change-password/change-password.component';
 import { EmailInviteComponent } from './email-invite/email-invite.component';
+import { InviteDialogComponent } from './email-invite/invite-dialog.component';
 import { DetailSnackBarComponent } from './notice/detail-snack-bar.component';
 import { NoticeComponent } from './notice/notice.component';
 import { ProjectsComponent } from './projects/projects.component';
@@ -15,7 +15,6 @@ import { UICommonModule } from './ui-common.module';
   imports: [
     CommonModule,
     OAuthModule.forRoot(),
-    PasswordStrengthMeterModule,
     RouterModule,
     UICommonModule
   ],
@@ -24,6 +23,7 @@ import { UICommonModule } from './ui-common.module';
     DetailSnackBarComponent,
     NoticeComponent,
     EmailInviteComponent,
+    InviteDialogComponent,
     ProjectsComponent
   ],
   exports: [
@@ -31,6 +31,7 @@ import { UICommonModule } from './ui-common.module';
     DetailSnackBarComponent,
     NoticeComponent,
     EmailInviteComponent,
+    InviteDialogComponent,
     ProjectsComponent
   ]
 })

--- a/test/SIL.XForge.Identity.Tests/Controllers/Account/AccountControllerTests.cs
+++ b/test/SIL.XForge.Identity.Tests/Controllers/Account/AccountControllerTests.cs
@@ -320,27 +320,6 @@ namespace SIL.XForge.Identity.Controllers.Account
             Assert.That(env.Controller.ModelState.ErrorCount, Is.EqualTo(1));
         }
 
-        [Test]
-        public async Task InviteFriend_Email()
-        {
-            var env = new TestEnvironment();
-            var model = new UserEntity
-            {
-                Email = "abc1@example.com"
-            };
-            Assert.That(env.Users.Query().Any(x => x.Email == model.Email), Is.False);
-
-            var result = await env.Controller.SendInvitation(model);
-
-            Assert.That(result, Is.Not.Null);
-            Assert.That(env.Controller.ModelState.ErrorCount, Is.EqualTo(0));
-            Assert.That(env.Users.Query().Any(x => x.Email == model.Email), Is.True);
-            Assert.AreEqual($"An invitation email has been sent to {model.Email}", result);
-            string subject = "You've been invited to the project [Project Name] on xForge";
-            // Skip verification for the body, we may change the content
-            await env.EmailService.Received().SendEmailAsync(Arg.Is(model.Email), Arg.Is(subject), Arg.Any<string>());
-        }
-
         private class TestEnvironment
         {
             public TestEnvironment(bool isResetLinkExpired = false)

--- a/test/SIL.XForge.Identity.Tests/Controllers/IdentityControllerTests.cs
+++ b/test/SIL.XForge.Identity.Tests/Controllers/IdentityControllerTests.cs
@@ -210,6 +210,59 @@ namespace SIL.XForge.Identity.Controllers
         }
 
         [Test]
+        public async Task SendInvite_NoUser_InvitedEmail()
+        {
+            var env = new TestEnvironment();
+            var parameters = new SendInviteParams
+            {
+                Email = "abc1@example.com"
+            };
+            Assert.That(env.Users.Query().Any(x => x.Email == parameters.Email), Is.False);
+
+            var result = await env.Controller.SendInvite(parameters);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(env.Users.Query().Any(x => x.Email == parameters.Email), Is.True);
+            Assert.That(result.Value.Success, Is.True);
+            Assert.That(result.Value.IsAlreadyInProject, Is.False);
+            Assert.AreEqual("invited", result.Value.EmailTypeSent);
+            string subject = "You've been invited to the project [Project Name] on xForge";
+            // Skip verification for the body, we may change the content
+            await env.EmailService.Received().SendEmailAsync(Arg.Is(parameters.Email), Arg.Is(subject), Arg.Any<string>());
+        }
+
+        [Test]
+        public async Task SendInvite_UserNoProjects_JoinedEmail()
+        {
+            var env = new TestEnvironment();
+            var parameters = new SendInviteParams
+            {
+                Email = "abc1@example.com"
+            };
+            env.Users.Add(new[]
+                {
+                    new UserEntity
+                    {
+                        Id = "userWithNoProjects",
+                        Email = parameters.Email,
+                        CanonicalEmail = parameters.Email
+                    }
+                });
+            Assert.That(env.Users.Query().Any(x => x.Email == parameters.Email), Is.True);
+
+            var result = await env.Controller.SendInvite(parameters);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(env.Users.Query().Any(x => x.Email == parameters.Email), Is.True);
+            Assert.That(result.Value.Success, Is.True);
+            Assert.That(result.Value.IsAlreadyInProject, Is.False);
+            Assert.AreEqual("joined", result.Value.EmailTypeSent);
+            string subject = "You've been added to the project [Project Name] on xForge";
+            // Skip verification for the body, we may change the content
+            await env.EmailService.Received().SendEmailAsync(Arg.Is(parameters.Email), Arg.Is(subject), Arg.Any<string>());
+        }
+
+        [Test]
         public async Task SignUp_NewUserAdded()
         {
             var env = new TestEnvironment();
@@ -238,20 +291,43 @@ namespace SIL.XForge.Identity.Controllers
             env.Users.Add(new UserEntity
                 {
                     Id = "uniqueidwithdupemailid",
-                    Username = TestUsername,
-                    Email = "duplicate@fakegmail.com",
-                    CanonicalEmail = "duplicate@fakegmail.com"
+                    Password = BCrypt.Net.BCrypt.HashPassword("unimportant1234", 7),
+                    Email = "duplicate@example.com",
+                    CanonicalEmail = "duplicate@example.com",
+                    Active = true
                 });
             // Duplicate emailid should result in an error
             var input = new SignUpParams
             {
                 Name = "Non Duplicated Name",
                 Password = "unimportant1234",
-                Email = "DUPLICATE@fakegmail.com"
+                Email = "DUPLICATE@example.com"
             };
             ActionResult<IdentityResult> result = await env.Controller.SignUp(input);
 
             Assert.That(result.Value.Success, Is.False);
+        }
+
+        [Test]
+        public async Task SignUp_InvitedUser()
+        {
+            var env = new TestEnvironment();
+
+            env.Users.Add(new UserEntity
+                {
+                    Id = "uniqueidforinviteduser",
+                    Email = "me@example.com",
+                    CanonicalEmail = "me@example.com"
+                });
+            var input = new SignUpParams
+            {
+                Name = "User Name",
+                Password = "unimportant1234",
+                Email = "me@example.com"
+            };
+            ActionResult<IdentityResult> result = await env.Controller.SignUp(input);
+
+            Assert.That(result.Value.Success, Is.True);
         }
 
         private class TestEnvironment


### PR DESCRIPTION
- fix unit tests
- don't display server messages directly
- use LocationService for siteOrigin
- add join email
- don't send inviter name to back-end
- extract invite dialog to its own component

The only thing it doesn't do yet is add the user to the current project. We need the context of a current project before we can finish this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/465)
<!-- Reviewable:end -->
