### PR TITLE
Ignore Javascript errors from outdated browsers

### DIFF
--- a/src/angular-app/bellows/core/exception-handling.service.ts
+++ b/src/angular-app/bellows/core/exception-handling.service.ts
@@ -56,6 +56,15 @@ export class ExceptionHandlingService {
       return;
     }
 
+    // Silence errors coming from out-of-date browser versions
+    // So far we've only seen errors from Chrome version 30, but if other old
+    // browser versions trigger errors, they can be added below as well
+    const userAgent = navigator.userAgent;
+    if (userAgent.indexOf('Chrome/30') >= 0) {
+      // Outdated browser: don't submit error to Bugsnag
+      return;
+    }
+
     this.bugsnagClient.notify(exception, {
       beforeSend: report => {
         if (this.metadata != null) {


### PR DESCRIPTION
We have one device with an outdated browser (Chrome Mobile 30) that's sending a lot of Bugsnag reports about Javascript features that that browser doesn't implement (e.g., the Array.includes function). These reports aren't actually bugs and we won't do anything about them, so we'll ignore them and not send them to Bugsnag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/705)
<!-- Reviewable:end -->
