### PR TITLE
Fix message when changing role of invited user

### DIFF
--- a/src/angular-app/bellows/apps/usermanagement/members.component.ts
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.ts
@@ -97,7 +97,8 @@ export class UserManagementMembersController implements angular.IController {
   onRoleChange(user: User): void {
     this.projectService.updateUserRole(user.id, user.role, result => {
       if (result.ok) {
-        this.notice.push(this.notice.SUCCESS, user.username + '\'s role was changed to ' + user.role);
+        const message = `${user.username || user.email}'s role was changed to ${this.roles[user.role]}.`;
+        this.notice.push(this.notice.SUCCESS, message);
       }
     });
   }


### PR DESCRIPTION
Fixes the message shown when changing an invited user's role on a project.

Old message: "undefined's role was changed to observer_with_comment"

New message: "user@example.com's role was changed to Observer with comment."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/691)
<!-- Reviewable:end -->
