### PR TITLE
Report bugs to Bugsnag even if username is null

### DIFF
--- a/src/angular-app/bellows/core/exception-handling.service.ts
+++ b/src/angular-app/bellows/core/exception-handling.service.ts
@@ -51,7 +51,7 @@ export class ExceptionHandlingService {
   }
 
   private notifyBugsnag(exception: Error, cause?: string) {
-    if (this.metadata != null && this.metadata.userName.startsWith('test_runner_')) {
+    if (this.metadata != null && this.metadata.userName != null && this.metadata.userName.startsWith('test_runner_')) {
       // running unit tests
       return;
     }

--- a/src/angular-app/bellows/core/exception-handling.service.ts
+++ b/src/angular-app/bellows/core/exception-handling.service.ts
@@ -51,13 +51,14 @@ export class ExceptionHandlingService {
   }
 
   private notifyBugsnag(exception: Error, cause?: string) {
-    if (this.metadata != null && this.metadata.userName != null && this.metadata.userName.startsWith('test_runner_')) {
+    if (this.metadata != null && this.metadata.userName.startsWith('test_runner_')) {
       // running unit tests
       return;
     }
 
     this.bugsnagClient.notify(exception, {
       beforeSend: report => {
+        (this.metadata.userName == null) ? this.metadata.userName = "unknown" 
         if (this.metadata != null) {
           report.user = {
             id: this.metadata.userId,

--- a/src/angular-app/bellows/core/exception-handling.service.ts
+++ b/src/angular-app/bellows/core/exception-handling.service.ts
@@ -58,7 +58,7 @@ export class ExceptionHandlingService {
 
     this.bugsnagClient.notify(exception, {
       beforeSend: report => {
-        (this.metadata.userName == null) ? this.metadata.userName = "unknown" 
+        (this.metadata.userName == null) ? this.metadata.userName = "unknown";
         if (this.metadata != null) {
           report.user = {
             id: this.metadata.userId,

--- a/src/angular-app/bellows/core/exception-handling.service.ts
+++ b/src/angular-app/bellows/core/exception-handling.service.ts
@@ -51,14 +51,13 @@ export class ExceptionHandlingService {
   }
 
   private notifyBugsnag(exception: Error, cause?: string) {
-    if (this.metadata != null && this.metadata.userName.startsWith('test_runner_')) {
+    if (this.metadata != null && this.metadata.userName != null && this.metadata.userName.startsWith('test_runner_')) {
       // running unit tests
       return;
     }
 
     this.bugsnagClient.notify(exception, {
       beforeSend: report => {
-        (this.metadata.userName == null) ? this.metadata.userName = "unknown";
         if (this.metadata != null) {
           report.user = {
             id: this.metadata.userId,


### PR DESCRIPTION
Should fix LF-222, and possibly reveal some bug reports that we'd been missing before (because when `this.metadata` was non-null but `this.metadata.userName` was null, the original exception was swallowed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/707)
<!-- Reviewable:end -->
