### PR TITLE
Back end for link sharing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "phpunit.args": [
-        "--configuration", "test/php/phpunit.xml"
-    ]
+    "--configuration",
+    "test/php/phpunit.xml"
+  ],
+  "phpcs.composerJsonPath": "src"
 }

--- a/src/Api/Model/Shared/Command/ProjectCommands.php
+++ b/src/Api/Model/Shared/Command/ProjectCommands.php
@@ -359,11 +359,7 @@ class ProjectCommands
 
         $project->write();
 
-        if (!$result)
-        {
-            return 'Link generation failed. Please try again.';
-        }
-        return 'https://' . $project->siteName . '.org/invite/' . $newAuthToken;
+        return $project->website()->baseUrl() . '/invite/' . $newAuthToken;
     }
 
     /**
@@ -373,8 +369,10 @@ class ProjectCommands
      */
     public static function getInviteLink($projectId)
     {
+        // TODO: check that invite token exists.  If not, throw exception.
+        // TODO: check that project invite sharing is enabled.  If not, throw exception if disabled.
         $project = ProjectModel::getById($projectId);
-        return 'https://' . $project->siteName . '.org/invite/' . $project->inviteToken->token;
+        return $project->website()->baseUrl() . '/invite/' . $project->inviteToken->token;
     }
 
     /**

--- a/src/Api/Model/Shared/Command/ProjectCommands.php
+++ b/src/Api/Model/Shared/Command/ProjectCommands.php
@@ -344,4 +344,74 @@ class ProjectCommands
 
         return $project->readByProperties(array('projectCode' => $code));
     }
+
+    /**
+     * @param string $projectId
+     * @param string $defaultRole
+     * @return string invite link to project
+     */
+    public static function createInviteLink($projectId, $defaultRole)
+    {
+        $project = ProjectModel::getById($projectId);
+
+        $newAuthToken = $project->generateNewInviteToken();
+        $project->setInviteTokenDefaultRole($defaultRole);
+
+        $project->write();
+
+        if (!$result)
+        {
+            return 'Link generation failed. Please try again.';
+        }
+        return 'https://' . $project->siteName . '.org/invite/' . $newAuthToken;
+    }
+
+    /**
+     * @param string $projectId
+     * @param string $defaultRole
+     * @return string invite link to project
+     */
+    public static function getInviteLink($projectId)
+    {
+        $project = ProjectModel::getById($projectId);
+        return 'https://' . $project->siteName . '.org/invite/' . $project->inviteToken->token;
+    }
+
+    /**
+     * Removes the invite token from a project
+     * @param $projectId
+     */
+    public static function disableInviteToken($projectId)
+    {
+        $project = ProjectModel::getById($projectId);
+        $project->inviteToken->token = '';
+        $project->write();
+    }
+
+    /**
+     * Updates the role associated with an invite token
+     * @param $projectId
+     * @param $newRole the roleName to associate with
+     */
+    public static function updateInviteTokenRole($projectId, $newRole)
+    {
+        $project = ProjectModel::getById($projectId);
+        $project->setInviteTokenDefaultRole($newRole);
+        $project->write();
+    }
+
+    /**
+     * Add a user to the project based on the invite token for the project
+     * @param $projectId
+     * @param $newRole the value of the roles array to link
+     */
+    public static function useInviteToken($userId, $projectId) {
+        $model = ProjectModel::getById($projectId);
+        $model->addUserByInviteToken($userId);
+        $model->write();
+
+        $user = new UserModel($userId);
+        $user->addProject($projectId);
+        $user->write();
+    }
 }

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -26,7 +26,8 @@ class RightsHelper
      * @param ProjectModel $projectModel
      * @return mixed
      */
