### PR TITLE
add become:yes

### DIFF
--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -409,6 +409,7 @@
         chdir: ..
     - name: run php unit tests (gulp test-php)
       shell: "gulp test-php"
+      become: yes
       become_user: www-data
       args:
         chdir: ..


### PR DESCRIPTION
# Overview
In Ansible scripts, `become_user: www-data` will be ignored unless `become: yes` is set prior to it. This PR adds `become: yes`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/741)
<!-- Reviewable:end -->
