### PR TITLE
Right to left support in Scripture Forge (SFv1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ src/userConfig.php
 src/angular-app/bellows/apps/**/*.css
 src/angular-app/bellows/shared/*.css
 src/angular-app/bellows/shared/**/*.css
+src/angular-app/bellows/directive/*.css
 src/angular-app/languageforge/**/*.css
 src/angular-app/scriptureforge/**/*.css
 src/Site/views/**/*.css

--- a/src/angular-app/bellows/shared/palaso-ui.scss
+++ b/src/angular-app/bellows/shared/palaso-ui.scss
@@ -59,25 +59,6 @@ div.listview div.pagination select {
     width: 70px;
 }
 
-/* Listview for projects, questions, answers views */
-.listview .attention-block {
-    text-align: center;
-    background-color: #f0f0f0; /* lightgray */
-    color: #dc143c; /* crimson */
-
-    a {
-      color: #dc143c;
-    }
-}
-
-div.listview div.attention-block .count {
-    font-size: 1.8em;
-}
-
-div.listview div.attention-block .subtitle {
-    font-size: 1.0em;
-}
-
 .larger-text {
     font-size: 1.25em;
 }

--- a/src/angular-app/scriptureforge/sfchecks/project/project-settings.html
+++ b/src/angular-app/scriptureforge/sfchecks/project/project-settings.html
@@ -179,11 +179,9 @@
                             <span class="larger-text">{{text.title}}</span>
                         </a>
                     </td>
-                    <td><a data-ng-href="{{text.url}}">
-                        <div class="attention-block">
-                            <span class="subtitle"><span class="notranslate">{{text.questionCount}}</span> questions</span>
-                        </div>
-                    </a></td>
+                    <td>
+                        <span class="notranslate">{{text.questionCount}}</span> questions
+                    </td>
                     <td><span class="notranslate">{{text.responseCount}}</span> responses</td>
                     <td>Archived on <span class="notranslate">{{text.dateModified | date:'fullDate'}}</span></td>
                 </tr>

--- a/src/angular-app/scriptureforge/sfchecks/project/project-settings.html
+++ b/src/angular-app/scriptureforge/sfchecks/project/project-settings.html
@@ -152,9 +152,9 @@
                 <td align="center">
                     <label><input type="checkbox" data-ng-checked="isSelected(template)"
                                   data-ng-click="updateSelection($event, template)"></label></td>
-                <td class="align-middle"><a title="Click to edit this template" data-ng-click="showTemplateEditor(template)">
+                <td class="align-middle" dir="auto"><a title="Click to edit this template" data-ng-click="showTemplateEditor(template)">
                     {{template.title}}</a></td>
-                <td class="align-middle" style="text-overflow: ellipsis">{{template.description}}</td>
+                <td class="align-middle" dir="auto" "text-overflow: ellipsis">{{template.description}}</td>
             </tr>
         </table>
         </listview>
@@ -174,7 +174,7 @@
                     <td data-ng-show="rights.archive">
                         <label><input type="checkbox" data-ng-checked="isSelected(text)"
                                       data-ng-click="updateSelection($event, text)"></label></td>
-                    <td>
+                    <td dir="auto">
                         <a data-ng-href="{{text.url}}">
                             <span class="larger-text">{{text.title}}</span>
                         </a>

--- a/src/angular-app/scriptureforge/sfchecks/project/project.html
+++ b/src/angular-app/scriptureforge/sfchecks/project/project.html
@@ -35,12 +35,13 @@
                     <div>
                         <div class="form-group">
                             <label>Title
-                                <input class="form-control" required data-ng-model="title" type="text" placeholder="Title">
+                                <input class="form-control" required data-ng-model="title" type="text" placeholder="Title" dir="auto">
                             </label>
                         </div>
                         <div class="form-group">
                             <label>Text
-                                <textarea class="form-control" textdrop data-ng-model="content" rows="4" placeholder="Paste the USX text here"></textarea>
+                                <textarea class="form-control" textdrop data-ng-model="content" rows="4"
+                                          placeholder="Paste the USX text here" dir="auto"></textarea>
                             </label>
                         </div>
                         <div class="form-group">
@@ -108,7 +109,7 @@
                         <input type="checkbox" data-ng-checked="isSelected(text)" data-ng-click="updateSelection($event, text)">
                     </label>
                 </td>
-                <td>
+                <td dir="auto">
                     <a data-ng-href="{{text.url}}"><div class="larger-text">{{text.title}}</div></a>
                 </td>
                 <td ng-class="{'text-muted':text.questionCount == 0}">

--- a/src/angular-app/scriptureforge/sfchecks/sfchecks.scss
+++ b/src/angular-app/scriptureforge/sfchecks/sfchecks.scss
@@ -1,3 +1,8 @@
+body {
+  // Overide text-align: left; in Bootstrap's _reboot.scss, so that dir=auto will work
+  text-align: initial;
+}
+
 .no-margin {
     /* Fix Bootstrap's margins on checkboxes, etc. */
     margin: 0 !important;
@@ -228,4 +233,12 @@ div.new-item.collapse.in {
   margin-top:10px;
   padding: 5px;
   border: #C1DBC1 2px solid;
+}
+
+.text-heading {
+  max-width: 50%;
+}
+
+.question-heading {
+  margin-right: 2em;
 }

--- a/src/angular-app/scriptureforge/sfchecks/text/question.html
+++ b/src/angular-app/scriptureforge/sfchecks/text/question.html
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row text-heading" dir="auto">
     <h2>{{text.title}}</h2>
 </div>
 <div class="row">
@@ -10,26 +10,26 @@
             </a>
             <pui-soundplayer pui-url="audioPlayUrl" title="Play audio"></pui-soundplayer>
         </div>
-        <div id="textcontrol" style="font-family: {{text.fontfamily}}" data-sil-selection data-sil-selected-text="selectedText" content="text.content"></div>
+        <div id="textcontrol" dir="auto" style="font-family: {{text.fontfamily}}" data-sil-selection data-sil-selected-text="selectedText" content="text.content"></div>
     </div>
     <div id="comments" class="col-md-6" data-ng-show="finishedLoading">
         <div class="question">
             <button class="btn btn-std float-right" data-ng-show="rightsEditQuestion()" data-ng-click="toggleQuestionEditor()">
                 <i class="fa fa-cog fa-lg"></i></button>
-            <h2>{{questionTitleCalculated}}</h2>
+            <h2 class="question-heading" dir="auto">{{questionTitleCalculated}}</h2>
             <h4 data-ng-show="questionIsClosed()" style="color: gray; font-style: italic">This question is marked closed</h4>
-            <div>{{question.description}}</div>
+            <div dir="auto">{{question.description}}</div>
             <div class="edit-question" uib-collapse="editQuestionCollapsed">
                 <form class="card">
                     <b>Question Settings</b>
                     <fieldset class="card-body">
                         <label class="form-group">Question
                             <textarea required data-ng-model="editedQuestion.description" class="form-control col-12"
-                                      rows="4" placeholder="The Question"></textarea>
+                                      rows="4" placeholder="The Question" dir="auto"></textarea>
                         </label>
                         <label class="form-group">Title
                             <input type="text" data-ng-model="editedQuestion.title" class="form-control col-12"
-                                   maxlength="35" placeholder="One-line Summary For Title">
+                                   maxlength="35" placeholder="One-line Summary For Title" dir="auto">
                         </label>
                         <label class="form-group">Workflow
                             <select class="form-control custom-select" data-ng-model="editedQuestion.workflowState"
@@ -58,7 +58,7 @@
 
                     <div class="form-group">
                     <textarea required data-ng-model="newAnswer.content" class="newAnswer form-control" id="question-new-answer"
-                              placeholder='Type your answer here. Click "Save Answer" when finished.'></textarea>
+                              placeholder='Type your answer here. Click "Save Answer" when finished.' dir="auto"></textarea>
                     </div>
                     <div data-ng-hide="unreadResponseCount() == 0" class="right badge badge-important">
                         <span class="notranslate">{{unreadResponseCount()}}</span> new response<span data-ng-show="unreadResponseCount() > 1">s</span>
@@ -82,7 +82,7 @@
                         <!--<b>DEBUG:</b>answer = {{answer}}<br>-->
                         <div data-ng-show="answer.textHighlight" data-ng-bind-html="answer.textHighlight"
                              class="scripture-quote"></div>
-                        <div class="answerContent" data-ng-bind-html="answer.content"></div>
+                        <div class="answerContent" dir="auto" data-ng-bind-html="answer.content"></div>
                         <div class="answer-footer">
                             <view-tags class="tag-list" ng-show="$parent.rightsCreateTag()"
                                  tags="answer.tags" on-delete="deletedTags(answer)"
@@ -110,7 +110,7 @@
                             </div>
                             <div data-ng-switch data-on="answerEditorVisible(answerId)">
                                 <form data-ng-submit="editAnswer(editedAnswer)" data-ng-switch-when="true">
-                                    <label><textarea required data-ng-model="editedAnswer.content" class="editAnswer form-control">
+                                    <label><textarea required data-ng-model="editedAnswer.content" class="editAnswer form-control" dir="auto">
                                     </textarea></label>
                                     <button type="submit" class="btn btn-sm btn-primary answerBtn"> <i class="fa fa-check"></i>Save </button>
                                     <a href data-ng-click="hideAnswerEditor()">Cancel</a>
@@ -132,9 +132,9 @@
                         <div class="comments">
                             <div data-ng-repeat="comment in answer.comments">
                                 <div class="comment" data-ng-class="{unread: isUnreadComment(comment.id)}">
-                                    <span class="notranslate">{{comment.content}} -
-                                    {{comment.userRef.username}} -
-                                    {{comment.dateCreated | date:mediumdate}}</span>
+                                    <span class="notranslate">
+                                    <p dir="auto">{{comment.content}}</p>
+                                    {{comment.userRef.username}} - {{comment.dateCreated | date:mediumdate}}</span>
                                     <a href data-ng-show="rightsEditResponse(comment.userRef.userid) && !questionIsClosed()"
                                        data-ng-click="showCommentEditor(comment.id)">edit</a>&nbsp;
                                     <a href data-ng-show="rightsDeleteResponse(comment.userRef.userid) && !questionIsClosed()"
@@ -143,7 +143,7 @@
                                         <form data-ng-submit="editComment(answerId, answer, editedComment)"
                                               data-ng-switch-when="true">
                                             <div class="form-group">
-                                                <label><textarea class="form-control" required data-ng-model="editedComment.content"></textarea></label>
+                                                <label><textarea class="form-control" required data-ng-model="editedComment.content" dir="auto"></textarea></label>
                                                 <button type="submit" class="btn btn-sm btn-primary">Save</button>
                                                 <a href data-ng-click="hideCommentEditor()">Cancel</a>
                                             </div>
@@ -156,7 +156,8 @@
                                     add comment</a>
                                 <div uib-collapse="!collapsed">
                                     <form data-ng-submit="submitComment(answerId, answer); collapsed = !collapsed;">
-                                        <label class="form-group"><textarea class="form-control" required data-ng-model="newComment.content"></textarea></label>
+                                        <label class="form-group"><textarea class="form-control"
+                                            required data-ng-model="newComment.content" dir="auto"></textarea></label>
                                         <button type="submit" class="btn btn-sm btn-primary save-new-comment">Save Comment</button>
                                     </form>
                                 </div>

--- a/src/angular-app/scriptureforge/sfchecks/text/text-settings.html
+++ b/src/angular-app/scriptureforge/sfchecks/text/text-settings.html
@@ -7,12 +7,13 @@
                     <div>
                         <div class="form-group">
                             <label>Title
-                                <input class="form-control" required data-ng-model="editedText.title" type="text" placeholder="Title">
+                                <input class="form-control" required data-ng-model="editedText.title" type="text" placeholder="Title" dir="auto">
                             </label>
                         </div>
                         <div class="form-group">
                             <label>Text
-                                <textarea class="form-control" textdrop data-ng-model="editedText.content" rows="4" placeholder="Paste the USX text here"></textarea>
+                                <textarea class="form-control" textdrop data-ng-model="editedText.content" rows="4"
+                                          placeholder="Paste the USX text here" dir="auto"></textarea>
                             </label>
                         </div>
                         <div class="form-group">
@@ -83,7 +84,7 @@
                              class="details-row" data-ng-class="{active: isSelected(question)}">
                                 <td data-ng-show="rights.archive">
                                     <label><input type="checkbox" data-ng-click="updateSelection($event, question)"></label></td>
-                                <td><a class="col-md-5" data-ng-href="{{question.url}}">
+                                <td dir="auto"><a class="col-md-5" data-ng-href="{{question.url}}">
                                     <span class="larger-text">{{question.calculatedTitle}}</span></a></td>
                                 <td><a data-ng-href="{{question.url}}">
                                         <span class="notranslate">{{question.answerCount}}</span> answers

--- a/src/angular-app/scriptureforge/sfchecks/text/text.html
+++ b/src/angular-app/scriptureforge/sfchecks/text/text.html
@@ -40,11 +40,11 @@
                 <fieldset class="col-md-4">
                     <label class="form-group">Title
                         <input type="text" data-ng-model="questionTitle" class="form-control" maxlength="70"
-                            placeholder="One-line Summary For Title">
+                            placeholder="One-line Summary For Title" dir="auto">
                     </label>
                     <label class="form-group">Question
                         <textarea required data-ng-model="questionDescription" class="form-control" rows="4"
-                              placeholder="The Question"></textarea>
+                              placeholder="The Question" dir="auto"></textarea>
                     </label>
                     <label class="form-group">
                         <input title="A summary title is required for templates"
@@ -71,14 +71,14 @@
     <hr>
     <div class="row">
         <div class="col-md-5" oncopy="return false;">
-            <h2>{{text.title}}</h2>
+            <h2 dir="auto">{{text.title}}</h2>
             <div class="audio-buttons" data-ng-show="text.audioFileName">
                 <a data-ng-show="project.allowAudioDownload" data-ng-href="{{audioDownloadUrl}}">
                     <i class="fa fa-arrow-circle-o-down" title="Download audio"></i>
                 </a>
                 <pui-soundplayer pui-url="audioPlayUrl" title="Play audio"></pui-soundplayer>
             </div>
-            <div id="textcontrol" style="font-family: {{text.fontfamily}}" data-ng-bind-html="text.content"></div>
+            <div id="textcontrol" style="font-family: {{text.fontfamily}}" dir="auto" data-ng-bind-html="text.content"></div>
         </div>
         <div class="col-md-7">
             <listview hide-if-empty="true" search="queryQuestions()"
@@ -95,7 +95,7 @@
                             <!--suppress HtmlFormInputWithoutLabel -->
                             <input type="checkbox" data-ng-show="rights.archive" data-ng-checked="isSelected(question)" data-ng-click="updateSelection($event, question)">
                         </td>
-                        <td>
+                        <td dir="auto">
                             <a data-ng-href="{{question.url}}"><span class="larger-text">{{question.calculatedTitle}}</span></a>
                         </td>
                         <td ng-class="{'text-muted':question.answerCount == 0}">


### PR DESCRIPTION
This PR implement basic right to left support in Scripture Forge using HTML's `dir="auto"`.

SF e2e tests are passing.

Below are some screenshots showing major changes (this is not exhaustive):

![Screen Shot 2019-03-17 at 00 20 58-fullpage](https://user-images.githubusercontent.com/6140710/54485186-adabad80-484a-11e9-8f9d-049c2d513272.png)
![Screen Shot 2019-03-17 at 00 21 16-fullpage](https://user-images.githubusercontent.com/6140710/54485187-adabad80-484a-11e9-8327-0c7d5cc2f2ad.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/594)
<!-- Reviewable:end -->
