### PR TITLE
Fix audio recording sample rate (LFv1)

### DIFF
--- a/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
+++ b/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
@@ -63,7 +63,7 @@ export class AudioRecorderController implements angular.IController {
       const processor = context.createScriptProcessor(bufferSize, channels, channels);
       context.createMediaStreamSource(stream).connect(processor);
       processor.connect(context.destination);
-      const sampleRate = 44100;
+      const sampleRate = context.sampleRate;
       const bitrate = 128;
       const mp3Encoder = new MP3Encoder(channels, sampleRate, bitrate);
 


### PR DESCRIPTION
Fixes a bug reported by @megahirt.

Previously the audio sample rate was hard-coded at 44100. This caused pitch and playback distortions on some machines. This PR bases the sample rate on the rate provided by the AudioContext supplied by the browser.

I've verified that this change still works on my machine, but I haven't actually experienced the audio distortion, so I can't be absolutely certain it fixed the actual problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/569)
<!-- Reviewable:end -->
