### PR TITLE
SF-233 Handle null doc types

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-doc.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-doc.spec.ts
@@ -1,0 +1,101 @@
+import { Callback, Doc, OTType, Snapshot } from 'sharedb/lib/client';
+import { SharedbRealtimeDoc } from './realtime-doc';
+
+describe('SharedbRealtimeDoc', () => {
+  it('does not crash with null type', () => {
+    // Connection.cs permits type to be null
+    const doc = new MockDoc();
+    doc.type = null;
+    const realtimeDoc = new SharedbRealtimeDoc(doc);
+    expect(() => {}).not.toThrow();
+  });
+});
+
+class MockDoc implements Doc {
+  type: OTType;
+  id: string;
+  data: any;
+  version: number;
+  subscribed: boolean;
+  wantSubscribe: boolean;
+  inflightOp: any;
+  pendingOps: any[];
+  on(event: any, callback: any): this {
+    throw new Error('Method not implemented.');
+  }
+  off(event: any, callback: any): this {
+    throw new Error('Method not implemented.');
+  }
+  addListener(event: any, callback: any): this {
+    throw new Error('Method not implemented.');
+  }
+  removeListener(event: any, callback: any): this {
+    throw new Error('Method not implemented.');
+  }
+  fetch(callback: Callback): void {
+    throw new Error('Method not implemented.');
+  }
+  subscribe(callback: Callback): void {
+    throw new Error('Method not implemented.');
+  }
+  unsubscribe(callback: Callback): void {
+    throw new Error('Method not implemented.');
+  }
+  ingestSnapshot(snapshot: Snapshot, callback: Callback): void {
+    throw new Error('Method not implemented.');
+  }
+  destroy(callback: Callback): void {
+    throw new Error('Method not implemented.');
+  }
+  create(data: any, type?: string | OTType, options?: any, callback?: Callback): void {
+    throw new Error('Method not implemented.');
+  }
+  submitOp(data: any, options?: any, callback?: Callback): void {
+    throw new Error('Method not implemented.');
+  }
+  del(options: any, callback: Callback): void {
+    throw new Error('Method not implemented.');
+  }
+  whenNothingPending(callback: Callback): void {
+    throw new Error('Method not implemented.');
+  }
+  hasWritePending(): boolean {
+    throw new Error('Method not implemented.');
+  }
+  flush(): void {
+    throw new Error('Method not implemented.');
+  }
+  once(event: string | symbol, listener: (...args: any[]) => void): this {
+    throw new Error('Method not implemented.');
+  }
+  prependListener(event: string | symbol, listener: (...args: any[]) => void): this {
+    throw new Error('Method not implemented.');
+  }
+  prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this {
+    throw new Error('Method not implemented.');
+  }
+  removeAllListeners(event?: string | symbol): this {
+    throw new Error('Method not implemented.');
+  }
+  setMaxListeners(n: number): this {
+    throw new Error('Method not implemented.');
+  }
+  getMaxListeners(): number {
+    throw new Error('Method not implemented.');
+  }
+  listeners(event: string | symbol): Function[] {
+    throw new Error('Method not implemented.');
+  }
+  rawListeners(event: string | symbol): Function[] {
+    throw new Error('Method not implemented.');
+  }
+  emit(event: string | symbol, ...args: any[]): boolean {
+    throw new Error('Method not implemented.');
+  }
+  eventNames(): (string | symbol)[] {
+    throw new Error('Method not implemented.');
+  }
+  listenerCount(type: string | symbol): number {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-doc.ts
@@ -34,7 +34,7 @@ export class SharedbRealtimeDoc implements RealtimeDoc {
   }
 
   get type(): string {
-    return this.doc.type.name;
+    return this.doc.type == null ? null : this.doc.type.name;
   }
 
   get pendingOps(): any[] {


### PR DESCRIPTION

----
I'm still working on the parent issue, but this fixes a problem encountered along the way. It looks from Connection.cs like it's okay for `type` to be null, so I modified realtime-doc.ts to handle that possibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/639)
<!-- Reviewable:end -->
