### PR TITLE
Add next entry and previous entry buttons

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -7,10 +7,18 @@
                         <a id="toListLink" data-ng-show="$ctrl.isAtEditorEntry()" class="btn btn-std"
                            data-ng-click="$ctrl.returnToList()"
                            title="Back to List">
-                            <i class="fa fa-arrow-circle-left"></i>
+                            <i class="fa fa-reply"></i>
                             <span class="d-none d-md-inline-block">List</span></a>
                     </div>
                     <div class="float-right" data-ng-show="$ctrl.isAtEditorEntry()">
+                        <div class="btn-group">
+                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1)">
+                                <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
+                            </button>
+                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1)">
+                                <span class="d-none d-lg-inline-block">Next</span> <span class="fa fa-arrow-right"></span>
+                            </button>
+                        </div>
                         <span data-ng-if="$ctrl.lecRights.canEditEntry()">
                             <button id="saveEntryBtn" class="btn btn-primary" data-ng-click="$ctrl.saveCurrentEntry(true)"
                                     data-ng-disabled="!$ctrl.currentEntryIsDirty()">
@@ -21,7 +29,7 @@
                             <button id="toggleHiddenFieldsBtn" class="btn btn-std"
                                     data-ng-click="$ctrl.show.emptyFields = !$ctrl.show.emptyFields">
                                 <i class="fa" data-ng-class="$ctrl.show.emptyFields ? 'fa-minus-square-o' : 'fa-plus-square-o'"></i>
-                                <span class="d-none d-md-inline-block">{{$ctrl.show.emptyFields ? 'Hide Extra Fields' : 'Show Extra Fields'}}</span>
+                                <span class="d-none d-lg-inline-block">{{$ctrl.show.emptyFields ? 'Hide Extra Fields' : 'Show Extra Fields'}}</span>
                             </button>
                         </span>
                         <button id="toCommentsLink"

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -12,7 +12,6 @@
                     </div>
                     <div class="float-right" data-ng-show="$ctrl.isAtEditorEntry()">
                         <span data-ng-if="$ctrl.lecRights.canEditEntry()">
-                            <span class="text-muted">{{$ctrl.saveNotice()}}</span>
                             <button id="saveEntryBtn" class="btn btn-primary" data-ng-click="$ctrl.saveCurrentEntry(true)"
                                     data-ng-disabled="!$ctrl.currentEntryIsDirty()">
                                 <i class="fa fa-save"></i> <span class="d-none d-md-inline-block">{{$ctrl.saveButtonTitle()}}</span>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -260,7 +260,7 @@ export class LexiconEditorController implements angular.IController {
       if (this.$state.params.sortReverse === 'true') {
         this.entryListModifiers.sortReverse = true;
         this.sortEntries(true);
-      }else {
+      } else {
         this.entryListModifiers.sortReverse = false;
         this.sortEntries(false);
        }
@@ -435,6 +435,16 @@ export class LexiconEditorController implements angular.IController {
     }
 
     this.goToEntry(id);
+  }
+
+  canSkipToEntry(distance: number): boolean {
+    const i = this.editorService.getIndexInList(this.currentEntry.id, this.visibleEntries) + distance;
+    return i >= 0 && i < this.visibleEntries.length;
+  }
+
+  skipToEntry(distance: number): void {
+    const i = this.editorService.getIndexInList(this.currentEntry.id, this.visibleEntries) + distance;
+    this.editEntry(this.visibleEntries[i].id);
   }
 
   newEntry(): void {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -305,25 +305,11 @@ export class LexiconEditorController implements angular.IController {
     this.filterEntries(true);
   }
 
-  saveNotice(): string {
-    switch (this.saveStatus) {
-      case 'saving':
-        return 'Saving';
-      case 'saved':
-        return 'Saved';
-      default:
-        return '';
-    }
-  }
-
   saveButtonTitle(): string {
-    if (this.currentEntryIsDirty()) {
-      return 'Save Entry';
-    } else if (LexiconEditorController.entryIsNew(this.currentEntry)) {
-      return 'Entry unchanged';
-    } else {
-      return 'Entry saved';
-    }
+    if (this.saveStatus === 'saving') return 'Saving';
+    else if (this.currentEntryIsDirty()) return 'Save Entry';
+    else if (LexiconEditorController.entryIsNew(this.currentEntry)) return 'Entry unchanged';
+    else return 'Entry saved';
   }
 
   currentEntryIsDirty(): boolean {


### PR DESCRIPTION
- These buttons navigate to the next and previous entry in the order they are listed (they're not history buttons). If entries are sorted and/or filtered, the buttons navigate through the sorted/filtered version of the list.
- On medium displays the text for the show/hide extra fields button is now hidden. This makes room for the new buttons.
- The status text to the left of the save button is now gone. All the same information is now directly on the save button.

Small display:
![Screenshot from 2019-05-29 19-51-41](https://user-images.githubusercontent.com/6140710/58598639-3a131d00-824b-11e9-97b8-3c8b34563fc4.png)
Medium display:
![Screenshot from 2019-05-29 19-50-17](https://user-images.githubusercontent.com/6140710/58598602-06d08e00-824b-11e9-855d-867813f6e149.png)
Large display:
![Screenshot from 2019-05-29 19-50-07](https://user-images.githubusercontent.com/6140710/58598603-06d08e00-824b-11e9-9438-a3222d81e709.png)


Trello: https://trello.com/c/ioYzPULU/361-next-previous-arrow-buttons-to-browse-entry-list

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/693)
<!-- Reviewable:end -->
