### PR TITLE
Tech Support Role

### DIFF
--- a/src/Api/Library/Shared/SilexSessionHelper.php
+++ b/src/Api/Library/Shared/SilexSessionHelper.php
@@ -70,7 +70,7 @@ class SilexSessionHelper
             // Add an admin to the project if they are not already a member
             if ($user->role == SystemRoles::SYSTEM_ADMIN) {
                 if (!$project->userIsMember($userId)) {
-                    $project->addUser($userId, ProjectRoles::MANAGER);
+                    $project->addUser($userId, ProjectRoles::TECH_SUPPORT);
                     $projectId = $project->write();
                     $user->addProject($projectId); // $user->write() occurs in the following if-block
                 }

--- a/src/Api/Model/Languageforge/Lexicon/Config/LexConfiguration.php
+++ b/src/Api/Model/Languageforge/Lexicon/Config/LexConfiguration.php
@@ -362,6 +362,7 @@ class LexConfiguration
         $this->roleViews[LexRoles::OBSERVER_WITH_COMMENT] = new LexRoleViewConfig();
         $this->roleViews[LexRoles::CONTRIBUTOR] = new LexRoleViewConfig();
         $this->roleViews[LexRoles::MANAGER] = new LexRoleViewConfig();
+        $this->roleViews[LexRoles::TECH_SUPPORT] = new LexRoleViewConfig();
 
         $this->roleViews[LexRoles::OBSERVER]->fields[LexConfig::LEXEME] = new LexViewMultiTextFieldConfig(true);
         $this->roleViews[LexRoles::OBSERVER]->fields[LexConfig::DEFINITION] = new LexViewMultiTextFieldConfig(true);
@@ -413,6 +414,7 @@ class LexConfiguration
         $this->roleViews[LexRoles::OBSERVER_WITH_COMMENT]->fields = clone $this->roleViews[LexRoles::OBSERVER]->fields;
         $this->roleViews[LexRoles::CONTRIBUTOR]->fields = clone $this->roleViews[LexRoles::OBSERVER]->fields;
         $this->roleViews[LexRoles::MANAGER]->fields = clone $this->roleViews[LexRoles::OBSERVER]->fields;
+        $this->roleViews[LexRoles::TECH_SUPPORT]->fields = clone $this->roleViews[LexRoles::MANAGER]->fields;
 
         $this->roleViews[LexRoles::OBSERVER]->showTasks[LexTask::VIEW] = true;
         $this->roleViews[LexRoles::OBSERVER]->showTasks[LexTask::DASHBOARD] = true;
@@ -438,6 +440,7 @@ class LexConfiguration
         $this->roleViews[LexRoles::MANAGER]->showTasks[LexTask::WORDLIST] = true;
         $this->roleViews[LexRoles::MANAGER]->showTasks[LexTask::REVIEW] = true;
 
+        $this->roleViews[LexRoles::TECH_SUPPORT]->showTasks = clone $this->roleViews[LexRoles::MANAGER]->showTasks;
     }
 
     /**

--- a/src/Api/Model/Languageforge/Lexicon/LexRoles.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexRoles.php
@@ -52,6 +52,8 @@ class LexRoles extends ProjectRoles
         $rights[] = Domain::USERS + Operation::VIEW;
         self::grantAllOnDomain($rights, Domain::ENTRIES);
         self::$_rights[self::MANAGER] = $rights;
+
+        self::$_rights[self::TECH_SUPPORT] = $rights;
     }
 
     private static $_rights;

--- a/src/Api/Model/Shared/Command/ProjectCommands.php
+++ b/src/Api/Model/Shared/Command/ProjectCommands.php
@@ -197,9 +197,9 @@ class ProjectCommands
      * @param string $projectId
      * @return array of users join requests
      */
-    public static function getJoinRequests($projectId) 
-    {        
-        $projectModel = ProjectModel::getById($projectId);        
+    public static function getJoinRequests($projectId)
+    {
+        $projectModel = ProjectModel::getById($projectId);
         $list = $projectModel->listRequests();
         return $list;
     }
@@ -227,6 +227,10 @@ class ProjectCommands
 
         if ($userId == $project->ownerRef->asString()) {
             throw new \Exception("Cannot update role for project owner");
+        }
+
+        if ($projectRole == ProjectRoles::TECH_SUPPORT && $user->role != SystemRoles::SYSTEM_ADMIN) {
+            throw new UserUnauthorizedException("Attempted to add non-admin as Tech Support");
         }
 
         ProjectCommands::usersDto($projectId);
@@ -267,7 +271,7 @@ class ProjectCommands
 
         return $projectId;
     }
