### PR TITLE
Fix missing comment indicator in LF entry list (LFv1)

### DIFF
--- a/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
+++ b/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
@@ -108,7 +108,7 @@ export class LexiconCommentService {
   }
 
   getEntryCommentCount(entryId: string): number {
-    if (this.comments == null || this.comments.counts.byEntry[entryId] == null) {
+    if (this.comments.counts.byEntry[entryId] == null) {
       return 0;
     }
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -79,7 +79,7 @@ export class LexiconEditorController implements angular.IController {
   entries = this.editorService.entries;
   entryListModifiers = this.editorService.entryListModifiers;
   filteredEntries = this.editorService.filteredEntries;
-  getEntryCommentCount = this.commentService.getEntryCommentCount;
+  getEntryCommentCount = this.commentService.getEntryCommentCount.bind(this.commentService);
   getPrimaryListItemForDisplay = this.editorService.getSortableValue;
   visibleEntries = this.editorService.visibleEntries;
   unreadCount = this.activityService.unreadCount;


### PR DESCRIPTION
This issue was caused by `this` referring to the wrong object (possibly starting in 6345e3f4ed27b74c54b51bdbe1395e30557f7bc9). The view calls a function that is a property of the component, but the function is actually defined in the comment service (in the component we have `getEntryCommentCount = this.commentService.getEntryCommentCount`). When AngularJS calls the function it uses the wrong context (most likely the context of the component). When the function references `this.comments` it is undefined.

Because this type of bug is so easy to create I think we should consider whether all methods should be written using arrow functions so `this` will have lexical scope. It's not the default TypeScript syntax, but it is safer and actually more "correct."

The two main ways of writing methods in TypeScript using arrow function are:
``` typescript
public functionA = () => {}
public functionB: () => void = () => {}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/605)
<!-- Reviewable:end -->
