### PR TITLE
Improve TC unit tests when run locally

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/karma.conf.js
+++ b/src/SIL.XForge.Scripture/ClientApp/src/karma.conf.js
@@ -31,9 +31,8 @@ module.exports = function(config) {
     autoWatch: true,
     captureTimeout: 120000, // compile needs to finished otherwise first capture fails
     browsers: isTC ? ['ChromiumHeadless'] : ['Chrome'],
-    browserDisconnectTimeout: isTC ? 10000 : config.browserDisconnectTimeout,
-    browserDisconnectTolerance: isTC ? 3 : config.browserDisconnectTolerance,
-    browserNoActivityTimeout: isTC ? 60000 : config.browserNoActivityTimeout,
+    browserDisconnectTimeout: 10000,
+    browserNoActivityTimeout: 60000,
     flags: isTC
       ? ['--no-sandbox', '--headless', '--disable-gpu', '--disable-translate', '--disable-extensions']
       : config.flags,


### PR DESCRIPTION
* remove retries (it just fails slower on TC)
* always use browserDisconnectTimeout and browserNoActivityTimeout values

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/653)
<!-- Reviewable:end -->