-    public static function encode($userModel, $projectModel) {
+    public static function encode($userModel, $projectModel)
+    {
         return $projectModel->getRightsArray($userModel->id->asString());
     }
 
@@ -39,7 +40,8 @@ class RightsHelper
     // I named this static function slightly different from userHasSiteRight to avoid this naming conflict
     // @see http://stackoverflow.com/questions/11331616/php-is-it-possible-to-declare-a-method-static-and-nonstatic
     // @see https://bugs.php.net/bug.php?id=40837
-    public static function hasSiteRight($userId, $right) {
+    public static function hasSiteRight($userId, $right)
+    {
         return self::_hasSiteRight($userId, $right);
     }
 
@@ -47,11 +49,13 @@ class RightsHelper
      * @param int $right
      * @return bool
      */
-    public function userHasSiteRight($right) {
+    public function userHasSiteRight($right)
+    {
         return self::_hasSiteRight($this->_userId, $right);
     }
 
-    private static function _hasSiteRight($userId, $right) {
+    private static function _hasSiteRight($userId, $right)
+    {
         $userModel = new UserModel($userId);
         return (SiteRoles::hasRight($userModel->siteRole, $right) || SystemRoles::hasRight($userModel->role, $right));
     }
@@ -61,7 +65,8 @@ class RightsHelper
      * @param ProjectModel $projectModel
      * @param Website $website
      */
-    public function __construct($userId, $projectModel, $website) {
+    public function __construct($userId, $projectModel, $website)
+    {
         $this->_userId = $userId;
         $this->_projectModel = $projectModel;
         $this->_website = $website;
@@ -71,7 +76,8 @@ class RightsHelper
      * @param int $right
      * @return bool
      */
-    public function userHasSystemRight($right) {
+    public function userHasSystemRight($right)
+    {
         $userModel = new UserModel($this->_userId);
 
         return SystemRoles::hasRight($userModel->role, $right);
@@ -82,7 +88,8 @@ class RightsHelper
      * @param int $right
      * @return bool
      */
-    public function userHasProjectRight($right) {
+    public function userHasProjectRight($right)
+    {
         return $this->_projectModel->hasRight($this->_userId, $right);
     }
 
@@ -92,285 +99,286 @@ class RightsHelper
      * @return bool
      * @throws \Exception
      */
-    public function userCanAccessMethod($methodName) {
+    public function userCanAccessMethod($methodName)
+    {
         switch ($methodName) {
 
-            // User Role (Project Context)
-            case 'semdom_editor_dto':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
-            case 'semdom_get_open_projects':
-                return true;
-            case 'semdom_item_update':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
-            case 'semdom_project_exists':
-                return true;
-            case 'semdom_create_project':
-                return true;
-            case 'semdom_workingset_update':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
-            case 'project_getJoinRequests':
-                return $this->userHasProjectRight(Domain::USERS + Operation::EDIT);
-            case 'project_sendJoinRequest':
-                return true;
-            case 'project_createInviteLink':
-                return $this-userHasProjectRight(Domain::USERS + Operation::EDIT);
-            case 'project_getInviteLink':
-                return $this-userHasProjectRight(Domain::USERS + Operation::EDIT);
-            case 'project_disableInviteToken':
-                return $this-userHasProjectRight(Domain::USERS + Operation::EDIT);
-            case 'project_updateInviteTokenRole':
-                return $this-userHasProjectRight(Domain::USERS + Operation::EDIT);
-            case 'semdom_does_googletranslatedata_exist':
-                return true;
-            case 'project_acceptJoinRequest':
-                return $this->userHasProjectRight(Domain::USERS + Operation::EDIT);
-            case 'project_denyJoinRequest':
-                return $this->userHasProjectRight(Domain::USERS + Operation::EDIT);
-            case 'semdom_export_project':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT );
+                // User Role (Project Context)
+        case 'semdom_editor_dto':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
+        case 'semdom_get_open_projects':
+            return true;
+        case 'semdom_item_update':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
+        case 'semdom_project_exists':
+            return true;
+        case 'semdom_create_project':
+            return true;
+        case 'semdom_workingset_update':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
+        case 'project_getJoinRequests':
+            return $this->userHasProjectRight(Domain::USERS + Operation::EDIT);
+        case 'project_sendJoinRequest':
+            return true;
 
-            case 'user_sendInvite':
-            case 'message_markRead':
-            case 'project_pageDto':
-            case 'lex_projectDto':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
+        case 'project_getInviteLink':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
 
-            case 'answer_vote_up':
-            case 'answer_vote_down':
-                return $this->userHasProjectRight(Domain::ANSWERS + Operation::VIEW);
+        case 'project_disableInviteToken':
+        case 'project_createInviteLink':
+        case 'project_updateInviteTokenRole':
+            return $this->userHasProjectRight(Domain::USERS + Operation::EDIT);
+        case 'semdom_does_googletranslatedata_exist':
+            return true;
+        case 'project_acceptJoinRequest':
+            return $this->userHasProjectRight(Domain::USERS + Operation::EDIT);
+        case 'project_denyJoinRequest':
+            return $this->userHasProjectRight(Domain::USERS + Operation::EDIT);
+        case 'semdom_export_project':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
 
-            case 'question_update_answer':
-                return $this->userHasProjectRight(Domain::ANSWERS + Operation::EDIT_OWN);
+        case 'user_sendInvite':
+        case 'message_markRead':
+        case 'project_pageDto':
+        case 'lex_projectDto':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
 
-            case 'question_remove_answer':
-                return $this->userHasProjectRight(Domain::ANSWERS + Operation::DELETE_OWN);
+        case 'answer_vote_up':
+        case 'answer_vote_down':
+            return $this->userHasProjectRight(Domain::ANSWERS + Operation::VIEW);
 
-            case 'question_update_comment':
-                return $this->userHasProjectRight(Domain::COMMENTS + Operation::EDIT_OWN);
+        case 'question_update_answer':
+            return $this->userHasProjectRight(Domain::ANSWERS + Operation::EDIT_OWN);
 
-            case 'question_remove_comment':
-                return $this->userHasProjectRight(Domain::COMMENTS + Operation::DELETE_OWN);
+        case 'question_remove_answer':
+            return $this->userHasProjectRight(Domain::ANSWERS + Operation::DELETE_OWN);
 
-            case 'question_comment_dto':
-                return $this->userHasProjectRight(Domain::ANSWERS + Operation::VIEW);
+        case 'question_update_comment':
+            return $this->userHasProjectRight(Domain::COMMENTS + Operation::EDIT_OWN);
 
-            case 'question_list_dto':
-                return $this->userHasProjectRight(Domain::QUESTIONS + Operation::VIEW);
+        case 'question_remove_comment':
+            return $this->userHasProjectRight(Domain::COMMENTS + Operation::DELETE_OWN);
 
-            // Project Manager Role (Project Context)
-            case 'user_createSimple':
-                return $this->userHasProjectRight(Domain::USERS + Operation::CREATE);
+        case 'question_comment_dto':
+            return $this->userHasProjectRight(Domain::ANSWERS + Operation::VIEW);
 
-            case 'user_typeahead':
-            case 'user_typeaheadExclusive':
-                return $this->userHasProjectRight(Domain::USERS + Operation::VIEW);
+        case 'question_list_dto':
+            return $this->userHasProjectRight(Domain::QUESTIONS + Operation::VIEW);
 
-            case 'message_send':
-            case 'project_read':
-            case 'project_settings':
-            case 'project_updateSettings':
-            case 'project_readSettings':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
+                // Project Manager Role (Project Context)
+        case 'user_createSimple':
+            return $this->userHasProjectRight(Domain::USERS + Operation::CREATE);
 
-            case 'project_update':
-            case 'lex_project_update':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
+        case 'user_typeahead':
+        case 'user_typeaheadExclusive':
+            return $this->userHasProjectRight(Domain::USERS + Operation::VIEW);
 
-            case 'project_updateUserRole':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
+        case 'message_send':
+        case 'project_read':
+        case 'project_settings':
+        case 'project_updateSettings':
+        case 'project_readSettings':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
 
-            case 'project_joinProject':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::EDIT);
+        case 'project_update':
+        case 'lex_project_update':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
 
-            case 'project_usersDto':
-                return $this->userHasProjectRight(Domain::USERS + Operation::VIEW);
+        case 'project_updateUserRole':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
 
-            case 'project_removeUsers':
-                return $this->userHasProjectRight(Domain::USERS + Operation::DELETE);
+        case 'project_joinProject':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::EDIT);
 
-            case 'text_update':
-            case 'text_read':
-            case 'text_settings_dto':
-            case 'text_exportComments':
-                return $this->userHasProjectRight(Domain::TEXTS + Operation::EDIT);
+        case 'project_usersDto':
+            return $this->userHasProjectRight(Domain::USERS + Operation::VIEW);
 
-            case 'text_archive':
-            case 'text_publish':
-                return $this->userHasProjectRight(Domain::TEXTS + Operation::ARCHIVE);
+        case 'project_removeUsers':
+            return $this->userHasProjectRight(Domain::USERS + Operation::DELETE);
 
-            case 'sfChecks_uploadFile':
-                return $this->userHasProjectRight(Domain::TEXTS + Operation::EDIT);
+        case 'text_update':
+        case 'text_read':
+        case 'text_settings_dto':
+        case 'text_exportComments':
+            return $this->userHasProjectRight(Domain::TEXTS + Operation::EDIT);
 
-            case 'question_update':
-            case 'question_read':
-                return $this->userHasProjectRight(Domain::QUESTIONS + Operation::EDIT);
+        case 'text_archive':
+        case 'text_publish':
+            return $this->userHasProjectRight(Domain::TEXTS + Operation::ARCHIVE);
 
-            case 'question_update_answerExportFlag':
-                return $this->userHasProjectRight(Domain::TEXTS + Operation::EDIT);
+        case 'sfChecks_uploadFile':
+            return $this->userHasProjectRight(Domain::TEXTS + Operation::EDIT);
 
-            case 'question_update_answerTags':
-                return $this->userHasProjectRight(Domain::TAGS + Operation::EDIT);
+        case 'question_update':
+        case 'question_read':
+            return $this->userHasProjectRight(Domain::QUESTIONS + Operation::EDIT);
 
-            case 'question_archive':
-            case 'question_publish':
-                return $this->userHasProjectRight(Domain::QUESTIONS + Operation::ARCHIVE);
+        case 'question_update_answerExportFlag':
+            return $this->userHasProjectRight(Domain::TEXTS + Operation::EDIT);
 
-            // Admin (system context)
-            case 'user_read':
-            case 'user_list':
-                return $this->userHasSiteRight(Domain::USERS + Operation::VIEW);
+        case 'question_update_answerTags':
+            return $this->userHasProjectRight(Domain::TAGS + Operation::EDIT);
 
-            case 'user_ban':
-            case 'user_update':
-            case 'user_create':
-                return $this->userHasSiteRight(Domain::USERS + Operation::EDIT);
+        case 'question_archive':
+        case 'question_publish':
+            return $this->userHasProjectRight(Domain::QUESTIONS + Operation::ARCHIVE);
 
-            case 'user_delete':
-                return $this->userHasSiteRight(Domain::USERS + Operation::DELETE);
+                // Admin (system context)
+        case 'user_read':
+        case 'user_list':
+            return $this->userHasSiteRight(Domain::USERS + Operation::VIEW);
 
-            case 'project_archive':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::ARCHIVE) ||
-                        $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
+        case 'user_ban':
+        case 'user_update':
+        case 'user_create':
+            return $this->userHasSiteRight(Domain::USERS + Operation::EDIT);
 
-            case 'project_archivedList':
-            case 'project_publish':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::ARCHIVE);
+        case 'user_delete':
+            return $this->userHasSiteRight(Domain::USERS + Operation::DELETE);
 
-            case 'project_list':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW);
+        case 'project_archive':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::ARCHIVE) ||
+                    $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
 
-            case 'project_create':
-            case 'project_create_switchSession':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
+        case 'project_archivedList':
+        case 'project_publish':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::ARCHIVE);
 
-            case 'project_join_switchSession':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
+        case 'project_list':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW);
 
-            case 'project_delete':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::DELETE) ||
-                        $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
+        case 'project_create':
+        case 'project_create_switchSession':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
 
-            case 'projectcode_exists':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
+        case 'project_join_switchSession':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
 
-            case 'questionTemplate_update':
-                return $this->userHasProjectRight(Domain::TEMPLATES + Operation::EDIT);
+        case 'project_delete':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::DELETE) ||
+                    $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
 
-            case 'questionTemplate_read':
-                return $this->userHasProjectRight(Domain::TEMPLATES + Operation::VIEW);
+        case 'projectcode_exists':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
 
-            case 'questionTemplate_delete':
-                return $this->userHasProjectRight(Domain::TEMPLATES + Operation::DELETE);
+        case 'questionTemplate_update':
+            return $this->userHasProjectRight(Domain::TEMPLATES + Operation::EDIT);
 
-            case 'questionTemplate_list':
-                return $this->userHasProjectRight(Domain::TEMPLATES + Operation::VIEW);
+        case 'questionTemplate_read':
+            return $this->userHasProjectRight(Domain::TEMPLATES + Operation::VIEW);
 
-            // User (site context)
-            case 'user_readProfile':
-                return $this->userHasSiteRight(Domain::USERS + Operation::VIEW_OWN);
+        case 'questionTemplate_delete':
+            return $this->userHasProjectRight(Domain::TEMPLATES + Operation::DELETE);
 
-            case 'user_updateProfile':
-            case 'check_unique_identity':
-            case 'change_password': // change_password requires additional protection in the method itself
+        case 'questionTemplate_list':
+            return $this->userHasProjectRight(Domain::TEMPLATES + Operation::VIEW);
+
+                // User (site context)
+        case 'user_readProfile':
+            return $this->userHasSiteRight(Domain::USERS + Operation::VIEW_OWN);
+
+        case 'user_updateProfile':
+        case 'check_unique_identity':
+        case 'change_password': // change_password requires additional protection in the method itself
 
                 return $this->userHasSiteRight(Domain::USERS + Operation::EDIT_OWN);
-            case 'project_list_dto':
-            case 'activity_list_dto':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW_OWN);
+        case 'project_list_dto':
+        case 'activity_list_dto':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW_OWN);
 
