### PR TITLE
Fix admin page username field state (xFv1)

### DIFF
--- a/src/angular-app/bellows/apps/siteadmin/site-admin-users.component.html
+++ b/src/angular-app/bellows/apps/siteadmin/site-admin-users.component.html
@@ -76,7 +76,7 @@
                                class="form-control"
                                data-idle-validate-keypress="$ctrl.resetValidateUserForm()"
                                type="text" placeholder="(username)"
-                               data-ng-disabled="$ctrl.vars.state === 'add'"
+                               data-ng-disabled="$ctrl.vars.state !== 'add'"
                                data-ng-model="$ctrl.record.username">
                         <span class="input-group-addon" data-ng-show="$ctrl.uniqueUserState === 'loading'">
                                 <i id="userNameLoading" class="fa fa-spinner fa-spin"></i>


### PR DESCRIPTION
This is a tiny fix to a bug I encountered while trying to reproduce another bug. The username field on the admin page should be editable when creating a user, but not when editing a user. Previously the functionality was exactly the opposite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/604)
<!-- Reviewable:end -->
