### PR TITLE
Add Array.includes polyfill to fix lots of Bugsnag errors

### DIFF
--- a/src/angular-app/bellows/polyfills.browser.ts
+++ b/src/angular-app/bellows/polyfills.browser.ts
@@ -2,24 +2,26 @@
 
 // import 'core-js/es6';
 // Added parts of es6 which are necessary for your project or your browser support requirements.
-import 'core-js/es6/symbol';
-import 'core-js/es6/object';
-import 'core-js/es6/function';
-import 'core-js/es6/parse-int';
-import 'core-js/es6/parse-float';
-import 'core-js/es6/number';
-import 'core-js/es6/math';
-import 'core-js/es6/string';
-import 'core-js/es6/date';
 import 'core-js/es6/array';
-import 'core-js/es6/regexp';
+import 'core-js/es6/date';
+import 'core-js/es6/function';
 import 'core-js/es6/map';
+import 'core-js/es6/math';
+import 'core-js/es6/number';
+import 'core-js/es6/object';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/parse-int';
+import 'core-js/es6/reflect';
+import 'core-js/es6/regexp';
 import 'core-js/es6/set';
+import 'core-js/es6/string';
+import 'core-js/es6/symbol';
+import 'core-js/es6/typed';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/weak-set';
-import 'core-js/es6/typed';
-import 'core-js/es6/reflect';
 // see issue https://github.com/AngularClass/angular2-webpack-starter/issues/709
 // import 'core-js/es6/promise';
 
 import 'core-js/es7/reflect';
+
+import 'core-js/fn/array/includes';


### PR DESCRIPTION
A lot of the most common errors in Bugsnag are from `Array.includes` being undefined in IE11 and UC Browser. A few days ago proximately 2/3 of the events from the top ten errors on Bugsnag were due to this.

I also alphabetized the list of polyfill imports to make TSLint happy. The _only_ substantive change is adding the last line in the file.

I've tested in IE11 and verified that `Array.prototype.includes` is defined and works as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/755)
<!-- Reviewable:end -->
