### PR TITLE
Fix lexicon editor in Safari < 10 (LFv1)

### DIFF
--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -567,20 +567,15 @@ export class EditorDataService {
   }
 
   private sortList(config: any, list: any): any {
-    const collator = Intl.Collator(this.getInputSystemForSort(config));
+    const inputSystem = this.getInputSystemForSort(config);
+    const compare = ('Intl' in window) ? Intl.Collator(inputSystem).compare : (a: string, b: string) => a < b ? -1 : 1;
 
-    // temporary mapped array
-    const mapped = list.map((entry: any, i: number) => {
-      return { index: i, value: this.getSortableValue(config, entry) };
-    });
+    const mapped = list.map((entry: any, i: number) => ({
+      index: i,
+      value: this.getSortableValue(config, entry)
+    }));
 
-    mapped.sort((a: any, b: any) => {
-      if (this.entryListModifiers.sortReverse === true) {
-        return -collator.compare(a.value, b.value);
-      } else {
-        return collator.compare(a.value, b.value);
-      }
-    });
+    mapped.sort((a: any, b: any) => compare(a.value, b.value) * (this.entryListModifiers.sortReverse ? -1 : 1));
 
     return mapped.map((el: any) => list[el.index]);
   }


### PR DESCRIPTION
Replaces the use of Intl for sorting strings when Intl is not defined. Sorts instead based on Unicode value by simple string comparison (`"apple" < "cow"` in JavaScript). [According to MDN,](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators) "Strings are compared based on standard lexicographical ordering, using Unicode values."

I've tested this on an older iPad with Safari 9.x, and it works correctly. Searching entries does not seem to work (every word is a result whether it matches or not), but I don't think that is related to this PR. Also search not working in an older browser is a much less critical issue than the entire page being broken due to an error, which is what this PR is fixing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/613)
<!-- Reviewable:end -->
