### PR TITLE
Remove double title on login page and autofocus username input

### DIFF
--- a/src/angular-app/bellows/apps/public/login/login-app.component.html
+++ b/src/angular-app/bellows/apps/public/login/login-app.component.html
@@ -7,7 +7,7 @@
             </div>
 
             <p><a href="/oauthcallback/google"><img src="/Site/views/shared/image/btn_google_signin_dark_normal_web.png"></a></p>
-            <p><a href="/oauthcallback/facebook"><img src="/Site/views/shared/image/facebook_login_button.png" height="46" width="191"></a></p>
+            <p><a href="/oauthcallback/facebook"><img src="/Site/views/shared/image/facebook_login_button.png" width="191"></a></p>
             <!-- TODO: Replace the PNG button with an HTML+CSS one to allow translation, as in http://tech.yeesiang.com/social-login-button-with-font-awesome-bootstrap/ -->
             <form id="login-loginForm" action="/app/login_check" method="post"
                   accept-charset="utf-8" name="loginForm" novalidate>

--- a/src/angular-app/bellows/apps/public/login/login-app.component.ts
+++ b/src/angular-app/bellows/apps/public/login/login-app.component.ts
@@ -5,6 +5,10 @@ import { NoticeService } from '../../../core/notice/notice.service';
 export class LoginAppController implements angular.IController {
   static $inject = ['silNoticeService'];
   constructor(private notice: NoticeService) { }
+
+  $onInit() {
+    (document.querySelector('input[name="_username"]') as HTMLElement).focus();
+  }
 }
 
 export const LoginAppComponent: angular.IComponentOptions = {

--- a/src/angular-app/bellows/apps/public/login/login.html
+++ b/src/angular-app/bellows/apps/public/login/login.html
@@ -1,5 +1,4 @@
 <div class="text-center">
-    <h1>Login</h1>
     {% for infoMessage in app.session.getFlashBag.get('infoMessage') %}
         <div uib-alert class="alert-info">{{ infoMessage }}</div>
     {% endfor %}

--- a/src/angular-app/bellows/apps/public/signup/signup-app.component.html
+++ b/src/angular-app/bellows/apps/public/signup/signup-app.component.html
@@ -19,7 +19,7 @@
                     <label class="col-form-label col-md-4 text-md-right" for="name">Full Name</label>
                     <div class="col-md-8">
                         <div class="input-group">
-                            <input class="form-control" id="name" autofocus
+                            <input class="form-control" id="name"
                                    required type="text" name="name"
                                    placeholder="your name"
                                    data-ng-model="$ctrl.record.name">

--- a/src/angular-app/bellows/apps/public/signup/signup-app.component.ts
+++ b/src/angular-app/bellows/apps/public/signup/signup-app.component.ts
@@ -40,6 +40,8 @@ export class SignupAppController implements angular.IController {
     this.record.id = '';
     this.record.password = '';
 
+    (document.querySelector('input[name="name"]') as HTMLElement).focus();
+
     // Parse for user details if given
     const email = this.$location.search().e;
     if (email != null && email.length > 0) {


### PR DESCRIPTION
Before | After
-----|-----
![Screenshot from 2019-08-12 18-44-16](https://user-images.githubusercontent.com/6140710/62903708-a7eec100-bd31-11e9-8e8b-2de8277b6b79.png) | ![Screen Shot 2019-08-12 at 18 39 29](https://user-images.githubusercontent.com/6140710/62903729-b3da8300-bd31-11e9-80f4-2ddb30363486.png)

- Fixes "Login" being on the page twice
- Fixes stretching of "Continue with Facebook" button
- Autofocuses first input on login and sign up pages

Should "Continue with Facebook" be on the sign up page? Right now we just have the option to sign in with Google.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/761)
<!-- Reviewable:end -->
