### PR TITLE
Fix race condition in setContextGuid that caused comments disappear (LFv1)

### DIFF
--- a/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
+++ b/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
@@ -100,11 +100,7 @@ export class LexiconCommentService {
   }
 
   getFieldCommentCount(contextGuid: string): number {
-    if (this.comments == null || this.comments.counts.currentEntry.fields[contextGuid] == null) {
-      return 0;
-    }
-
-    return this.comments.counts.currentEntry.fields[contextGuid];
+    return this.comments.counts.currentEntry.fields[contextGuid] || 0;
   }
 
   getEntryCommentCount(entryId: string): number {

--- a/src/angular-app/languageforge/lexicon/editor/comment/comment-bubble.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/comment/comment-bubble.component.ts
@@ -49,12 +49,7 @@ export class CommentBubbleController implements angular.IController {
   }
 
   getCountForDisplay(): number | string {
-    const count = this.getCount();
-    if (count) {
-      return count;
-    } else {
-      return '';
-    }
+    return this.getCount() || '';
   }
 
   getComments(): void {
@@ -115,8 +110,8 @@ export class CommentBubbleController implements angular.IController {
   }
 
   private setContextGuid(): void {
-    this.contextGuid = this.parentContextGuid + (this.parentContextGuid ? ' ' : '') + this.field;
     this.lexConfig.getFieldConfig(this.field).then(fieldConfig => {
+      this.contextGuid = this.parentContextGuid + (this.parentContextGuid ? ' ' : '') + this.field;
       if (this.configType == null) {
         this.configType = fieldConfig.type;
       }


### PR DESCRIPTION
This PR fixes a race condition that I believe is the cause of disappearing comments. I don't fully understand exactly how this race condition happens sometimes but not other times, but it does appear to be the cause when we do see the bug.

This is a companion pull request to #665.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/664)
<!-- Reviewable:end -->
