### PR TITLE
Fix SF reports when user has no email (SFv1)

### DIFF
--- a/src/Api/Library/Scriptureforge/Sfchecks/SfchecksReports.php
+++ b/src/Api/Library/Scriptureforge/Sfchecks/SfchecksReports.php
@@ -44,13 +44,13 @@ class SfchecksReports
 
             foreach($listModel->entries as $user) {
                 $userModel = new UserModel($user['id']);
-                $user['isActive'] = $userModel->active;
+                if (!isset($user['email'])) $user['email'] = $userModel->emailPending;
                 $user['answers'] = 0;
                 $user['comments'] = 0;
                 $user['questions'] = 0;
                 $user['responses'] = 0;
                 $user['textIds'] = array();
-                if (!$user['isActive']) {
+                if (!$userModel->last_login) {
                     continue;
                 }
                 if ($project->users->offsetExists($user['id'])) {
@@ -346,17 +346,14 @@ class SfchecksReports
 
             foreach($listModel->entries as $user) {
                 $userModel = new UserModel($user['id']);
-                $user['isActive'] = $userModel->active;
+                if (!isset($user['email'])) $user['email'] = $userModel->emailPending;
                 $user['questions'] = 0;
                 $user['texts'] = 0;
                 $user['answers'] = 0;
                 $user['comments'] = 0;
                 $user['responses'] = 0;
                 $user['textIds'] = array();
-                if (!$user['isActive']) {
-                    if (!$user['email']) {
-                        $user['email'] = $userModel->emailPending;
-                    }
+                if (!$userModel->last_login && !isset($user['email'])) {
                     array_push($invalidUsers, $user);
                     continue;
                 }


### PR DESCRIPTION
Previously the reports would throw an exception if a user didn't have email. The report generator also assumed users marked as "active" are actually active (it actually just means they can log in). This commit changes it to instead check whether they have ever logged in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/603)
<!-- Reviewable:end -->
