### PR TITLE
Update doc, script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Delete the PR branch after merge.
 
 - Angular Tutorial https://angular.io/tutorial
 - Angular https://angular.io/api
+- Angular MDC https://trimox.github.io/angular-mdc-web/#/angular-mdc-web/button-demo/api
 - Angular Material https://material.angular.io/components/categories
 - TypeScript https://www.typescriptlang.org/docs/home.html
 - JavaScript https://developer.mozilla.org/en-US/docs/Web/JavaScript

--- a/src/SIL.XForge.Scripture/ClientApp/monitor-test-headless.sh
+++ b/src/SIL.XForge.Scripture/ClientApp/monitor-test-headless.sh
@@ -3,9 +3,9 @@
 # Usage:
 #   src/SIL.XForge.Scripture/ClientApp/monitor-test-headless.sh
 
-ROOT_PATH="$(dirname "$0")"
+readonly ROOT_PATH="$(dirname "$0")"
 
-which inotifywait >/dev/null || {
+command -v inotifywait >/dev/null || {
   echo "Prerequisite not found. Run sudo apt install inotify-tools"
   exit 1
 }

--- a/src/SIL.XForge.Scripture/ClientApp/test-headless.sh
+++ b/src/SIL.XForge.Scripture/ClientApp/test-headless.sh
@@ -3,7 +3,7 @@
 # Usage:
 #   src/SIL.XForge.Scripture/ClientApp/test-headless.sh
 
-ROOT_PATH="$(dirname "$0")"
+readonly ROOT_PATH="$(dirname "$0")"
 
 echo -e "\033[1;34mRunning tests\033[0m"
 date +"%F %T"


### PR DESCRIPTION
The Angular MDC URI might look a little funny, but I find it slightly confusing to find the API docs if I instead am pointed to https://trimox.github.io/angular-mdc-web/ . Throwing a developer right into one of the API docs for a control may make it more intuitive to find the rest of the documentation (it is for me).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/565)
<!-- Reviewable:end -->
