### PR TITLE
Enable sourcemaps in production build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,7 +142,7 @@ module.exports = function (env) {
       'process.env.NODE_ENV': JSON.stringify('production')
     }));
     webpackConfig.plugins.push(new UglifyJsPlugin({
-      sourceMap: webpackConfig.devtool === 'source-map'
+      sourceMap: true
     }));
     webpackConfig.plugins.push(new LoaderOptionsPlugin({
       minimize: true


### PR DESCRIPTION
I believe this is all that is required to enable sourcemaps in production, assuming the command for building the TypeScript for production is `gulp build-webpack --applicationName languageforge --doNoCompression false`.

In addition to helping us locate the source of bugs, I'm guessing it will also help Bugsnag to correctly group errors, which it is currently doing quite poorly.

When the sources are uploaded to production the .map files need to go along with them. I don't see them listed in either upload-exclude.txt or upload-include.txt, which I am guessing are used in the deploy process.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/679)
<!-- Reviewable:end -->
