### PR TITLE
[SFv1] Add project-level font size and RTL script options.  This completes the RTL fix from earlier.

### DIFF
--- a/src/Api/Model/Scriptureforge/Sfchecks/Dto/QuestionCommentDto.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Dto/QuestionCommentDto.php
@@ -99,6 +99,8 @@ class QuestionCommentDto
         $dto['votes'] = $votesDto;
         $dto['text'] = JsonEncoder::encode($text);
         $dto['text']['content'] = $usxHelper->toHtml();
+        $dto['text']['isRightToLeft'] = $project->isRightToLeft;
+        $dto['text']['fontSize'] = $project->fontSize;
         $dto['project'] = JsonEncoder::encode($project);
         $dto['project']['slug'] = $project->databaseName();
         $dto['rights'] = RightsHelper::encode($user, $project);

--- a/src/Api/Model/Scriptureforge/Sfchecks/Dto/QuestionListDto.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Dto/QuestionListDto.php
@@ -44,6 +44,8 @@ class QuestionListDto
         $data['text'] = JsonEncoder::encode($text);
         $usxHelper = new UsxHelper($text->content);
         $data['text']['content'] = $usxHelper->toHtml();
+        $data['text']['isRightToLeft'] = $project->isRightToLeft;
+        $data['text']['fontSize'] = $project->fontSize;
         $shouldSeeOtherUsersResponses = $project->shouldSeeOtherUsersResponses($userId);  // Look it up just once
         foreach ($questionList->entries as $questionData) {
             $question = new QuestionModel($project, $questionData['id']);

--- a/src/Api/Model/Scriptureforge/Sfchecks/SfchecksProjectModel.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/SfchecksProjectModel.php
@@ -12,6 +12,8 @@ class SfchecksProjectModel extends SfProjectModel
         $this->rolesClass = 'Api\Model\Scriptureforge\Sfchecks\SfchecksRoles';
         $this->appName = SfProjectModel::SFCHECKS_APP;
         $this->usersSeeEachOthersResponses = true;
+        $this->isRightToLeft = false;
+        $this->fontSize = 16;
 
         // This must be last, the constructor reads data in from the database which must overwrite the defaults above.
         parent::__construct($id);
@@ -39,4 +41,11 @@ class SfchecksProjectModel extends SfProjectModel
 
     /** @var boolean Does this project allows users to see each other's answers and comments, or just their own? */
     public $usersSeeEachOthersResponses;
+
+    /** @var boolean (optional) Indicates if the project deals primarily with a right-to-left script.  Controls the RTL direction property
+     *  for all texts in this project */
+    public $isRightToLeft;
+
+    /** @var int (optional) Specifies a font size for all texts in the project.  Some scripts may tend not to be readable at the default font size. */
+    public $fontSize;
 }

--- a/src/angular-app/scriptureforge/sfchecks/project/project-settings.html
+++ b/src/angular-app/scriptureforge/sfchecks/project/project-settings.html
@@ -220,13 +220,13 @@
             </div>
             <div class="form-group">
                 <label class="checkbox"><input type="checkbox" data-ng-model="project.isRightToLeft">
-                    All text in this project use right-to-left scripts</label>
+                    All texts in this project use right-to-left scripts</label>
             </div>
             <div class="form-group row">
                 <div class="col-md-2 col-4">
                     <input class="form-control" type="number" data-ng-model="project.fontSize" id="project-font-size">
                 </div>
-                <label for="project-font-size" class="col col-form-label">Font size in pixels (applies to all text in project)</label>
+                <label for="project-font-size" class="col col-form-label">Font size in pixels (applies to all texts in project)</label>
             </div>
             <div>
                 <button class="btn btn-primary" type="submit" id="project-properties-save-button">

--- a/src/angular-app/scriptureforge/sfchecks/project/project-settings.html
+++ b/src/angular-app/scriptureforge/sfchecks/project/project-settings.html
@@ -205,7 +205,6 @@
             </div>
             <div class="form-group">
                 <label class="col-form-label"><b>Project Owner:</b> <span class="notranslate">{{project.ownerRef.username}}</span></label>
-            <!-- <label class="checkbox"><input type="checkbox" data-ng-model="project.featured"> Featured on website</label> -->
             </div>
             <div class="form-group">
                 <label class="checkbox"><input type="checkbox" data-ng-model="project.usersSeeEachOthersResponses">