-    
+
     /**
      * Removes users from the project (two-way unlink)
      * @param string $projectId
@@ -280,20 +284,20 @@ class ProjectCommands
         $project->removeUserJoinRequest($joinRequestId);
         return $project->write();
     }
-    
+
     public static function grantAccessForUserRequest($projectId, $userId, $projectRole) {
         // check if userId exists in request queue on project model
         self::updateUserRole($projectId, $userId, $projectRole);
         // remove userId from request queue
         // send email notifying of acceptance
     }
-    
+
     public static function requestAccessForProject($projectId, $userId) {
         // add userId to request queue
         // send email to project owner and all managers
     }
-    
-    
+
+
 
     public static function renameProject($projectId, $oldName, $newName)
     {

--- a/src/Api/Model/Shared/Command/ProjectCommands.php
+++ b/src/Api/Model/Shared/Command/ProjectCommands.php
@@ -297,8 +297,6 @@ class ProjectCommands
         // send email to project owner and all managers
     }
 
-
-
     public static function renameProject($projectId, $oldName, $newName)
     {
         // TODO: Write this. (Move renaming logic over from sf->project_update). RM 2013-08

--- a/src/Api/Model/Shared/Dto/ManageUsersDto.php
+++ b/src/Api/Model/Shared/Dto/ManageUsersDto.php
@@ -15,9 +15,11 @@ class ManageUsersDto
     {
         $projectModel = ProjectModel::getById($projectId);
 
+        // In order to filter the list of roles on the front end,
+        //  each role must be in its own object (JSON encoded PHP array) with common property names
         $projectRoles = array();
         foreach($projectModel->getRolesList() as $roleKey=>$roleName) {
-            $projectRoles[] = array('roleKey'=>$roleKey, 'roleName' => $roleName);
+            $projectRoles[] = array('roleKey' => $roleKey, 'roleName' => $roleName);
         }
 
         $list = $projectModel->listUsers();

--- a/src/Api/Model/Shared/Dto/ManageUsersDto.php
+++ b/src/Api/Model/Shared/Dto/ManageUsersDto.php
@@ -15,13 +15,18 @@ class ManageUsersDto
     {
         $projectModel = ProjectModel::getById($projectId);
 
+        $projectRoles = array();
+        foreach($projectModel->getRolesList() as $roleKey=>$roleName) {
+            $projectRoles[] = array('roleKey'=>$roleKey, 'roleName' => $roleName);
+        }
+
         $list = $projectModel->listUsers();
         $data = array();
         $data['userCount'] = $list->count;
         $data['users'] = $list->entries;
         $data['invitees'] = $projectModel->listInvitees()->entries;
         $data['project'] = array(
-            'roles' => $projectModel->getRolesList(),
+            'roles' => $projectRoles,
             'ownerRef' => $projectModel->ownerRef,
             'projectName' => $projectModel->projectName,
             'appLink' => "/app/{$projectModel->appName}/$projectId/"

--- a/src/Api/Model/Shared/Rights/ProjectRoles.php
+++ b/src/Api/Model/Shared/Rights/ProjectRoles.php
@@ -7,12 +7,18 @@ class ProjectRoles extends RolesBase
     const MANAGER = 'project_manager';
     const CONTRIBUTOR = 'contributor';
     const NONE = 'none';
+    const TECH_SUPPORT = 'tech_support';
 
     public static function getRolesList() {
         $roles = array(
             self::MANAGER => "Manager",
-            self::CONTRIBUTOR => "Contributor"
+            self::CONTRIBUTOR => "Contributor",
+            self::TECH_SUPPORT => "Tech Support"
         );
         return $roles;
+    }
+
+    public static function isManager($role) {
+        return ($role == self::MANAGER || $role == self::TECH_SUPPORT);
     }
 }

--- a/src/angular-app/bellows/apps/projects/projects-app.component.html
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.html
@@ -56,7 +56,7 @@
                             <small class="text-muted">{{$ctrl.projectTypeNames[project.appName]}}</small>
                         </div>
                         <div class="col-5 col-md-3 text-right" data-ng-show="$ctrl.rights.canEditProjects">
-                            <button id="managerButton" class="btn btn-std" data-ng-show="!$ctrl.isTechSupport(project)"
+                            <button id="techSupportButton" class="btn btn-std" data-ng-show="!$ctrl.isTechSupport(project)"
                                     data-ng-click="$ctrl.addTechSupportToProject(project)">
                                 <i class="fa fa-plus"></i> Tech Support</button>
                         </div>

--- a/src/angular-app/bellows/apps/projects/projects-app.component.html
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.html
@@ -56,9 +56,9 @@
                             <small class="text-muted">{{$ctrl.projectTypeNames[project.appName]}}</small>
                         </div>
                         <div class="col-5 col-md-3 text-right" data-ng-show="$ctrl.rights.canEditProjects">
-                            <button id="managerButton" class="btn btn-std" data-ng-show="!$ctrl.isManager(project)"
-                                    data-ng-click="$ctrl.addManagerToProject(project)">
-                                <i class="fa fa-plus"></i> Manager</button>
+                            <button id="managerButton" class="btn btn-std" data-ng-show="!$ctrl.isTechSupport(project)"
+                                    data-ng-click="$ctrl.addTechSupportToProject(project)">
+                                <i class="fa fa-plus"></i> Tech Support</button>
                         </div>
                     </div>
                     <hr>

--- a/src/angular-app/bellows/apps/projects/projects-app.component.html
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.html
@@ -56,7 +56,7 @@
                             <small class="text-muted">{{$ctrl.projectTypeNames[project.appName]}}</small>
                         </div>
                         <div class="col-5 col-md-3 text-right" data-ng-show="$ctrl.rights.canEditProjects">
-                            <button id="techSupportButton" class="btn btn-std" data-ng-show="!$ctrl.isTechSupport(project)"
+                            <button id="techSupportButton" class="btn btn-std" data-ng-show="!$ctrl.isManager(project)"
                                     data-ng-click="$ctrl.addTechSupportToProject(project)">
                                 <i class="fa fa-plus"></i> Tech Support</button>
                         </div>

--- a/src/angular-app/bellows/apps/projects/projects-app.component.ts
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.ts
@@ -82,8 +82,8 @@ export class ProjectsAppController implements angular.IController {
     return (project.role !== 'none');
   }
 
-  isTechSupport(project: Project) {
-    return project.role === 'tech_support';
+  isManager(project: Project) {
+    return project.role === 'project_manager' || project.role === 'tech_support';
   }
 
   // Add user as Manager of project

--- a/src/angular-app/bellows/apps/projects/projects-app.component.ts
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.ts
@@ -82,15 +82,15 @@ export class ProjectsAppController implements angular.IController {
     return (project.role !== 'none');
   }
 
-  isManager(project: Project) {
-    return (project.role === 'project_manager' || project.role === 'tech_support');
+  isTechSupport(project: Project) {
+    return project.role === 'tech_support';
   }
 
   // Add user as Manager of project
-  addManagerToProject(project: Project) {
-    this.projectService.joinProject(project.id, 'project_manager', result => {
+  addTechSupportToProject(project: Project) {
+    this.projectService.joinProject(project.id, 'tech_support', result => {
       if (result.ok) {
-        this.notice.push(this.notice.SUCCESS, 'You are now a Manager of the \'' +
+        this.notice.push(this.notice.SUCCESS, 'You are now Tech Support for the \'' +
           project.projectName + '\' project.');
         this.queryProjectsForUser();
       }

--- a/src/angular-app/bellows/apps/projects/projects-app.component.ts
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.ts
@@ -83,7 +83,7 @@ export class ProjectsAppController implements angular.IController {
   }
 
   isManager(project: Project) {
-    return (project.role === 'project_manager');
+    return (project.role === 'project_manager' || project.role === 'tech_support');
   }
 
   // Add user as Manager of project

--- a/src/angular-app/bellows/apps/usermanagement/members.component.html
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.html
@@ -59,17 +59,17 @@
                 </td>
                 <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'tech_support'">
                     <!--suppress HtmlFormInputWithoutLabel -->
-                    <select class="form-control custom-select" disabled><option>Tech Support</option></select>
+                    <select id="tech-support-dropdown" class="form-control custom-select" disabled><option>Tech Support</option></select>
                 </td>
                 <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'admin'">
                     <!-- suppress HtmlFormInputWithoutLabel -->
-                    <select class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="!$ctrl.isRoleDropdownEnabled(user)"
+                    <select id="admin-dropdown" class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="$ctrl.selectRoleDropdown(user) != 'admin'"
                             data-ng-change="$ctrl.onRoleChange(user)"
                             data-ng-options="role.roleKey as role.roleName for role in $ctrl.roles"></select>
                 </td>
                 <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'default'">
                     <!-- suppress HtmlFormInputWithoutLabel -->
-                    <select class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="!$ctrl.isRoleDropdownEnabled(user)"
+                    <select id="default-dropdown" class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="$ctrl.selectRoleDropdown(user) != 'default'"
                             data-ng-change="$ctrl.onRoleChange(user)"
                             data-ng-options="role.roleKey as role.roleName for role in $ctrl.roles | filter:{roleKey:'!tech_support'}"></select>
                 </td>

--- a/src/angular-app/bellows/apps/usermanagement/members.component.html
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.html
@@ -53,25 +53,10 @@
                 <td ng-if="!user.isInvitee">{{user.username}}</td>
                 <td ng-if="user.isInvitee" class="invited-user">{{user.username || user.email}} [invited]</td>
                 <td>{{user.name}}</td>
-                <td data-ng-show="$ctrl.getRoleSelectMode(user) == 'owner'">
-                    <!--suppress HtmlFormInputWithoutLabel -->
-                    <select class="form-control custom-select" disabled><option>Manager and Project Owner</option></select>
-                </td>
-                <td data-ng-show="$ctrl.getRoleSelectMode(user) == 'tech_support'">
-                    <!--suppress HtmlFormInputWithoutLabel -->
-                    <select id="tech-support-role-select" class="form-control custom-select" disabled><option>Tech Support</option></select>
-                </td>
-                <td data-ng-show="$ctrl.getRoleSelectMode(user) == 'admin'">
+                <td>
                     <!-- suppress HtmlFormInputWithoutLabel -->
-                    <select id="admin-role-select" class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="$ctrl.getRoleSelectMode(user) != 'admin'"
-                            data-ng-change="$ctrl.onRoleChange(user)"
-                            data-ng-options="role.roleKey as role.roleName for role in $ctrl.roles"></select>
-                </td>
-                <td data-ng-show="$ctrl.getRoleSelectMode(user) == 'default'">
-                    <!-- suppress HtmlFormInputWithoutLabel -->
-                    <select id="default-role-select" class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="$ctrl.getRoleSelectMode(user) != 'default'"
-                            data-ng-change="$ctrl.onRoleChange(user)"
-                            data-ng-options="role.roleKey as role.roleName for role in $ctrl.roles | filter:{roleKey:'!tech_support'}"></select>
+                    <select id="default-role-select" class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="$ctrl.isRoleSelectDisabled(user)"
+                            data-ng-change="$ctrl.onRoleChange(user)" data-ng-options="role.roleKey as role.roleName for role in $ctrl.getRoles(user)"></select>
                 </td>
             </tr>
             </tbody>

--- a/src/angular-app/bellows/apps/usermanagement/members.component.html
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.html
@@ -53,15 +53,25 @@
                 <td ng-if="!user.isInvitee">{{user.username}}</td>
                 <td ng-if="user.isInvitee" class="invited-user">{{user.username || user.email}} [invited]</td>
                 <td>{{user.name}}</td>
-                <td data-ng-show="user.id == $ctrl.project.ownerRef.id">
+                <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'owner'">
                     <!--suppress HtmlFormInputWithoutLabel -->
                     <select class="form-control custom-select" disabled><option>Manager and Project Owner</option></select>
                 </td>
-                <td data-ng-hide="user.id == $ctrl.project.ownerRef.id">
+                <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'tech_support'">
                     <!--suppress HtmlFormInputWithoutLabel -->
-                    <select class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="!$ctrl.rights.changeRole"
+                    <select class="form-control custom-select" disabled><option>Tech Support</option></select>
+                </td>
+                <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'admin'">
+                    <!-- suppress HtmlFormInputWithoutLabel -->
+                    <select class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="!$ctrl.isRoleDropdownEnabled(user)"
                             data-ng-change="$ctrl.onRoleChange(user)"
-                            data-ng-options="roleKey as roleName for (roleKey, roleName) in $ctrl.roles"></select>
+                            data-ng-options="role.roleKey as role.roleName for role in $ctrl.roles"></select>
+                </td>
+                <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'default'">
+                    <!-- suppress HtmlFormInputWithoutLabel -->
+                    <select class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="!$ctrl.isRoleDropdownEnabled(user)"
+                            data-ng-change="$ctrl.onRoleChange(user)"
+                            data-ng-options="role.roleKey as role.roleName for role in $ctrl.roles | filter:{roleKey:'!tech_support'}"></select>
                 </td>
             </tr>
             </tbody>

--- a/src/angular-app/bellows/apps/usermanagement/members.component.html
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.html
@@ -53,23 +53,23 @@
                 <td ng-if="!user.isInvitee">{{user.username}}</td>
                 <td ng-if="user.isInvitee" class="invited-user">{{user.username || user.email}} [invited]</td>
                 <td>{{user.name}}</td>
-                <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'owner'">
+                <td data-ng-show="$ctrl.getRoleSelectMode(user) == 'owner'">
                     <!--suppress HtmlFormInputWithoutLabel -->
                     <select class="form-control custom-select" disabled><option>Manager and Project Owner</option></select>
                 </td>
-                <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'tech_support'">
+                <td data-ng-show="$ctrl.getRoleSelectMode(user) == 'tech_support'">
                     <!--suppress HtmlFormInputWithoutLabel -->
-                    <select id="tech-support-dropdown" class="form-control custom-select" disabled><option>Tech Support</option></select>
+                    <select id="tech-support-role-select" class="form-control custom-select" disabled><option>Tech Support</option></select>
                 </td>
-                <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'admin'">
+                <td data-ng-show="$ctrl.getRoleSelectMode(user) == 'admin'">
                     <!-- suppress HtmlFormInputWithoutLabel -->
-                    <select id="admin-dropdown" class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="$ctrl.selectRoleDropdown(user) != 'admin'"
+                    <select id="admin-role-select" class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="$ctrl.getRoleSelectMode(user) != 'admin'"
                             data-ng-change="$ctrl.onRoleChange(user)"
                             data-ng-options="role.roleKey as role.roleName for role in $ctrl.roles"></select>
                 </td>
-                <td data-ng-show="$ctrl.selectRoleDropdown(user) == 'default'">
+                <td data-ng-show="$ctrl.getRoleSelectMode(user) == 'default'">
                     <!-- suppress HtmlFormInputWithoutLabel -->
-                    <select id="default-dropdown" class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="$ctrl.selectRoleDropdown(user) != 'default'"
+                    <select id="default-role-select" class="form-control custom-select col-12" data-ng-model="user.role" data-ng-disabled="$ctrl.getRoleSelectMode(user) != 'default'"
                             data-ng-change="$ctrl.onRoleChange(user)"
                             data-ng-options="role.roleKey as role.roleName for role in $ctrl.roles | filter:{roleKey:'!tech_support'}"></select>
                 </td>

--- a/src/angular-app/bellows/apps/usermanagement/members.component.ts
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.ts
@@ -71,17 +71,6 @@ export class UserManagementMembersController implements angular.IController {
     return 'default';
   }
 
-  isRoleDropdownEnabled(user: User): boolean {
-    if (user.role === 'tech_support' && this.currentUser.id !== user.id) {
-      return false;
-    }
-    if (this.rights.changeRole) {
-      return true;
-    }
-    return false;
-  }
-
-
   removeProjectUsers(): void {
     const userIds: string[] = [];
     const l = this.selected.length;

--- a/src/angular-app/bellows/apps/usermanagement/members.component.ts
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.ts
@@ -56,7 +56,7 @@ export class UserManagementMembersController implements angular.IController {
     return user !== null && this.selected.indexOf(user) >= 0;
   }
 
-  selectRoleDropdown(user: User): string {
+  getRoleSelectMode(user: User): string {
     if (user.id === this.project.ownerRef.id) {
       return 'owner';
     }

--- a/src/angular-app/bellows/apps/usermanagement/user-management-app.component.ts
+++ b/src/angular-app/bellows/apps/usermanagement/user-management-app.component.ts
@@ -14,11 +14,16 @@ export class Rights {
   showControlBar: boolean;
 }
 
+export interface Role {
+  roleKey: string;
+  roleName: string;
+}
+
 export class UserManagementAppController implements angular.IController {
   rights = new Rights();
-  roles = {};
+  roles: Role[] = [];
   project = {
-    roles: {},
+    roles: [] as Role[],
     projectName: '',
     appLink: ''
   };
@@ -48,7 +53,7 @@ export class UserManagementAppController implements angular.IController {
     });
 
     // load roles if they have not been loaded yet
-    if (Object.keys(this.roles).length === 0) {
+    if (this.roles.length === 0) {
       this.queryUserList();
     }
 

--- a/src/angular-app/bellows/apps/usermanagement/user-management-app.module.ts
+++ b/src/angular-app/bellows/apps/usermanagement/user-management-app.module.ts
@@ -36,7 +36,8 @@ export const UserManagementAppModule = angular
           views: {
             '@': {
               template: `<user-management-members query-user-list="$ctrl.queryUserList()"
-                list="$ctrl.list" project="$ctrl.project" roles="$ctrl.roles" rights="$ctrl.rights">
+                list="$ctrl.list" project="$ctrl.project" roles="$ctrl.roles" rights="$ctrl.rights"
+                current-user="$ctrl.currentUser">
                 </user-management-members>`
             }
           }

--- a/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
@@ -343,7 +343,7 @@ export class ConfigurationFieldUnifiedViewModel {
     }
   }
 
-  private static setInputSystemsViewModel(config: LexiconConfig): [InputSystemSettings[], InputSystemSettings] { // ANDREW
+  private static setInputSystemsViewModel(config: LexiconConfig): [InputSystemSettings[], InputSystemSettings] {
     const inputSystems: InputSystemSettings[] = [];
     const overrides: InputSystemSettings = new InputSystemSettings();
     const selectedManagerTags = ConfigurationFieldUnifiedViewModel.getSelectedInputSystemsManagerTags(config);

--- a/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
@@ -640,10 +640,9 @@ export class RoleType {
   commenter: string = 'observer_with_comment';
   contributor: string = 'contributor';
   manager: string = 'project_manager';
-  techSupport: string = 'tech_support';
 
   static roles(): string[] {
-    return ['observer', 'commenter', 'contributor', 'manager', 'tech_support'];
+    return ['observer', 'commenter', 'contributor', 'manager'];
   }
 }
 

--- a/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
@@ -343,7 +343,7 @@ export class ConfigurationFieldUnifiedViewModel {
     }
   }
 
-  private static setInputSystemsViewModel(config: LexiconConfig): [InputSystemSettings[], InputSystemSettings] {
+  private static setInputSystemsViewModel(config: LexiconConfig): [InputSystemSettings[], InputSystemSettings] { // ANDREW
     const inputSystems: InputSystemSettings[] = [];
     const overrides: InputSystemSettings = new InputSystemSettings();
     const selectedManagerTags = ConfigurationFieldUnifiedViewModel.getSelectedInputSystemsManagerTags(config);
@@ -640,9 +640,10 @@ export class RoleType {
   commenter: string = 'observer_with_comment';
   contributor: string = 'contributor';
   manager: string = 'project_manager';
+  techSupport: string = 'tech_support';
 
   static roles(): string[] {
-    return ['observer', 'commenter', 'contributor', 'manager'];
+    return ['observer', 'commenter', 'contributor', 'manager', 'tech_support'];
   }
 }
 

--- a/src/angular-app/scriptureforge/sfchecks/project/project-settings.controller.ts
+++ b/src/angular-app/scriptureforge/sfchecks/project/project-settings.controller.ts
@@ -490,7 +490,8 @@ export const SfChecksProjectSettingsModule = angular
     // Roles in list
     $scope.roles = [
           { key: 'contributor', name: 'Contributor' },
-          { key: 'project_manager', name: 'Manager' }
+          { key: 'project_manager', name: 'Manager' },
+          { key: 'tech_support', name: 'Tech Support'}
       ];
 
     $scope.onRoleChange = function onRoleChange(user: User): void {

--- a/src/angular-app/scriptureforge/sfchecks/project/project-settings.controller.ts
+++ b/src/angular-app/scriptureforge/sfchecks/project/project-settings.controller.ts
@@ -491,7 +491,6 @@ export const SfChecksProjectSettingsModule = angular
     $scope.roles = [
           { key: 'contributor', name: 'Contributor' },
           { key: 'project_manager', name: 'Manager' },
-          { key: 'tech_support', name: 'Tech Support'}
       ];
 
     $scope.onRoleChange = function onRoleChange(user: User): void {

--- a/test/app/bellows/projects.e2e-spec.ts
+++ b/test/app/bellows/projects.e2e-spec.ts
@@ -43,8 +43,8 @@ describe('Bellows E2E Projects List app', () => {
   };
 
   const shouldProjectHaveButtons = (projectRow: ElementFinder, bool: boolean) => {
-    const addAsManagerBtn = projectRow.element(by.id('managerButton'));
-    expect<any>(addAsManagerBtn.isDisplayed()).toBe(bool);
+    const addAsTechSupportBtn = projectRow.element(by.id('techSupportButton'));
+    expect<any>(addAsTechSupportBtn.isDisplayed()).toBe(bool);
   };
 
   describe('for System Admin User', () => {
@@ -89,7 +89,7 @@ describe('Bellows E2E Projects List app', () => {
         shouldProjectHaveButtons(projectRow, true);
 
         // Now add the admin back to the project
-        projectRow.element(by.id('managerButton')).click();
+        projectRow.element(by.id('techSupportButton')).click();
       });
 
       // And the buttons should go away after one of them is clicked

--- a/test/app/bellows/shared/projects.page.ts
+++ b/test/app/bellows/shared/projects.page.ts
@@ -1,11 +1,9 @@
 import {browser, by, element, ExpectedConditions, protractor} from 'protractor';
-import {UserManagementPage} from './user-management.page'
 
 import {Utils} from './utils';
 
 export class ProjectsPage {
   private readonly utils = new Utils();
-  private readonly userManagementPage = new UserManagementPage();
 
   url = '/app/projects';
   get() {
@@ -56,7 +54,7 @@ export class ProjectsPage {
   userManagementLink = (browser.baseUrl.includes('languageforge')) ?
     element(by.id('userManagementLink')) : element(by.id('dropdown-project-settings'));
 
-  addUserToProject(projectName: any, usersName: string, roleText: string) {
+  addUserToProject(projectName: any, usersName: string, roleText: string) { // TODO: Refactor to use UserManagement.page.ts
     this.findProject(projectName).then((projectRow: any) => {
       const projectLink = projectRow.element(by.css('a'));
       projectLink.click();
@@ -82,6 +80,7 @@ export class ProjectsPage {
       // This should be unique no matter what
       newMembersDiv.element(by.id('addUserButton')).click();
 
+      // Now set the user to member or manager, as needed
       const projectMemberRows = element.all(by.repeater('user in $ctrl.list.visibleUsers'));
       let foundUserRow: any;
       projectMemberRows.map((row: any) => {

--- a/test/app/bellows/shared/projects.page.ts
+++ b/test/app/bellows/shared/projects.page.ts
@@ -1,9 +1,10 @@
 import {browser, by, element, ExpectedConditions, protractor} from 'protractor';
-
+import {UserManagementPage} from './user-management.page';
 import {Utils} from './utils';
 
 export class ProjectsPage {
   private readonly utils = new Utils();
+  private readonly userManagementPage = new UserManagementPage();
 
   url = '/app/projects';
   get() {
@@ -54,7 +55,7 @@ export class ProjectsPage {
   userManagementLink = (browser.baseUrl.includes('languageforge')) ?
     element(by.id('userManagementLink')) : element(by.id('dropdown-project-settings'));
 
-  addUserToProject(projectName: any, usersName: string, roleText: string) { // TODO: Refactor to use UserManagement.page.ts
+  addUserToProject(projectName: any, usersName: string, roleText: string) {
     this.findProject(projectName).then((projectRow: any) => {
       const projectLink = projectRow.element(by.css('a'));
       projectLink.click();
@@ -63,27 +64,21 @@ export class ProjectsPage {
       browser.wait(ExpectedConditions.visibilityOf(this.userManagementLink), Utils.conditionTimeout);
       this.userManagementLink.click();
 
-      const addMembersBtn = element(by.id('addMembersButton'));
-      browser.wait(ExpectedConditions.visibilityOf(addMembersBtn), Utils.conditionTimeout);
-      addMembersBtn.click();
-      const newMembersDiv = element(by.id('newMembersDiv'));
-      const userNameInput = newMembersDiv.element(by.id('typeaheadInput'));
-      browser.wait(ExpectedConditions.visibilityOf(userNameInput), Utils.conditionTimeout);
-      userNameInput.sendKeys(usersName);
+      browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.addMembersBtn), Utils.conditionTimeout);
+      this.userManagementPage.addMembersBtn.click();
+      browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.userNameInput), Utils.conditionTimeout);
+      this.userManagementPage.userNameInput.sendKeys(usersName);
 
-      const typeaheadDiv = element(by.id('typeaheadDiv'));
-      const typeaheadItems = typeaheadDiv.all(by.css('ul li'));
-      this.utils.findRowByText(typeaheadItems, usersName).then((item: any) => {
+      this.utils.findRowByText(this.userManagementPage.typeaheadItems, usersName).then((item: any) => {
         item.click();
       });
 
       // This should be unique no matter what
-      newMembersDiv.element(by.id('addUserButton')).click();
+      this.userManagementPage.newMembersDiv.element(by.id('addUserButton')).click();
 
       // Now set the user to member or manager, as needed
-      const projectMemberRows = element.all(by.repeater('user in $ctrl.list.visibleUsers'));
       let foundUserRow: any;
-      projectMemberRows.map((row: any) => {
+      this.userManagementPage.projectMemberRows.map((row: any) => {
         const nameColumn = row.element(by.binding('user.username'));
         nameColumn.getText().then((text: string) => {
           if (text === usersName) {
@@ -92,7 +87,7 @@ export class ProjectsPage {
         });
       }).then(() => {
         if (foundUserRow) {
-          const select = foundUserRow.element(by.css('select:not([disabled])'));
+          const select = foundUserRow.element(by.css('select'));
           Utils.clickDropdownByValue(select, roleText);
         }
       });
@@ -115,7 +110,9 @@ export class ProjectsPage {
       const projectLink = projectRow.element(by.css('a'));
       projectLink.click();
 
+      browser.wait(ExpectedConditions.visibilityOf(this.settingsBtn), Utils.conditionTimeout);
       this.settingsBtn.click();
+      browser.wait(ExpectedConditions.visibilityOf(this.userManagementLink), Utils.conditionTimeout);
       this.userManagementLink.click();
 
       let userFilter: any;

--- a/test/app/bellows/shared/projects.page.ts
+++ b/test/app/bellows/shared/projects.page.ts
@@ -1,9 +1,11 @@
 import {browser, by, element, ExpectedConditions, protractor} from 'protractor';
+import {UserManagementPage} from './user-management.page'
 
 import {Utils} from './utils';
 
 export class ProjectsPage {
   private readonly utils = new Utils();
+  private readonly userManagementPage = new UserManagementPage();
 
   url = '/app/projects';
   get() {
@@ -80,7 +82,6 @@ export class ProjectsPage {
       // This should be unique no matter what
       newMembersDiv.element(by.id('addUserButton')).click();
 
-      // Now set the user to member or manager, as needed
       const projectMemberRows = element.all(by.repeater('user in $ctrl.list.visibleUsers'));
       let foundUserRow: any;
       projectMemberRows.map((row: any) => {

--- a/test/app/bellows/shared/user-management.page.ts
+++ b/test/app/bellows/shared/user-management.page.ts
@@ -1,19 +1,22 @@
 import { browser, element, by, ElementFinder, ElementArrayFinder, protractor } from "protractor";
 import { Utils } from "./utils";
 
-
 export class UserManagementPage {
   static get(projectId: string) {
     browser.get(browser.baseUrl + '/app/usermanagement' + projectId );
   }
 
-  usersList = element.all(by.repeater('user in $ctrl.list.visibleUsers'));
+  addMembersBtn = element(by.id('addMembersButton'));
+  newMembersDiv = element(by.id('newMembersDiv'));
+  projectMemberRows = element.all(by.repeater('user in $ctrl.list.visibleUsers'));
+  typeaheadDiv = element(by.id('typeaheadDiv'));
+  typeaheadItems = this.typeaheadDiv.all(by.css('ul li'));
+  userNameInput = this.newMembersDiv.element(by.id('typeaheadInput'));
 
-  // NOTE: This function is untested
   changeUserRole(userName: string, roleText: string) {
     this.getUserRow(userName).then( (row: ElementFinder) => {
       if (row) {
-        const select = row.element(by.css('select:not([disabled])'));
+        const select = row.element(by.css('select'));
         Utils.clickDropdownByValue(select, roleText);
       }
     });
@@ -22,7 +25,7 @@ export class UserManagementPage {
   getUserRow(userName: string) {
     const result = protractor.promise.defer();
     let foundUserRow: ElementFinder;
-    this.usersList.map((row: any) => {
+    this.projectMemberRows.map((row: any) => {
       const nameColumn = row.element(by.binding('user.username'));
       nameColumn.getText().then( (text: string) => {
         if (text === userName) {

--- a/test/app/bellows/shared/user-management.page.ts
+++ b/test/app/bellows/shared/user-management.page.ts
@@ -1,0 +1,41 @@
+import { browser, element, by, ElementFinder, ElementArrayFinder, protractor } from "protractor";
+import { Utils } from "./utils";
+
+
+export class UserManagementPage {
+  static get(projectId: string) {
+    browser.get(browser.baseUrl + '/app/usermanagement' + projectId );
+  }
+
+  usersList = element.all(by.repeater('user in $ctrl.list.visibleUsers'));
+
+  changeUserRole(userName: string, roleText: string) {
+    this.findUserRow(userName).then( (row: ElementFinder) => {
+      if (row) {
+        const select = row.element(by.css('select:not([disabled])'));
+        Utils.clickDropdownByValue(select, roleText);
+      }
+    });
+  }
+
+  findUserRow(userName: string) {
+    const result = protractor.promise.defer();
+    let foundUserRow: any;
+    this.usersList.map((row: any) => {
+      const nameColumn = row.element(by.binding('user.username'));
+      nameColumn.getText().then((text: string) => {
+        if (text === userName) {
+          foundUserRow = row;
+        }
+      });
+    }).then(() => {
+      if (foundUserRow) {
+        result.fulfill(foundUserRow);
+      } else {
+        result.reject('User ' + userName + ' not found.');
+      }
+    });
+
+    return result.promise;
+  }
+}

--- a/test/app/bellows/shared/user-management.page.ts
+++ b/test/app/bellows/shared/user-management.page.ts
@@ -9,8 +9,9 @@ export class UserManagementPage {
 
   usersList = element.all(by.repeater('user in $ctrl.list.visibleUsers'));
 
+  // NOTE: This function is untested
   changeUserRole(userName: string, roleText: string) {
-    this.findUserRow(userName).then( (row: ElementFinder) => {
+    this.getUserRow(userName).then( (row: ElementFinder) => {
       if (row) {
         const select = row.element(by.css('select:not([disabled])'));
         Utils.clickDropdownByValue(select, roleText);
@@ -18,12 +19,12 @@ export class UserManagementPage {
     });
   }
 
-  findUserRow(userName: string) {
+  getUserRow(userName: string) {
     const result = protractor.promise.defer();
-    let foundUserRow: any;
+    let foundUserRow: ElementFinder;
     this.usersList.map((row: any) => {
       const nameColumn = row.element(by.binding('user.username'));
-      nameColumn.getText().then((text: string) => {
+      nameColumn.getText().then( (text: string) => {
         if (text === userName) {
           foundUserRow = row;
         }

--- a/test/app/bellows/user-management.e2e-spec.ts
+++ b/test/app/bellows/user-management.e2e-spec.ts
@@ -1,9 +1,10 @@
-import {by, element, browser} from 'protractor';
+import {by, element, browser, ExpectedConditions} from 'protractor';
 import {ElementFinder} from 'protractor/built/element';
 
 import {BellowsLoginPage} from './shared/login.page';
 import {ProjectsPage} from './shared/projects.page';
 import {UserManagementPage} from './shared/user-management.page';
+import { Utils } from './shared/utils';
 
 describe('Bellows E2E User Management App', () => {
   const constants = require('../testConstants.json');
@@ -12,20 +13,32 @@ describe('Bellows E2E User Management App', () => {
   const userManagementPage = new UserManagementPage();
 
   it('Can add admin as Tech Support', () => {
+    // Remove admin from Other Project for Testing
+    loginPage.loginAsManager();
+    projectsPage.get();
+    projectsPage.removeUserFromProject(constants.otherProjectName, constants.adminUsername);
+
     loginPage.loginAsAdmin();
     projectsPage.get();
+
     // Click "+ Tech Support" button
     projectsPage.findProject(constants.otherProjectName).then((projectRow: ElementFinder) => {
       projectRow.element(by.id('techSupportButton')).click();
     });
+
     // Assert admin is Tech Support
     projectsPage.clickOnProject(constants.otherProjectName);
+    browser.wait(ExpectedConditions.visibilityOf(projectsPage.settingsBtn), Utils.conditionTimeout);
     projectsPage.settingsBtn.click();
     projectsPage.userManagementLink.click();
-    browser.sleep(10000);
+    browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+
     userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      expect<any>(row.element(by.id('admin-role-select')).isDisplayed()).toBe(true);
-      expect<any>(row.element(by.id('admin-role-select')).isEnabled()).toBe(true);
+      const selector = row.element(by.css('select'));
+      expect<any>(selector.isEnabled()).toBe(true);
+      selector.element(by.css('option[selected=selected]')).getText().then( text => {
+        expect<any>(text).toBe('Tech Support');
+      });
     });
   });
 
@@ -33,11 +46,18 @@ describe('Bellows E2E User Management App', () => {
     loginPage.loginAsManager();
     projectsPage.get();
     projectsPage.clickOnProject(constants.otherProjectName);
+
+    browser.wait(ExpectedConditions.visibilityOf(projectsPage.settingsBtn), Utils.conditionTimeout);
     projectsPage.settingsBtn.click();
     projectsPage.userManagementLink.click();
+    browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+
     userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      expect<any>(row.element(by.id('tech-support-role-select')).isDisplayed()).toBe(true);
-      expect<any>(row.element(by.id('tech-support-role-select')).isEnabled()).toBe(false);
+      const selector = row.element(by.css('select'));
+      expect<any>(selector.isEnabled()).toBe(false);
+      selector.element(by.css('option[selected=selected]')).getText().then( text => {
+        expect<any>(text).toBe('Tech Support');
+      });
     });
   });
 
@@ -45,12 +65,17 @@ describe('Bellows E2E User Management App', () => {
     loginPage.loginAsAdmin();
     projectsPage.get();
     projectsPage.clickOnProject(constants.otherProjectName);
+
+    browser.wait(ExpectedConditions.visibilityOf(projectsPage.settingsBtn), Utils.conditionTimeout);
     projectsPage.settingsBtn.click();
     projectsPage.userManagementLink.click();
     userManagementPage.changeUserRole(constants.adminUsername, 'Manager');
+
+    browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
     userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      const selectedRole = row.element(by.css('select:not([disabled])')).element(by.css('option[selected=selected]'));
-      selectedRole.getText().then( text => {
+      const selector = row.element(by.css('select'));
+      expect<any>(selector.isEnabled()).toBe(true);
+      selector.element(by.css('option[selected=selected]')).getText().then( text => {
         expect<any>(text).toBe('Manager');
       });
     });
@@ -60,10 +85,14 @@ describe('Bellows E2E User Management App', () => {
     loginPage.loginAsManager();
     projectsPage.get();
     projectsPage.clickOnProject(constants.otherProjectName);
+
+    browser.wait(ExpectedConditions.visibilityOf(projectsPage.settingsBtn), Utils.conditionTimeout);
     projectsPage.settingsBtn.click();
     projectsPage.userManagementLink.click();
+    browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+
     userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      row.element(by.css('select:not([disabled])')).getText().then( text => {
+      row.element(by.css('select')).getText().then( text => {
         expect<any>(text).toContain('Manager');
         expect<any>(text).toContain('Contributor');
         expect<any>(text).toContain('Observer');

--- a/test/app/bellows/user-management.e2e-spec.ts
+++ b/test/app/bellows/user-management.e2e-spec.ts
@@ -1,0 +1,74 @@
+import {browser, by, element} from 'protractor';
+import {ElementFinder} from 'protractor/built/element';
+
+import {BellowsLoginPage} from './shared/login.page';
+import {ProjectsPage} from './shared/projects.page';
+import {UserManagementPage} from './shared/user-management.page';
+
+describe('Bellows E2E User Management App', () => {
+  const constants = require('../testConstants.json');
+  const loginPage = new BellowsLoginPage();
+  const projectsPage = new ProjectsPage();
+  const userManagementPage = new UserManagementPage();
+
+  it('Can add admin as Tech Support', () => {
+    loginPage.loginAsAdmin();
+    projectsPage.get();
+    // Click "+ Tech Support" button
+    projectsPage.findProject(constants.otherProjectName).then((projectRow: ElementFinder) => {
+      projectRow.element(by.id('techSupportButton')).click();
+    });
+    // Assert admin is Tech Support
+    projectsPage.clickOnProject(constants.otherProjectName);
+    projectsPage.settingsBtn.click();
+    projectsPage.userManagementLink.click();
+    userManagementPage.findUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+      expect<any>(element(by.id('admin-dropdown')).isDisplayed()).toBe(true);
+      expect<any>(element(by.id('admin-dropdown')).isEnabled()).toBe(true);
+    });
+  });
+
+  it('Non admin cannot remove Tech Support user', () => {
+    loginPage.loginAsManager();
+    projectsPage.get();
+    projectsPage.clickOnProject(constants.otherProjectName);
+    projectsPage.settingsBtn.click();
+    projectsPage.userManagementLink.click();
+    userManagementPage.findUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+      expect<any>(element(by.id('tech-support-dropdown')).isDisplayed()).toBe(true);
+      expect<any>(element(by.id('tech-support-dropdown')).isEnabled()).toBe(false);
+    });
+  });
+
+  it('Tech Support user can change own role', () => {
+    loginPage.loginAsAdmin();
+    projectsPage.get();
+    projectsPage.clickOnProject(constants.otherProjectName);
+    projectsPage.settingsBtn.click();
+    projectsPage.userManagementLink.click();
+    userManagementPage.changeUserRole(constants.adminUsername, 'Manager');
+    userManagementPage.findUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+      const selectedRole = row.element(by.css('select:not([disabled])')).element(by.css('option[selected=selected]'));
+      selectedRole.getText().then( text => {
+        expect<any>(text).toBe('Manager');
+      });
+    });
+  });
+
+  it('Non admin cannot add Tech Support user', () => {
+    loginPage.loginAsManager();
+    projectsPage.get();
+    projectsPage.clickOnProject(constants.otherProjectName);
+    projectsPage.settingsBtn.click();
+    projectsPage.userManagementLink.click();
+    userManagementPage.findUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+      row.element(by.css('select:not([disabled])')).getText().then( text => {
+        expect<any>(text).toContain('Manager');
+        expect<any>(text).toContain('Contributor');
+        expect<any>(text).toContain('Observer');
+        expect<any>(text).toContain('Observer with comment');
+        expect<any>(text).not.toContain('Tech Support');
+      });
+    });
+  });
+});

--- a/test/app/bellows/user-management.e2e-spec.ts
+++ b/test/app/bellows/user-management.e2e-spec.ts
@@ -1,4 +1,4 @@
-import {browser, by, element} from 'protractor';
+import {by, element, browser} from 'protractor';
 import {ElementFinder} from 'protractor/built/element';
 
 import {BellowsLoginPage} from './shared/login.page';
@@ -22,32 +22,33 @@ describe('Bellows E2E User Management App', () => {
     projectsPage.clickOnProject(constants.otherProjectName);
     projectsPage.settingsBtn.click();
     projectsPage.userManagementLink.click();
-    userManagementPage.findUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      expect<any>(element(by.id('admin-dropdown')).isDisplayed()).toBe(true);
-      expect<any>(element(by.id('admin-dropdown')).isEnabled()).toBe(true);
+    browser.sleep(10000);
+    userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+      expect<any>(row.element(by.id('admin-role-select')).isDisplayed()).toBe(true);
+      expect<any>(row.element(by.id('admin-role-select')).isEnabled()).toBe(true);
     });
   });
 
-  it('Non admin cannot remove Tech Support user', () => {
+  it('Other user cannot assign Tech Support user\'s role', () => {
     loginPage.loginAsManager();
     projectsPage.get();
     projectsPage.clickOnProject(constants.otherProjectName);
     projectsPage.settingsBtn.click();
     projectsPage.userManagementLink.click();
-    userManagementPage.findUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      expect<any>(element(by.id('tech-support-dropdown')).isDisplayed()).toBe(true);
-      expect<any>(element(by.id('tech-support-dropdown')).isEnabled()).toBe(false);
+    userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+      expect<any>(row.element(by.id('tech-support-role-select')).isDisplayed()).toBe(true);
+      expect<any>(row.element(by.id('tech-support-role-select')).isEnabled()).toBe(false);
     });
   });
 
-  it('Tech Support user can change own role', () => {
+  it('Tech Support user can assign their own role', () => {
     loginPage.loginAsAdmin();
     projectsPage.get();
     projectsPage.clickOnProject(constants.otherProjectName);
     projectsPage.settingsBtn.click();
     projectsPage.userManagementLink.click();
     userManagementPage.changeUserRole(constants.adminUsername, 'Manager');
-    userManagementPage.findUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+    userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
       const selectedRole = row.element(by.css('select:not([disabled])')).element(by.css('option[selected=selected]'));
       selectedRole.getText().then( text => {
         expect<any>(text).toBe('Manager');
@@ -55,13 +56,13 @@ describe('Bellows E2E User Management App', () => {
     });
   });
 
-  it('Non admin cannot add Tech Support user', () => {
+  it('User cannot assign member to Tech Support role', () => {
     loginPage.loginAsManager();
     projectsPage.get();
     projectsPage.clickOnProject(constants.otherProjectName);
     projectsPage.settingsBtn.click();
     projectsPage.userManagementLink.click();
-    userManagementPage.findUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+    userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
       row.element(by.css('select:not([disabled])')).getText().then( text => {
         expect<any>(text).toContain('Manager');
         expect<any>(text).toContain('Contributor');

--- a/test/php/model/shared/commands/ProjectCommandsTest.php
+++ b/test/php/model/shared/commands/ProjectCommandsTest.php
@@ -650,7 +650,7 @@ class ProjectCommandsTest extends TestCase
         $this->assertEquals(2, $usersDto['userCount']);
     }
 
-    public function testAddTechSupport()
+    public function testUpdateUserRole_userIsAdminAndSetTechSupportRole_techSupportRoleSet()
     {
         self::$environ->clean();
 
@@ -669,7 +669,7 @@ class ProjectCommandsTest extends TestCase
         $this->assertEquals($project->users[$adminId]->role, ProjectRoles::TECH_SUPPORT);
     }
 
-    public function testAddTechSupport_Exception()
+    public function testUpdateUserRole_userIsNotAdminAndSetTechSupportRole_throwsException()
     {
         $this->expectException(UserUnauthorizedException::class); // TODO: Add proper exception
         self::$environ->clean();


### PR DESCRIPTION
**Problem:**
In order to troubleshoot, devs are often added to projects in order to solve issues. When accessing projects, admins are added to those projects as Managers. This can create confusion.

**Solution:**
To solve this problem a Tech Support user was implemented that is effectively a clone of the manager role. It is implemented throughout the front and back ends. On the user management app, a Tech Support user is the only one who can change their own role, it is locked to anyone else. Further, there is no way for a user to assign another user to Tech Support. Currently the only way to become Tech Support is to click the "+ Tech Support" button as an admin from the projects app or attempt to access a project you are not of member of whilst being logged-in as an admin. The role is defined within the `RoleBase` class, which means it exists in SF as well, though it lacks permissions there.  There is no current support for the front-end knowing the admin status of a user which is why an admin cannot change the role of other Tech Support users.

**Tests:**
E2E and PHPUnit tests were written and all tests are passing. Being relatively new to the LF system, a manual test from the reviewer that ensures a Tech Support user can do everything a Manager can may provide useful.

**Screenshots:**
![image](https://user-images.githubusercontent.com/24280478/61857514-82b72180-aeee-11e9-995c-7dc675f1f297.png)
*Tech Support user looking at the User Management app.*

___

![image](https://user-images.githubusercontent.com/24280478/61857598-ae3a0c00-aeee-11e9-9772-a5338376431b.png)
*User Management app page from the project owner's perspective.*


[Trello Card](https://trello.com/c/nXZeK5E7/382-techsupport-project-role)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/746)
<!-- Reviewable:end -->
