### PR TITLE
Remove references to temp/jsonSessionData

### DIFF
--- a/src/Api/Model/Shared/Command/SessionCommands.php
+++ b/src/Api/Model/Shared/Command/SessionCommands.php
@@ -83,51 +83,8 @@ class SessionCommands
         $sessionData['accessToken'] = JWTToken::getAccessToken(720, $userId, $website);
 
         //return JsonEncoder::encode($sessionData);  // This is handled elsewhere
-        self::write($sessionData, $mockFilename);
 
         return $sessionData;
-    }
-
-    public static function getSessionFilePath($mockFilename = null)
-    {
-        $sessionId = session_id();
-        if(!is_null($mockFilename)){
-            $sessionId = $mockFilename;
-        }
-        if($sessionId == ""){
-            return false;
-        }
-
-        return self::getSessionDirectory($mockFilename) . DIRECTORY_SEPARATOR . $sessionId . ".json";
-    }
-
-    private static function getSessionDirectory($mockFilename = null)
-    {
-        if(is_null($mockFilename)) {
-            $subdir = "jsonSessionData";
-        } else {
-            $subdir = "jsonSessionData4tests";
-        }
-
-        return sys_get_temp_dir() . DIRECTORY_SEPARATOR . $subdir;
-    }
-
-    private static function write($data, $mockFilename = null)
-    {
-        $jsonData = json_encode($data);
-
-        if(!file_exists(self::getSessionDirectory($mockFilename))){
-            mkdir(self::getSessionDirectory($mockFilename));
-        }
-
-        //May pose a possible security risk to save with ID as filename.
-        $filePath = self::getSessionFilePath($mockFilename);
-        if(!$filePath){
-            return false;
-        }
-        $isWritten = file_put_contents($filePath, $jsonData);
-
-        return $isWritten !== false;
     }
 
     /**

--- a/test/php/model/shared/commands/SessionCommandsTest.php
+++ b/test/php/model/shared/commands/SessionCommandsTest.php
@@ -61,11 +61,6 @@ class LfSessionTestEnvironment extends SessionTestEnvironment {
 
 class SessionCommandsTest extends TestCase
 {
-    public function tearDown(): void
-    {
-        @unlink(SessionCommands::getSessionFilePath('mockSessionFile'));
-    }
-
     /**
      * @throws Exception
      */
@@ -159,23 +154,6 @@ class SessionCommandsTest extends TestCase
         // ... which should not be empty once the user has been assigned to the project
         $this->assertFalse(empty($data['userProjectRights']));
         $this->assertTrue(is_integer($data['userProjectRights'][0]));
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testGetSessionData_sessionFileExists_dataInFile()
-    {
-        $environ = new SessionTestEnvironment();
-        $environ->create();
-        ProjectCommands::updateUserRole($environ->projectId, $environ->userId);
-
-        $this->assertFalse(file_exists(SessionCommands::getSessionFilePath('mockSessionFile')));
-
-        $data = SessionCommands::getSessionData($environ->projectId, $environ->userId, $environ->website, 'mockSessionFile');
-
-        $this->assertTrue(file_exists(SessionCommands::getSessionFilePath('mockSessionFile')));
-        $this->assertJsonStringEqualsJsonFile(SessionCommands::getSessionFilePath('mockSessionFile'), json_encode($data));
     }
 
 }


### PR DESCRIPTION
The current testing infrastructure copies data to `tmp/jsonSessionData` in order for it to be accessed externally. This is no longer a need and thus references to `jsonSessionData` are extraneous. This PR removes all related code. All PHP and E2E tests pass.

**PHP**:
![image](https://user-images.githubusercontent.com/24280478/62027651-71308b00-b208-11e9-8ad5-7fba4609cc93.png)

**E2E**:
![image](https://user-images.githubusercontent.com/24280478/62027697-8e655980-b208-11e9-9d5a-73cd97b782ac.png)

[Trello card](https://trello.com/c/lksCxYVL/398-remove-jsonsessiondata-from-tmp-dir-usage)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/750)
<!-- Reviewable:end -->