### PR TITLE
Change to use languageforge.localhost

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "msjsdiag.debugger-for-chrome",
     "EditorConfig.editorconfig",
     "felixfbecker.php-pack",
-    "ms-vscode.vscode-typescript-tslint-plugin"
+    "ms-vscode.vscode-typescript-tslint-plugin",
+    "emallin.phpunit"
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,14 +32,14 @@
       "runtimeExecutable": "/usr/bin/chromium-browser",
       "request": "launch",
       "name": "Launch Chromium on Linux",
-      "url": "https://languageforge.local",
+      "url": "https://languageforge.localhost",
       "webRoot": "${workspaceRoot}"
     },
     {
       "type": "chrome",
       "request": "launch",
       "name": "Launch Chrome",
-      "url": "https://languageforge.local",
+      "url": "https://languageforge.localhost",
       "webRoot": "${workspaceRoot}"
     },
     {

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ ansible-playbook playbook_bionic.yml --limit localhost -K
 
 To build the JavaScript and CSS, run `refreshDeps.sh lf` if you are working on Language Forge, or `refreshDeps.sh sf` if you are working on Scripture Forge. Running `refreshDeps.sh` without arguments defaults to Language Forge.
 
-That's it; you should now be able to open your browser to languageforge.local and scriptureforge.local and log in with the credentials "admin" and "password".
+That's it; you should now be able to open your browser to languageforge.localhost and scriptureforge.local and log in with the credentials "admin" and "password".
 
 Now would be a good time to check that PHP unit tests, TS unit tests, and E2E tests all work. See the [Testing](#Testing) section below.
 
@@ -241,8 +241,8 @@ Click **Create New Project from Existing Files**. Leave the default option (Web 
  From the **Create New Project: Choose Project Directory** dialog,  browse to the `web-languageforge` directory, then mark it as **Project Root** (using the `Project Root` button in the toolbar) and click **Next**.
 
 From the **Add Local Server** dialog set
-Name: `languageforge.local`
-Web server root URL: `http://languageforge.local`
+Name: `languageforge.localhost`
+Web server root URL: `http://languageforge.localhost`
 --> **Next** --> **Finish**
 
 ### Xdebug ###
@@ -267,7 +267,7 @@ Adding *Servers* from PhpStorm
 Click the "+" to add the following Name & Hosts:
 
 - default.local
-- languageforge.local
+- languageforge.localhost
 - scriptureforge.local
 
 Restart apache2

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ ansible-playbook playbook_bionic.yml --limit localhost -K
 
 To build the JavaScript and CSS, run `refreshDeps.sh lf` if you are working on Language Forge, or `refreshDeps.sh sf` if you are working on Scripture Forge. Running `refreshDeps.sh` without arguments defaults to Language Forge.
 
-That's it; you should now be able to open your browser to languageforge.localhost and scriptureforge.local and log in with the credentials "admin" and "password".
+That's it; you should now be able to open your browser to languageforge.localhost and scriptureforge.localhost and log in with the credentials "admin" and "password".
 
 Now would be a good time to check that PHP unit tests, TS unit tests, and E2E tests all work. See the [Testing](#Testing) section below.
 
@@ -268,7 +268,7 @@ Click the "+" to add the following Name & Hosts:
 
 - default.local
 - languageforge.localhost
-- scriptureforge.local
+- scriptureforge.localhost
 
 Restart apache2
 

--- a/browserStackE2E.sh
+++ b/browserStackE2E.sh
@@ -12,7 +12,7 @@ if [ "$1" = "sf" ]
   then
     E2EHOSTNAME="e2etest.scriptureforge.local"
 else
-    E2EHOSTNAME="e2etest.languageforge.local"
+    E2EHOSTNAME="e2etest.languageforge.localhost"
 fi
 gulp test-e2e-run --webserverHost $E2EHOSTNAME ${@:2}
 STATUS=$?

--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -348,7 +348,7 @@
         create: yes
       with_items:
         - "default.local"
-        - "languageforge.local"
+        - "languageforge.localhost"
         - "scriptureforge.local"
       when: inventory_hostname == "localhost"
 

--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -349,7 +349,7 @@
       with_items:
         - "default.local"
         - "languageforge.localhost"
-        - "scriptureforge.local"
+        - "scriptureforge.localhost"
       when: inventory_hostname == "localhost"
 
   handlers:

--- a/deploy/vars/config_developer.yml
+++ b/deploy/vars/config_developer.yml
@@ -32,12 +32,12 @@ ssl_items:
         locality: "Chiang Mai"
         organization: "SIL"
         organization_unit: ""
-        common_name: "scriptureforge.local"
+        common_name: "scriptureforge.localhost"
         alt_names:
           - key: DNS.1
-            value: "www.scriptureforge.local"
+            value: "www.scriptureforge.localhost"
           - key: DNS.2
-            value: "scriptureforge.local"
+            value: "scriptureforge.localhost"
     sign:
 
 

--- a/deploy/vars/config_developer.yml
+++ b/deploy/vars/config_developer.yml
@@ -71,10 +71,6 @@ apache_vhosts:
         port: 80
         server_alias:
           - localhost
-        proxy:
-          - '/api2/ http://localhost:5000/'
-          - '/machine/ http://localhost:5001/'
-          - '/sharedb/ "ws://localhost:5002/"'
   - server_name: languageforge.org
     server_admin: webmaster@palaso.org
     server_file_name: languageforge_org
@@ -87,7 +83,6 @@ apache_vhosts:
       - has_ssl: false
         port: 80
         server_alias:
-          - languageforge.local
           - languageforge.localhost
           - localhost
         extra:
@@ -108,7 +103,6 @@ apache_vhosts:
       - has_ssl: false
         port: 80
         server_alias:
-          - scriptureforge.local
           - scriptureforge.localhost
           - localhost
         extra:
@@ -117,10 +111,6 @@ apache_vhosts:
         - '        Header Set Service-Worker-allowed "/"'
         - '    </Files>'
         - '</IfModule>'
-        proxy:
-          - '/api2/ http://localhost:5000/'
-          - '/machine/ http://localhost:5001/'
-          - '/sharedb/ "ws://localhost:5002/"'
       - has_ssl: true
         port: 443
         certificate_file: "scriptureforge.pem"
@@ -131,7 +121,3 @@ apache_vhosts:
         - '        Header Set Service-Worker-allowed "/"'
         - '    </Files>'
         - '</IfModule>'
-        proxy:
-          - '/api2/ http://localhost:5000/'
-          - '/machine/ http://localhost:5001/'
-          - '/sharedb/ "ws://localhost:5002/"'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -638,13 +638,13 @@ gulp.task('test-e2e-doTest', function (cb) {
     .alias('?', 'help')
     .example('$0 test-e2e-run --webserverHost languageforge.localhost',
       'Runs all the E2E tests for languageforge')
-    .example('$0 test-e2e-run --webserverHost scriptureforge.local --specs projectSettingsPage',
+    .example('$0 test-e2e-run --webserverHost scriptureforge.localhost --specs projectSettingsPage',
       'Runs the scriptureforge E2E test for projectSettingsPage')
     .fail(yargFailure)
     .argv;
 
   var protocol =
-    (params.webserverHost === 'jamaicanpsalms.scriptureforge.local') ? 'https://' : 'http://';
+    (params.webserverHost === 'jamaicanpsalms.scriptureforge.localhost') ? 'https://' : 'http://';
 
   var configFile;
   var isBrowserStack = false;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -568,7 +568,7 @@ gulp.task('test-e2e-env', function () {
       type: 'string' })
     .option('webserverHost', {
       demand: false,
-      default: 'languageforge.local',
+      default: 'languageforge.localhost',
       type: 'string' })
     .fail(yargFailure)
     .argv;
@@ -636,7 +636,7 @@ gulp.task('test-e2e-doTest', function (cb) {
       type: 'string' })
     .help('?')
     .alias('?', 'help')
-    .example('$0 test-e2e-run --webserverHost languageforge.local',
+    .example('$0 test-e2e-run --webserverHost languageforge.localhost',
       'Runs all the E2E tests for languageforge')
     .example('$0 test-e2e-run --webserverHost scriptureforge.local --specs projectSettingsPage',
       'Runs the scriptureforge E2E test for projectSettingsPage')

--- a/installer/ubuntu1604Installer.sh
+++ b/installer/ubuntu1604Installer.sh
@@ -100,7 +100,7 @@ fi
 
 cd ..
 if [ ! -L web-scriptureforge ]; then
-    echo "Fix scriptureforge.local symlink"
+    echo "Fix scriptureforge.localhost symlink"
     sudo rm -r web-scriptureforge
     ln -s web-languageforge web-scriptureforge
 fi
@@ -123,7 +123,7 @@ echo "Set file permissions"
 sudo chmod g+w src/assets/lexicon/
 
 echo "You should now be able to access Language Forge locally at http://languageforge.localhost"
-echo "You should now be able to access Scripture Forge locally at http://scriptureforge.local"
+echo "You should now be able to access Scripture Forge locally at http://scriptureforge.localhost"
 echo "username: admin"
 echo "password: password"
 echo "Installation finished!"

--- a/installer/ubuntu1604Installer.sh
+++ b/installer/ubuntu1604Installer.sh
@@ -79,7 +79,7 @@ sudo adduser $USER fieldworks
 
 if [ $OS == "Windows" ]; then
     HOSTSFILE=/mnt/c/Windows/System32/drivers/etc/hosts
-    ALREADYHASHOSTS=`grep "languageforge.local" $HOSTSFILE`
+    ALREADYHASHOSTS=`grep "languageforge.localhost" $HOSTSFILE`
     if [ -f "$HOSTSFILE" -a ! -n "$ALREADYHASHOSTS" ]; then
         echo "Modifying Windows hosts file"
         ADDITIONSFILE=installer/windowsHostFileAdditions.txt
@@ -95,7 +95,7 @@ if [ $OS == "Windows" ]; then
         cat installer/bashrcFileAdditions.txt >> $BASHRCFILE
     fi
 
-    echo "Note: the Windows Bash window must be open in order for languageforge.local to work"
+    echo "Note: the Windows Bash window must be open in order for languageforge.localhost to work"
 fi
 
 cd ..
@@ -122,7 +122,7 @@ cd ../..
 echo "Set file permissions"
 sudo chmod g+w src/assets/lexicon/
 
-echo "You should now be able to access Language Forge locally at http://languageforge.local"
+echo "You should now be able to access Language Forge locally at http://languageforge.localhost"
 echo "You should now be able to access Scripture Forge locally at http://scriptureforge.local"
 echo "username: admin"
 echo "password: password"

--- a/installer/windowsHostFileAdditions.txt
+++ b/installer/windowsHostFileAdditions.txt
@@ -1,5 +1,5 @@
 
-127.0.0.1 languageforge.local
+127.0.0.1 languageforge.localhost
 127.0.0.1 default.local
 127.0.0.1 scriptureforge.local
 127.0.0.1 jamaicanpsalms.scriptureforge.local

--- a/installer/windowsHostFileAdditions.txt
+++ b/installer/windowsHostFileAdditions.txt
@@ -1,5 +1,5 @@
 
 127.0.0.1 languageforge.localhost
 127.0.0.1 default.local
-127.0.0.1 scriptureforge.local
-127.0.0.1 jamaicanpsalms.scriptureforge.local
+127.0.0.1 scriptureforge.localhost
+127.0.0.1 jamaicanpsalms.scriptureforge.localhost

--- a/rune2e.sh
+++ b/rune2e.sh
@@ -10,15 +10,15 @@
 
 if [ "$1" = "lf" ]
   then
-    E2EHOSTNAME="languageforge.local"
+    E2EHOSTNAME="languageforge.localhost"
 elif [ "$1" = "sf" ]
   then
-    E2EHOSTNAME="scriptureforge.local"
+    E2EHOSTNAME="scriptureforge.localhost"
 elif [ "$1" = "jp" ]
   then
-    E2EHOSTNAME="jamaicanpsalms.scriptureforge.local"
+    E2EHOSTNAME="jamaicanpsalms.scriptureforge.localhost"
 else
-    E2EHOSTNAME="languageforge.local"
+    E2EHOSTNAME="languageforge.localhost"
 fi
 
 attach_debugger () {

--- a/scripts/server/mongodb/copyServerToLocalChris.bat
+++ b/scripts/server/mongodb/copyServerToLocalChris.bat
@@ -4,5 +4,5 @@ set today=%MyDate:~0,4%-%MyDate:~4,2%-%MyDate:~6,2%
 plink chris@scriptureforge.org -m backupMongoOnServer.sh
 pscp chris@scriptureforge.org:mongodb_backup_%today%.tgz c:\src
 plink chris@scriptureforge.org -m deleteTarFileOnServer.sh
-plink root@scriptureforge.local -m restoreMongoOnLocal.sh
-plink root@scriptureforge.local "php /var/www/host/sil/languageforge/scripts/tools/ChangeSiteNameToLocal.php"
+plink root@scriptureforge.localhost -m restoreMongoOnLocal.sh
+plink root@scriptureforge.localhost "php /var/www/host/sil/languageforge/scripts/tools/ChangeSiteNameToLocal.php"

--- a/scripts/tools/FactoryReset.php
+++ b/scripts/tools/FactoryReset.php
@@ -124,8 +124,8 @@ class FactoryReset
             $siteNameMap['languageforge.org'] = 'qa.languageforge.org';
         } else if ($this->environment == "local") {
             print "Site names being converted for LOCAL MACHINE khrap\n";
-            $siteNameMap['scriptureforge.org'] = 'scriptureforge.local';
-            $siteNameMap['jamaicanpsalms.scriptureforge.org'] = 'jamaicanpsalms.scriptureforge.local';
+            $siteNameMap['scriptureforge.org'] = 'scriptureforge.localhost';
+            $siteNameMap['jamaicanpsalms.scriptureforge.org'] = 'jamaicanpsalms.scriptureforge.localhost';
             $siteNameMap['languageforge.org'] = 'languageforge.localhost';
         }
 

--- a/scripts/tools/FactoryReset.php
+++ b/scripts/tools/FactoryReset.php
@@ -126,7 +126,7 @@ class FactoryReset
             print "Site names being converted for LOCAL MACHINE khrap\n";
             $siteNameMap['scriptureforge.org'] = 'scriptureforge.local';
             $siteNameMap['jamaicanpsalms.scriptureforge.org'] = 'jamaicanpsalms.scriptureforge.local';
-            $siteNameMap['languageforge.org'] = 'languageforge.local';
+            $siteNameMap['languageforge.org'] = 'languageforge.localhost';
         }
 
         $siteNameCount = array();

--- a/src/Api/Library/Shared/WebsiteInstances.json
+++ b/src/Api/Library/Shared/WebsiteInstances.json
@@ -1,28 +1,11 @@
 {
   "scriptureforge": [
     {
-      "__comment": "scriptureforge.local sites",
-      "domain": "scriptureforge.local",
-      "base": "Website::SCRIPTUREFORGE",
-      "name": "Scripture Forge",
-      "ssl": false,
-      "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
-      "releaseStage": "local"
-    },
-    {
       "__comment": "scriptureforge.localhost sites",
       "domain": "scriptureforge.localhost",
       "base": "Website::SCRIPTUREFORGE",
       "name": "Scripture Forge",
       "ssl": false,
-      "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
-      "releaseStage": "local"
-    },
-    {
-      "domain": "e2etest.scriptureforge.localhost",
-      "base": "Website::SCRIPTUREFORGE",
-      "name": "Scripture Forge",
-      "ssl": "false",
       "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
       "releaseStage": "local"
     },
@@ -36,15 +19,6 @@
       "releaseStage": "local"
     },
     {
-      "domain": "jamaicanpsalms.e2etest.scriptureforge.localhost",
-      "base": "Website::SCRIPTUREFORGE",
-      "name": "The Jamaican Psalms Project",
-      "ssl": "true",
-      "theme": "jamaicanpsalms",
-      "defaultProjectCode": "jamaicanpsalms",
-      "releaseStage": "local"
-    },
-    {
       "domain": "demo.scriptureforge.localhost",
       "base": "Website::SCRIPTUREFORGE",
       "name": "Scripture Forge",
@@ -54,47 +28,11 @@
       "releaseStage": "local"
     },
     {
-      "__comment": "dev.scriptureforge.org sites",
-      "domain": "dev.scriptureforge.org",
-      "base": "Website::SCRIPTUREFORGE",
-      "name": "Scripture Forge",
-      "ssl": "true",
-      "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
-      "releaseStage": "development"
-    },
-    {
-      "domain": "demo.dev.scriptureforge.org",
-      "base": "Website::SCRIPTUREFORGE",
-      "name": "Scripture Forge",
-      "ssl": "true",
-      "theme": "simple",
-      "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
-      "releaseStage": "development"
-    },
-    {
-      "domain": "jamaicanpsalms.dev.scriptureforge.org",
-      "base": "Website::SCRIPTUREFORGE",
-      "name": "The Jamaican Psalms Project",
-      "ssl": "true",
-      "theme": "jamaicanpsalms",
-      "defaultProjectCode": "jamaican_psalms",
-      "releaseStage": "development"
-    },
-    {
       "__comment": "qa.scriptureforge.org",
       "domain": "qa.scriptureforge.org",
       "base": "Website::SCRIPTUREFORGE",
       "name": "Scripture Forge",
       "ssl": "true",
-      "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
-      "releaseStage": "qa"
-    },
-    {
-      "domain": "demo.qa.scriptureforge.org",
-      "base": "Website::SCRIPTUREFORGE",
-      "name": "Scripture Forge",
-      "ssl": "true",
-      "theme": "simple",
       "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
       "releaseStage": "qa"
     },
@@ -133,15 +71,6 @@
   ],
   "languageforge": [
     {
-      "__comment": "languageforge.local sites",
-      "domain": "languageforge.local",
-      "base": "Website::LANGUAGEFORGE",
-      "name": "Language Forge",
-      "ssl": "false",
-      "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
-      "releaseStage": "local"
-    },
-    {
       "__comment": "languageforge.localhost sites",
       "domain": "languageforge.localhost",
       "base": "Website::LANGUAGEFORGE",
@@ -149,23 +78,6 @@
       "ssl": "false",
       "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
       "releaseStage": "local"
-    },
-    {
-      "domain": "e2etest.languageforge.localhost",
-      "base": "Website::LANGUAGEFORGE",
-      "name": "Language Forge",
-      "ssl": "false",
-      "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
-      "releaseStage": "local"
-    },
-    {
-      "__comment": "dev.languageforge.org",
-      "domain": "dev.languageforge.org",
-      "base": "Website::LANGUAGEFORGE",
-      "name": "Language Forge",
-      "ssl": "true",
-      "userDefaultSiteRole": "SiteRoles::PROJECT_CREATOR",
-      "releaseStage": "development"
     },
     {
       "__comment": "qa.languageforge.org",

--- a/src/Site/Provider/AuthUserProvider.php
+++ b/src/Site/Provider/AuthUserProvider.php
@@ -47,7 +47,7 @@ class AuthUserProvider implements UserProviderInterface
             // This is because scriptureforge and languageforge are sister sites where cross-login is expected and allowed.
             $sisterSiteMap = array(
                 'scriptureforge.org' => 'languageforge.org',
-                'scriptureforge.local' => 'languageforge.localhost',
+                'scriptureforge.localhost' => 'languageforge.localhost',
                 'dev.scriptureforge.org' => 'dev.languageforge.org',
                 'qa.scriptureforge.org' => 'qa.languageforge.org'
             );

--- a/src/Site/Provider/AuthUserProvider.php
+++ b/src/Site/Provider/AuthUserProvider.php
@@ -47,7 +47,7 @@ class AuthUserProvider implements UserProviderInterface
             // This is because scriptureforge and languageforge are sister sites where cross-login is expected and allowed.
             $sisterSiteMap = array(
                 'scriptureforge.org' => 'languageforge.org',
-                'scriptureforge.local' => 'languageforge.local',
+                'scriptureforge.local' => 'languageforge.localhost',
                 'dev.scriptureforge.org' => 'dev.languageforge.org',
                 'qa.scriptureforge.org' => 'qa.languageforge.org'
             );

--- a/test/app/browserstackConf.js
+++ b/test/app/browserstackConf.js
@@ -26,7 +26,7 @@ exports.config = {
     // }
   ],
 
-    baseUrl: 'http://languageforge.local', // GULP and specs
+    baseUrl: 'http://languageforge.localhost', // GULP and specs
     framework: 'jasmine',
     jasmineNodeOpts: {
         showColors: true,

--- a/test/app/chromeDirectHeadlessLFProtractorConf.js
+++ b/test/app/chromeDirectHeadlessLFProtractorConf.js
@@ -1,6 +1,6 @@
 exports.config = {
   directConnect: true,
-  baseUrl: 'http://languageforge.local',
+  baseUrl: 'http://languageforge.localhost',
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {

--- a/test/app/chromeDirectLFProtractorConf.js
+++ b/test/app/chromeDirectLFProtractorConf.js
@@ -1,6 +1,6 @@
 exports.config = {
   directConnect: true,
-  baseUrl: 'http://languageforge.local',
+  baseUrl: 'http://languageforge.localhost',
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {

--- a/test/app/protractorConf.js
+++ b/test/app/protractorConf.js
@@ -2,7 +2,7 @@
 exports.config = {
   // The address of a running selenium server.
   seleniumAddress: 'http://default.local:4444/wd/hub',
-  baseUrl: 'http://languageforge.local',
+  baseUrl: 'http://languageforge.localhost',
 
   // The timeout in milliseconds for each script run on the browser. This should
   // be longer than the maximum time your application needs to stabilize between

--- a/test/app/setupTestEnvironment.php
+++ b/test/app/setupTestEnvironment.php
@@ -25,7 +25,7 @@ use Api\Model\Shared\UserModel;
 $constants = json_decode(file_get_contents(TestPath . 'app/testConstants.json'), true);
 
 // Fake some $_SERVER variables like HTTP_HOST for the sake of the code that needs it
-$hostname = "languageforge.local";
+$hostname = "languageforge.localhost";
 if (count($argv) > 1) {
     // hostname is passed in on command line
     $hostname = $argv[1];

--- a/test/app/setupTestEnvironment.php
+++ b/test/app/setupTestEnvironment.php
@@ -417,7 +417,7 @@ if ($site == 'scriptureforge') {
     copy(TestPath . "common/$fileName", $tmpFilePath);
 }
 
-if ($website->domain == 'jamaicanpsalms.scriptureforge.local') {
+if ($website->domain == 'jamaicanpsalms.scriptureforge.localhost') {
     $jpProject = ProjectCommands::createProject(
         "The Jamaican Psalms Project",
         "jamaican_psalms",

--- a/test/app/testConstants.json
+++ b/test/app/testConstants.json
@@ -2,8 +2,8 @@
   "Bellows_Test_Constants" : "",
 
   "siteType"           : "languageforge",
-  "siteHostname"       : "languageforge.local",
-  "baseUrl"            : "http://languageforge.local",
+  "siteHostname"       : "languageforge.localhost",
+  "baseUrl"            : "http://languageforge.localhost",
   "conditionTimeout"   : 3000,
 
   "adminUsername"      : "test_runner_admin",

--- a/test/php/TestConfig.php
+++ b/test/php/TestConfig.php
@@ -33,6 +33,6 @@ define('BCRYPT_COST', 7);
 define('JWT_KEY', 'this_is_not_a_secret_dev_only');
 
 global $WEBSITE;
-$WEBSITE = Website::get('dev.scriptureforge.org');
+$WEBSITE = Website::get('languageforge.localhost');
 
 require_once TestCommonPath . 'MongoTestEnvironment.php';

--- a/test/php/model/shared/UserModelTest.php
+++ b/test/php/model/shared/UserModelTest.php
@@ -79,7 +79,7 @@ class UserModelTest extends TestCase
         $environ->createUser('someuser', 'Some User','user@example.com');
 
         // Check no users exist on another website
-        $website = new Website('languageforge.local', Website::LANGUAGEFORGE);
+        $website = new Website('languageforge.localhost', Website::LANGUAGEFORGE);
         $model = new UserTypeaheadModel('some', '', $website);
         $model->read();
 


### PR DESCRIPTION
The `.localhost` TLD is recognized by browsers and systems for localhost use while our use of `.local` is not.  This change across the entire code-base changes all references from `.local` to `.localhost`

Once this PR is merged, ***developers may need to run ansible and FactoryReset.php again*** before the site is operational again.

The PR also removes references to:
dev.languageforge.local
dev.scriptureforge.local
demo.*

as these are no longer in use.

The site will now be accessed at http://languageforge.localhost

All PHP Tests are passing and all but the 3 E2E tests that are known to fail are passing.

![image](https://user-images.githubusercontent.com/3444521/61063004-6b296480-a429-11e9-830e-11c2b8a2ee5e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/734)
<!-- Reviewable:end -->
