### PR TITLE
Create a build-agent shell script

### DIFF
--- a/buildagentInstall.sh
+++ b/buildagentInstall.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+PRIVATE_ANSIBLE_REPO_PATH=/path/to/the/repo
+
+NC='\033[0m' # No Color
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\e[33m'
+
+echo "${YELLOW}Pre-install message:\nThis script is meant to be run on an existing TeamCity build-agent.${NC}"
+
+echo "${GREEN}install Ansible${NC}"
+sudo apt install ansible
+
+echo "${GREEN}cd into deploy${NC}"
+cd deploy
+
+echo "${GREEN}run Ansible install script:${NC}"
+echo "${GREEN}ansible-playbook playbook_bionic.yml --limit build_agents -K${NC}"
+ansible-playbook playbook_bionic.yml --skip-tags "developer" --limit ba-web-bionic64.psonet -k -K
+
+echo "${GREEN}cd into the private repo${NC}"
+cd PRIVATE_ANSIBLE_REPO_PATH
+
+echo "${GREEN}ansible-playbook playbook_buildagent.yml --limit build_agents -K${NC}"
+ansible-playbook playbook_buildagent.yml --limit ba-web-bionic64.psonet -k -k

--- a/deploy/hosts
+++ b/deploy/hosts
@@ -3,3 +3,4 @@ localhost ansible_connection=local
 
 [build_agents]
 ba_xenial_web_s2_138 ansible_ssh_host=lf-dev
+ba-web-bionic64.psonet

--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -211,6 +211,8 @@
         name: "{{ lookup('env','USER') }}"
         groups: fieldworks
         append: yes
+      when: inventory_hostname == "localhost"
+      tags: developer
 
       # Could look up home dir of www-data user on remote system, but that turns out to
       # be a bit complicated. And since we just set it to /var/www, just use that.


### PR DESCRIPTION
# Overview
Do you need to set up a new build-agent? Wouldn't it be nice if you could have a script that just ran and built it from the ground up? This PR adds such a script. It also adds some tweaks to the `playbook_bionic.yml` script and `hosts` file to make it easier to isolate when running to configure a build-agent.

# Technical Details
The script is assumed to be run on a box that is already configured as a build-agent. The shell script runs two separate ansible playbooks:
1. `playbook_bionic.yml --skip-tags "developer"`
This sets up the machine environment for xForge v1.
2. `playbook_buildagent.yml` (from the private repo)
This sets up the machine to be an xForge v1 buildagent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/748)
<!-- Reviewable:end -->
