### PR TITLE
Display messages from url in angular

### DIFF
--- a/src/angular-app/bellows/apps/projects/projects-app.component.ts
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.ts
@@ -60,6 +60,8 @@ export class ProjectsAppController implements angular.IController {
         this.helpHeroService.anonymous();
       }
     });
+
+    this.notice.checkUrlForNotices();
   }
 
   isSelected(project: Project) {

--- a/src/angular-app/bellows/core/notice/notice.service.ts
+++ b/src/angular-app/bellows/core/notice/notice.service.ts
@@ -26,8 +26,8 @@ export class NoticeService {
   private isLoadingNotice: boolean;
   private loadingMessage: string;
 
-  static $inject: string[] = ['$interval'];
-  constructor(private $interval: angular.IIntervalService) {
+  static $inject: string[] = ['$interval', '$location'];
+  constructor(private $interval: angular.IIntervalService, private $location: angular.ILocationService) {
     this.notices = [];
     this.timers = {};
     this.percentComplete = 0;
@@ -43,15 +43,19 @@ export class NoticeService {
     }
   }
 
-  checkUrlForNotices(query: any): void {
+  checkUrlForNotices(): void {
+    const query = this.$location.search();
     if (query.errorMessage) {
       this.push(this.ERROR, atob(query.errorMessage));
+      this.$location.search('errorMessage', null);
     }
     if (query.infoMessage) {
       this.push(this.INFO, atob(query.infoMessage));
+      this.$location.search('infoMessage', null);
     }
     if (query.successMessage) {
       this.push(this.SUCCESS, atob(query.successMessage));
+      this.$location.search('successMessage', null);
     }
   }
 

--- a/src/angular-app/bellows/core/notice/notice.service.ts
+++ b/src/angular-app/bellows/core/notice/notice.service.ts
@@ -43,6 +43,18 @@ export class NoticeService {
     }
   }
 
+  checkUrlForNotices(query: any): void {
+    if (query.errorMessage) {
+      this.push(this.ERROR, atob(query.errorMessage));
+    }
+    if (query.infoMessage) {
+      this.push(this.INFO, atob(query.infoMessage));
+    }
+    if (query.successMessage) {
+      this.push(this.SUCCESS, atob(query.successMessage));
+    }
+  }
+
   push(type: () => string, message: string, details?: string, cannotClose?: boolean, time?: number): string {
     const id = UtilityService.uuid();
 


### PR DESCRIPTION
There is currently no way for the back-end to pass messages to angular's `notice.service`. This PR creates `noticeService.checkUrlForNotices()` which is designed to be called from the `onInit()` of a controller and be passed `$location.search()`. It displays base64 decoded strings from the URL query parameters: `errorMessage`, `infoMessage`, and `successMessage`. The following screenshot shows functionality, but is taken from another branch where the method is implemented.

The function takes an `any` argument because `$location.search()` returns a basic JSON object. Is it worth it to parse that into a type to before passing into `checkUrlForNotices`?

![image](https://user-images.githubusercontent.com/24280478/62606416-64a5e400-b926-11e9-91c4-b4d6c11d9cb4.png)

Developer's Note: This seemed like a separate piece from what I have been working on, so I put it in it's own PR. If you would prefer to just lump it in with the rest of my back end work for link-sharing, I can.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/758)
<!-- Reviewable:end -->
