### PR TITLE
Fix running PHP tests as www-data in Ansible install script

### DIFF
--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -409,6 +409,7 @@
         chdir: ..
     - name: run php unit tests (gulp test-php)
       shell: "gulp test-php"
+      become: yes
       become_user: www-data
       args:
         chdir: ..


### PR DESCRIPTION
#Overview
In the ansible script, `become_user: www-data` will be ignored unless `become: yes` is set prior to it. This PR adds `become: yes`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/740)
<!-- Reviewable:end -->
