### PR TITLE
Adds "Start Language Forge Tour" to the Help menu

### DIFF
--- a/src/Site/Controller/App.php
+++ b/src/Site/Controller/App.php
@@ -69,6 +69,7 @@ class App extends Base
         $this->data['isAngular2'] = $model->isAppAngular2();
         $this->data['appName'] = $model->appName;
         $this->data['appFolder'] = $model->appFolder;
+        $this->data['projectId'] = $model->projectId;
 
         if ($model->requireProject) {
             if ($model->isPublicApp) {

--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -21,6 +21,9 @@
                     <li class="nav-item" uib-dropdown>
                         <a class="nav-link" uib-dropdown-toggle href id="helpDropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-life-ring"></i> <span>Help</span></a>
                         <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu aria-labelledby="helpDropdown">
+                            {% if projectId is not empty %}
+                                <a class="dropdown-item" target="_blank" href="https://hlp.sh/t/_/GsubLqNFYR2?~id={{projectId}}">Start Language Forge Tour</a>
+                            {% endif %}
                             <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge/how-to">Tutorials and How-Tos</a>
                             <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge">Community Support</a>
                             <a class="dropdown-item" target="_blank" href="mailto:issues@languageforge.org">Report a Problem<br />(email issues@languageforge.org)</a>


### PR DESCRIPTION
**Problem**: An LF user [suggested](https://community.software.sil.org/t/request-walk-through/2322) that we add a link within the Help menu to start the Lexicon tour. 

**Solution**: This is achieved through HelpHero's linked tour start (a HelpHero generated URL that redirects to the homepage of the tour and starts it) inserted into the LF HTML template. 

**How to Test Locally**: The HH URL is hashed, in part, by the path of the tour's homepage. Because we have set the tour to only run on production, an attempt to start the tour from `.localhost` will redirect to the live site, require authentication, and then link to a project that does not exist. In order to test the tour locally, go into the HelpHero Editor in Chrome on an https of `.localhost`. Navigate to Lexicon (LF) tour and remove the leading `//languageforge.org` from the first filter. Then back out to the list of tours and select the arrow next to Lexicon (LF). Click *Get Link* to copy the new URL and paste in into the href found on line 27 of `languageforge.html.twig`. Make sure to remove the 0 at the end of the copied link so that the projectId populates as intended. You can now reload the webpage and attempt to start the tour. When finished, simply re-add the `//languageforge.org` to the tour filter.

[Trello](https://trello.com/c/Wz3jPLMq/396-add-take-a-tour-link-under-the-help-menu-to-trigger-help-hero-tour)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/738)
<!-- Reviewable:end -->
