### PR TITLE
Attempt to fix "empty items in project view" bug

### DIFF
--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -385,7 +385,7 @@ export class EditorDataService {
             deferred.resolve(newResult);
           });
         } else {
-          this.sortAndFilterEntries(false).then(() => {
+          this.sortAndFilterEntries(true).then(() => {
             deferred.resolve(result);
           });
         }


### PR DESCRIPTION
I haven't been able to reproduce the "initial load of dictionary list view shows empty list" issue since https://github.com/sillsdev/web-languageforge/pull/701 was merged, but this is one thing that *might* be causing it, and there's no reason for not resetting the visible items every time `sortAndFilterEntries` is called. So this is worth a try.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/717)
<!-- Reviewable:end -->
