### PR TITLE
Update recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,6 @@
     "msjsdiag.debugger-for-chrome",
     "EditorConfig.editorconfig",
     "felixfbecker.php-pack",
-    "eg2.tslint"
+    "ms-vscode.vscode-typescript-tslint-plugin"
 	]
 }


### PR DESCRIPTION
The [eg2.tslint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) extension by Erich Gamma has been deprecated in favor of the [ms-vscode.vscode-typescript-tslint-plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) extension maintained by the official Microsoft VS Code team.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/704)
<!-- Reviewable:end -->
