### PR TITLE
Update Twig code to be >2.7 compatible

### DIFF
--- a/src/Api/Library/Shared/Communicate/CommunicateHelper.php
+++ b/src/Api/Library/Shared/Communicate/CommunicateHelper.php
@@ -35,7 +35,7 @@ class CommunicateHelper
     /**
      *
      * @param string $fileName
-     * @return \Twig_Template
+     * @return \Twig\Template
      */
     public static function templateFromFile($fileName)
     {
@@ -46,8 +46,8 @@ class CommunicateHelper
                     'cache' => APPPATH . 'cache',
             );
         }
-        $loader = new \Twig_Loader_Filesystem(APPPATH . 'Site/views');
-        $twig = new \Twig_Environment($loader, $options);
+        $loader = new \Twig\Loader\FilesystemLoader(APPPATH . 'Site/views');
+        $twig = new \Twig\Environment($loader, $options);
         $template = $twig->loadTemplate($fileName);
 
         return $template;
@@ -56,7 +56,7 @@ class CommunicateHelper
     /**
      *
      * @param string $templateCode
-     * @return \Twig_Template
+     * @return \Twig\Template
      */
     public static function templateFromString($templateCode)
     {
@@ -67,8 +67,8 @@ class CommunicateHelper
                     'cache' => APPPATH . 'cache',
             );
         }
-        $loader = new \Twig_Loader_Array(array());
-        $twig = new \Twig_Environment($loader, $options);
+        $loader = new \Twig\Loader\ArrayLoader(array());
+        $twig = new \Twig\Environment($loader, $options);
         $template = $twig->createTemplate($templateCode);
 
         return $template;

--- a/src/Site/Controller/Base.php
+++ b/src/Site/Controller/Base.php
@@ -136,7 +136,7 @@ class Base
 
         try {
             return $app['twig']->render($viewName.'.html.twig', $this->data);
-        } catch (\Twig_Error_Loader $e) {
+        } catch (\Twig\Loader\ErrorLoader $e) {
             $app->abort(404, "Page not found: $viewName.twig\n" . $e->getMessage() . "\n" . $e->getTraceAsString());
         }
 

--- a/src/Site/Controller/Page.php
+++ b/src/Site/Controller/Page.php
@@ -36,7 +36,7 @@ class Page extends Base
                 $this->data['baseDir'] = $this->getThemePath() . '/page/home';
                 try {
                     return $app['twig']->render('home/index.html.twig', $this->data);
-                } catch (\Twig_Error_Loader $e) {
+                } catch (\Twig\Loader\ErrorLoader $e) {
                     $app->abort(404, "Page not found: home/index.html.twig");
                 }
             }


### PR DESCRIPTION
Composer updates included bringing Twig to 2.11.3. In Twig 2.7, Twig refactored it's namespaces and classes, deprecating the old names. This PR refactors our code to be Twig >2.7 complaint.

The E2E tests did catch the errors when attempting to sign up as a new user, but it was caught as a timeout error rather than as an exception. Aside from those addressed in #735, all tests pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/736)
<!-- Reviewable:end -->
