### PR TITLE
Fix activity log not showing in Safari

### DIFF
--- a/src/Api/Model/Shared/Mapper/JsonEncoder.php
+++ b/src/Api/Model/Shared/Mapper/JsonEncoder.php
@@ -189,7 +189,9 @@ class JsonEncoder
      */
     public function encodeDateTime($model)
     {
-        return $model->format(\DateTime::ISO8601);
+        // Can't use DateTime::ISO8601 here since it returns timezones like "+0700" (format code "O") and we need "+07:00" (format code "P")
+        // But format code "c" returns a proper RFC 3339 date (2012-12-25T12:34:56+00:00) which will be parsed by every browser
+        return $model->format('c');
     }
 
     /**
@@ -198,7 +200,9 @@ class JsonEncoder
      */
     public function encodeUniversalTimestamp($model)
     {
-        return $model->asFormattedString(UniversalTimestamp::ISO8601_WITH_MILLISECONDS);
+        // Unfortunately, UniversalTimestamp::ISO8601_WITH_MILLISECONDS returns timezones like "+0700" (format code "O") and we need "+07:00" (format code "P")
+        $dt = $model->asDateTimeInterface();
+        return $model->asFormattedString(UniversalTimestamp::ISO8601_WITH_MILLISECONDS_WITHOUT_TZ) . $dt->format('P');
     }
 
 }

--- a/test/php/model/shared/mapper/json/JsonDateMapperTest.php
+++ b/test/php/model/shared/mapper/json/JsonDateMapperTest.php
@@ -33,10 +33,10 @@ class JsonDateMapperTest extends TestCase
 
         $decodedModel = new TestJsonDateModel();
         JsonDecoder::decode($decodedModel, $encoded);
-        $iso8601 = $decodedModel->dateTime->format(DateTime::ISO8601);
-        $this->assertEquals($encoded['dateTime'], $iso8601);
+        $rfc3339 = $decodedModel->dateTime->format('c');
+        $this->assertEquals($encoded['dateTime'], $rfc3339);
         $this->assertEquals($model->dateTime, $decodedModel->dateTime);
- //       var_dump($iso8601);
+ //       var_dump($rfc3339);
     }
 
     public function testEncodeDecodeUniversalTimestamp_HistoricalDate_Same()
@@ -49,9 +49,10 @@ class JsonDateMapperTest extends TestCase
 
         $decodedModel = new TestJsonDateModel();
         JsonDecoder::decode($decodedModel, $encoded);
-        $iso8601 = $decodedModel->universalTimestamp->asFormattedString(UniversalTimestamp::ISO8601_WITH_MILLISECONDS);
-        $this->assertEquals($encoded['universalTimestamp'], $iso8601);
+        $rfc3339 = $decodedModel->universalTimestamp->asFormattedString(UniversalTimestamp::ISO8601_WITH_MILLISECONDS_WITHOUT_TZ) .
+                   $decodedModel->universalTimestamp->asDateTimeInterface()->format('P');
+        $this->assertEquals($encoded['universalTimestamp'], $rfc3339);
         $this->assertEquals($model->universalTimestamp, $decodedModel->universalTimestamp);
-//        var_dump($iso8601);
+//        var_dump($rfc3339);
     }
 }


### PR DESCRIPTION
Safari parses timestamps strictly according to [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6), which requires a colon in the timezone (`"+07:00"`, not `"+0700"`). The default ISO8601 format codes in PHP use `"+0700"` format, so we need to change how we encode dates in JSON so that Safari (and other strictly-compliant browsers, like Safari Mobile) accept the dates the server returns.

Tested in BrowserStack and confirmed to work: with this change, the activity log shows up properly in Safari.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/706)
<!-- Reviewable:end -->
