### PR TITLE
Use C.UTF-8 to ensure non-Roman script filenames are retained during unzipping

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Import/LiftImport.php
+++ b/src/Api/Model/Languageforge/Lexicon/Import/LiftImport.php
@@ -412,7 +412,7 @@ class LiftImport
         $destFilesBeforeUnpacking = scandir($destDir);
 
         // ensure non-roman filesnames are returned
-        $cmd = 'LANG="en_US.UTF-8" ' . $cmd;
+        $cmd = 'LANG="C.UTF-8" ' . $cmd;
         $output = array();
         $retcode = 0;
         exec($cmd, $output, $retcode);


### PR DESCRIPTION
# Overview
When running the PHP unit tests on the build agent (and only on the build agent) one 7z related test always failed (see below). This PR resolves the error and all PHP unit tests are now passing on the build agent.
![php-7z-error](https://user-images.githubusercontent.com/10179226/61939167-d8f29600-afbc-11e9-8115-416d37795b0b.png)

# Technical Details
It turns out that the system was falling back to a non-UTF-8 encoding. Since the files in question in the unit test contained non-Roman characters, these characters got mapped to `?`'s during the unzipping process. `LiftImport` was prefixing the `7z` command with `LANG=en_us.UTF-8` with the goal of setting a UTF-8 encoding. This works on most systems since `en_us` is so common. On minimal installs (like the build agent), the `en_us` locale may not be installed, so the system falls back to the `C` locale (not `C.UTF-8`). The `C.UTF-8` encoding exists on every system, so changing `en_us.UTF-8` to `C.UTF-8` prevented the fallback and resolved the error.

## All PHP unit tests are now passing on the build agent!
![php-all-green](https://user-images.githubusercontent.com/10179226/61939261-11926f80-afbd-11e9-9519-ad2333b61802.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/747)
<!-- Reviewable:end -->
