### PR TITLE
Solve the "lowercase is not a function" error loading Angular

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -334,9 +334,9 @@
       }
     },
     "angular-route": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/angular-route/-/angular-route-1.6.9.tgz",
-      "integrity": "sha512-giE0PD0T17ZvtJmAB6di27YPPSzYC1kP1BDpM2ZIGZUbs02PvJWRIgYA8z3dy9olzCS35TOwxmE2fJoHWTMm1A=="
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/angular-route/-/angular-route-1.6.10.tgz",
+      "integrity": "sha512-BxjrjQNCbVqQKyB3nHjNI8zSUwhnQWFZnSBv5BZ336VbMKhWu74ad5xpFx5VMk6WyHlmMGDoRagzB6AKkRcvKA=="
     },
     "angular-sanitize": {
       "version": "1.6.10",
@@ -1556,7 +1556,7 @@
         "browserify-versionify": "^1.0.6",
         "error-stack-parser": "^2.0.1",
         "iserror": "0.0.2",
-        "stack-generator": "github:bengourley/stack-generator#190a6f500cfc4a9ef77db204b4f571964e39c3d8"
+        "stack-generator": "stack-generator@github:bengourley/stack-generator#190a6f500cfc4a9ef77db204b4f571964e39c3d8"
       }
     },
     "builtin-modules": {
@@ -5304,7 +5304,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5332,6 +5333,7 @@
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5346,7 +5348,8 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -5357,7 +5360,8 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5474,7 +5478,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -5486,6 +5491,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -5500,6 +5506,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -5507,12 +5514,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -5531,6 +5540,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -5611,7 +5621,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5623,6 +5634,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5708,7 +5720,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5744,6 +5757,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5763,6 +5777,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5806,12 +5821,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -14814,7 +14831,8 @@
                 "ansi-regex": {
                   "version": "2.1.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
@@ -14842,6 +14860,7 @@
                   "version": "1.1.11",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
@@ -14856,7 +14875,8 @@
                 "code-point-at": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
@@ -14867,7 +14887,8 @@
                 "console-control-strings": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
@@ -14984,7 +15005,8 @@
                 "inherits": {
                   "version": "2.0.3",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
@@ -14996,6 +15018,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
                   }
@@ -15010,6 +15033,7 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   }
@@ -15017,12 +15041,14 @@
                 "minimist": {
                   "version": "0.0.8",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "minipass": {
                   "version": "2.3.5",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "safe-buffer": "^5.1.2",
                     "yallist": "^3.0.0"
@@ -15041,6 +15067,7 @@
                   "version": "0.5.1",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "minimist": "0.0.8"
                   }
@@ -15121,7 +15148,8 @@
                 "number-is-nan": {
                   "version": "1.0.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
@@ -15133,6 +15161,7 @@
                   "version": "1.4.0",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "wrappy": "1"
                   }
@@ -15218,7 +15247,8 @@
                 "safe-buffer": {
                   "version": "5.1.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
@@ -15254,6 +15284,7 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -15273,6 +15304,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
@@ -15316,12 +15348,14 @@
                 "wrappy": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "yallist": {
                   "version": "3.0.3",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1556,7 +1556,7 @@
         "browserify-versionify": "^1.0.6",
         "error-stack-parser": "^2.0.1",
         "iserror": "0.0.2",
-        "stack-generator": "stack-generator@github:bengourley/stack-generator#190a6f500cfc4a9ef77db204b4f571964e39c3d8"
+        "stack-generator": "github:bengourley/stack-generator#190a6f500cfc4a9ef77db204b4f571964e39c3d8"
       }
     },
     "builtin-modules": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "angular": "1.6.10",
     "angular-moment-picker": "git+https://github.com/sillsdev/angular-moment-picker.git",
-    "angular-route": "^1.6.5",
-    "angular-sanitize": "^1.6.10",
+    "angular-route": "1.6.10",
+    "angular-sanitize": "1.6.10",
     "angular-ui-bootstrap-4": "git+https://github.com/sillsdev/bootstrap.git",
     "angular-ui-router": "0.4.2",
     "angular-ui-validate": "^1.2.3",


### PR DESCRIPTION
This PR forces angular-* modules to match the version of angular, which should solve the "lowercase is not a function" error that was sometimes showing up. The cause is that between Angular 1.6 and 1.7, they removed the long-deprecated angular.lowercase function, which some code (including angular-sanitize) had been depending on. This means that the 1.6 to 1.7 upgrade is a breaking change, which means that it's not safe to use a package version like "^1.6.10" for the angular-sanitize module, because that will pull in 1.7.x (since npm thinks that angular is following SemVer). The angular-* modules need to be the same version as angular to be safe, so we use "1.6.10" instead of "^1.6.10" in the angular-sanitize version in package.json.

See also https://stackoverflow.com/questions/50448326/uncaught-typeerror-angular-lowercase-is-not-a-function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/757)
<!-- Reviewable:end -->
