### PR TITLE
Re-enable lfmerge package in ansible installer

### DIFF
--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -58,7 +58,7 @@
       vars:
         packages:
           - default-jre-headless
-          #- lfmerge # waiting for lfmerge bionic package
+          - lfmerge
           - libapache2-mod-php
           - mongodb-org
           - nodejs


### PR DESCRIPTION
# Overview
The lfmerge package has been commented out in the ansible installer because the package had not been deployed yet to Ubuntu 18.04 Bionic yet. It is now available on Bionic, so I am un-commenting lfmerge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/728)
<!-- Reviewable:end -->
