### PR TITLE
update backup and rsync script

### DIFF
--- a/scripts/server/backup/doBackupsAndRsyncToPalasoBackupServer.sh
+++ b/scripts/server/backup/doBackupsAndRsyncToPalasoBackupServer.sh
@@ -2,10 +2,10 @@
 
 backupXForgeServer.sh
 
-# from https://archive-rotator.readthedocs.io/en/latest/
-archive-rotator --tiered -n 6 -n 4 -n 6 /backup/lf_assets_backup.tgz
-archive-rotator --tiered -n 6 -n 4 -n 6 /backup/sf_assets_backup.tgz
-archive-rotator --tiered -n 6 -n 4 -n 6 /backup/mongodb_backup.tgz
-
 echo "Rsyncing to backups.palaso.org..."
-rsync -vazHAX --delete-during /backup/*.tgz.* backup@backup.palaso.org:/backup/svr01-vm106/xForge
+rsync -vazHAX --delete-during /backup/*.tgz backup@backup.palaso.org:/backup/svr01-vm106/xForge
+
+echo "Rotating Backups on backups.palaso.org"
+ssh backup@backup.palaso.org 'archive-rotator --tiered -n 6 -n 4 -n 6 /backup/svr01-vm106/xForge/mongodb_backup.tgz'
+ssh backup@backup.palaso.org 'archive-rotator --tiered -n 6 -n 4 -n 6 /backup/svr01-vm106/xForge/sf_assets_backup.tgz'
+ssh backup@backup.palaso.org 'archive-rotator --tiered -n 6 -n 4 -n 6 /backup/svr01-vm106/xForge/lf_assets_backup.tgz'


### PR DESCRIPTION
This reflects the current state of the script on the production server.  At some point the script was changed to do the archive-rotator function on the backup server instead of the production machine.  This change saves space on the production server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/690)
<!-- Reviewable:end -->
