### PR TITLE
Flush active edit buffer on dispose in translate metrics

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
@@ -266,10 +266,7 @@ describe('TranslateMetricsSession', () => {
 
     env.keyPress('a');
     env.keyPress('b');
-    tick(ACTIVE_EDIT_TIMEOUT);
     expect(env.session.metrics.type).toBe('edit');
-    expect(env.session.metrics.timeEditActive).toBeDefined();
-    expect(env.session.metrics.keyCharacterCount).toBe(2);
     verify(env.mockedSFProjectService.addTranslateMetrics('project01', anything())).never();
 
     const sessionId = env.session.id;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/634)
<!-- Reviewable:end -->
