### PR TITLE
SF-61: catch only DuplicateKey exceptions in sa-user-entry

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.spec.ts
@@ -192,15 +192,28 @@ describe('System Administration User Entry Component', () => {
       verify(env.mockedUserService.onlineUpdateAttributes(anything(), anything())).never();
     }));
 
-    it('should report any errors', fakeAsync(() => {
+    it('should report conflicts', fakeAsync(() => {
       const env = new TestUserEntryComponent();
-      when(env.mockedUserService.onlineUpdateAttributes(anything(), anything())).thenThrow(new Error('Server Error!'));
+      when(env.mockedUserService.onlineUpdateAttributes(anything(), anything())).thenThrow(
+        new MockClientError(409, 'Duplicate Email!')
+      );
       env.useExistingUser();
       env.setInputValue(env.nameInput, 'Something New');
       env.clickElement(env.updateButton);
       verify(env.mockedUserService.onlineUpdateAttributes(anything(), anything())).once();
-      verify(env.mockedNoticeService.show('Error updating: Server Error!')).once();
+      verify(env.mockedNoticeService.show('User account could not be updated due to a conflict!')).once();
       expect().nothing();
+    }));
+
+    it('should rethrow unrecognized errors', fakeAsync(() => {
+      const env = new TestUserEntryComponent();
+      when(env.mockedUserService.onlineUpdateAttributes(anything(), anything())).thenThrow(
+        new Error('Ordered rabbit stew but got vegetable soup!')
+      );
+      env.useExistingUser();
+      env.setInputValue(env.nameInput, 'Something New');
+      const expected = new RegExp('.*Ordered rabbit stew but got vegetable soup!.*');
+      expect(() => env.clickElement(env.updateButton)).toThrowError(expected);
     }));
 
     it('should allow the user to be updated when password field is untouched', fakeAsync(() => {
@@ -289,9 +302,9 @@ describe('System Administration User Entry Component', () => {
       verify(env.mockedNoticeService.show('User account created successfully.')).once();
     }));
 
-    it('should report any errors', fakeAsync(() => {
+    it('should report conflicts', fakeAsync(() => {
       const env = new TestUserEntryComponent();
-      when(env.mockedUserService.onlineCreate(anything())).thenThrow(new Error('Server Error!'));
+      when(env.mockedUserService.onlineCreate(anything())).thenThrow(new MockClientError(409, 'Duplicate Email!'));
       env.simulateAddUser();
       env.setInputValue(env.nameInput, 'New Name');
       env.setInputValue(env.emailInput, env.testUser.email);
@@ -299,7 +312,27 @@ describe('System Administration User Entry Component', () => {
       expect(env.component.accountUserForm.valid).toBe(true);
       env.clickElement(env.addButton);
       verify(env.mockedUserService.onlineCreate(anything())).once();
-      verify(env.mockedNoticeService.show('Error creating: Server Error!')).once();
+      verify(env.mockedNoticeService.show('User account could not be created due to a conflict!')).once();
+    }));
+
+    it('should rethrow unrecognized errors', fakeAsync(() => {
+      const env = new TestUserEntryComponent();
+      when(env.mockedUserService.onlineCreate(anything())).thenThrow(new Error('Ordered rabbit stew but got veggie!'));
+      env.simulateAddUser();
+      env.setInputValue(env.nameInput, 'New Name');
+      env.setInputValue(env.emailInput, 'newEmail@example.com');
+      env.setInputValue(env.passwordInput, 'new password');
+      const expected = new RegExp('.*Ordered rabbit stew but got veggie!.*');
+      expect(() => env.clickElement(env.addButton)).toThrowError(expected);
     }));
   });
 });
+
+class MockClientError extends Error {
+  readonly response: any;
+
+  constructor(responseCode: number, message?: string) {
+    super(message);
+    this.response = { status: responseCode };
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.spec.ts
@@ -201,7 +201,7 @@ describe('System Administration User Entry Component', () => {
       env.setInputValue(env.nameInput, 'Something New');
       env.clickElement(env.updateButton);
       verify(env.mockedUserService.onlineUpdateAttributes(anything(), anything())).once();
-      verify(env.mockedNoticeService.show('User account could not be updated due to a conflict!')).once();
+      verify(env.mockedNoticeService.show('User account could not be updated due to a conflict.')).once();
       expect().nothing();
     }));
 
@@ -312,7 +312,7 @@ describe('System Administration User Entry Component', () => {
       expect(env.component.accountUserForm.valid).toBe(true);
       env.clickElement(env.addButton);
       verify(env.mockedUserService.onlineCreate(anything())).once();
-      verify(env.mockedNoticeService.show('User account could not be created due to a conflict!')).once();
+      verify(env.mockedNoticeService.show('User account could not be created due to a conflict.')).once();
     }));
 
     it('should rethrow unrecognized errors', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
@@ -139,8 +139,11 @@ export class SaUserEntryComponent implements OnInit {
     try {
       await this.userService.onlineCreate(newUser);
     } catch (e) {
-      this.noticeService.show('Error creating: ' + e.message);
-      return; // rethrow if not 409 (and other place)
+      if (e.response.status === 409) {
+        this.noticeService.show('Error creating: ' + e.message);
+        return;
+      }
+      throw e;
     } finally {
       this.isSubmitted = false;
     }
@@ -171,8 +174,11 @@ export class SaUserEntryComponent implements OnInit {
     try {
       await this.userService.onlineUpdateAttributes(this.editUserId, updateUser);
     } catch (e) {
-      this.noticeService.show('Error updating: ' + e.message);
-      return;
+      if (e.response.status === 409) {
+        this.noticeService.show('Error updating: ' + e.message);
+        return;
+      }
+      throw e;
     }
     this.accountUserForm.reset();
     this.noticeService.show('User account updated.');

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
@@ -140,7 +140,7 @@ export class SaUserEntryComponent implements OnInit {
       await this.userService.onlineCreate(newUser);
     } catch (e) {
       this.noticeService.show('Error creating: ' + e.message);
-      return;
+      return; // rethrow if not 409 (and other place)
     } finally {
       this.isSubmitted = false;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
@@ -140,7 +140,7 @@ export class SaUserEntryComponent implements OnInit {
       await this.userService.onlineCreate(newUser);
     } catch (e) {
       if (SaUserEntryComponent.isConflict(e)) {
-        this.noticeService.show('User account could not be created due to a conflict!');
+        this.noticeService.show('User account could not be created due to a conflict.');
         return;
       }
       throw e;
@@ -175,7 +175,7 @@ export class SaUserEntryComponent implements OnInit {
       await this.userService.onlineUpdateAttributes(this.editUserId, updateUser);
     } catch (e) {
       if (SaUserEntryComponent.isConflict(e)) {
-        this.noticeService.show('User account could not be updated due to a conflict!');
+        this.noticeService.show('User account could not be updated due to a conflict.');
         return;
       }
       throw e;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
@@ -139,8 +139,8 @@ export class SaUserEntryComponent implements OnInit {
     try {
       await this.userService.onlineCreate(newUser);
     } catch (e) {
-      if (e.response.status === 409) {
-        this.noticeService.show('Error creating: ' + e.message);
+      if (SaUserEntryComponent.isConflict(e)) {
+        this.noticeService.show('User account could not be created due to a conflict!');
         return;
       }
       throw e;
@@ -174,8 +174,8 @@ export class SaUserEntryComponent implements OnInit {
     try {
       await this.userService.onlineUpdateAttributes(this.editUserId, updateUser);
     } catch (e) {
-      if (e.response.status === 409) {
-        this.noticeService.show('Error updating: ' + e.message);
+      if (SaUserEntryComponent.isConflict(e)) {
+        this.noticeService.show('User account could not be updated due to a conflict!');
         return;
       }
       throw e;
@@ -212,5 +212,15 @@ export class SaUserEntryComponent implements OnInit {
         this.onChange({ checked: response.data.active });
       }
     });
+  }
+
+  private static isConflict(error: any): boolean {
+    if (!error) {
+      return false;
+    }
+    if (!error.response) {
+      return false;
+    }
+    return error.response.status === 409;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.ts
@@ -13,6 +13,16 @@ import { UserService } from '../user.service';
   styleUrls: ['./sa-user-entry.component.scss']
 })
 export class SaUserEntryComponent implements OnInit {
+  private static isConflict(error: any): boolean {
+    if (!error) {
+      return false;
+    }
+    if (!error.response) {
+      return false;
+    }
+    return error.response.status === 409;
+  }
+
   @Output() outputUserList: EventEmitter<boolean> = new EventEmitter<boolean>(false);
 
   accountUserForm: FormGroup;
@@ -212,15 +222,5 @@ export class SaUserEntryComponent implements OnInit {
         this.onChange({ checked: response.data.active });
       }
     });
-  }
-
-  private static isConflict(error: any): boolean {
-    if (!error) {
-      return false;
-    }
-    if (!error.response) {
-      return false;
-    }
-    return error.response.status === 409;
   }
 }

--- a/src/SIL.XForge/DataAccess/MongoRepository.cs
+++ b/src/SIL.XForge/DataAccess/MongoRepository.cs
@@ -68,12 +68,21 @@ namespace SIL.XForge.DataAccess
             UpdateDefinition<T> updateDef = updateBuilder.Build()
                 .Set(e => e.DateModified, now)
                 .SetOnInsert(e => e.DateCreated, now);
-            return await _collection.FindOneAndUpdateAsync(filter, updateDef,
-                new FindOneAndUpdateOptions<T>
-                {
-                    IsUpsert = upsert,
-                    ReturnDocument = ReturnDocument.After
-                });
+            try
+            {
+                return await _collection.FindOneAndUpdateAsync(filter, updateDef,
+                    new FindOneAndUpdateOptions<T>
+                    {
+                        IsUpsert = upsert,
+                        ReturnDocument = ReturnDocument.After
+                    });
+            }
+            catch (MongoWriteException e)
+            {
+                if (e.WriteError.Category == ServerErrorCategory.DuplicateKey)
+                    return null;
+                throw;
+            }
         }
 
         public Task<T> DeleteAsync(Expression<Func<T, bool>> filter)

--- a/src/SIL.XForge/DataAccess/MongoRepository.cs
+++ b/src/SIL.XForge/DataAccess/MongoRepository.cs
@@ -77,9 +77,9 @@ namespace SIL.XForge.DataAccess
                         ReturnDocument = ReturnDocument.After
                     });
             }
-            catch (MongoWriteException e)
+            catch (MongoCommandException e)
             {
-                if (e.WriteError.Category == ServerErrorCategory.DuplicateKey)
+                if ("DuplicateKey".Equals(e.CodeName))
                     return null;
                 throw;
             }

--- a/src/SIL.XForge/DataAccess/MongoRepository.cs
+++ b/src/SIL.XForge/DataAccess/MongoRepository.cs
@@ -68,21 +68,12 @@ namespace SIL.XForge.DataAccess
             UpdateDefinition<T> updateDef = updateBuilder.Build()
                 .Set(e => e.DateModified, now)
                 .SetOnInsert(e => e.DateCreated, now);
-            try
-            {
                 return await _collection.FindOneAndUpdateAsync(filter, updateDef,
                     new FindOneAndUpdateOptions<T>
                     {
                         IsUpsert = upsert,
                         ReturnDocument = ReturnDocument.After
                     });
-            }
-            catch (MongoCommandException e)
-            {
-                if ("DuplicateKey".Equals(e.CodeName))
-                    return null;
-                throw;
-            }
         }
 
         public Task<T> DeleteAsync(Expression<Func<T, bool>> filter)

--- a/src/SIL.XForge/Services/RepositoryResourceServiceBase.cs
+++ b/src/SIL.XForge/Services/RepositoryResourceServiceBase.cs
@@ -27,7 +27,7 @@ namespace SIL.XForge.Services
 
         protected override async Task<TEntity> InsertEntityAsync(TEntity entity)
         {
-            await Entities.InsertAsync(entity);
+            await Entities.InsertAsync(entity); // if false, throw 409
             return await Entities.GetAsync(entity.Id);
         }
 
@@ -54,7 +54,7 @@ namespace SIL.XForge.Services
                                 $"The relationship '{relName}' cannot be updated.");
                         }
                     }
-                });
+                }); /// if null, throw 409
         }
 
         protected override Task<TEntity> UpdateEntityRelationshipAsync(string id, string propertyName,

--- a/test/SIL.XForge.Tests/DataAccess/MemoryRepository.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryRepository.cs
@@ -2,8 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
 using System.Threading.Tasks;
 using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Connections;
+using MongoDB.Driver.Core.Servers;
 using Newtonsoft.Json;
 using SIL.XForge.Models;
 
@@ -146,7 +151,13 @@ namespace SIL.XForge.DataAccess
                 update(builder);
 
                 if (CheckDuplicateKeys(entity, original))
-                    return Task.FromResult<T>(null);
+                {
+                    throw new MongoCommandException(new ConnectionId(new ServerId(new ClusterId(), new TestEndPoint())),
+                        "Duplicate key!", null, new BsonDocument(new Dictionary<string, object>
+                        {
+                            {"codeName", "DuplicateKey"}
+                        }));
+                }
 
                 Replace(entity);
             }
