### PR TITLE
Fix bug with multiple audio players (LFv1)

### DIFF
--- a/src/angular-app/bellows/shared/sound-player.component.html
+++ b/src/angular-app/bellows/shared/sound-player.component.html
@@ -6,5 +6,5 @@
         {{$ctrl.currentTime()}} / {{$ctrl.duration()}}
     </span>
     <!--suppress HtmlFormInputWithoutLabel -->
-    <input class="seek-slider" type="range" min="0" max="{{$ctrl.durationInSeconds()}}" value="0" id="puiSoundplayerSlider">
+    <input class="seek-slider" type="range" min="0" max="{{$ctrl.durationInSeconds()}}" value="0">
 </span>

--- a/src/angular-app/bellows/shared/sound-player.component.ts
+++ b/src/angular-app/bellows/shared/sound-player.component.ts
@@ -7,12 +7,14 @@ export class SoundController implements angular.IController {
   playing = false;
 
   private isUserMovingSlider: boolean = false;
-  private readonly slider = document.getElementById('puiSoundplayerSlider') as HTMLInputElement;
+  private slider: HTMLInputElement;
 
-  static $inject = ['$scope'];
-  constructor(private $scope: angular.IScope) { }
+  static $inject = ['$scope', '$element'];
+  constructor(private $scope: angular.IScope, private $element: angular.IRootElementService) { }
 
   $onInit(): void {
+    this.slider = this.$element.find('.seek-slider').get(0) as HTMLInputElement;
+
     this.audioElement.addEventListener('ended', () => {
       this.$scope.$apply(() => {
         if (this.playing) {


### PR DESCRIPTION
Due to a bug on the config page I wasn't able to test this locally. I did see it in production though.

The actual cause of the bug is an incorrect assumption that only one sound player is present on the page. Given the simplicity of the bug, I don't think it's a problem that I wasn't able to test it with multiple sliders locally. Since it works with one I can be reasonably confident it will work with multiple. At the very least it shouldn't be a regression.

EDIT: The branch name is definitely incorrect. It should be audio player, not audio recorder. Unfortunately there's not simple way to rename it at this point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/657)
<!-- Reviewable:end -->