-            case 'activity_list_dto_for_current_project':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW_OWN);
+        case 'activity_list_dto_for_current_project':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW_OWN);
 
-            case 'activity_list_dto_for_lexical_entry':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
+        case 'activity_list_dto_for_lexical_entry':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
 
-            case 'session_getSessionData':
-                return true;
+        case 'session_getSessionData':
+            return true;
 
-            case 'valid_activity_types_dto':
-                return true;
+        case 'valid_activity_types_dto':
+            return true;
 
 
 
-            // LanguageForge (lexicon)
-            case 'lex_configuration_update':
-            case 'lex_upload_importLift':
-            case 'lex_upload_importProjectZip':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
+                // LanguageForge (lexicon)
+        case 'lex_configuration_update':
+        case 'lex_upload_importLift':
+        case 'lex_upload_importProjectZip':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
 
-            case 'lex_baseViewDto':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
+        case 'lex_baseViewDto':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
 
-            case 'lex_dbeDtoFull':
-            case 'lex_dbeDtoUpdatesOnly':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
+        case 'lex_dbeDtoFull':
+        case 'lex_dbeDtoUpdatesOnly':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
 
-            // case 'lex_entry_read':
-            case 'lex_entry_update':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
+               // case 'lex_entry_read':
+        case 'lex_entry_update':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
 
