### PR TITLE
Enable proper breaking of consecutive blank verses

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -82,6 +82,31 @@ export function registerScripture(): void {
     }
   }
 
+  class BlankEmbed extends Embed {
+    static blotName = 'blank';
+    static tagName = 'usx-blank';
+
+    static create(value: string): Node {
+      const node = super.create(value) as HTMLElement;
+      node.setAttribute(customAttributeName('type'), value);
+      let text: string;
+      switch (value) {
+        case 'initial':
+          text = ' ';
+          break;
+        case 'normal':
+          text = '        ';
+          break;
+      }
+      node.innerText = text;
+      return node;
+    }
+
+    static value(node: HTMLElement): any {
+      return node.getAttribute(customAttributeName('type'));
+    }
+  }
+
   class CharInline extends Inline {
     static blotName = 'char';
     static tagName = 'usx-char';
@@ -136,6 +161,7 @@ export function registerScripture(): void {
   }
 
   Block.allowedChildren.push(VerseEmbed);
+  Block.allowedChildren.push(BlankEmbed);
   Block.allowedChildren.push(NoteEmbed);
 
   class ParaBlock extends Block {
@@ -375,6 +401,7 @@ export function registerScripture(): void {
   Quill.register('formats/highlight', HighlightClass);
   Quill.register('formats/segment', SegmentClass);
   Quill.register('blots/verse', VerseEmbed);
+  Quill.register('blots/blank', BlankEmbed);
   Quill.register('blots/note', NoteEmbed);
   Quill.register('blots/char', CharInline);
   Quill.register('blots/para', ParaBlock);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -2,6 +2,7 @@
   spellcheck="false"
   placeholder="No book selected"
   [readOnly]="isReadOnly"
+  [strict]="false"
   [modules]="modules"
   (onEditorCreated)="onEditorCreated($event)"
   (onContentChanged)="onContentChanged($event.delta, $event.source)"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.scss
@@ -9,10 +9,6 @@ quill-editor {
     flex-direction: column;
     flex: 1 1 auto;
   }
-  p {
-    display: flex;
-    flex-wrap: wrap;
-  }
 }
 
 .highlight-source {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -10,13 +10,7 @@ import { Segment } from './segment';
 import { Segmenter } from './segmenter';
 import { UsxSegmenter } from './usx-segmenter';
 
-export const INITIAL_BLANK_TEXT = '\u00a0';
-export const NORMAL_BLANK_TEXT = '\u2003\u2003';
 const EDITORS = new Set<Quill>();
-
-export function isBlankText(text: string): boolean {
-  return text === INITIAL_BLANK_TEXT || text === NORMAL_BLANK_TEXT;
-}
 
 function onNativeSelectionChanged(): void {
   // workaround for bug where Quill allows a selection inside of an embed
@@ -392,7 +386,7 @@ export class TextComponent implements OnDestroy {
       return;
     }
     let newSel: RangeStatic;
-    if (isBlankText(this._segment.text)) {
+    if (this._segment.text === '') {
       // always select whole segment if blank
       newSel = this._segment.range;
     } else {
@@ -413,14 +407,9 @@ export class TextComponent implements OnDestroy {
 
     if (text === '' && range.length === 0) {
       // insert blank
-      let blankText: string;
-      if (ref.includes('/p')) {
-        blankText = INITIAL_BLANK_TEXT;
-      } else {
-        blankText = NORMAL_BLANK_TEXT;
-      }
-      this._editor.insertText(range.index, blankText, 'user');
-      range = { index: range.index, length: blankText.length };
+      const type = ref.includes('/p') ? 'initial' : 'normal';
+      this._editor.insertEmbed(range.index, 'blank', type, 'user');
+      range = { index: range.index, length: 1 };
     }
 
     const formats = this._editor.getFormat(range.index, range.length);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/usx-segmenter.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/usx-segmenter.ts
@@ -36,12 +36,12 @@ export class UsxSegmenter extends Segmenter {
     let curVerseRef = '';
     for (const op of delta.ops) {
       const len = typeof op.insert === 'string' ? op.insert.length : 1;
-      if (op.attributes == null) {
+      if (op.insert !== '\n' && op.attributes == null) {
         curRangeLen += len;
       } else {
-        if (op.attributes.para != null) {
-          const style = op.attributes.para.style as string;
-          if (isParagraphStyle(style)) {
+        if (op.insert === '\n' || op.attributes.para != null) {
+          const style = op.attributes == null ? null : (op.attributes.para.style as string);
+          if (style == null || isParagraphStyle(style)) {
             for (const _ch of op.insert) {
               if (curVerseRef !== '') {
                 paraVerses.set(curVerseRef, { index: curIndex, length: curRangeLen });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -75,7 +75,7 @@ describe('EditorComponent', () => {
     env.waitForSuggestion();
     expect(env.component.target.segmentRef).toEqual('verse_2_1');
     const selection = env.component.target.editor.getSelection();
-    expect(selection.index).toEqual(35);
+    expect(selection.index).toEqual(34);
     expect(selection.length).toEqual(0);
     expect(env.component.translateUserConfig.selectedSegment).toEqual('verse_2_1');
     verify(env.mockedSFProjectUserService.update(anything())).once();
@@ -96,7 +96,7 @@ describe('EditorComponent', () => {
     expect(env.component.target.segmentRef).toEqual('verse_1_2');
     const selection = env.component.target.editor.getSelection();
     expect(selection.index).toEqual(30);
-    expect(selection.length).toEqual(2);
+    expect(selection.length).toEqual(1);
     expect(env.component.translateUserConfig.selectedSegment).toEqual('verse_1_2');
     verify(env.mockedSFProjectUserService.update(anything())).once();
     verify(env.mockedRemoteTranslationEngine.translateInteractively(1, anything())).once();
@@ -563,7 +563,7 @@ class TestEnvironment {
         delta.insert(`${textType}: chapter 1, verse 2.`, { segment: 'verse_1_2' });
         break;
       case 'target':
-        delta.insert('\u2003\u2003', { segment: 'verse_1_2' });
+        delta.insert({ blank: 'normal' }, { segment: 'verse_1_2' });
         break;
     }
     delta.insert('\n', { para: { style: 'p' } });
@@ -573,7 +573,7 @@ class TestEnvironment {
     delta.insert({ verse: 2 }, { verse: { style: 'v' } });
     delta.insert(`${textType}: chapter 2, verse 2.`, { segment: 'verse_2_2' });
     delta.insert('\n', { para: { style: 'p' } });
-    delta.insert('\u00a0', { segment: 'verse_2_2/p_1' });
+    delta.insert({ blank: 'initial' }, { segment: 'verse_2_2/p_1' });
     delta.insert({ verse: 3 }, { verse: { style: 'v' } });
     switch (textType) {
       case 'source':

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -26,7 +26,7 @@ import { SFProjectUserService } from '../../core/sfproject-user.service';
 import { SFProjectService } from '../../core/sfproject.service';
 import { TextService, TextType } from '../../core/text.service';
 import { Segment } from '../../shared/text/segment';
-import { INITIAL_BLANK_TEXT, isBlankText, NORMAL_BLANK_TEXT, TextComponent } from '../../shared/text/text.component';
+import { TextComponent } from '../../shared/text/text.component';
 
 const Delta: new () => DeltaStatic = Quill.import('delta');
 const PUNCT_SPACE_REGEX = XRegExp('^(\\p{P}|\\p{S}|\\p{Cc}|\\p{Z})+$');
@@ -375,7 +375,7 @@ export class EditorComponent extends SubscriptionDisposable implements OnInit, O
     let i: number;
     for (i = range.index; i < range.index + range.length; i++) {
       const ch = this.target.editor.getText(i, 1);
-      if (ch === INITIAL_BLANK_TEXT[0] || ch === NORMAL_BLANK_TEXT[0] || !/\s/.test(ch)) {
+      if (ch === '' || !/\s/.test(ch)) {
         return { index: i, length: range.length - (i - range.index) };
       }
     }
@@ -396,7 +396,7 @@ export class EditorComponent extends SubscriptionDisposable implements OnInit, O
     return (
       segment != null &&
       segment.range.length > 0 &&
-      !isBlankText(segment.text) &&
+      segment.text !== '' &&
       this.isSegmentComplete(segment.range) &&
       segment.isChanged
     );

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
@@ -61,12 +61,13 @@ namespace SIL.XForge.Scripture.Services
 
         public static Delta InsertBlank(this Delta delta, string segRef)
         {
-            string blankText;
-            if (segRef.Contains("/p"))
-                blankText = DeltaUsxMapper.InitialBlankText;
-            else
-                blankText = DeltaUsxMapper.NormalBlankText;
-            return delta.InsertText(blankText, segRef);
+            string type = segRef.Contains("/p") ? "initial" : "normal";
+
+            var attrs = new JObject();
+            if (segRef != null)
+                attrs.Add(new JProperty("segment", segRef));
+
+            return delta.Insert(new { blank = type }, attrs);
         }
 
         public static Delta InsertVerse(this Delta delta, string number)


### PR DESCRIPTION
- Chrome does not break on em-spaces
- Use spaces inside of an inline embed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/584)
<!-- Reviewable:end -->
