### PR TITLE
Remove GeoIP references

### DIFF
--- a/scripts/server/elasticSearch/setupElasticSearchCATIndex.sh
+++ b/scripts/server/elasticSearch/setupElasticSearchCATIndex.sh
@@ -18,8 +18,6 @@ curl -XPUT "http://es_401:9200/cat_metrics_2" -H 'Content-Type: application/json
             "name": { "type": "text" }
           }
         },
-        "geoCountryIsoCode": { "type": "keyword" },
-        "geoLocation": { "type": "geo_point" },
         "isTestData": { "type": "boolean" },
         "metrics": {
           "properties": {

--- a/src/composer.json
+++ b/src/composer.json
@@ -14,7 +14,6 @@
     "bugsnag/bugsnag-silex": "^2.0",
     "elasticsearch/elasticsearch": "^5.3",
     "firebase/php-jwt": "^5.0",
-    "geoip2/geoip2": "^2.6",
     "guzzlehttp/guzzle": "~6.0",
     "ircmaxell/password-compat": "^1.0",
     "litipk/php-jiffy": "^1.4",


### PR DESCRIPTION
# Overview
GeoIP is no longer being used in this project. One of the PHP Unit tests was failing due to a missing GeoIP file,  `/usr/share/GeoIP/GeoLite2-City.mmdb`, so this PR deletes all straggler references to GeoIP. All of the PHP unit tests are passing after this change except the following, which was already broken.
![php-tests](https://user-images.githubusercontent.com/10179226/61841895-80d66980-aec0-11e9-967a-2c1b0cf29e6e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/743)
<!-- Reviewable:end -->