@@ -183,5 +194,7 @@ namespace SIL.XForge.DataAccess
             }
             return false;
         }
+
+    private class TestEndPoint : EndPoint {}
     }
 }

--- a/test/SIL.XForge.Tests/Services/ResourceServiceTestEnvironmentBase.cs
+++ b/test/SIL.XForge.Tests/Services/ResourceServiceTestEnvironmentBase.cs
@@ -40,7 +40,7 @@ namespace SIL.XForge.Services
             JsonApiContext.RequestEntity.Returns(ResourceGraph.GetContextEntity(_resourceName));
             JsonApiContext.Options.Returns(new JsonApiOptions { IncludeTotalRecordCount = true });
 
-            Entities = new MemoryRepository<TEntity>(GetInitialData());
+            Entities = new MemoryRepository<TEntity>(GetUniqueKeySelectors(), GetInitialData());
 
             var config = new MapperConfiguration(cfg =>
                 {
@@ -92,6 +92,11 @@ namespace SIL.XForge.Services
             if (Directory.Exists(SharedDir))
                 Directory.Delete(SharedDir, true);
             Directory.CreateDirectory(SharedDir);
+        }
+
+        protected virtual IEnumerable<Func<TEntity, object>> GetUniqueKeySelectors()
+        {
+            return null;
         }
 
         protected virtual IEnumerable<TEntity> GetInitialData()


### PR DESCRIPTION
- If an insert or update fails (due to a conflict), throw status 409 (Conflict)
- Check caught exceptions' status codes; rethrow if not 409

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/571)
<!-- Reviewable:end -->
