### PR TITLE
Fix blank lexicon entries on first load

### DIFF
--- a/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
@@ -42,11 +42,6 @@ export class LexiconAppController implements angular.IController {
               private readonly sendReceive: LexiconSendReceiveService) { }
 
   $onInit(): void {
-    this.editorService.loadEditorData().then(() => {
-      this.finishedLoading = true;
-      this.sendReceive.checkInitialState();
-    });
-
     this.$q.all([this.rightsService.getRights(), this.configService.getEditorConfig()])
       .then(([rights, editorConfig]) => {
         if (rights.canEditProject()) {
@@ -85,7 +80,13 @@ export class LexiconAppController implements angular.IController {
           }
         });
       }
-    );
+    )
+    .then(() => {
+      this.editorService.loadEditorData().then(() => {
+        this.finishedLoading = true;
+        this.sendReceive.checkInitialState();
+      });
+    });
 
     this.setupOffline();
   }


### PR DESCRIPTION
This fixes a race condition where the project data might finish loading before the project config is loaded, which results in it looking empty because the lexicon-entry renderer depends on the project config being populated. Now we load the initial project data only after the config is completely loaded, which should ensure that it's always ready to render as soon as it loads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/701)
<!-- Reviewable:end -->