-            case 'lex_entry_remove':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::DELETE);
+        case 'lex_entry_remove':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::DELETE);
 
-            case 'lex_comment_update':
-            case 'lex_commentReply_update':
-                return $this->userHasProjectRight(Domain::COMMENTS + Operation::EDIT_OWN);
+        case 'lex_comment_update':
+        case 'lex_commentReply_update':
+            return $this->userHasProjectRight(Domain::COMMENTS + Operation::EDIT_OWN);
 
-            case 'lex_comment_delete':
-            case 'lex_commentReply_delete':
-                return $this->userHasProjectRight(Domain::COMMENTS + Operation::DELETE_OWN);
+        case 'lex_comment_delete':
+        case 'lex_commentReply_delete':
+            return $this->userHasProjectRight(Domain::COMMENTS + Operation::DELETE_OWN);
 
-            case 'lex_comment_updateStatus':
-                return $this->userHasProjectRight(Domain::COMMENTS + Operation::EDIT);
+        case 'lex_comment_updateStatus':
+            return $this->userHasProjectRight(Domain::COMMENTS + Operation::EDIT);
 
-            case 'lex_comment_plusOne':
-                return $this->userHasProjectRight(Domain::COMMENTS + Operation::VIEW);
+        case 'lex_comment_plusOne':
+            return $this->userHasProjectRight(Domain::COMMENTS + Operation::VIEW);
 
-            case 'lex_uploadAudioFile':
-            case 'lex_uploadImageFile':
-            case 'lex_project_removeMediaFile':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
+        case 'lex_uploadAudioFile':
+        case 'lex_uploadImageFile':
+        case 'lex_project_removeMediaFile':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
 
-            // send receive api
-            case 'sendReceive_getProjectStatus':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
+                // send receive api
+        case 'sendReceive_getProjectStatus':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
 
-            case 'sendReceive_updateSRProject':
-            case 'sendReceive_receiveProject':
-            case 'sendReceive_commitProject':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
+        case 'sendReceive_updateSRProject':
+        case 'sendReceive_receiveProject':
+        case 'sendReceive_commitProject':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
 
-            // LanguageForge (translate)
-            case 'translate_projectDto':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
+                // LanguageForge (translate)
+        case 'translate_projectDto':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
 
-            case 'translate_projectUpdate':
-            case 'translate_configUpdate':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
+        case 'translate_projectUpdate':
+        case 'translate_configUpdate':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
 
-            case 'translate_configUpdateUserPreferences':
-            case 'translate_documentSetListDto':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
+        case 'translate_configUpdateUserPreferences':
+        case 'translate_documentSetListDto':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
 
-            case 'translate_documentSetUpdate':
-            case 'translate_updateMetrics':
-            case 'translate_usxToHtml':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
+        case 'translate_documentSetUpdate':
+        case 'translate_updateMetrics':
+        case 'translate_usxToHtml':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::EDIT);
 
-            case 'translate_documentSetRemove':
-                return $this->userHasProjectRight(Domain::ENTRIES + Operation::DELETE);
+        case 'translate_documentSetRemove':
+            return $this->userHasProjectRight(Domain::ENTRIES + Operation::DELETE);
 
-            // project management app
-            case 'project_management_dto':
-            case 'project_management_report_sfchecks_userEngagementReport':
-            case 'project_management_report_sfchecks_topContributorsWithTextReport':
-            case 'project_management_report_sfchecks_responsesOverTimeReport':
-                return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
+                // project management app
+        case 'project_management_dto':
+        case 'project_management_report_sfchecks_userEngagementReport':
+        case 'project_management_report_sfchecks_topContributorsWithTextReport':
+        case 'project_management_report_sfchecks_responsesOverTimeReport':
+            return $this->userHasProjectRight(Domain::PROJECTS + Operation::EDIT);
 
