### PR TITLE
Close audio recorder when switching entry (LFv1)

### DIFF
--- a/src/angular-app/bellows/shared/sound-player.component.ts
+++ b/src/angular-app/bellows/shared/sound-player.component.ts
@@ -51,7 +51,7 @@ export class SoundController implements angular.IController {
 
   }
 
-  $onChanges(changes: any): void {
+  $onChanges(changes: angular.IOnChangesObject): void {
     const urlChange = changes.puiUrl as angular.IChangesObject<string>;
     if (urlChange != null && urlChange.currentValue) {
       if (this.playing) {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-audio.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-audio.component.ts
@@ -23,12 +23,15 @@ export class FieldAudioController implements angular.IController {
   static $inject = ['$filter', '$state',
     'Upload', 'modalService',
     'silNoticeService', 'sessionService',
-    'lexProjectService'
+    'lexProjectService', '$scope'
   ];
   constructor(private $filter: angular.IFilterService, private $state: angular.ui.IStateService,
               private Upload: any, private modalService: ModalService,
               private notice: NoticeService, private sessionService: SessionService,
-              private lexProjectService: LexiconProjectService) { }
+              private lexProjectService: LexiconProjectService, private $scope: angular.IScope) {
+
+                this.$scope.$watch(() => this.dcFilename, () => this.showAudioRecorder = false);
+              }
 
   hasAudio(): boolean {
     if (this.dcFilename == null) {


### PR DESCRIPTION
Previously the audio recorder would remain open when switching between dictionary entries. This commit fixes the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/593)
<!-- Reviewable:end -->
