### PR TITLE
Skip PECL Mongo compile if already installed

### DIFF
--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -279,10 +279,15 @@
         group: www-data
         mode: 0755
 
+    - name: check for PECL Mongo Extension
+      command: ls /etc/php/{{php_version}}/mods-available/
+      register: pecl_mongo_ini
+      changed_when: false
     - name: Install PECL Mongo Extension
       pear:
         name: pecl/mongodb
         state: present
+      when: pecl_mongo_ini.stdout is not search('mongodb.ini')
     - name: Enable PECL Mongo module in mods-available
       lineinfile:
         dest: /etc/php/{{php_version}}/mods-available/mongodb.ini


### PR DESCRIPTION
# Overview
When running the Ansible install script after it has already been initially run, it still builds PECL Mongo, which takes an exorbitant amount of time to complete. This PR adds a check that will skip the PECL Mongo install if it is already present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/737)
<!-- Reviewable:end -->
