### PR TITLE
[LFv1] .htaccess mod_headers to allow proper service worker scoping

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -6,3 +6,9 @@
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [QSA,L]
 </IfModule>
+
+<ifModule mod_headers.c>
+   <Files "service-worker.js">
+       Header Set Service-Worker-allowed "/"
+   </Files>
+</IfModule>


### PR DESCRIPTION
This is a small change that adds the following to the .htaccess file.

`Header Set Service-Worker-allowed "/"`       

This change resolves the console errors we are seeing on live currently

![image](https://user-images.githubusercontent.com/3444521/55528133-03df7400-56c6-11e9-83e8-0ac81eb06c98.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/646)
<!-- Reviewable:end -->
