### PR TITLE
Rendered entries now show correct part of speech

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -101,7 +101,7 @@
             <div class="col-md-7 col-lg-8 entry-primary-container">
                 <div class="word-definition-title">
                     <h3>Entry Preview</h3>
-                    <dc-rendered global-config="$ctrl.lecConfig" config="$ctrl.lecConfig.entry" model="$ctrl.currentEntry" option-lists="$ctrl.optionLists"></dc-rendered>
+                    <dc-rendered global-config="$ctrl.lecConfig" config="$ctrl.lecConfig.entry" model="$ctrl.currentEntry" option-lists="$ctrl.lecOptionLists"></dc-rendered>
                 </div>
                 <div>
                     <div class="entryItemView" data-ng-if="$ctrl.entryLoaded()">

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -84,7 +84,7 @@
                             <div class="list-group" data-ng-show="$ctrl.entries.length > 0 && $ctrl.lecFinishedLoading">
                                 <div class="lexiconListItem list-group-item list-group-item-action" data-ng-repeat="entry in $ctrl.visibleEntries track by entry.id"
                                      data-ng-click="$ctrl.editEntryAndScroll(entry.id)">
-                                    <dc-rendered global-config="$ctrl.lecConfig" config="$ctrl.lecConfig.entry" model="entry" option-lists="$ctrl.optionLists"></dc-rendered>
+                                    <dc-rendered global-config="$ctrl.lecConfig" config="$ctrl.lecConfig.entry" model="entry" option-lists="$ctrl.lecOptionLists"></dc-rendered>
                                     <div data-ng-show="$ctrl.getEntryCommentCount(entry.id) > 0"
                                          style="position:absolute; right:5px;top:3px">
                                         <i class="fa fa-comment commentColor"></i>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -26,6 +26,7 @@ import {
 } from '../shared/model/lexicon-config.model';
 import {LexiconProject} from '../shared/model/lexicon-project.model';
 import {FieldControl} from './field/field-control.model';
+import {LexOptionList} from '../shared/model/option-list.model';
 
 class SortOption {
   label: string;
@@ -61,6 +62,7 @@ export class LexiconEditorController implements angular.IController {
   lecInterfaceConfig: InterfaceConfig;
   lecFinishedLoading: boolean;
   lecProject: LexiconProject;
+  lecOptionLists: LexOptionList[];
   lecRights: Rights;
 
   lastSavedDate = new Date();
@@ -1350,6 +1352,7 @@ export const LexiconEditorComponent: angular.IComponentOptions = {
     lecInterfaceConfig: '<',
     lecFinishedLoading: '<',
     lecProject: '<',
+    lecOptionLists: '<',
     lecRights: '<'
   },
   controller: LexiconEditorController,

--- a/src/angular-app/languageforge/lexicon/editor/editor.module.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.module.ts
@@ -39,6 +39,7 @@ export const LexiconEditorModule = angular
                             lec-interface-config="$ctrl.interfaceConfig"
                             lec-finished-loading="$ctrl.finishedLoading"
                             lec-project="$ctrl.project"
+                            lec-option-lists="$ctrl.optionLists"
                             lec-rights="$ctrl.rights"></lexicon-editor>`
       })
       .state('editor.list', {


### PR DESCRIPTION
Previously the optionLists data wasn't making it all the way to the dc-rendered component, so the component couldn't look up proper abbreviations for parts of speech and had to resort to using the key instead. This was mostly invisible for projects that had an English language user interface, but for non-English interfaces the English part-of-speech abbreviations were being wrongly shown. Fixed.

This should fix https://jira.sil.org/browse/LF-319

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/756)
<!-- Reviewable:end -->