-            // semdomtrans app management
-            case 'semdomtrans_app_management_dto':
-            case 'semdomtrans_export_all_projects':
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::EDIT);
+                // semdomtrans app management
+        case 'semdomtrans_app_management_dto':
+        case 'semdomtrans_export_all_projects':
+            return $this->userHasSiteRight(Domain::PROJECTS + Operation::EDIT);
 
             default:
                 throw new \Exception("API method '$methodName' has no security policy defined in RightsHelper::userCanAccessMethod()");

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -112,6 +112,14 @@ class RightsHelper
                 return $this->userHasProjectRight(Domain::USERS + Operation::EDIT);
             case 'project_sendJoinRequest':
                 return true;
+            case 'project_createInviteLink':
+                return $this-userHasProjectRight(Domain::USERS + Operation::EDIT);
+            case 'project_getInviteLink':
+                return $this-userHasProjectRight(Domain::USERS + Operation::EDIT);
+            case 'project_disableInviteToken':
+                return $this-userHasProjectRight(Domain::USERS + Operation::EDIT);
+            case 'project_updateInviteTokenRole':
+                return $this-userHasProjectRight(Domain::USERS + Operation::EDIT);
             case 'semdom_does_googletranslatedata_exist':
                 return true;
             case 'project_acceptJoinRequest':

--- a/src/Api/Model/Shared/InviteToken.php
+++ b/src/Api/Model/Shared/InviteToken.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Api\Model\Shared;
+
+use Api\Model\Languageforge\Lexicon\LexRoles;
+
+class InviteToken
+{
+
+    public function __construct() {
+
+    }
+
+    /** @var string */
+    public $token;
+
+    /** @var LexRole */
+    public $defaultRole;
+}

--- a/src/Api/Model/Shared/InviteToken.php
+++ b/src/Api/Model/Shared/InviteToken.php
@@ -6,11 +6,6 @@ use Api\Model\Languageforge\Lexicon\LexRoles;
 
 class InviteToken
 {
-
-    public function __construct() {
-
-    }
-
     /** @var string */
     public $token;
 

--- a/src/Api/Model/Shared/ProjectModel.php
+++ b/src/Api/Model/Shared/ProjectModel.php
@@ -228,7 +228,7 @@ class ProjectModel extends MapperModel
         $validRole = array_key_exists($this->inviteToken->defaultRole, $rolesArray);
         if(!$validRole)
         {
-            throw new ResourceNotAvailableException('Project ' . $projectId . '\'s invite token is associated with nonexistant role '
+            throw new ResourceNotAvailableException('Project ' . $projectId . '\'s invite token is associated with nonexistent role '
                 . $model->inviteToken->defaultRole);
         }
         $this->addUser($userId, $this->inviteToken->defaultRole);
@@ -340,7 +340,7 @@ class ProjectModel extends MapperModel
         if (array_key_exists($newRole, $validRoles)) {
             $this->inviteToken->defaultRole = $newRole;
         } else {
-            throw new \InvalidArgumentException("A nonexistant role tried to be linked to an invite token.");
+            throw new \InvalidArgumentException("A nonexistent role tried to be linked to an invite token.");
         }
     }
 

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -378,6 +378,26 @@ class Sf
         return ProjectCommands::getJoinRequests($this->projectId);
     }
 
