### PR TITLE
Remove access to v1 translate app

### DIFF
--- a/src/angular-app/bellows/core/api/project.service.ts
+++ b/src/angular-app/bellows/core/api/project.service.ts
@@ -51,7 +51,7 @@ export class ProjectService {
       const types = {
         // 'languageforge': ['lexicon', 'semdomtrans'],
         languageforge: ['lexicon'],
-        scriptureforge: ['sfchecks', 'translate']
+        scriptureforge: ['sfchecks']
       };
 
       this.projectTypesBySite = types[session.baseSite()];


### PR DESCRIPTION
This removes the link to create a new Translate app project on scriptureforge.org

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/688)
<!-- Reviewable:end -->
