### PR TITLE
Release microphone when done recording (LFv1)

### DIFF
--- a/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
+++ b/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
@@ -27,7 +27,7 @@ export class AudioRecorderController implements angular.IController {
   }
 
   close() {
-    this.cleanup();
+    this.stopRecording();
     this.callback(null);
   }
 
@@ -41,7 +41,7 @@ export class AudioRecorderController implements angular.IController {
   }
 
   $onDestroy() {
-    this.cleanup();
+    this.stopRecording();
   }
 
   private startRecording() {
@@ -83,9 +83,9 @@ export class AudioRecorderController implements angular.IController {
       }, 1000);
 
       this.stopMediaStream = () => {
-        this.destroyInterval();
         processor.removeEventListener('audioprocess', handleAudioData);
         mp3Encoder.end();
+        stream.getAudioTracks()[0].stop();
       };
 
     }, err => {
@@ -99,18 +99,10 @@ export class AudioRecorderController implements angular.IController {
   }
 
   private stopRecording() {
+    if (this.interval) this.$interval.cancel(this.interval);
     if (this.stopMediaStream) this.stopMediaStream();
   }
 
-  private cleanup() {
-    this.destroyInterval();
-    this.stopRecording();
-  }
-
-  private destroyInterval() {
-    // AngularJS does not automatically cancel the interval; it has to be done manually
-    if (this.interval) this.$interval.cancel(this.interval);
-  }
 }
 
 export class MP3Encoder {


### PR DESCRIPTION
My original plan was to hang on to the microphone until the recording component was closed. However, after experimenting a bit I found that hanging onto it after the recording stops has no advantages, and was even slightly more complicated to implement.

At present the audio recording indicators of Chrome and Firefox (only tested browsers) only show up when the user is actually recording an audio segment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/658)
<!-- Reviewable:end -->