+    public function project_createInviteLink($defaultRole)
+    {
+        return ProjectCommands::createInviteLink($this->projectId, $defaultRole);
+    }
+
+    public function project_getInviteLink()
+    {
+        return ProjectCommands::getInviteLink($this->projectId);
+    }
+
+    public function project_disableInviteToken()
+    {
+        ProjectCommands::disableInviteToken($this->projectId);
+    }
+
+    public function project_updateInviteTokenRole($newRole)
+    {
+        ProjectCommands::updateInviteTokenRole($this->projectId, $newRole);
+    }
+
     /**
      * Clear out the session projectId and permanently delete selected list of projects.
      *

--- a/src/Site/Controller/App.php
+++ b/src/Site/Controller/App.php
@@ -27,16 +27,25 @@ class App extends Base
         /** @noinspection PhpUnusedParameterInspection */
         Request $request, Application $app, $appName, $projectId = ''
     ) {
-        // Check if an invite token should be processed
-        if (($appName == LfProjectModel::LEXICON_APP || $appName == 'projects') && $app['session']->get('inviteToken'))
-        {
+
+
+        /**
+         * TODO: This logic should be moved into a future Authentication handler.
+         * As of right now, Auth.php cannot give us the answer we need to know if
+         * Authentication was successfully or not, so we check and process the invite token
+         * here.  CJH - 2019-08
+         */
+        if ($app['session']->get('inviteToken')) {
             try
             {
                 $projectId = $this->processInviteToken($app);
             }
             catch (ResourceNotAvailableException $e)
             {
-                return $app->redirect('/app/projects#!/?errorMessage=' . base64_encode($e->getMessage()));
+                return $app->redirect(
+                    '/app/projects#!/?errorMessage=' .
+                    base64_encode($e->getMessage())
+                );
             } finally
             {
                 $app['session']->set('inviteToken', '');

--- a/src/angular-app/bellows/apps/projects/projects-app.component.ts
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.ts
@@ -3,10 +3,10 @@ import * as angular from 'angular';
 import { ProjectService } from '../../core/api/project.service';
 import { ApplicationHeaderService } from '../../core/application-header.service';
 import { BreadcrumbService } from '../../core/breadcrumbs/breadcrumb.service';
+import { HelpHeroService } from '../../core/helphero.service';
 import { NoticeService } from '../../core/notice/notice.service';
 import { SessionService } from '../../core/session.service';
 import { Project } from '../../shared/model/project.model';
-import { HelpHeroService } from '../../core/helphero.service';
 
 class Rights {
   canEditProjects: boolean;
@@ -60,6 +60,8 @@ export class ProjectsAppController implements angular.IController {
         this.helpHeroService.anonymous();
       }
     });
+
+    this.notice.checkUrlForNotices();
   }
 
   isSelected(project: Project) {
@@ -86,7 +88,7 @@ export class ProjectsAppController implements angular.IController {
     return project.role === 'project_manager' || project.role === 'tech_support';
   }
 
-  // Add user as Manager of project
+  // Add user as Tech Support to a project
   addTechSupportToProject(project: Project) {
     this.projectService.joinProject(project.id, 'tech_support', result => {
       if (result.ok) {

--- a/src/angular-app/bellows/apps/public/login/login-app.component.html
+++ b/src/angular-app/bellows/apps/public/login/login-app.component.html
@@ -1,0 +1,39 @@
+<div class="content container-fluid">
+    <div class="row justify-content-center">
+        <div class="col-12 col-md-6 col-xl-4" id="form-container">
+            <div class="text-center">
+                <h1>Login</h1>
+                <sil-notices></sil-notices>
+            </div>
+
+            <p><a href="/oauthcallback/google"><img src="/Site/views/shared/image/btn_google_signin_dark_normal_web.png"></a></p>
+            <p><a href="/oauthcallback/facebook"><img src="/Site/views/shared/image/facebook_login_button.png" height="46" width="191"></a></p>
+            <!-- TODO: Replace the PNG button with an HTML+CSS one to allow translation, as in http://tech.yeesiang.com/social-login-button-with-font-awesome-bootstrap/ -->
+            <form id="login-loginForm" action="/app/login_check" method="post"
+                  accept-charset="utf-8" name="loginForm" novalidate>
+                <div class="form-group">
+                    <label class="col-form-label" for="username">Username or Email</label>
+                    <input class="form-control form-control-lg" id="username"
+                           required type="text" name="_username">
+                </div>
+                <div class="form-group">
+                    <label class="col-form-label" for="password">Password</label>
+                    <input class="form-control form-control-lg" id="password"
+                           required type="password" name="_password"
+                           value="">
+                </div>
+                <div class="form-check">
+                    <label class="form-check-label">
+                        <input class="form-check-input"type="checkbox" id="remember" checked name="_remember_me">
+                        Remember me on this device
+                    </label>
+                </div>
+                <div class="form-group form-group-last">
+                    <button id="login-submit" type="submit" class="btn btn-primary" name="submit">Login</button>
+                    <a href="forgot_password" id="forgot_password">Forgot your password?</a>
+                </div>
+                <p>Don't have an account? <a href="/public/signup">Register now.</a></p>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/angular-app/bellows/apps/public/login/login-app.component.ts
+++ b/src/angular-app/bellows/apps/public/login/login-app.component.ts
@@ -1,0 +1,17 @@
+import * as angular from 'angular';
+
+import { NoticeService } from '../../../core/notice/notice.service';
+
+export class LoginAppController implements angular.IController {
+  static $inject = ['silNoticeService'];
+  constructor(private notice: NoticeService) { }
+
+  $onInit() {
+    this.notice.checkUrlForNotices();
+  }
+}
+
+export const LoginAppComponent: angular.IComponentOptions = {
+  controller: LoginAppController,
+  templateUrl: '/angular-app/bellows/apps/public/login/login-app.component.html'
+};

--- a/src/angular-app/bellows/apps/public/login/login-app.component.ts
+++ b/src/angular-app/bellows/apps/public/login/login-app.component.ts
@@ -5,10 +5,6 @@ import { NoticeService } from '../../../core/notice/notice.service';
 export class LoginAppController implements angular.IController {
   static $inject = ['silNoticeService'];
   constructor(private notice: NoticeService) { }
-
-  $onInit() {
-    this.notice.checkUrlForNotices();
-  }
 }
 
 export const LoginAppComponent: angular.IComponentOptions = {

--- a/src/angular-app/bellows/apps/public/login/login-app.module.ts
+++ b/src/angular-app/bellows/apps/public/login/login-app.module.ts
@@ -1,11 +1,12 @@
 import * as angular from 'angular';
 
 import {CoreModule} from '../../../core/core.module';
+import {LoginAppComponent} from './login-app.component';
 
 export const LoginAppModule = angular
   .module('login', [
     'ui.bootstrap',
     CoreModule
   ])
-  .controller('LoginCtrl', () => {})
+  .component('loginApp', LoginAppComponent)
   .name;

--- a/src/angular-app/bellows/apps/public/login/login.html
+++ b/src/angular-app/bellows/apps/public/login/login.html
@@ -1,48 +1,13 @@
-{% verbatim %}
-{% endverbatim %}
-
-<div class="content container-fluid" data-ng-controller="LoginCtrl">
-    <div class="row justify-content-center">
-        <div class="col-12 col-md-6 col-xl-4" id="form-container">
-            <div class="text-center">
-                <h1>Login</h1>
-                {% for infoMessage in app.session.getFlashBag.get('infoMessage') %}
-                    <div uib-alert class="alert-info">{{ infoMessage }}</div>
-                {% endfor %}
-                {% for errorMessage in app.session.getFlashBag.get('errorMessage') %}
-                    <div uib-alert class="alert-danger">{{ errorMessage }}</div>
-                {% endfor %}
-            </div>
-
-            <p><a href="/oauthcallback/google"><img src="/Site/views/shared/image/btn_google_signin_dark_normal_web.png" height="46" width="191"></a></p>
-            <p><a href="/oauthcallback/facebook"><img src="/Site/views/shared/image/facebook_login_button.png" height="46" width="191"></a></p>
-            <!-- TODO: Replace the PNG button with an HTML+CSS one to allow translation, as in http://tech.yeesiang.com/social-login-button-with-font-awesome-bootstrap/ -->
-            <form id="login-loginForm" action="{{ path('app_login_check') }}" method="post"
-                  accept-charset="utf-8" name="loginForm" novalidate>
-                <div class="form-group">
-                    <label class="col-form-label" for="username">Username or Email</label>
-                    <input class="form-control form-control-lg" id="username"
-                           required type="text" name="_username"
-                           value="{{ last_username }}">
-                </div>
-                <div class="form-group">
-                    <label class="col-form-label" for="password">Password</label>
-                    <input class="form-control form-control-lg" id="password"
-                           required type="password" name="_password"
-                           value="">
-                </div>
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input"type="checkbox" id="remember" checked name="_remember_me">
-                        Remember me on this device
-                    </label>
-                </div>
-                <div class="form-group form-group-last">
-                    <button id="login-submit" type="submit" class="btn btn-primary" name="submit">Login</button>
-                    <a href="forgot_password" id="forgot_password">Forgot your password?</a>
-                </div>
-                <p>Don't have an account? <a href="/public/signup">Register now.</a></p>
-            </form>
-        </div>
-    </div>
+<div class="text-center">
+    <h1>Login</h1>
+    {% for infoMessage in app.session.getFlashBag.get('infoMessage') %}
+        <div uib-alert class="alert-info">{{ infoMessage }}</div>
+    {% endfor %}
+    {% for errorMessage in app.session.getFlashBag.get('errorMessage') %}
+        <div uib-alert class="alert-danger">{{ errorMessage }}</div>
+    {% endfor %}
 </div>
+
+{% verbatim %}
+<login-app></login-app>
+{% endverbatim %}

--- a/src/angular-app/bellows/core/notice/notice.component.ts
+++ b/src/angular-app/bellows/core/notice/notice.component.ts
@@ -14,6 +14,10 @@ export class NoticeController implements angular.IController {
     });
   }
 
+  $onInit() {
+    this.noticeService.checkUrlForNotices();
+  }
+
   closeNotice(id: string): void {
     this.noticeService.removeById(id);
   }

--- a/src/angular-app/bellows/core/notice/notice.service.ts
+++ b/src/angular-app/bellows/core/notice/notice.service.ts
@@ -26,8 +26,8 @@ export class NoticeService {
   private isLoadingNotice: boolean;
   private loadingMessage: string;
 
-  static $inject: string[] = ['$interval'];
-  constructor(private $interval: angular.IIntervalService) {
+  static $inject: string[] = ['$interval', '$location'];
+  constructor(private $interval: angular.IIntervalService, private $location: angular.ILocationService) {
     this.notices = [];
     this.timers = {};
     this.percentComplete = 0;
@@ -40,6 +40,22 @@ export class NoticeService {
       if (this.notices[i].id === id) {
         return i;
       }
+    }
+  }
+
+  checkUrlForNotices(): void {
+    const query: {[key: string]: string} = this.$location.search();
+    if (query.errorMessage) {
+      this.push(this.ERROR, atob(query.errorMessage));
+      this.$location.search('errorMessage', null);
+    }
+    if (query.infoMessage) {
+      this.push(this.INFO, atob(query.infoMessage));
+      this.$location.search('infoMessage', null);
+    }
+    if (query.successMessage) {
+      this.push(this.SUCCESS, atob(query.successMessage));
+      this.$location.search('successMessage', null);
     }
   }
 

--- a/src/composer.json
+++ b/src/composer.json
@@ -12,7 +12,6 @@
   "require": {
     "aptoma/twig-markdown": "^3.0",
     "bugsnag/bugsnag-silex": "^2.0",
-    "elasticsearch/elasticsearch": "^5.3",
     "firebase/php-jwt": "^5.0",
     "guzzlehttp/guzzle": "~6.0",
     "ircmaxell/password-compat": "^1.0",
@@ -35,7 +34,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
-    "phpunit/php-code-coverage": "^7.0"
+    "phpunit/php-code-coverage": "^7.0",
+    "squizlabs/php_codesniffer": "^3.4"
   },
   "autoload": {
     "psr-4": {

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa8860b47fbc51dbd3ef282c89d0acb4",
+    "content-hash": "eacb180010a58170fd617379c4aec4a8",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -1505,6 +1505,57 @@
                 "issues": "https://github.com/sillsdev/web-php-utilities/issues"
             },
             "time": "2019-07-25T03:25:51+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/index.php
+++ b/src/index.php
@@ -255,6 +255,8 @@ $app->get('/script',  'Site\Controller\Script::run');
 //public
 $app->post('/api/{apiName}',    'Site\Controller\Api::service');
 
+$app->get('/invite/{inviteToken}', 'Site\Controller\Validate::processInviteAndRedirect');
+
 $app->get('/public/{appName}/{projectId}/', 'Site\Controller\App::view');
 $app->get('/public/{appName}/{projectId}', 'Site\Controller\App::view');
 $app->get('/public/{appName}/', 'Site\Controller\App::view');

--- a/test/php/model/shared/commands/ProjectCommandsTest.php
+++ b/test/php/model/shared/commands/ProjectCommandsTest.php
@@ -671,7 +671,7 @@ class ProjectCommandsTest extends TestCase
 
     public function testUpdateUserRole_userIsNotAdminAndSetTechSupportRole_throwsException()
     {
-        $this->expectException(UserUnauthorizedException::class); // TODO: Add proper exception
+        $this->expectException(UserUnauthorizedException::class);
         self::$environ->clean();
 
         $userId = self::$environ->createUser("username", "user Name", "user@example.com");
@@ -683,5 +683,62 @@ class ProjectCommandsTest extends TestCase
 
         $projectId = ProjectCommands::createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE, SfProjectModel::SFCHECKS_APP, $ownerId, self::$environ->website);
         ProjectCommands::updateUserRole($projectId, $userId, ProjectRoles::TECH_SUPPORT);
+    }
+
+    public function testProjectInviteLink_enableAndDisableInviteLink_successfulEnableAndDisable()
+    {
+        self::$environ->clean();
+        $ownerId = self::$environ->createUser("ownername", "owner Name", "owner@example.com");
+        $projectId = ProjectCommands::createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE, SfProjectModel::SFCHECKS_APP, $ownerId, self::$environ->website);
+        $projectModel = ProjectModel::getById($projectId);
+        $inviteUrl = ProjectCommands::createInviteLink($projectId, ProjectRoles::MANAGER);
+
+        // Assert URL is valid to site
+        $this->assertStringContainsString($projectModel->siteName, $inviteUrl);
+        $this->assertStringContainsString('.org/invite/', $inviteUrl);
+
+        // Assert invite token is found in the database
+        $lastSlashPos = strrpos($inviteUrl, '/');
+        $token = substr($inviteUrl, $lastSlashPos + 1);
+        $this->assertTrue($projectModel->readByProperties(['inviteToken.token' => $token, 'inviteToken.defaultRole' => ProjectRoles::MANAGER]));
+
+        // Disable invite link and make sure it no longer exists in the DB
+        ProjectCommands::disableInviteToken($projectId);
+        $this->assertFalse($projectModel->readByProperty('inviteToken.token', $token));
+    }
+
+    public function testProjectInviteLink_changeInviteLinkDefaultRole_roleChangeSuccessful()
+    {
+        self::$environ->clean();
+        $ownerId = self::$environ->createUser("ownername", "owner Name", "owner@example.com");
+        $projectId = ProjectCommands::createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE, SfProjectModel::SFCHECKS_APP, $ownerId, self::$environ->website);
+        $projectModel = ProjectModel::getById($projectId);
+        $inviteUrl = ProjectCommands::createInviteLink($projectId, ProjectRoles::MANAGER);
+
+        // Assert defaultRole is set to initialized role
+        $lastSlashPos = strrpos($inviteUrl, '/');
+        $token = substr($inviteUrl, $lastSlashPos + 1);
+        $this->assertTrue($projectModel->readByProperties(['inviteToken.token' => $token, 'inviteToken.defaultRole' => ProjectRoles::MANAGER]));
+
+        // Change defaultRole
+        ProjectCommands::updateInviteTokenRole($projectId, ProjectRoles::CONTRIBUTOR);
+        $this->assertTrue($projectModel->readByProperties(['inviteToken.token' => $token, 'inviteToken.defaultRole' => ProjectRoles::CONTRIBUTOR]));
+    }
+
+    public function testProjectInviteLink_addUserFromLink_additionSuccessful()
+    {
+        self::$environ->clean();
+        $ownerId = self::$environ->createUser("ownername", "owner Name", "owner@example.com");
+        $projectId = ProjectCommands::createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE, SfProjectModel::SFCHECKS_APP, $ownerId, self::$environ->website);
+        $projectModel = ProjectModel::getById($projectId);
+        $inviteUrl = ProjectCommands::createInviteLink($projectId, ProjectRoles::MANAGER);
+
+        // Assert defaultRole is set to initialized role
+        $userId = self::$environ->createUser("user name", "user Name", "user@example.com");
+        ProjectCommands::useInviteToken($userId, $projectId);
+
+        $projectModel = ProjectModel::getById($projectId);
+        $this->assertArrayHasKey($userId, $projectModel->users);
+        $this->assertEquals($projectModel->users[$userId]->role, ProjectRoles::MANAGER);
     }
 }


### PR DESCRIPTION
**Overview:**
In order to better support users without emails and to streamline project sharing, it was determined that we should allow project managers to create invite links, which, upon accessing, add a user to a project with a specified role. This PR includes all of the back-end support for this link sharing. It includes three major partitions:

**1. Creation and management of share link:**
There are three new API calls related to the shareable link

- `'project_getInviteLink', [defaultRole]: link<string>`
  - Takes a roleKey and returns the invite Url
- `'project_disableInviteToken', []: void`
  - Makes the inviteToken an empty string, thereby disabling it
- `'project_updateInviteTokenRole', [newRole]: void`
  - Given a roleKey will update the role a user is assigned when joining via the link

All API calls require `Domain::USERS + Operation::EDIT` permission. These calls invoke ProjectCommands that manipulate a ProjectModel's new `inviteToken` object.

**2. Joining via the link:**
All links point towards `https://<app>.org/invite/<invite code>`. When such a link is accessed, the server looks up a project with that invite code. If it is found and the user is logged in, the user is added to the project and redirected there. If it is found and the user is not logged in, there are taken to the login page with a message encouraging them to register. The invite code is tracked within `$app['session']` and is processed when the `projects` or `lexicon` apps are next accessed. If the project is not found, the user is show an error message on whatever page is appropriate to take them to based on their log-in status.

**3. Miscellaneous Refactors:**
The following changes are also included to support the above features:

- The NoticeService now has an `checkUrlForNotices()` method which checks the Url for base-64 encoded messages in the `errorMessage`, `infoMessage`, and `successMessage` parameters.
- The login page has been turned into an angular component in order to use the NoticeService

**Screenshots:**
![image](https://user-images.githubusercontent.com/24280478/62753884-b0c46600-ba97-11e9-858d-8499d57e43ad.png)
Login page displaying a notice that a project could not be found with a given invite link.


![image](https://user-images.githubusercontent.com/24280478/62754735-53caaf00-ba9b-11e9-85a7-7517f383dd4e.png)
Successfully being added to a project after signing up

**Tests:**
All PHP unit tests run (including new ones for the ProjectCommands)

E2E tests fail at `Update and store different username. Login with new credentials`. My guess is that this is due to the fact that migrating to an angular component from Silex on the login page no longer saves the username when logging out and logging back in. I am looking into as you read this.

If you wish to manually test the invite link. `/invite/test` is set up to create a new project and handle it's invite code. Use branch `feature/linkSharingBackEndTestable`.

**Ideas for continued development:**
- Increase/test support for non-Lf apps (if desired)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/759)
<!-- Reviewable:end -->