@@ -218,6 +217,16 @@
             <div class="form-group">
                 <label class="checkbox"><input type="checkbox" data-ng-model="project.allowInviteAFriend">
                     Allow contributors to use "Invite a Friend" feature (managers can always use it)</label>
+            </div>
+            <div class="form-group">
+                <label class="checkbox"><input type="checkbox" data-ng-model="project.isRightToLeft">
+                    All text in this project use right-to-left scripts</label>
+            </div>
+            <div class="form-group row">
+                <div class="col-md-2 col-4">
+                    <input class="form-control" type="number" data-ng-model="project.fontSize" id="project-font-size">
+                </div>
+                <label for="project-font-size" class="col col-form-label">Font size in pixels (applies to all text in project)</label>
             </div>
             <div>
                 <button class="btn btn-primary" type="submit" id="project-properties-save-button">

--- a/src/angular-app/scriptureforge/sfchecks/text/question.html
+++ b/src/angular-app/scriptureforge/sfchecks/text/question.html
@@ -10,7 +10,7 @@
             </a>
             <pui-soundplayer pui-url="audioPlayUrl" title="Play audio"></pui-soundplayer>
         </div>
-        <div id="textcontrol" dir="auto" style="font-family: {{text.fontfamily}}" data-sil-selection data-sil-selected-text="selectedText" content="text.content"></div>
+        <div id="textcontrol" ng-attr-dir="{{text.isRightToLeft ? 'rtl' : 'ltr'}}" style="font-size: {{text.fontSize}}px; font-family: {{text.fontfamily}}" data-sil-selection data-sil-selected-text="selectedText" content="text.content"></div>
     </div>
     <div id="comments" class="col-md-6" data-ng-show="finishedLoading">
         <div class="question">
@@ -53,7 +53,7 @@
                 <form data-ng-submit="submitAnswer()">
                     Add your own answer<span data-ng-show="newAnswer.textHighlight">
                 about this part of the text</span>:
-                    <div class="scripture-quote" oncopy="return false;" data-ng-show="newAnswer.textHighlight"
+                    <div ng-attr-dir="{{text.isRightToLeft ? 'rtl' : 'ltr'}}" class="scripture-quote" oncopy="return false;" data-ng-show="newAnswer.textHighlight"
                          data-ng-bind-html="newAnswer.textHighlight"></div>
 
                     <div class="form-group">
@@ -81,7 +81,7 @@
                         <!--<b>DEBUG:</b>answerId = {{answerId}}, answer.id = {{answer.id}}<br>-->
                         <!--<b>DEBUG:</b>answer = {{answer}}<br>-->
                         <div data-ng-show="answer.textHighlight" data-ng-bind-html="answer.textHighlight"
-                             class="scripture-quote"></div>
+                             ng-attr-dir="{{text.isRightToLeft ? 'rtl' : 'ltr'}}" class="scripture-quote"></div>
                         <div class="answerContent" dir="auto" data-ng-bind-html="answer.content"></div>
                         <div class="answer-footer">
                             <view-tags class="tag-list" ng-show="$parent.rightsCreateTag()"

--- a/src/angular-app/scriptureforge/sfchecks/text/text.html
+++ b/src/angular-app/scriptureforge/sfchecks/text/text.html
@@ -78,7 +78,7 @@
                 </a>
                 <pui-soundplayer pui-url="audioPlayUrl" title="Play audio"></pui-soundplayer>
             </div>
-            <div id="textcontrol" style="font-family: {{text.fontfamily}}" dir="auto" data-ng-bind-html="text.content"></div>
+            <div id="textcontrol" ng-attr-dir="{{text.isRightToLeft ? 'rtl' : 'ltr'}}" style="font-size: {{text.fontSize}}px; font-family: {{text.fontfamily}}" dir="auto" data-ng-bind-html="text.content"></div>
         </div>
         <div class="col-md-7">
             <listview hide-if-empty="true" search="queryQuestions()"


### PR DESCRIPTION
This adds two new project properties which are editable by managers on the project properties tab:

![image](https://user-images.githubusercontent.com/3444521/55541972-4c138c00-56f0-11e9-901a-aa778b78d636.png)

The font size property controls the font size for all texts in the project, and controls the font size for the left-hand text column (not user-selected quotes).

The RTL property specifically sets the dir="rtl" for the text columns in both the text view and the question/comment view, and also sets dir="rtl" for the scripture quotation divs when user's include a quote in their answer.

![image](https://user-images.githubusercontent.com/3444521/55541719-bd9f0a80-56ef-11e9-9512-5927db162eb9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/647)
<!-- Reviewable:end -->
