### PR TITLE
SF-132 Simplify DateTime to object, for successful Unset to MongoRepo…

### DIFF
--- a/src/SIL.XForge.Identity/Controllers/IdentityRpcController.cs
+++ b/src/SIL.XForge.Identity/Controllers/IdentityRpcController.cs
@@ -22,6 +22,8 @@ using SIL.XForge.Utils;
 
 namespace SIL.XForge.Identity.Controllers
 {
+
+    /// <summary>Processes identity-related requests from front-end, such as from identity.service.ts.</summary>
     public class IdentityRpcController : RpcController
     {
         private const string VerificationUrl = "https://www.google.com/recaptcha/api/siteverify";
@@ -110,7 +112,7 @@ namespace SIL.XForge.Identity.Controllers
                 update => update
                     .Set(u => u.Password, UserEntity.HashPassword(password))
                     .Unset(u => u.ResetPasswordKey)
-                    .Unset(u => u.ResetPasswordExpirationDate));
+                    .Unset(u => u.ResetPasswordExpirationDate as object));
             if (user != null)
             {
                 await LogInUserAsync(user);
@@ -238,7 +240,7 @@ namespace SIL.XForge.Identity.Controllers
                 update => update
                     .Set(u => u.EmailVerified, true)
                     .Unset(u => u.ValidationKey)
-                    .Unset(u => u.ValidationExpirationDate));
+                    .Unset(u => u.ValidationExpirationDate as object));
             return user != null;
         }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/identity/identity.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/identity/identity.service.ts
@@ -6,6 +6,7 @@ import { LinkAccountResult } from './models/link-account-result';
 import { LogInResult } from './models/log-in-result';
 import { SignUpResult } from './models/sign-up-result';
 
+/** This interfaces to IdentityRpcController in the backend. */
 @Injectable()
 export class IdentityService {
   constructor(private readonly jsonRpcService: JsonRpcService) {}

--- a/src/SIL.XForge/DataAccess/MongoRepository.cs
+++ b/src/SIL.XForge/DataAccess/MongoRepository.cs
@@ -7,6 +7,7 @@ using SIL.XForge.Models;
 
 namespace SIL.XForge.DataAccess
 {
+    /// <summary>Mongo-backed database, for use in production.</summary>
     public class MongoRepository<T> : IRepository<T> where T : Entity
     {
         private readonly IMongoCollection<T> _collection;

--- a/test/SIL.XForge.Tests/DataAccess/MemoryRepository.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryRepository.cs
@@ -9,6 +9,7 @@ using SIL.XForge.Models;
 
 namespace SIL.XForge.DataAccess
 {
+    /// <summary>Memory-backed database, for use with tests.</summary>
     public class MemoryRepository<T> : IRepository<T> where T : Entity, new()
     {
         private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings

--- a/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilder.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilder.cs
@@ -55,6 +55,10 @@ namespace SIL.XForge.DataAccess
 
         public IUpdateBuilder<T> Unset<TField>(Expression<Func<T, TField>> field)
         {
+            if (field.Body.Type != typeof(System.Object) && field.Body.Type != typeof(System.String))
+            {
+                throw new ArgumentException("Error: This will probably fail when used with MongoRepository. Use a simpler type.", nameof(field));
+            }
             (object owner, PropertyInfo prop) = GetFieldOwner(field);
             object value = null;
             if (prop.PropertyType.IsValueType)


### PR DESCRIPTION
…sitory

Add Exception to MemoryRepository builder to catch these problems in
tests.
More information in SF-132.

---
So in MemoryUpdateBuild.cs I have a rather limited list, which could trigger problems as soon as someone uses it for a new purpose (though that might be good, depending on how Mongo would behave). I did not investigate why String works and DateTime does not. But certainly DateTime was causing problems. 
An alternate solution might be to modify MongoUpdateBuilder.cs to conform arguments to Unset to contain acceptable data, but then that adds divergence between Mongo and Memory repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/622)
<!-- Reviewable:end -->
