### PR TITLE
[LFv1] List invited users on user management page

### DIFF
--- a/src/Api/Model/Shared/Dto/ManageUsersDto.php
+++ b/src/Api/Model/Shared/Dto/ManageUsersDto.php
@@ -19,6 +19,7 @@ class ManageUsersDto
         $data = array();
         $data['userCount'] = $list->count;
         $data['users'] = $list->entries;
+        $data['invitees'] = $projectModel->listInvitees()->entries;
         $data['project'] = array(
             'roles' => $projectModel->getRolesList(),
             'ownerRef' => $projectModel->ownerRef,

--- a/src/Api/Model/Shared/InviteeListProjectModel.php
+++ b/src/Api/Model/Shared/InviteeListProjectModel.php
@@ -8,18 +8,18 @@ use Api\Model\Shared\Mapper\MongoMapper;
 /**
  * List of users who are members of the specified project
  */
-class UserListProjectModel extends MapperListModel
+class InviteeListProjectModel extends MapperListModel
 {
     /**
-     * UserListProjectModel constructor.
+     * InviteeListProjectModel constructor.
      * @param string $projectId
      */
     public function __construct($projectId)
     {
         parent::__construct(
                 UserModelMongoMapper::instance(),
-                array('isInvited' => array('$ne' => true), 'projects' => array('$in' => array(MongoMapper::mongoID($projectId)))),
-                array('username', 'email', 'name') // TODO Stop exposing email this way
+                array('isInvited' => true, 'projects' => array('$in' => array(MongoMapper::mongoID($projectId)))),
+                array('username', 'email', 'name')
         );
     }
 }

--- a/src/Api/Model/Shared/ProjectModel.php
+++ b/src/Api/Model/Shared/ProjectModel.php
@@ -268,6 +268,18 @@ class ProjectModel extends MapperModel
          return $userList;
     }
 
+    public function listInvitees()
+    {
+        $invitees = new InviteeListProjectModel($this->id->asString());
+        $invitees->read();
+        foreach ($invitees->entries as $i => $invitee) {
+            if (array_key_exists($invitee['id'], $this->users)) {
+                $invitees->entries[$i]['role'] = $this->users[$invitee['id']]->role;
+            }
+        }
+        return $invitees;
+    }
+
     public function listRequests()
     {
         $allUserList = UserCommands::listUsers();

--- a/src/angular-app/bellows/apps/usermanagement/members.component.html
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.html
@@ -33,7 +33,7 @@
         </div>
         </form>
     </div>
-    <listview search="$ctrl.queryUserList()" items="$ctrl.list.users" items-filter="$ctrl.userFilter" visible-items="$ctrl.list.visibleUsers" select="">
+    <listview search="$ctrl.queryUserList()" items="$ctrl.list.allUsers" items-filter="$ctrl.userFilter" visible-items="$ctrl.list.visibleUsers" select="">
         <table class="table table-hover table-responsive" >
             <thead class="thead-dark">
             <tr>
@@ -50,7 +50,8 @@
                     <input data-ng-show="$ctrl.rights.remove" type="checkbox" data-ng-checked="$ctrl.isSelected(user)"
                            data-ng-click="$ctrl.updateSelection($event, user)">
                 </td>
-                <td>{{user.username}}</td>
+                <td ng-if="!user.isInvitee">{{user.username}}</td>
+                <td ng-if="user.isInvitee" class="invited-user">{{user.username || user.email}} [invited]</td>
                 <td>{{user.name}}</td>
                 <td data-ng-show="user.id == $ctrl.project.ownerRef.id">
                     <!--suppress HtmlFormInputWithoutLabel -->

--- a/src/angular-app/bellows/apps/usermanagement/user-management-app.component.ts
+++ b/src/angular-app/bellows/apps/usermanagement/user-management-app.component.ts
@@ -24,6 +24,7 @@ export class UserManagementAppController implements angular.IController {
   list = {
     visibleUsers: {},
     users: {},
+    allUsers: {},
     userCount: 0
   };
   joinRequests = {};
@@ -66,6 +67,10 @@ export class UserManagementAppController implements angular.IController {
       if (result.ok) {
         this.list.users = result.data.users;
         this.list.userCount = result.data.userCount;
+        this.list.allUsers = result.data.users.concat(result.data.invitees.map((invitee: any) => {
+          invitee.isInvitee = true;
+          return invitee;
+        }));
         this.project = result.data.project;
         this.roles = this.project.roles;
         this.applicationHeaderService.setPageName(this.project.projectName + ' User Management');

--- a/src/angular-app/bellows/apps/usermanagement/user-management.scss
+++ b/src/angular-app/bellows/apps/usermanagement/user-management.scss
@@ -13,4 +13,9 @@
     #typeaheadDiv {
         position: relative;
     }
+
+    .invited-user {
+        font-style: italic;
+        color: #707070;
+    }
 }

--- a/test/php/model/scriptureforge/Sfchecks/dto/ProjectSettingsDtoTest.php
+++ b/test/php/model/scriptureforge/Sfchecks/dto/ProjectSettingsDtoTest.php
@@ -43,11 +43,11 @@ class ProjectSettingsDtoTest extends TestCase
 
         $dto = ProjectSettingsDto::encode($projectId, $user2Id);
 
-        $this->assertEquals(1, $dto['count']);
+        $this->assertEquals(2, $dto['count']);
         $this->assertInternalType('array', $dto['entries']);
-        $this->assertEquals($user2Id, $dto['entries'][0]['id']);
-        $this->assertEquals('Name', $dto['entries'][0]['name']);
-        $this->assertEquals(ProjectRoles::CONTRIBUTOR, $dto['entries'][0]['role']);
+        $this->assertEquals($user2Id, $dto['entries'][1]['id']);
+        $this->assertEquals('Name', $dto['entries'][1]['name']);
+        $this->assertEquals(ProjectRoles::CONTRIBUTOR, $dto['entries'][1]['role']);
         $this->assertCount(1, $dto['archivedTexts']);
         $this->assertEquals('Archived Title', $dto['archivedTexts'][0]['title']);
         $this->assertTrue(count($dto['rights']) > 0, 'No rights in dto');


### PR DESCRIPTION
These are fairly straightforward changes. On the back end it adds an invitees list to the user management DTO. On the front end it lists them after active users on the user management page.

This UI has the disadvantage of listing email under the username header when no username is available.

![Screenshot from 2019-04-03 21-31-05](https://user-images.githubusercontent.com/6140710/55523630-07d4ad00-5658-11e9-8069-84febedafc21.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/645)
<!-- Reviewable:end -->
