### PR TITLE
add clearstatscache() to fix lfmerge pid test race condition

### DIFF
--- a/test/php/model/languageforge/lexicon/command/SendReceiveCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/SendReceiveCommandsTest.php
@@ -302,6 +302,10 @@ class SendReceiveCommandsTest extends TestCase
                 break;
             }
             usleep($tenMicroSeconds);
+
+            // See https://www.php.net/manual/en/function.clearstatcache.php
+            // clearstatcache is necessary when checking file stat changes within a single script run
+            clearstatcache();
         }
         return file_exists($file) && filesize($file) > 0;
     }


### PR DESCRIPTION
Our PHP tests fail periodically with one failing test having to do with LFMerge pid file check.  This PR attempts to make this test a reliable one again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/749)
<!-- Reviewable:end -->
