### PR TITLE
Lexicon search/filter

### DIFF
--- a/rune2e.sh
+++ b/rune2e.sh
@@ -27,8 +27,8 @@ attach_debugger () {
 
   PID=""
   while [ "$PID" = "" ]; do
-    PID=$(pgrep -f protractor/built/cli.js)
     sleep 0.25;
+    PID=$(pgrep -f protractor/built/cli.js)
   done
 
   # See https://nodejs.org/en/docs/guides/debugging-getting-started/

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -619,6 +619,7 @@ export class EditorDataService {
   }
 
   private sortList(config: LexiconConfig, list: LexEntry[]): any[] {
+    const reverse = this.entryListModifiers.sortReverse;
     if (this.entryListModifiers.sortBy.value === 'default' && this.entryListModifiers.filterText() !== '') {
 
       // each of the five slots contain results of varying relevance:
@@ -654,14 +655,15 @@ export class EditorDataService {
         prioritizedResults[4].push(entry);
       }
 
+      if (reverse) prioritizedResults.reverse();
       // sort the individual lists and then flatten the results
-      return prioritizedResults.map(section => this.sortListAlphabetically(config, section))
+      return prioritizedResults.map(section => this.sortListAlphabetically(config, section, reverse))
                                 .reduce((main, sub) => main.concat(sub), []);
 
-    } else return this.sortListAlphabetically(config, list);
+    } else return this.sortListAlphabetically(config, list, reverse);
   }
 
-  private sortListAlphabetically(config: LexiconConfig, list: LexEntry[]): LexEntry[] {
+  private sortListAlphabetically(config: LexiconConfig, list: LexEntry[], reverse: boolean): LexEntry[] {
     const inputSystem = this.getInputSystemForSort(config);
     const compare = ('Intl' in window) ? Intl.Collator(inputSystem).compare : (a: string, b: string) => a < b ? -1 : 1;
 
@@ -670,7 +672,7 @@ export class EditorDataService {
       value: this.getSortableValue(config, entry)
     }));
 
-    mapped.sort((a: any, b: any) => compare(a.value, b.value) * (this.entryListModifiers.sortReverse ? -1 : 1));
+    mapped.sort((a: any, b: any) => compare(a.value, b.value) * (reverse ? -1 : 1));
 
     return mapped.map((el: any) => list[el.index]);
   }

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -36,7 +36,7 @@ class EntryListModifiers {
 
   filterText = () => this.filterBy && this.filterBy.text || '';
   filterByLabel = () => this.filterBy && this.filterBy.option && this.filterBy.option.label || '';
-  filterActive = () => this.filterText() || this.filterBy && this.filterBy.option;
+  filterActive = () => !!(this.filterText() || this.filterBy && this.filterBy.option);
   sortOptionLabel = (s: string) => s === 'Default' ? `Default (${this.filterText() ? 'Relevance' : 'Word'})` : s;
 }
 

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -427,24 +427,15 @@ export class EditorDataService {
       return blacklistKeys.includes(key) || key.includes(audio, key.length - audio.length);
     };
 
