### PR TITLE
add HelpHero JS snippet

### DIFF
--- a/src/Site/Controller/Base.php
+++ b/src/Site/Controller/Base.php
@@ -162,6 +162,7 @@ class Base
                 $this->data['isAdmin'] = SystemRoles::hasRight($this->_user->role, Domain::USERS + Operation::CREATE);
             }
             $this->data['userName'] = $this->_user->username;
+            $this->data['userId'] = $this->_userId;
             if ($this->_user->avatar_ref && substr($this->_user->avatar_ref, 0, 4) === 'http')
             {
                 $this->data['smallAvatarUrl'] = $this->_user->avatar_ref;

--- a/src/Site/views/shared/container/container.html.twig
+++ b/src/Site/views/shared/container/container.html.twig
@@ -76,5 +76,16 @@
 {% block script %}{% endblock %}
 {% block footer %}{% endblock %}
 {% block analytics %}{% endblock %}
+
+{# Help Hero script snippet #}
+<script src="https://unpkg.com/helphero"></script>
+<script type="text/javascript">
+var hlp = window.helphero('9yZMlWWMsDS');
+{% if userId %}
+    hlp.identify("{{ userId }}");
+{% else %}
+    hlp.anonymous();
+{% endif %}
+</script>
 </body>
 </html>


### PR DESCRIPTION
This adds support for the HelpHero tutorial walk throughs described at https://app.helphero.co/install?type=async-html

This is the HTML snippet method.  If we had a single page app for the entire site, then we would use the npm install method.  We could still use npm install and link locally, however linking to their CDN is a good first step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/689)
<!-- Reviewable:end -->
