### PR TITLE
Reduce audio recording gain from 10 to 1 (LFv1)

### DIFF
--- a/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
+++ b/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
@@ -131,7 +131,6 @@ export class MP3Encoder {
     // Flatten the buffer array while converting it from Float32 to Int16
     const pcmData = new Int16Array(this.buffer.length * this.buffer[0].length);
 
-    const gain = 10;
     // max and min 16-bit values
     const max = 0x7FFF;
     const min = 0x8000;
@@ -139,7 +138,7 @@ export class MP3Encoder {
     for (let i = 0, len1 = this.buffer.length; i < len1; ++i) {
       const chunk = this.buffer[i];
       for (let j = 0, len2 = chunk.length; j < len2; ++j) {
-        pcmData[index] = chunk[j] < 0 ? Math.max(-min, chunk[j] * gain * min) : Math.min(max, chunk[j] * gain * max);
+        pcmData[index] = chunk[j] < 0 ? chunk[j] * min : chunk[j] * max;
         ++index;
       }
     }


### PR DESCRIPTION
This commit reduces the audio recording gain from 10 to 1, which also eliminates the need to implement clipping.

Work on this was delayed a bit when I discovered an audio recording related bug and attempted to fix it. The audio recorder persists when switching between dictionary entries. That bug has proved to be somewhat more difficult to repair than I anticipated, and I am still working on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/592)
<!-- Reviewable:end -->