+    // toUpperCase is better than toLowerCase, but still has issues,
+    // e.g. 'ß'.toUpperCase() === 'SS'
+    const queryCapital = this.entryListModifiers.filterText().toUpperCase();
+
     const isMatch = (query: string, value: any): boolean => {
-      // toUpperCase is better than toLowerCase, but still has issues,
-      // e.g. 'ß'.toUpperCase() === 'SS'
-      const queryCapital = query.toUpperCase();
-      switch (value == null ? 'null' : typeof value) {
-        // Array.prototype.some tests whether some element satisfies the function
-        case 'object':
-          return Object.keys(value).some(key => !isBlacklisted(key) && isMatch(query, value[key]));
-        case 'string':
-          return value.toUpperCase().includes(queryCapital);
-        case 'null':
-          return false;
-        case 'boolean':
-          return false;
-        default:
-          console.error('Unexpected type ' + (typeof value) + ' on entry.');
-          return false;
-      }
+      if (typeof value === 'string') return value.toUpperCase().includes(queryCapital);
+      else if (value != null && typeof value === 'object') {
+        return Object.keys(value).some(key => !isBlacklisted(key) && isMatch(query, value[key]));
+      } else return false;
     };
 
     if (this.entryListModifiers.filterText() !== '') {

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -21,18 +21,18 @@ class FilterOption {
 }
 
 class EntryListModifiers {
-  sortBy: {
-    label: string,
-    value: string
+  sortBy = {
+    label: 'Default',
+    value: 'default'
   };
-  sortOptions: any;
-  sortReverse: boolean;
+  sortOptions: any[] = [];
+  sortReverse = false;
   filterBy: {
     text: string;
     option: FilterOption;
-  };
-  filterOptions: any;
-  filterType: string;
+  } = null;
+  filterOptions: any[] = [];
+  filterType = 'isNotEmpty';
 
   filterText = () => this.filterBy && this.filterBy.text || '';
   filterByLabel = () => this.filterBy && this.filterBy.option && this.filterBy.option.label || '';
@@ -48,19 +48,7 @@ export class EditorDataService {
   entries: LexEntry[] = [];
   visibleEntries: LexEntry[] = [];
   filteredEntries: LexEntry[] = [];
-  entryListModifiers = Object.assign(
-    new EntryListModifiers(),
-    {
-      sortBy: {
-        label: 'Default',
-        value: 'default'
-      },
-      sortOptions: {},
-      sortReverse: false,
-      filterBy: null,
-      filterOptions: {},
-      filterType: 'isNotEmpty'
-    });
+  entryListModifiers = new EntryListModifiers();
 
   private api: any;
 

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 import {SemanticDomainsService} from '../../../languageforge/core/semantic-domains/semantic-domains.service';
+import {LexiconConfigService} from '../../../languageforge/lexicon/core/lexicon-config.service';
 import {LexiconUtilityService} from '../../../languageforge/lexicon/core/lexicon-utility.service';
 import {LexEntry} from '../../../languageforge/lexicon/shared/model/lex-entry.model';
 import {LexMultiValue} from '../../../languageforge/lexicon/shared/model/lex-multi-value.model';
@@ -62,13 +63,15 @@ export class EditorDataService {
     'sessionService', 'editorOfflineCache',
     'commentsOfflineCache',
     'semanticDomainsService',
-    'lexCommentService'
+    'lexCommentService',
+    'lexConfigService'
   ];
   constructor(private readonly $q: angular.IQService, private readonly notice: NoticeService,
               private readonly sessionService: SessionService, private readonly cache: EditorOfflineCacheService,
               private readonly commentsCache: CommentsOfflineCacheService,
               private readonly semanticDomains: SemanticDomainsService,
-              private readonly commentService: LexiconCommentService) { }
+              private readonly commentService: LexiconCommentService,
+              private readonly configService: LexiconConfigService) { }
 
   showInitialEntries = (): angular.IPromise<any> => {
     return this.filterAndSortEntries(true);
@@ -256,9 +259,7 @@ export class EditorDataService {
 
   sortEntries = (shouldResetVisibleEntriesList: boolean): angular.IPromise<any> => {
     const startTime = performance.now();
-    return this.sessionService.getSession().then(session => {
-      const config = session.projectSettings<LexiconProjectSettings>().config;
-
+    return this.configService.getEditorConfig().then(config => {
       // Copies entries into the arrays while preserving references to the arrays
       const entriesSorted = this.sortList(config, this.entries);
       UtilityService.arrayCopyRetainingReferences(entriesSorted, this.entries);
@@ -276,8 +277,7 @@ export class EditorDataService {
   }
 
   filterEntries = (shouldResetVisibleEntriesList: boolean): angular.IPromise<any> => {
-    return this.sessionService.getSession().then(session => {
-      const config = session.projectSettings<LexiconProjectSettings>().config;
+    return this.configService.getEditorConfig().then(config => {
       if (this.entryListModifiers.filterBy) {
         UtilityService.arrayCopyRetainingReferences(this.entries.filter((entry: any) => {
           return this.entryMeetsFilterCriteria(config, entry);

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -37,6 +37,7 @@ class EntryListModifiers {
   filterText = () => this.filterBy && this.filterBy.text || '';
   filterByLabel = () => this.filterBy && this.filterBy.option && this.filterBy.option.label || '';
   filterActive = () => this.filterText() || this.filterBy && this.filterBy.option;
+  sortOptionLabel = (s: string) => s === 'Default' ? `Default (${this.filterText() ? 'Relevance' : 'Word'})` : s;
 }
 
 const entriesIncrement = 50;

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -35,7 +35,7 @@ class EntryListModifiers {
   filterType: string;
 
   filterText = () => this.filterBy && this.filterBy.text || '';
-  filterByLabel = () => this.filterBy && this.filterBy.option && this.filterBy.option.label || 'null';
+  filterByLabel = () => this.filterBy && this.filterBy.option && this.filterBy.option.label || '';
   filterActive = () => this.filterText() || this.filterBy && this.filterBy.option;
 }
 
@@ -448,7 +448,7 @@ export class EditorDataService {
     };
 
     if (this.entryListModifiers.filterText() !== '') {
-      const matchesSearch = isMatch(this.entryListModifiers.filterBy.text, entry);
+      const matchesSearch = isMatch(this.entryListModifiers.filterText(), entry);
       if (!matchesSearch) return false;
     }
     if (!this.entryListModifiers.filterBy.option) return true;

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -678,16 +678,17 @@ export class EditorDataService {
 
   private sortListAlphabetically(config: LexiconConfig, list: LexEntry[], reverse: boolean): LexEntry[] {
     const inputSystem = this.getInputSystemForSort(config);
-    const compare = ('Intl' in window) ? Intl.Collator(inputSystem).compare : (a: string, b: string) => a < b ? -1 : 1;
+    const compare = ('Intl' in window) ?
+          Intl.Collator(inputSystem).compare : (a: string, b: string) => a.localeCompare(b);
 
-    const mapped = list.map((entry: any, i: number) => ({
+    const mapped = list.map((entry: LexEntry, i: number) => ({
       index: i,
       value: this.getSortableValue(config, entry)
     }));
 
-    mapped.sort((a: any, b: any) => compare(a.value, b.value) * (reverse ? -1 : 1));
+    mapped.sort((a, b) => compare(a.value, b.value) * (reverse ? -1 : 1));
 
-    return mapped.map((el: any) => list[el.index]);
+    return mapped.map(el => list[el.index]);
   }
 
   /**

--- a/src/angular-app/bellows/core/utility.service.ts
+++ b/src/angular-app/bellows/core/utility.service.ts
@@ -45,6 +45,11 @@ export class UtilityService {
     Array.prototype.push.apply(target, extra);
   }
 
+  static isDigitsOnly(text: string) {
+    for (const char of text) if (char < '0' || char > '9') return false;
+    return text.length !== 0;
+  }
+
   // FixMe: move to sfchecks-utility service - IJH 2017-11
   readUsxFile(file: any): angular.IPromise<string> {
     return this.readFile(file, true);

--- a/src/angular-app/languageforge/lexicon/core/lexicon-editor-data.service.ts
+++ b/src/angular-app/languageforge/lexicon/core/lexicon-editor-data.service.ts
@@ -22,5 +22,6 @@ export class LexiconEditorDataService {
   sortEntries = this.editorDataService.sortEntries;
   filterEntries = this.editorDataService.filterEntries;
   filterAndSortEntries = this.editorDataService.filterAndSortEntries;
+  getMeaningForDisplay = this.editorDataService.getMeaningForDisplay;
   getSortableValue = this.editorDataService.getSortableValue;
 }

--- a/src/angular-app/languageforge/lexicon/core/lexicon-editor-data.service.ts
+++ b/src/angular-app/languageforge/lexicon/core/lexicon-editor-data.service.ts
@@ -21,5 +21,6 @@ export class LexiconEditorDataService {
   showMoreEntries = this.editorDataService.showMoreEntries;
   sortEntries = this.editorDataService.sortEntries;
   filterEntries = this.editorDataService.filterEntries;
+  filterAndSortEntries = this.editorDataService.filterAndSortEntries;
   getSortableValue = this.editorDataService.getSortableValue;
 }

--- a/src/angular-app/languageforge/lexicon/core/lexicon-utility.service.ts
+++ b/src/angular-app/languageforge/lexicon/core/lexicon-utility.service.ts
@@ -166,8 +166,7 @@ export class LexiconUtilityService extends UtilityService {
                                fieldName: string): string {
     let result = '';
     const multiTextConfigField = config.fields[fieldName] as LexConfigMultiText;
-    if (node[fieldName] && config && config.fields && multiTextConfigField &&
-      multiTextConfigField.inputSystems) {
+    if (node[fieldName] && multiTextConfigField && multiTextConfigField.inputSystems) {
       const inputSystems = multiTextConfigField.inputSystems;
       for (const languageTag of inputSystems) {
         result = LexiconUtilityService.getField(globalConfig, node, fieldName, languageTag);

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -540,12 +540,18 @@ dc-entry .card {
 }
 
 .reset-filter-btn {
+  background-color: $Eden;
+  color: white;
   float: right;
-  .fa-undo {
-    color: orange;
-  }
   .btn-text {
     display: none;
+  }
+}
+
+@include media-breakpoint-up(sm) {
+  #lexAppListView .reset-filter-btn {
+    float: none;
+    margin-left: 2em;
   }
 }
 

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -547,7 +547,7 @@ dc-entry .card {
     padding: 0;
     border-radius: $border-radius $border-radius 0 0;
     > div {
-        padding: 0.75rem 1.25rem;
+        padding: 0.75rem 0.8rem;
     }
     button {
       width: 65px;

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -538,35 +538,50 @@ dc-entry .card {
     }
   }
 }
+
+.reset-filter-btn {
+  float: right;
+  .fa-undo {
+    color: orange;
+  }
+  .btn-text {
+    display: none;
+  }
+}
+
+@include media-breakpoint-up(xl) {
+  #lexAppEditView .reset-filter-btn .btn-text {
+    display: inline;
+  }
+}
+
+@media (min-width: 470px) {
+  #lexAppListView .reset-filter-btn .btn-text {
+    display: inline;
+  }
+}
+
 .entry-words-container {
   opacity: 1;
   display: block;
   .words-container-title {
     display: flex;
-    justify-content: space-between;
     padding: 0;
     border-radius: $border-radius $border-radius 0 0;
     > div {
-        padding: 0.75rem 0.8rem;
+        padding: 0.5rem 0.5rem;
+        flex-grow: 1;
+        line-height: 1.9em;
     }
-    button {
-      width: 50px;
+    #newWord, #editorNewWordBtn {
+      width: 47px;
       background: $Downriver;
       cursor: pointer;
       &:hover {
         background: darken($Downriver, 15%);
       }
-      i {
+      .fa-plus {
         font-size: 24px;
-      }
-      @include media-breakpoint-down(md) {
-        width: 48px;
-        i {
-          font-size: 20px;
-        }
-      }
-      @include media-breakpoint-down(xs) {
-        width: 38px;
       }
     }
   }
@@ -578,7 +593,7 @@ dc-entry .card {
     display: flex;
     position: relative;
     > .btn {
-      flex: 0 0 110px;
+      flex: 0 0 100px;
       border-radius: 0;
       cursor: pointer;
       background: transparent;

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -639,9 +639,6 @@ dc-entry .card {
           cursor: pointer;
         }
       }
-      input[type=checkbox] {
-        margin-right: 5px;
-      }
       .sortfilter-control {
         width: 100%;
       }
@@ -653,6 +650,15 @@ dc-entry .card {
       border-top-left-radius: 0;
       border-top-right-radius: 0;
     }
+  }
+}
+
+.reverse-label {
+  float: right;
+  margin-right: 0.75em;
+  input[type=checkbox] {
+    margin-right: 0.25em;
+    vertical-align: middle;
   }
 }
 

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -673,6 +673,15 @@ dc-entry .card {
   }
 }
 
+.options-active-icon {
+  color: orange;
+  visibility: hidden;
+}
+
+.icon-active {
+  visibility: visible;
+}
+
 .lexiconListItemCompact {
     position: relative;
     overflow-y: hidden;

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -665,8 +665,12 @@ dc-entry .card {
 }
 
 .filter-entries-wrapper {
+  position: relative;
   flex-grow: 1;
   border-right: 1px solid $Downriver;
+  .clear-search-button {
+    top: 1em;
+  }
 }
 
 .lexiconListItemCompact {

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -293,12 +293,6 @@ dc-entry .card {
     justify-content: space-between;
 }
 
-.lexiconHeaderItem {
-}
-
-.flexColumnContainer {
-}
-
 #lexAppListView {
     margin-top: 20px;
     .lexiconListItem {
@@ -583,40 +577,6 @@ dc-entry .card {
     width: 100%;
     display: flex;
     position: relative;
-    .typeahead {
-      flex: 1 1 100%;
-      border-right: 1px solid $Downriver;
-      border-radius: 0;
-      #typeaheadInput {
-        width: 100%;
-        border: 0;
-        background: transparent;
-        border-radius: 0;
-        font-size: 14px;
-        line-height: 45px;
-        padding: 0 2.5em 0 1.5em;
-      }
-      .typeahead-results {
-        ul {
-          border-radius: 0;
-          .typeahead-item {
-            border-radius: 0;
-            padding: 0.35rem 1.25rem;
-            line-height: 1.2em;
-            &:hover {
-              background: $Botticelli;
-              color: $Eden;
-            }
-            small {
-              text-overflow: ellipsis;
-              overflow: hidden;
-              display: block;
-              white-space: nowrap;
-            }
-          }
-        }
-      }
-    }
     > .btn {
       flex: 0 0 110px;
       border-radius: 0;
@@ -683,6 +643,21 @@ dc-entry .card {
       border-top-right-radius: 0;
     }
   }
+}
+
+.filter-entries {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  border-radius: 0;
+  font-size: 14px;
+  line-height: 45px;
+  padding: 0 2.5em 0 1.5em;
+}
+
+.filter-entries-wrapper {
+  flex-grow: 1;
+  border-right: 1px solid $Downriver;
 }
 
 .lexiconListItemCompact {

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -703,6 +703,10 @@ dc-entry .card {
   visibility: visible;
 }
 
+.highlight-result {
+  background-color: #ffdf57;
+}
+
 .lexiconListItemCompact {
     position: relative;
     overflow-y: hidden;

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -550,7 +550,7 @@ dc-entry .card {
         padding: 0.75rem 0.8rem;
     }
     button {
-      width: 65px;
+      width: 50px;
       background: $Downriver;
       cursor: pointer;
       &:hover {
@@ -595,9 +595,13 @@ dc-entry .card {
     }
   }
   .word-form-filters {
+    display: flex;
+    flex-direction: column;
     .sortfilter-form {
+      flex-basis: 1;
+      width: 100%;
       border: 1px solid $line-color;
-      padding: 0.7em 1.25em 1.2em;
+      padding: 0.5em 1em 0.5em;
       margin: 0;
       font-size: 14px;
       background: #E5E5E5;
@@ -605,7 +609,7 @@ dc-entry .card {
         border-bottom: 0;
       }
       .sortfilter-control {
-        width: 150px;
+        width: 200px;
         font-size: 14px;
       }
       .form-inline {
@@ -623,16 +627,8 @@ dc-entry .card {
       input[type=checkbox] {
         margin-right: 5px;
       }
-      @include media-breakpoint-down(lg) {
-        .sortfilter-control {
-          margin: 0 0 5px;
-          width: 100%;
-        }
-        .form-inline {
-          label {
-            margin: 0;
-          }
-        }
+      .sortfilter-control {
+        width: 100%;
       }
     }
   }
@@ -641,6 +637,19 @@ dc-entry .card {
       border-top: 0;
       border-top-left-radius: 0;
       border-top-right-radius: 0;
+    }
+  }
+}
+
+#lexAppListView {
+  @include media-breakpoint-up(sm) {
+    .word-form-filters {
+      flex-direction: row;
+    }
+  }
+  @include media-breakpoint-up(md) {
+    .sortfilter-control {
+      width: unset;
     }
   }
 }

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -26,6 +26,7 @@
                                 <div class="filter-entries-wrapper">
                                     <input type="text" id="editor-entry-search-entries" class="filter-entries" placeholder="Filter Entries"
                                            data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
+                                           <span class="fa fa-times clear-search-button" data-ng-show="$ctrl.entryListModifiers.filterBy.text" data-ng-click="$ctrl.clearSearchText()"></span>
                                 </div>
                                 <button data-ng-click="$ctrl.toggleFilterOptions()" class="btn btn-sm">
                                     Options

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -11,6 +11,9 @@
                                     Showing <span data-ng-hide="$ctrl.entryListModifiers.filterActive()">all </span>
                                     <span id="totalNumberOfEntries" class="notranslate"><span data-ng-show="$ctrl.entryListModifiers.filterActive()">{{$ctrl.filteredEntries.length}} / </span>{{$ctrl.entries.length}}</span>
                                     <span data-ng-hide="$ctrl.entryListModifiers.filterActive()">entries</span>
+                                    <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.entryListModifiers.filterActive()" class="btn btn-sm btn-std reset-filter-btn">
+                                        <span class="fa fa-undo"></span><span class="btn-text"> Show All</span>
+                                    </button>
                                 </div>
                                 <button id="editorNewWordBtn" class="btn btn-primary"
                                     data-ng-show="$ctrl.isAtEditorEntry()" data-ng-if="$ctrl.lecRights.canEditEntry()"
@@ -52,7 +55,6 @@
                                                 data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                             <option value="">Show All</option>
                                         </select>
-                                        <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.shouldShowFilterReset()" class="btn btn-sm btn-std">Reset Filter</button>
                                     </div>
                                 </div>
                                 <div class="form-group sortfilter-form">

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -1,4 +1,4 @@
-<div ng-init="$ctrl.setUrlParams()" id="lexAppEditView" class="animate-switch" data-ng-class="{'panel-closing': $ctrl.rightPanelVisible === null, 'right-panel-visible': $ctrl.rightPanelVisible === true}" data-ng-if="$ctrl.lecFinishedLoading">
+<div id="lexAppEditView" class="animate-switch" data-ng-class="{'panel-closing': $ctrl.rightPanelVisible === null, 'right-panel-visible': $ctrl.rightPanelVisible === true}" data-ng-if="$ctrl.lecFinishedLoading">
     <div class="container">
         <div class="row">
             <div class="col-md-5 col-lg-4 entries-list-container d-none d-md-block">

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -28,7 +28,8 @@
                             <div class="words-search">
                                 <div class="filter-entries-wrapper">
                                     <input type="text" id="editor-entry-search-entries" class="filter-entries" placeholder="Filter Entries"
-                                           data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
+                                           data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.text"
+                                           data-ng-model-options="{debounce: 200}"></input>
                                            <span class="fa fa-times clear-search-button" data-ng-show="$ctrl.entryListModifiers.filterBy.text" data-ng-click="$ctrl.clearSearchText()"></span>
                                 </div>
                                 <button data-ng-click="$ctrl.toggleFilterOptions()" class="btn btn-sm">
@@ -80,7 +81,7 @@
                                          data-ng-class="{selected: entry.id == $ctrl.currentEntry.id, listItemHasComment: $ctrl.getEntryCommentCount(entry.id) > 0}"
                                          title="{{$ctrl.getCompactItemListOverlay(entry)}}"
                                          data-ng-repeat="entry in $ctrl.visibleEntries track by entry.id" data-ng-click="$ctrl.editEntry(entry.id)">
-                                        <div dir="auto" class="listItemPrimary" data-ng-bind-html="$ctrl.getPrimaryListItemForDisplay($ctrl.lecConfig, entry)"></div>
+                                        <div dir="auto" class="listItemPrimary" data-ng-bind-html="$ctrl.getPrimaryListItemForDisplay(entry)"></div>
                                         <div dir="auto" class="listItemSecondary" data-ng-bind-html="$ctrl.getSecondaryListItemForDisplay(entry)"></div>
                                     </div>
                                 </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -36,21 +36,9 @@
                     </div>
                     <div class="row" data-ng-show="$ctrl.show.entryListModifiers">
                         <div class="col">
-                            <div class="d-none d-md-block word-form-filters">
+                            <div class="word-form-filters">
                                 <div class="form-group sortfilter-form">
-                                    <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
-                                    <div class="form-inline">
-                                        <select id="sortEntriesBy" class="custom-select sortfilter-control"
-                                                data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
-                                                data-ng-options="item as $ctrl.entryListModifiers.sortOptionLabel(item.label) for item in $ctrl.entryListModifiers.sortOptions track by item.value">
-                                        </select>
-                                        <label>
-                                            <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
-                                        </label>
-                                    </div>
-                                </div>
-                                <div class="form-group sortfilter-form">
-                                    <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
+                                    <label class="font-weight-bold" for="filterEntriesFor">Filter Entries By</label>
                                     <div class="form-inline">
                                         <!--suppress HtmlFormInputWithoutLabel -->
                                         <select class="custom-select sortfilter-control" data-ng-show="$ctrl.entryListModifiers.filterBy.option"
@@ -63,7 +51,19 @@
                                                 data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                             <option value="">Show All</option>
                                         </select>
-                                        <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.shouldShowFilterReset()" class="btn btn-sm">Reset Filter</button>
+                                        <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.shouldShowFilterReset()" class="btn btn-sm btn-std">Reset Filter</button>
+                                    </div>
+                                </div>
+                                <div class="form-group sortfilter-form">
+                                    <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
+                                    <div class="form-inline">
+                                        <select id="sortEntriesBy" class="custom-select sortfilter-control"
+                                                data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
+                                                data-ng-options="item as $ctrl.entryListModifiers.sortOptionLabel(item.label) for item in $ctrl.entryListModifiers.sortOptions track by item.value">
+                                        </select>
+                                        <label>
+                                            <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
+                                        </label>
                                     </div>
                                 </div>
                             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -9,8 +9,8 @@
                             <div class="words-container-title list-group-item list-group-item-action active">
                                 <div>
                                     <h5>Words in dictionary</h5>
-                                    <small data-ng-hide="$ctrl.entryListModifiers.filterBy" id="totalNumberOfEntries"><span class="notranslate">{{$ctrl.entries.length}}</span> {{ ($ctrl.entries.length == 1 ? 'entry' : 'entries') }}</small>
-                                    <small data-ng-show="$ctrl.entryListModifiers.filterBy" class="notranslate">{{$ctrl.filteredEntries.length}} / {{$ctrl.entries.length}}</small>
+                                    <small data-ng-hide="$ctrl.entryListModifiers.filterActive()" id="totalNumberOfEntries"><span class="notranslate">{{$ctrl.entries.length}}</span> {{ ($ctrl.entries.length == 1 ? 'entry' : 'entries') }}</small>
+                                    <small data-ng-show="$ctrl.entryListModifiers.filterActive()" class="notranslate">{{$ctrl.filteredEntries.length}} / {{$ctrl.entries.length}}</small>
                                 </div>
                                 <button id="editorNewWordBtn" class="btn btn-primary"
                                     data-ng-show="$ctrl.isAtEditorEntry()" data-ng-if="$ctrl.lecRights.canEditEntry()"
@@ -24,7 +24,8 @@
                         <div class="col d-flex align-content-stretch">
                             <div class="words-search">
                                 <div class="filter-entries-wrapper">
-                                    <input id="editor-entry-search-entries" class="filter-entries" placeholder="Filter Entries"></input>
+                                    <input type="text" id="editor-entry-search-entries" class="filter-entries" placeholder="Filter Entries"
+                                           data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
                                 </div>
                                 <button data-ng-click="$ctrl.toggleFilterOptions()" class="btn btn-sm">
                                     Options
@@ -52,13 +53,13 @@
                                     <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
                                     <div class="form-inline">
                                         <!--suppress HtmlFormInputWithoutLabel -->
-                                        <select class="custom-select sortfilter-control" data-ng-show="$ctrl.entryListModifiers.filterBy"
+                                        <select class="custom-select sortfilter-control" data-ng-show="$ctrl.entryListModifiers.filterBy.option"
                                                 data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterType">
                                             <option value="isEmpty">Doesn't have</option>
                                             <option value="isNotEmpty">Has</option>
                                         </select>
                                         <select class="custom-select sortfilter-control" id="filterEntriesFor"
-                                                data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy"
+                                                data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy.option"
                                                 data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                             <option value="">Show All</option>
                                         </select>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -23,22 +23,9 @@
                     <div class="row">
                         <div class="col d-flex align-content-stretch">
                             <div class="words-search">
-                                <pui-typeahead id="editor-entry-search-entries"
-                                               class="typeahead" placeholder="'Search Entries'"
-                                               items="$ctrl.typeahead.searchResults" term="$ctrl.typeahead.searchItemSelected"
-                                               search="$ctrl.typeahead.searchEntries" select="$ctrl.typeahead.searchSelect">
-                                    <ul data-ng-if="$ctrl.typeahead.searchResults.length > 0" class="list-group">
-                                        <li data-typeahead-item="e" class="typeahead-item list-group-item"
-                                            data-ng-repeat="e in $ctrl.typeahead.searchResults | limitTo: $ctrl.typeahead.limit">
-                                            <div class="listItemPrimary" data-ng-bind-html="$ctrl.getPrimaryListItemForDisplay($ctrl.lecConfig, e)"></div>
-                                            <small class="listItemSecondary" data-ng-bind-html="$ctrl.getMeaningForDisplay(e)"></small>
-                                        </li>
-                                    </ul>
-                                    <div style="text-align:center; background-color: #d3d3d3; color:black;"
-                                         data-ng-if="$ctrl.typeahead.searchResults.length > 0">
-                                        <small><i>{{$ctrl.typeahead.matchCountCaption}}</i></small>
-                                    </div>
-                                </pui-typeahead>
+                                <div class="filter-entries-wrapper">
+                                    <input id="editor-entry-search-entries" class="filter-entries" placeholder="Filter Entries"></input>
+                                </div>
                                 <button data-ng-click="$ctrl.toggleFilterOptions()" class="btn btn-sm">
                                     Options
                                     <i class="fa" data-ng-class="$ctrl.show.entryListModifiers ? 'fa-angle-up': 'fa-angle-down'"></i>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -63,7 +63,7 @@
                                                 data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                             <option value="">Show All</option>
                                         </select>
-                                        <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.entryListModifiers.filterActive()" class="btn btn-sm">Reset Filter</button>
+                                        <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.shouldShowFilterReset()" class="btn btn-sm">Reset Filter</button>
                                     </div>
                                 </div>
                             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -62,7 +62,7 @@
                                                 data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                             <option value="">Show All</option>
                                         </select>
-                                        <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
+                                        <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.entryListModifiers.filterActive()" class="btn btn-sm">Reset Filter</button>
                                     </div>
                                 </div>
                             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -81,7 +81,7 @@
                                          title="{{$ctrl.getCompactItemListOverlay(entry)}}"
                                          data-ng-repeat="entry in $ctrl.visibleEntries track by entry.id" data-ng-click="$ctrl.editEntry(entry.id)">
                                         <div dir="auto" class="listItemPrimary" data-ng-bind-html="$ctrl.getPrimaryListItemForDisplay($ctrl.lecConfig, entry)"></div>
-                                        <div dir="auto" class="listItemSecondary" data-ng-bind-html="$ctrl.getMeaningForDisplay(entry)"></div>
+                                        <div dir="auto" class="listItemSecondary" data-ng-bind-html="$ctrl.getSecondaryListItemForDisplay(entry)"></div>
                                     </div>
                                 </div>
                             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -59,14 +59,14 @@
                                 </div>
                                 <div class="form-group sortfilter-form">
                                     <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
+                                    <label class="reverse-label">
+                                        <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
+                                    </label>
                                     <div class="form-inline">
                                         <select id="sortEntriesBy" class="custom-select sortfilter-control"
                                                 data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
                                                 data-ng-options="item as $ctrl.entryListModifiers.sortOptionLabel(item.label) for item in $ctrl.entryListModifiers.sortOptions track by item.value">
                                         </select>
-                                        <label>
-                                            <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
-                                        </label>
                                     </div>
                                 </div>
                             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -9,7 +9,7 @@
                             <div class="words-container-title list-group-item list-group-item-action active">
                                 <div>
                                     Showing <span data-ng-hide="$ctrl.entryListModifiers.filterActive()">all </span>
-                                    <span class="notranslate"><span data-ng-show="$ctrl.entryListModifiers.filterActive()">{{$ctrl.filteredEntries.length}} / </span>{{$ctrl.entries.length}}</span>
+                                    <span id="totalNumberOfEntries" class="notranslate"><span data-ng-show="$ctrl.entryListModifiers.filterActive()">{{$ctrl.filteredEntries.length}} / </span>{{$ctrl.entries.length}}</span>
                                     <span data-ng-hide="$ctrl.entryListModifiers.filterActive()">entries</span>
                                 </div>
                                 <button id="editorNewWordBtn" class="btn btn-primary"

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -25,7 +25,7 @@
                             <div class="words-search">
                                 <div class="filter-entries-wrapper">
                                     <input type="text" id="editor-entry-search-entries" class="filter-entries" placeholder="Filter Entries"
-                                           data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
+                                           data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
                                 </div>
                                 <button data-ng-click="$ctrl.toggleFilterOptions()" class="btn btn-sm">
                                     Options
@@ -41,11 +41,11 @@
                                     <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
                                     <div class="form-inline">
                                         <select id="sortEntriesBy" class="custom-select sortfilter-control"
-                                                data-ng-change="$ctrl.sortEntries(true)" data-ng-model="$ctrl.entryListModifiers.sortBy"
+                                                data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
                                                 data-ng-options="item as item.label for item in $ctrl.entryListModifiers.sortOptions track by item.value">
                                         </select>
                                         <label>
-                                            <input type="checkbox" data-ng-change="$ctrl.sortEntries(true)" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
+                                            <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
                                         </label>
                                     </div>
                                 </div>
@@ -54,12 +54,12 @@
                                     <div class="form-inline">
                                         <!--suppress HtmlFormInputWithoutLabel -->
                                         <select class="custom-select sortfilter-control" data-ng-show="$ctrl.entryListModifiers.filterBy.option"
-                                                data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterType">
+                                                data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterType">
                                             <option value="isEmpty">Doesn't have</option>
                                             <option value="isNotEmpty">Has</option>
                                         </select>
                                         <select class="custom-select sortfilter-control" id="filterEntriesFor"
-                                                data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy.option"
+                                                data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.option"
                                                 data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                             <option value="">Show All</option>
                                         </select>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -29,7 +29,7 @@
                                            <span class="fa fa-times clear-search-button" data-ng-show="$ctrl.entryListModifiers.filterBy.text" data-ng-click="$ctrl.clearSearchText()"></span>
                                 </div>
                                 <button data-ng-click="$ctrl.toggleFilterOptions()" class="btn btn-sm">
-                                    Options
+                                    <span class="options-active-icon fa fa-circle" data-ng-class="{'icon-active': $ctrl.filterSortOptionsActive()}"></span> Options
                                     <i class="fa" data-ng-class="$ctrl.show.entryListModifiers ? 'fa-angle-up': 'fa-angle-down'"></i>
                                 </button>
                             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -42,7 +42,7 @@
                                     <div class="form-inline">
                                         <select id="sortEntriesBy" class="custom-select sortfilter-control"
                                                 data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
-                                                data-ng-options="item as item.label for item in $ctrl.entryListModifiers.sortOptions track by item.value">
+                                                data-ng-options="item as $ctrl.entryListModifiers.sortOptionLabel(item.label) for item in $ctrl.entryListModifiers.sortOptions track by item.value">
                                         </select>
                                         <label>
                                             <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -8,9 +8,9 @@
                         <div class="col">
                             <div class="words-container-title list-group-item list-group-item-action active">
                                 <div>
-                                    <h5>Words in dictionary</h5>
-                                    <small data-ng-hide="$ctrl.entryListModifiers.filterActive()" id="totalNumberOfEntries"><span class="notranslate">{{$ctrl.entries.length}}</span> {{ ($ctrl.entries.length == 1 ? 'entry' : 'entries') }}</small>
-                                    <small data-ng-show="$ctrl.entryListModifiers.filterActive()" class="notranslate">{{$ctrl.filteredEntries.length}} / {{$ctrl.entries.length}}</small>
+                                    Showing <span data-ng-hide="$ctrl.entryListModifiers.filterActive()">all </span>
+                                    <span class="notranslate"><span data-ng-show="$ctrl.entryListModifiers.filterActive()">{{$ctrl.filteredEntries.length}} / </span>{{$ctrl.entries.length}}</span>
+                                    <span data-ng-hide="$ctrl.entryListModifiers.filterActive()">entries</span>
                                 </div>
                                 <button id="editorNewWordBtn" class="btn btn-primary"
                                     data-ng-show="$ctrl.isAtEditorEntry()" data-ng-if="$ctrl.lecRights.canEditEntry()"
@@ -88,7 +88,6 @@
             </div>
             <div class="col-md-7 col-lg-8 entry-primary-container">
                 <div class="word-definition-title">
-                    <h3>Entry Preview</h3>
                     <dc-rendered global-config="$ctrl.lecConfig" config="$ctrl.lecConfig.entry" model="$ctrl.currentEntry" option-lists="$ctrl.lecOptionLists"></dc-rendered>
                 </div>
                 <div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -7,9 +7,9 @@
                         <div class="words-container-title lexiconListItem list-group-item list-group-item-action active">
                             <div>
                                 <h5>Words in dictionary</h5>
-                                <small data-ng-hide="$ctrl.entryListModifiers.filterBy" id="totalNumberOfEntries">
+                                <small data-ng-show="$ctrl.filteredEntries.length == $ctrl.entries.length" id="totalNumberOfEntries">
                                     <span class="notranslate">{{$ctrl.entries.length}}</span> {{ ($ctrl.entries.length == 1 ? 'entry' : 'entries') }}</small>
-                                <small data-ng-show="$ctrl.entryListModifiers.filterBy" class="float-right notranslate">{{$ctrl.filteredEntries.length}} / {{$ctrl.entries.length}}</small>
+                                <small data-ng-hide="$ctrl.filteredEntries.length == $ctrl.entries.length" class="float-right notranslate">{{$ctrl.filteredEntries.length}} / {{$ctrl.entries.length}}</small>
                             </div>
                             <button id="newWord" type="button" class="btn btn-primary"
                                 data-ng-if="$ctrl.lecRights.canEditEntry()"
@@ -21,9 +21,10 @@
                 </div>
                 <div class="row">
                     <div class="col">
-                        <div data-ng-hide="$ctrl.visibleEntries.length === 0" class="words-search">
+                        <div data-ng-hide="$ctrl.entries.length === 0" class="words-search">
                             <div class="filter-entries-wrapper">
-                                <input type="text" id="editor-list-search-entries" class="filter-entries" placeholder="Filter Entries"></input>
+                                <input type="text" id="editor-list-search-entries" class="filter-entries" placeholder="Filter Entries"
+                                       data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
                             </div>
                             <button class="btn btn-sm" type="button" data-ng-click="$ctrl.toggleFilterOptions()">
                                 Options
@@ -51,17 +52,17 @@
                                 <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
                                 <div class="form-inline">
                                     <!--suppress HtmlFormInputWithoutLabel -->
-                                    <select class="custom-select sortfilter-control" data-ng-show="$ctrl.entryListModifiers.filterBy"
+                                    <select class="custom-select sortfilter-control" data-ng-show="$ctrl.entryListModifiers.filterBy.option"
                                             data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterType">
                                         <option value="isEmpty">Doesn't have</option>
                                         <option value="isNotEmpty">Has</option>
                                     </select>
                                     <select class="custom-select sortfilter-control" id="filterEntriesFor"
-                                            data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy"
+                                            data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy.option"
                                             data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                         <option value="">Show All</option>
                                     </select>
-                                    <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.entryListModifiers.filterBy" class="btn btn-sm">Reset</button>
+                                    <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.entryListModifiers.filterActive()" class="btn btn-sm">Reset Filter</button>
                                 </div>
                             </div>
                         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -57,14 +57,14 @@
                             </div>
                             <div class="form-group sortfilter-form">
                                 <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
+                                <label class="reverse-label">
+                                    <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
+                                </label>
                                 <div class="form-inline">
                                     <select id="sortEntriesBy" class="custom-select sortfilter-control"
                                             data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
                                             data-ng-options="item as $ctrl.entryListModifiers.sortOptionLabel(item.label) for item in $ctrl.entryListModifiers.sortOptions track by item.value">
                                     </select>
-                                    <label style="margin: 7px">
-                                        <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
-                                    </label>
                                 </div>
                             </div>
                         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -23,7 +23,7 @@
                         <div data-ng-hide="$ctrl.entries.length === 0" class="words-search">
                             <div class="filter-entries-wrapper">
                                 <input type="text" id="editor-list-search-entries" class="filter-entries" placeholder="Filter Entries"
-                                       data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
+                                       data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
                             </div>
                             <button class="btn btn-sm" type="button" data-ng-click="$ctrl.toggleFilterOptions()">
                                 Options
@@ -39,11 +39,11 @@
                                 <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
                                 <div class="form-inline">
                                     <select id="sortEntriesBy" class="custom-select sortfilter-control"
-                                            data-ng-change="$ctrl.sortEntries(true)" data-ng-model="$ctrl.entryListModifiers.sortBy"
+                                            data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
                                             data-ng-options="item as item.label for item in $ctrl.entryListModifiers.sortOptions track by item.value">
                                     </select>
                                     <label style="margin: 7px">
-                                        <input type="checkbox" data-ng-change="$ctrl.sortEntries(true)" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
+                                        <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
                                     </label>
                                 </div>
                             </div>
@@ -52,12 +52,12 @@
                                 <div class="form-inline">
                                     <!--suppress HtmlFormInputWithoutLabel -->
                                     <select class="custom-select sortfilter-control" data-ng-show="$ctrl.entryListModifiers.filterBy.option"
-                                            data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterType">
+                                            data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterType">
                                         <option value="isEmpty">Doesn't have</option>
                                         <option value="isNotEmpty">Has</option>
                                     </select>
                                     <select class="custom-select sortfilter-control" id="filterEntriesFor"
-                                            data-ng-change="$ctrl.filterEntries(true)" data-ng-model="$ctrl.entryListModifiers.filterBy.option"
+                                            data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.option"
                                             data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                         <option value="">Show All</option>
                                     </select>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -7,7 +7,7 @@
                         <div class="words-container-title lexiconListItem list-group-item list-group-item-action active">
                             <div>
                                 Showing <span data-ng-hide="$ctrl.entryListModifiers.filterActive()">all </span>
-                                <span class="notranslate"><span data-ng-show="$ctrl.entryListModifiers.filterActive()">{{$ctrl.filteredEntries.length}} / </span>{{$ctrl.entries.length}}</span>
+                                <span id="totalNumberOfEntries" class="notranslate"><span data-ng-show="$ctrl.entryListModifiers.filterActive()">{{$ctrl.filteredEntries.length}} / </span>{{$ctrl.entries.length}}</span>
                                 entries
                             </div>
                             <button id="newWord" type="button" class="btn btn-primary"

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -36,19 +36,7 @@
                     <div class="col">
                         <div class="word-form-filters">
                             <div class="form-group sortfilter-form">
-                                <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
-                                <div class="form-inline">
-                                    <select id="sortEntriesBy" class="custom-select sortfilter-control"
-                                            data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
-                                            data-ng-options="item as $ctrl.entryListModifiers.sortOptionLabel(item.label) for item in $ctrl.entryListModifiers.sortOptions track by item.value">
-                                    </select>
-                                    <label style="margin: 7px">
-                                        <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
-                                    </label>
-                                </div>
-                            </div>
-                            <div class="form-group sortfilter-form">
-                                <label class="font-weight-bold" for="filterEntriesFor">Filter Entries</label>
+                                <label class="font-weight-bold" for="filterEntriesFor">Filter Entries By</label>
                                 <div class="form-inline">
                                     <!--suppress HtmlFormInputWithoutLabel -->
                                     <select class="custom-select sortfilter-control" data-ng-show="$ctrl.entryListModifiers.filterBy.option"
@@ -61,7 +49,19 @@
                                             data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                         <option value="">Show All</option>
                                     </select>
-                                    <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.shouldShowFilterReset()" class="btn btn-sm">Reset Filter</button>
+                                    <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.shouldShowFilterReset()" class="btn btn-sm btn-std">Reset Filter</button>
+                                </div>
+                            </div>
+                            <div class="form-group sortfilter-form">
+                                <label class="font-weight-bold" for="sortEntriesBy">Sort Entries By</label>
+                                <div class="form-inline">
+                                    <select id="sortEntriesBy" class="custom-select sortfilter-control"
+                                            data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
+                                            data-ng-options="item as $ctrl.entryListModifiers.sortOptionLabel(item.label) for item in $ctrl.entryListModifiers.sortOptions track by item.value">
+                                    </select>
+                                    <label style="margin: 7px">
+                                        <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse
+                                    </label>
                                 </div>
                             </div>
                         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -26,7 +26,8 @@
                         <div data-ng-hide="$ctrl.entries.length === 0" class="words-search">
                             <div class="filter-entries-wrapper">
                                 <input type="text" id="editor-list-search-entries" class="filter-entries" placeholder="Filter Entries"
-                                       data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
+                                       data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.text"
+                                       data-ng-model-options="{debounce: 200}"></input>
                                 <span class="fa fa-times clear-search-button" data-ng-show="$ctrl.entryListModifiers.filterBy.text" data-ng-click="$ctrl.clearSearchText()"></span>
                             </div>
                             <button class="btn btn-sm" type="button" data-ng-click="$ctrl.toggleFilterOptions()">

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -24,6 +24,7 @@
                             <div class="filter-entries-wrapper">
                                 <input type="text" id="editor-list-search-entries" class="filter-entries" placeholder="Filter Entries"
                                        data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.filterBy.text"></input>
+                                <span class="fa fa-times clear-search-button" data-ng-show="$ctrl.entryListModifiers.filterBy.text" data-ng-click="$ctrl.clearSearchText()"></span>
                             </div>
                             <button class="btn btn-sm" type="button" data-ng-click="$ctrl.toggleFilterOptions()">
                                 Options

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -61,7 +61,7 @@
                                             data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                         <option value="">Show All</option>
                                     </select>
-                                    <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.entryListModifiers.filterActive()" class="btn btn-sm">Reset Filter</button>
+                                    <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.shouldShowFilterReset()" class="btn btn-sm">Reset Filter</button>
                                 </div>
                             </div>
                         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -9,6 +9,9 @@
                                 Showing <span data-ng-hide="$ctrl.entryListModifiers.filterActive()">all </span>
                                 <span id="totalNumberOfEntries" class="notranslate"><span data-ng-show="$ctrl.entryListModifiers.filterActive()">{{$ctrl.filteredEntries.length}} / </span>{{$ctrl.entries.length}}</span>
                                 entries
+                                <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.entryListModifiers.filterActive()" class="btn btn-sm btn-std reset-filter-btn">
+                                    <span class="fa fa-undo"></span><span class="btn-text"> Show All</span>
+                                </button>
                             </div>
                             <button id="newWord" type="button" class="btn btn-primary"
                                 data-ng-if="$ctrl.lecRights.canEditEntry()"
@@ -50,7 +53,6 @@
                                             data-ng-options="item as item.label for item in $ctrl.entryListModifiers.filterOptions track by item.key">
                                         <option value="">Show All</option>
                                     </select>
-                                    <button data-ng-click="$ctrl.resetEntryListFilter()" data-ng-show="$ctrl.shouldShowFilterReset()" class="btn btn-sm btn-std">Reset Filter</button>
                                 </div>
                             </div>
                             <div class="form-group sortfilter-form">

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -7,9 +7,9 @@
                         <div class="words-container-title lexiconListItem list-group-item list-group-item-action active">
                             <div>
                                 <h5>Words in dictionary</h5>
-                                <small data-ng-show="$ctrl.filteredEntries.length == $ctrl.entries.length" id="totalNumberOfEntries">
+                                <small data-ng-hide="$ctrl.entryListModifiers.filterActive()" id="totalNumberOfEntries">
                                     <span class="notranslate">{{$ctrl.entries.length}}</span> {{ ($ctrl.entries.length == 1 ? 'entry' : 'entries') }}</small>
-                                <small data-ng-hide="$ctrl.filteredEntries.length == $ctrl.entries.length" class="float-right notranslate">{{$ctrl.filteredEntries.length}} / {{$ctrl.entries.length}}</small>
+                                <small data-ng-show="$ctrl.entryListModifiers.filterActive()" class="float-right notranslate">{{$ctrl.filteredEntries.length}} / {{$ctrl.entries.length}}</small>
                             </div>
                             <button id="newWord" type="button" class="btn btn-primary"
                                 data-ng-if="$ctrl.lecRights.canEditEntry()"

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -1,4 +1,4 @@
-<div ng-init="$ctrl.setUrlParams()" id="lexAppListView" class="animate-switch">
+<div id="lexAppListView" class="animate-switch">
     <div class="container">
         <div class="entry-words-container">
             <div data-ng-show="$ctrl.entries.length > 0">

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -22,20 +22,9 @@
                 <div class="row">
                     <div class="col">
                         <div data-ng-hide="$ctrl.visibleEntries.length === 0" class="words-search">
-                            <pui-typeahead class="typeahead" id="editor-list-search-entries" placeholder="'Search Entries'"
-                                           items="$ctrl.typeahead.searchResults" term="$ctrl.typeahead.searchItemSelected"
-                                           search="$ctrl.typeahead.searchEntries" select="$ctrl.typeahead.searchSelect">
-                                <ul data-ng-if="$ctrl.typeahead.searchResults.length > 0" class="list-group">
-                                    <li data-typeahead-item="e" class="typeahead-item list-group-item"
-                                        data-ng-repeat="e in $ctrl.typeahead.searchResults | limitTo: $ctrl.typeahead.limit">
-                                        <div class="listItemPrimary" data-ng-bind-html="$ctrl.getWordForDisplay(e)"></div>
-                                        <small class="listItemSecondary" data-ng-bind-html="$ctrl.getMeaningForDisplay(e)"></small>
-                                    </li>
-                                </ul>
-                                <div style="text-align:center; background-color: #d3d3d3; color:black;"
-                                     data-ng-if="$ctrl.typeahead.searchResults.length > 0">
-                                    <small><i>{{$ctrl.typeahead.matchCountCaption}}</i></small></div>
-                            </pui-typeahead>
+                            <div class="filter-entries-wrapper">
+                                <input type="text" id="editor-list-search-entries" class="filter-entries" placeholder="Filter Entries"></input>
+                            </div>
                             <button class="btn btn-sm" type="button" data-ng-click="$ctrl.toggleFilterOptions()">
                                 Options
                                 <i class="fa" data-ng-class="$ctrl.show.entryListModifiers ? 'fa-angle-up': 'fa-angle-down'"></i>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -27,7 +27,7 @@
                                 <span class="fa fa-times clear-search-button" data-ng-show="$ctrl.entryListModifiers.filterBy.text" data-ng-click="$ctrl.clearSearchText()"></span>
                             </div>
                             <button class="btn btn-sm" type="button" data-ng-click="$ctrl.toggleFilterOptions()">
-                                Options
+                                <span class="options-active-icon fa fa-circle" data-ng-class="{'icon-active': $ctrl.filterSortOptionsActive()}"></span> Options
                                 <i class="fa" data-ng-class="$ctrl.show.entryListModifiers ? 'fa-angle-up': 'fa-angle-down'"></i>
                             </button>
                         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -40,7 +40,7 @@
                                 <div class="form-inline">
                                     <select id="sortEntriesBy" class="custom-select sortfilter-control"
                                             data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortBy"
-                                            data-ng-options="item as item.label for item in $ctrl.entryListModifiers.sortOptions track by item.value">
+                                            data-ng-options="item as $ctrl.entryListModifiers.sortOptionLabel(item.label) for item in $ctrl.entryListModifiers.sortOptions track by item.value">
                                     </select>
                                     <label style="margin: 7px">
                                         <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse"> Reverse

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -6,10 +6,9 @@
                     <div class="col">
                         <div class="words-container-title lexiconListItem list-group-item list-group-item-action active">
                             <div>
-                                <h5>Words in dictionary</h5>
-                                <small data-ng-hide="$ctrl.entryListModifiers.filterActive()" id="totalNumberOfEntries">
-                                    <span class="notranslate">{{$ctrl.entries.length}}</span> {{ ($ctrl.entries.length == 1 ? 'entry' : 'entries') }}</small>
-                                <small data-ng-show="$ctrl.entryListModifiers.filterActive()" class="float-right notranslate">{{$ctrl.filteredEntries.length}} / {{$ctrl.entries.length}}</small>
+                                Showing <span data-ng-hide="$ctrl.entryListModifiers.filterActive()">all </span>
+                                <span class="notranslate"><span data-ng-show="$ctrl.entryListModifiers.filterActive()">{{$ctrl.filteredEntries.length}} / </span>{{$ctrl.entries.length}}</span>
+                                entries
                             </div>
                             <button id="newWord" type="button" class="btn btn-primary"
                                 data-ng-if="$ctrl.lecRights.canEditEntry()"

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -269,6 +269,13 @@ export class LexiconEditorController implements angular.IController {
     });
   }
 
+  clearSearchText = () => {
+    if (this.entryListModifiers.filterBy) {
+      this.entryListModifiers.filterBy.text = '';
+      this.filterAndSortEntries();
+    }
+  }
+
   filterAndSortEntries(): void {
     this.$state.go('.', {
       sortBy: this.entryListModifiers.sortBy.label,

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -247,28 +247,15 @@ export class LexiconEditorController implements angular.IController {
     const clear = this.$scope.$watch(() => this.entryListModifiers.sortOptions.length > 0, (ready: boolean) => {
       if (!ready) return;
       clear(); // remove the watcher
-      this.$state.go('.', {
-        sortBy: this.entryListModifiers.sortBy.label,
-        filterText: this.entryListModifiers.filterText(),
-        sortReverse: this.entryListModifiers.sortReverse,
-        filterType: this.entryListModifiers.filterType,
-        filterBy: this.entryListModifiers.filterByLabel()
-      }, { notify: false });
+
       if (this.$state.params.sortBy) {
         this.entryListModifiers.sortBy =
         this.setSelectedFilter(this.entryListModifiers.sortOptions, this.$state.params.sortBy)[0];
-        this.sortEntries(true);
       }
-      if (this.$state.params.sortReverse === 'true') {
-        this.entryListModifiers.sortReverse = true;
-        this.sortEntries(true);
-      } else {
-        this.entryListModifiers.sortReverse = false;
-        this.sortEntries(false);
-       }
+      this.entryListModifiers.sortReverse = this.$state.params.sortReverse === 'true';
+
       if (this.$state.params.filterType) {
         this.entryListModifiers.filterType = this.$state.params.filterType;
-        this.filterEntries(true);
       }
       if (this.$state.params.filterBy || this.$state.params.filterText) {
         this.entryListModifiers.filterBy = {
@@ -276,8 +263,10 @@ export class LexiconEditorController implements angular.IController {
           option: this.$state.params.filterBy ?
                   this.setSelectedFilter(this.entryListModifiers.filterOptions, this.$state.params.filterBy)[0] : null
         };
-        this.filterEntries(true);
       }
+
+      this.filterEntries(true);
+      this.sortEntries(true);
     });
   }
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -250,7 +250,7 @@ export class LexiconEditorController implements angular.IController {
 
       if (this.$state.params.sortBy) {
         this.entryListModifiers.sortBy =
-        this.setSelectedFilter(this.entryListModifiers.sortOptions, this.$state.params.sortBy)[0];
+        this.findSelectedFilter(this.entryListModifiers.sortOptions, this.$state.params.sortBy);
       }
       this.entryListModifiers.sortReverse = this.$state.params.sortReverse === 'true';
 
@@ -261,7 +261,7 @@ export class LexiconEditorController implements angular.IController {
         this.entryListModifiers.filterBy = {
           text: this.$state.params.filterText || '',
           option: this.$state.params.filterBy ?
-                  this.setSelectedFilter(this.entryListModifiers.filterOptions, this.$state.params.filterBy)[0] : null
+                  this.findSelectedFilter(this.entryListModifiers.filterOptions, this.$state.params.filterBy) : null
         };
       }
 
@@ -878,14 +878,8 @@ export class LexiconEditorController implements angular.IController {
     });
   }
 
-  private setSelectedFilter(collections: any[], params: string) {
-    if (collections && params) {
-      return this.$filter('filter')(collections, (item: any) => {
-        if (item.label === params) {
-          return item;
-        }
-      });
-    }
+  private findSelectedFilter(collections: any[], params: string) {
+    if (collections && params) return collections.filter(item => item.label === params)[0];
   }
 
   private setSortAndFilterOptionsFromConfig(): void {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -287,6 +287,11 @@ export class LexiconEditorController implements angular.IController {
     this.editorService.filterAndSortEntries.apply(this, arguments);
   }
 
+  filterSortOptionsActive() {
+    const mod = this.entryListModifiers;
+    return mod.filterBy && mod.filterBy.option || mod.sortBy.value !== 'default' || mod.sortReverse;
+  }
+
   shouldShowFilterReset() {
     const modifiers = this.entryListModifiers;
     return modifiers.filterActive() || modifiers.sortBy.value !== 'default' || modifiers.sortReverse;

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -73,7 +73,7 @@ export class LexiconEditorController implements angular.IController {
   entryListModifiers = this.editorService.entryListModifiers;
   filteredEntries = this.editorService.filteredEntries;
   getEntryCommentCount = this.commentService.getEntryCommentCount.bind(this.commentService);
-  getPrimaryListItemForDisplay = this.editorService.getSortableValue;
+  getSortableValue = this.editorService.getSortableValue;
   visibleEntries = this.editorService.visibleEntries;
   unreadCount = this.activityService.unreadCount;
   getMeaningForDisplay = this.editorService.getMeaningForDisplay;
@@ -602,8 +602,33 @@ export class LexiconEditorController implements angular.IController {
     return lexeme;
   }
 
+  getPrimaryListItemForDisplay(entry: LexEntry) {
+    return this.highlightMatches(this.getSortableValue(this.lecConfig, entry));
+  }
+
   getSecondaryListItemForDisplay(entry: LexEntry): string {
-    return this.getMeaningForDisplay(this.lecConfig, entry);
+    return this.highlightMatches(this.getMeaningForDisplay(this.lecConfig, entry));
+  }
+
+  highlightMatches(text: string) {
+    let filterText = this.entryListModifiers.filterText();
+    if (!filterText || text === '[Empty]') return text;
+
+    // FIXME this assumes the uppercase length of a string is the same as its lowercase, which is not necessarily true
+    //  e.g. 'ß'.length !== 'ß'.toUpperCase().length
+    filterText = filterText.toUpperCase();
+    const upperCaseText = text.toUpperCase();
+    let output = '';
+    let previousIndex = 0;
+    while (upperCaseText.indexOf(filterText, previousIndex) !== -1) {
+      const resultIndex = upperCaseText.indexOf(filterText, previousIndex);
+      const end = resultIndex + filterText.length;
+      output += text.slice(previousIndex, resultIndex) + '<span class="highlight-result">'
+              + text.slice(resultIndex, end) + '</span>';
+      previousIndex = end;
+    }
+    output += text.slice(previousIndex);
+    return output;
   }
 
   getCompactItemListOverlay(entry: LexEntry): string {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -227,6 +227,7 @@ export class LexiconEditorController implements angular.IController {
     this.setCurrentEntry();
     this.$state.go('editor.list', {
       sortBy: this.$state.params.sortBy,
+      filterText: this.$state.params.filterText,
       sortReverse: this.$state.params.sortReverse,
       filterType: this.$state.params.filterType,
       filterBy: this.$state.params.filterBy
@@ -259,16 +260,16 @@ export class LexiconEditorController implements angular.IController {
       clear(); // remove the watcher
       this.$state.go('.', {
         sortBy: this.entryListModifiers.sortBy.label,
+        filterText: this.entryListModifiers.filterText(),
         sortReverse: this.entryListModifiers.sortReverse,
         filterType: this.entryListModifiers.filterType,
-        filterBy: this.entryListModifiers.filterBy ? this.entryListModifiers.filterBy.label : 'null'
+        filterBy: this.entryListModifiers.filterByLabel()
       }, { notify: false });
       if (this.$state.params.sortBy) {
         this.entryListModifiers.sortBy =
         this.setSelectedFilter(this.entryListModifiers.sortOptions, this.$state.params.sortBy)[0];
         this.sortEntries(true);
       }
-
       if (this.$state.params.sortReverse === 'true') {
         this.entryListModifiers.sortReverse = true;
         this.sortEntries(true);
@@ -280,9 +281,12 @@ export class LexiconEditorController implements angular.IController {
         this.entryListModifiers.filterType = this.$state.params.filterType;
         this.filterEntries(true);
       }
-      if (this.$state.params.filterBy) {
-        this.entryListModifiers.filterBy =
-        this.setSelectedFilter(this.entryListModifiers.filterOptions, this.$state.params.filterBy)[0];
+      if (this.$state.params.filterBy || this.$state.params.filterText) {
+        this.entryListModifiers.filterBy = {
+          text: this.$state.params.filterText,
+          option: this.$state.params.filterBy ?
+                  this.setSelectedFilter(this.entryListModifiers.filterOptions, this.$state.params.filterBy)[0] : null
+        };
         this.filterEntries(true);
       }
     });
@@ -291,9 +295,10 @@ export class LexiconEditorController implements angular.IController {
   sortEntries(args: any): void {
     this.$state.go('.', {
       sortBy: this.entryListModifiers.sortBy.label,
+      filterText: this.entryListModifiers.filterText(),
       sortReverse: this.entryListModifiers.sortReverse,
       filterType: this.entryListModifiers.filterType,
-      filterBy: this.entryListModifiers.filterBy ? this.entryListModifiers.filterBy.label : 'null'
+      filterBy: this.entryListModifiers.filterByLabel()
     }, { notify: false });
     this.editorService.sortEntries.apply(this, arguments).then(() => {
       this.typeahead.searchEntries(this.typeahead.searchItemSelected);
@@ -303,9 +308,10 @@ export class LexiconEditorController implements angular.IController {
   filterEntries(args: any): void {
     this.$state.go('.', {
       sortBy: this.entryListModifiers.sortBy.label,
+      filterText: this.entryListModifiers.filterText(),
       sortReverse: this.entryListModifiers.sortReverse,
       filterType: this.entryListModifiers.filterType,
-      filterBy: this.entryListModifiers.filterBy ? this.entryListModifiers.filterBy.label : 'null'
+      filterBy: this.entryListModifiers.filterByLabel()
     }, { notify: false });
     this.editorService.filterEntries.apply(this, arguments).then(() => {
       this.typeahead.searchEntries(this.typeahead.searchItemSelected);
@@ -401,9 +407,10 @@ export class LexiconEditorController implements angular.IController {
               this.$state.go('.', {
                 entryId: entry.id,
                 sortBy: this.entryListModifiers.sortBy.label,
+                filterText: this.entryListModifiers.filterText(),
                 sortReverse: this.entryListModifiers.sortReverse,
                 filterType: this.entryListModifiers.filterType,
-                filterBy: this.entryListModifiers.filterBy ? this.entryListModifiers.filterBy.label : 'null'
+                filterBy: this.entryListModifiers.filterByLabel()
               }, { notify: false });
               this.scrollListToEntry(entry.id, 'top');
             }
@@ -484,9 +491,10 @@ export class LexiconEditorController implements angular.IController {
         this.$state.go('.', {
           entryId: this.visibleEntries[iShowList].id,
           sortBy: this.entryListModifiers.sortBy.label,
+          filterText: this.entryListModifiers.filterText(),
           sortReverse: this.entryListModifiers.sortReverse,
           filterType: this.entryListModifiers.filterType,
-          filterBy: this.entryListModifiers.filterBy ? this.entryListModifiers.filterBy.label : 'null'
+          filterBy: this.entryListModifiers.filterByLabel()
         }, { notify: false });
       } else {
         this.returnToList();
@@ -974,14 +982,16 @@ export class LexiconEditorController implements angular.IController {
       this.$state.go('.', {
         entryId,
         sortBy: this.entryListModifiers.sortBy.label,
+        filterText: this.entryListModifiers.filterText(),
         sortReverse: this.entryListModifiers.sortReverse,
         filterType: this.entryListModifiers.filterType,
-        filterBy: this.entryListModifiers.filterBy ? this.entryListModifiers.filterBy.label : 'null'
+        filterBy: this.entryListModifiers.filterByLabel()
       }, { notify: false });
     } else {
       this.$state.go('editor.entry', {
         entryId,
         sortBy: this.$state.params.sortBy,
+        filterText: this.$state.params.filterText,
         sortReverse: this.$state.params.sortReverse,
         filterType: this.$state.params.filterType,
         filterBy: this.$state.params.filterBy

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -259,7 +259,7 @@ export class LexiconEditorController implements angular.IController {
       }
       if (this.$state.params.filterBy || this.$state.params.filterText) {
         this.entryListModifiers.filterBy = {
-          text: this.$state.params.filterText,
+          text: this.$state.params.filterText || '',
           option: this.$state.params.filterBy ?
                   this.setSelectedFilter(this.entryListModifiers.filterOptions, this.$state.params.filterBy)[0] : null
         };

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -904,7 +904,10 @@ export class LexiconEditorController implements angular.IController {
       return;
     }
 
-    const sortOptions: SortOption[] = [];
+    const sortOptions: SortOption[] = [{
+      label: 'Default',
+      value: 'default'
+    }];
     const filterOptions: FilterOption[] = [];
     for (const entryFieldName of this.lecConfig.entry.fieldOrder) {
       const entryField = this.lecConfig.entry.fields[entryFieldName];

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -76,6 +76,7 @@ export class LexiconEditorController implements angular.IController {
   getPrimaryListItemForDisplay = this.editorService.getSortableValue;
   visibleEntries = this.editorService.visibleEntries;
   unreadCount = this.activityService.unreadCount;
+  getMeaningForDisplay = this.editorService.getMeaningForDisplay;
 
   private pristineEntry: LexEntry = new LexEntry();
   private warnOfUnsavedEditsId: string;
@@ -601,25 +602,15 @@ export class LexiconEditorController implements angular.IController {
     return lexeme;
   }
 
-  getMeaningForDisplay(entry: LexEntry): string {
-    let meaning = '';
-    if (entry.senses && entry.senses[0]) {
-      meaning = LexiconUtilityService.getMeaning(this.lecConfig,
-        this.lecConfig.entry.fields.senses as LexConfigFieldList, entry.senses[0]);
-    }
-
-    if (!meaning) {
-      return '[Empty]';
-    }
-
-    return meaning;
+  getSecondaryListItemForDisplay(entry: LexEntry): string {
+    return this.getMeaningForDisplay(this.lecConfig, entry);
   }
 
   getCompactItemListOverlay(entry: LexEntry): string {
     let title;
     let subtitle;
     title = this.getWordForDisplay(entry);
-    subtitle = this.getMeaningForDisplay(entry);
+    subtitle = this.getMeaningForDisplay(this.lecConfig, entry);
     if (title.length > 19 || subtitle.length > 25) {
       return title + '         ' + subtitle;
     } else {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -122,6 +122,7 @@ export class LexiconEditorController implements angular.IController {
     this.$scope.$watch(() => this.lecConfig, () => {
       this.setSortAndFilterOptionsFromConfig();
     });
+    this.initFilterAndSearchOptions();
 
     this.sendReceive.setPollUpdateSuccessCallback(this.pollUpdateSuccess);
     this.sendReceive.setSyncProjectStatusSuccessCallback(this.syncProjectStatusSuccess);
@@ -242,7 +243,7 @@ export class LexiconEditorController implements angular.IController {
     }
   }
 
-  setUrlParams(): void {
+  initFilterAndSearchOptions(): void {
     const clear = this.$scope.$watch(() => this.entryListModifiers.sortOptions.length > 0, (ready: boolean) => {
       if (!ready) return;
       clear(); // remove the watcher

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -280,9 +280,15 @@ export class LexiconEditorController implements angular.IController {
     this.editorService.filterAndSortEntries.apply(this, arguments);
   }
 
+  shouldShowFilterReset() {
+    const modifiers = this.entryListModifiers;
+    return modifiers.filterActive() || modifiers.sortBy.value !== 'default' || modifiers.sortReverse;
+  }
+
   resetEntryListFilter(): void {
     this.entryListModifiers.filterBy = null;
     this.entryListModifiers.sortReverse = false;
+    this.entryListModifiers.sortBy = this.findSelectedFilter(this.entryListModifiers.sortOptions, 'Default');
     this.filterAndSortEntries();
   }
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -299,8 +299,6 @@ export class LexiconEditorController implements angular.IController {
 
   resetEntryListFilter(): void {
     this.entryListModifiers.filterBy = null;
-    this.entryListModifiers.sortReverse = false;
-    this.entryListModifiers.sortBy = this.findSelectedFilter(this.entryListModifiers.sortOptions, 'Default');
     this.filterAndSortEntries();
   }
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -265,12 +265,11 @@ export class LexiconEditorController implements angular.IController {
         };
       }
 
-      this.filterEntries(true);
-      this.sortEntries(true);
+      this.filterAndSortEntries();
     });
   }
 
-  sortEntries(args: any): void {
+  filterAndSortEntries(): void {
     this.$state.go('.', {
       sortBy: this.entryListModifiers.sortBy.label,
       filterText: this.entryListModifiers.filterText(),
@@ -278,23 +277,13 @@ export class LexiconEditorController implements angular.IController {
       filterType: this.entryListModifiers.filterType,
       filterBy: this.entryListModifiers.filterByLabel()
     }, { notify: false });
-    this.editorService.sortEntries.apply(this, arguments);
-  }
-
-  filterEntries(args: any): void {
-    this.$state.go('.', {
-      sortBy: this.entryListModifiers.sortBy.label,
-      filterText: this.entryListModifiers.filterText(),
-      sortReverse: this.entryListModifiers.sortReverse,
-      filterType: this.entryListModifiers.filterType,
-      filterBy: this.entryListModifiers.filterByLabel()
-    }, { notify: false });
-    this.editorService.filterEntries.apply(this, arguments);
+    this.editorService.filterAndSortEntries.apply(this, arguments);
   }
 
   resetEntryListFilter(): void {
     this.entryListModifiers.filterBy = null;
-    this.filterEntries(true);
+    this.entryListModifiers.sortReverse = false;
+    this.filterAndSortEntries();
   }
 
   hasUnsavedChanges(): boolean {

--- a/src/angular-app/languageforge/lexicon/editor/editor.module.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.module.ts
@@ -43,12 +43,12 @@ export const LexiconEditorModule = angular
                             lec-rights="$ctrl.rights"></lexicon-editor>`
       })
       .state('editor.list', {
-        url: '/list?sortBy&sortReverse&filterType&filterBy',
+        url: '/list?sortBy&filterText&sortReverse&filterType&filterBy',
         templateUrl: '/angular-app/languageforge/lexicon/editor/editor-list.view.html',
         controller: 'EditorListCtrl'
       })
       .state('editor.entry', {
-        url: '/entry/{entryId:[0-9a-z_]{6,24}}?sortBy&sortReverse&filterType&filterBy',
+        url: '/entry/{entryId:[0-9a-z_]{6,24}}?sortBy&filterText&sortReverse&filterType&filterBy',
         templateUrl: '/angular-app/languageforge/lexicon/editor/editor-entry.view.html',
         controller: 'EditorEntryCtrl'
       })

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
@@ -1,7 +1,7 @@
-<div class="dc-rendered-entryContainer" id="entryContainer" data-ng-hide="$ctrl.hideIfEmpty && !$ctrl.entry.word">
+<div class="dc-rendered-entryContainer" data-ng-hide="$ctrl.hideIfEmpty && !$ctrl.entry.word">
     <span class="dc-rendered-word" data-ng-bind-html="$ctrl.entry.word"></span>
     <span class="dc-rendered-senseContainer" data-ng-repeat="sense in $ctrl.entry.senses track by $index">
-        <span dir="ltr" data-ng-hide="$ctrl.entry.senses.length === 1" class="notranslate dc-rendered-senseNumber">{{$index + 1}})</span>
+        <span dir="ltr" data-ng-if="$ctrl.entry.senses.length !== 1" class="notranslate dc-rendered-senseNumber">{{$index + 1}})</span>
         <span class="dc-rendered-partOfSpeech" data-ng-bind-html="sense.partOfSpeech"></span>
         <span class="dc-rendered-definition" data-ng-bind-html="sense.meaning"></span>
         <span class="dc-rendered-exampleContainer" data-ng-repeat="example in sense.examples track by $index">

--- a/src/angular-app/languageforge/lexicon/lexicon-app.component.html
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.component.html
@@ -1,7 +1,4 @@
 <div class="content container-fluid" data-ng-cloak dir="{{$ctrl.interfaceConfig.direction}}">
-    <div id="lexicon-hmenu">
-        <div class="lexnav form-group"></div>
-    </div>
 
     <sil-notices></sil-notices>
     <div data-ui-view></div>

--- a/src/angular-app/languageforge/lexicon/lexicon-app.module.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.module.ts
@@ -32,7 +32,7 @@ export const LexiconAppModule = angular
       // this is needed to allow style="font-family" on ng-bind-html elements
       $sanitizeProvider.addValidAttrs(['style']);
 
-      $urlRouterProvider.otherwise('/editor/list?sortBy=Word&sortReverse=false&filterType=isNotEmpty&filterBy=null');
+      $urlRouterProvider.otherwise('/editor/list?sortBy=Default&sortReverse=false&filterType=isNotEmpty&filterBy=null');
 
       // State machine from ui.router
       $stateProvider

--- a/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
@@ -34,10 +34,10 @@ describe('Lexicon E2E Editor List and Entry', () => {
   it('search function works correctly', () => {
     editorPage.browse.search.input.sendKeys('asparagus');
     expect<any>(editorPage.browse.search.getMatchCount()).toBe(1);
-    editorPage.browse.search.clearBtn.click();
+    editorPage.browse.search.input.clear();
     editorPage.browse.search.input.sendKeys('Asparagus');
     expect<any>(editorPage.browse.search.getMatchCount()).toBe(1);
-    editorPage.browse.search.clearBtn.click();
+    editorPage.browse.search.input.clear();
   });
 
   it('refresh returns to list view', () => {
@@ -498,7 +498,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
   it('new word is visible in edit page', () => {
     editorPage.edit.search.input.sendKeys(constants.testEntry3.senses[0].definition.en.value);
     expect<any>(editorPage.edit.search.getMatchCount()).toBe(1);
-    editorPage.edit.search.clearBtn.click();
+    editorPage.edit.search.input.clear();
   });
 
   it('check that Semantic Domain field is visible (for view settings test later)', () => {
@@ -580,7 +580,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
     editorPage.edit.toListLink.click();
     editorPage.browse.search.input.sendKeys(constants.testEntry3.senses[0].definition.en.value);
     expect<any>(editorPage.browse.search.getMatchCount()).toBe(1);
-    editorPage.browse.search.clearBtn.click();
+    editorPage.browse.search.input.clear();
   });
 
   it('check that word count is still correct in browse page', () => {

--- a/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
@@ -34,10 +34,10 @@ describe('Lexicon E2E Editor List and Entry', () => {
   it('search function works correctly', () => {
     editorPage.browse.search.input.sendKeys('asparagus');
     expect<any>(editorPage.browse.search.getMatchCount()).toBe(1);
-    editorPage.browse.search.input.clear();
+    editorPage.browse.search.clearBtn.click();
     editorPage.browse.search.input.sendKeys('Asparagus');
     expect<any>(editorPage.browse.search.getMatchCount()).toBe(1);
-    editorPage.browse.search.input.clear();
+    editorPage.browse.search.clearBtn.click();
   });
 
   it('refresh returns to list view', () => {
@@ -498,7 +498,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
   it('new word is visible in edit page', () => {
     editorPage.edit.search.input.sendKeys(constants.testEntry3.senses[0].definition.en.value);
     expect<any>(editorPage.edit.search.getMatchCount()).toBe(1);
-    editorPage.edit.search.input.clear();
+    editorPage.edit.search.clearBtn.click();
   });
 
   it('check that Semantic Domain field is visible (for view settings test later)', () => {
@@ -580,7 +580,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
     editorPage.edit.toListLink.click();
     editorPage.browse.search.input.sendKeys(constants.testEntry3.senses[0].definition.en.value);
     expect<any>(editorPage.browse.search.getMatchCount()).toBe(1);
-    editorPage.browse.search.input.clear();
+    editorPage.browse.search.clearBtn.click();
   });
 
   it('check that word count is still correct in browse page', () => {

--- a/test/app/languageforge/lexicon/shared/editor.page.ts
+++ b/test/app/languageforge/lexicon/shared/editor.page.ts
@@ -46,9 +46,7 @@ export class EditorPage {
   firstNoticeCloseButton = this.noticeList.first().element(by.partialButtonText('×'));
 
   browseDiv = element(by.id('lexAppListView'));
-  browseDivSearch = this.browseDiv.element(by.id('editor-list-search-entries'));
   editDiv = element(by.id('lexAppEditView'));
-  editDivSearch = this.editDiv.element(by.id('editor-entry-search-entries'));
   editToolbarDiv = element(by.id('lexAppToolbar'));
   commentDiv = element(by.id('lexAppCommentView'));
 
@@ -67,16 +65,13 @@ export class EditorPage {
       );
     },
 
-    // Search typeahead
+    // Search/filter
     search: {
-      input: this.browseDivSearch.element(by.css('input')),
-      clearBtn: this.browseDivSearch.element(by.className('fa-times')),
-      results: this.browseDivSearch.all(by.repeater('e in $ctrl.typeahead.searchResults')),
-      matchCountElem: this.browseDivSearch.element(by.binding('$ctrl.typeahead.matchCountCaption')),
+      input: this.browseDiv.element(by.id('editor-list-search-entries')),
       getMatchCount: () => {
         // Inside this function, "this" ==  EditorPage.browse.search
-        return this.browse.search.matchCountElem.getText().then((s: string) =>
-          parseInt(s, 10)
+        return this.browse.entryCountElem.getText().then((s: string) =>
+          parseInt(/^(\d+)/.exec(s)[1], 10)
         );
       }
     },
@@ -154,14 +149,12 @@ export class EditorPage {
     },
 
     search: {
-      input: this.editDivSearch.element(by.css('input')),
-      clearBtn: this.editDivSearch.element(by.className('fa-times')),
-      results: this.editDivSearch.all(by.repeater('e in $ctrl.typeahead.searchResults')),
-      matchCountElem: this.editDivSearch.element(by.binding('$ctrl.typeahead.matchCountCaption')),
+      input: this.editDiv.element(by.id('editor-entry-search-entries')),
+      entryCountElem: this.editDiv.element(by.id('totalNumberOfEntries')),
       getMatchCount: () => {
         // Inside this function, "this" == EditorPage.edit.search
-        return this.edit.search.matchCountElem.getText().then((s: string) =>
-          parseInt(s, 10)
+        return this.edit.search.entryCountElem.getText().then((s: string) =>
+          parseInt(/^(\d+)/.exec(s)[1], 10)
         );
       }
     },
@@ -271,7 +264,7 @@ export class EditorPage {
       actionMenus: this.editDiv.all(by.css('dc-sense .ellipsis-menu-toggle')),
       deleteSense: this.editDiv.all(by.css('dc-sense .ellipsis-menu-toggle ~ .dropdown-menu fa-trash')),
       moveUp: this.editDiv.all(by.css('dc-sense .ellipsis-menu-toggle ~ .dropdown-menu .fa-arrow-up')),
-      moveDown: this.editDiv.all(by.css('dc-sense .ellipsis-menu-toggle ~ .dropdown-menu .fa-arrow-down')),
+      moveDown: this.editDiv.all(by.css('dc-sense .ellipsis-menu-toggle ~ .dropdown-menu .fa-arrow-down'))
     },
 
     pictures: {

--- a/test/app/languageforge/lexicon/shared/editor.page.ts
+++ b/test/app/languageforge/lexicon/shared/editor.page.ts
@@ -68,6 +68,7 @@ export class EditorPage {
     // Search/filter
     search: {
       input: this.browseDiv.element(by.id('editor-list-search-entries')),
+      clearBtn: this.browseDiv.element(by.className('clear-search-button')),
       getMatchCount: () => {
         // Inside this function, "this" ==  EditorPage.browse.search
         return this.browse.entryCountElem.getText().then((s: string) =>
@@ -150,6 +151,7 @@ export class EditorPage {
 
     search: {
       input: this.editDiv.element(by.id('editor-entry-search-entries')),
+      clearBtn: this.editDiv.element(by.className('clear-search-button')),
       entryCountElem: this.editDiv.element(by.id('totalNumberOfEntries')),
       getMatchCount: () => {
         // Inside this function, "this" == EditorPage.edit.search

--- a/test/app/languageforge/lexicon/shared/editor.page.ts
+++ b/test/app/languageforge/lexicon/shared/editor.page.ts
@@ -162,7 +162,7 @@ export class EditorPage {
     },
 
     // Top-row
-    renderedDiv: this.editDiv.element(by.id('entryContainer')),
+    renderedDiv: this.editDiv.element(by.className('dc-rendered-entryContainer')),
     actionMenu: this.editDiv.element(by.css('.entry-card .card-header .ellipsis-menu-toggle')),
     deleteMenuItem: this.editDiv.element(by.css('.entry-card .card-header .dropdown-menu .dropdown-item')),
 

--- a/test/app/languageforge/lexicon/shared/editor.page.ts
+++ b/test/app/languageforge/lexicon/shared/editor.page.ts
@@ -63,7 +63,7 @@ export class EditorPage {
       // assumption is entry count > 0
       browser.wait(ExpectedConditions.visibilityOf(this.browse.entryCountElem), Utils.conditionTimeout);
       return this.browse.entryCountElem.getText().then((s: string) =>
-        parseInt(s, 10)
+        parseInt(/(\d+)$/.exec(s)[1], 10)
       );
     },
 


### PR DESCRIPTION
The improved lexicon search/filter is mostly complete and all e2e tests are passing.

Description | Before | After
-------|------|-----
When all entries are being shown | ![Screenshot from 2019-08-02 15-03-17](https://user-images.githubusercontent.com/6140710/62392896-b28da700-b536-11e9-9977-667fcf76fed7.png) | ![Screenshot from 2019-08-02 15-01-36](https://user-images.githubusercontent.com/6140710/62392849-807c4500-b536-11e9-9116-1bc1befb6642.png)
When searching for entries | ![Screenshot from 2019-08-02 15-04-55](https://user-images.githubusercontent.com/6140710/62393118-43fd1900-b537-11e9-8f31-0cfae833fb04.png) | ![Screenshot from 2019-08-02 15-07-49](https://user-images.githubusercontent.com/6140710/62393141-5bd49d00-b537-11e9-8467-eebd4f28c987.png)
Filtering options || ![Screenshot from 2019-08-02 15-09-57](https://user-images.githubusercontent.com/6140710/62393237-a229fc00-b537-11e9-9aac-1f725b3a8cc9.png)

Notes:
- This is not yet complete. The UI in particular is not yet what we decided on. I wanted to get the substantive changes completed first and not get too far behind master.
- The functionality on the editor list page is identical and the UI almost identical.
- The "Default" sort option changes meaning based on whether or not the search box contains search terms. When there are no search terms, the label is "Default (Word)", which sorts the entries alphabetically by lexeme. When there is a search term, they are sorted by relevance and then alphabetically by lexeme. The label in this case changes to "Default (Relevance)".
- The "Reset Filter" button resets the filter text, any filter options, and the sort order.
- While some code was reused from the typeahead, I found that the code for sorting by relevance was incorrect, so it was rewritten. When sorting by relevance, entries with a lexeme that matches the search term at the very beginning come first, then those that match anywhere in the lexeme, then those that match at the beginning of a gloss, then those that match anywhere in a gloss, then all other entries with matches anywhere. I'm not at all confident that this is the correct solution, but it's what the typeahead was trying to do. Even if this is seen as an approximately correct sort order, I think the citation form ought to be included.
- It's worth noting that the filter code searches all string properties of an entry, except those on a blacklist. This includes part of speech and semantic domains (though they would have to be searched by number).
- The search term is persisted in the URL.
- @megahirt and I discussed wording above the list of entries. We didn't come to an exact conclusion on what it should be, but decided it should take up less space than currently, and it should be able to handle five-digit numbers without wrapping text.

I've merged master into my feature branch and resolved conflicts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/753)
<!-- Reviewable:end -->
