### PR TITLE
Disable systemd /tmp isolation for dev machines

### DIFF
--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -137,6 +137,18 @@
           value: '60M'
         - property: 'upload_max_filesize'
           value: '60M'
+    - name: copy apache2 service config from /lib to /etc for modification
+      copy:
+        src: /lib/systemd/system/apache2.service
+        dest: /etc/systemd/system/apache2.service
+        owner: root
+        group: root
+        mode: 0644
+    - name: disable systemd /tmp isolation for apache2
+      lineinfile:
+        dest: /etc/systemd/system/apache2.service
+        regexp: '^#?PrivateTmp=true'
+        line: "PrivateTmp=false"
     - name: configure xdebug.ini
       blockinfile:
         path: /etc/php/{{php_version}}/mods-available/xdebug.ini


### PR DESCRIPTION
# Overview
Ubuntu 18.04 systemd uses /tmp isolation by default, which means every process gets its own private /tmp folder. Since our php e2e tests run in two processes (a setup script and then the actual tests), the actual tests cannot access the needed tempfiles when /tmp isolation is enabled, causing tests--like file upload tests--to always fail.

Disabling this feature is less secure, but since we only ever need to run these tests on dev machines and never on the production box, this is a safe solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/727)
<!-- Reviewable:end -->
