### PR TITLE
Consistent, translatable login buttons for Google and Facebook

### DIFF
--- a/src/Site/OAuth/FacebookOAuth.php
+++ b/src/Site/OAuth/FacebookOAuth.php
@@ -24,8 +24,22 @@ class FacebookOAuth extends OAuthBase
 
     public function getFullSizeAvatarUrl(string $avatarUrl)
     {
-        // TODO: Learn what Facebook avatar URLs look like
-        return $avatarUrl;
+        // Facebook avatar URL returned from OAuth looks like
+        // https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=10218006774054654&height=200&width=200&ext=1568255043&hash=AeRaWctQlN6CA17U
+        // Facebook docs say to GET https://graph.facebook.com/v4.0/{user-id}/picture to get the actual URL
+        $queryStr = parse_url($avatarUrl, PHP_URL_QUERY);
+        if ($queryStr == null) {
+            return $avatarUrl;
+        }
+        $query = [];
+        parse_str($queryStr, $query);
+        if (array_key_exists('asid', $query)) {
+            $userId = $query['asid'];
+            $url = "https://graph.facebook.com/v4.0/$userId/picture";
+            return $url;
+        } else {
+            return $avatarUrl;
+        }
     }
 
     protected function handleOAuthToken(Application $app, AbstractProvider $provider, OAuthAccessToken $token)

--- a/src/angular-app/bellows/apps/public/login/login-app.component.html
+++ b/src/angular-app/bellows/apps/public/login/login-app.component.html
@@ -6,9 +6,23 @@
                 <sil-notices></sil-notices>
             </div>
 
-            <p><a href="/oauthcallback/google"><img src="/Site/views/shared/image/btn_google_signin_dark_normal_web.png"></a></p>
-            <p><a href="/oauthcallback/facebook"><img src="/Site/views/shared/image/facebook_login_button.png" width="191"></a></p>
-            <!-- TODO: Replace the PNG button with an HTML+CSS one to allow translation, as in http://tech.yeesiang.com/social-login-button-with-font-awesome-bootstrap/ -->
+            <p><a href="/oauthcallback/google">
+                <button type="button" class="social-button google">
+                    <span class="social-button__icon google">
+                        <img src="/Site/views/shared/image/google-logo.svg" width="22">
+                    </span>
+                    <span class="social-button__text google">Sign in with Google</span>
+                </button>
+            </a></p>
+
+            <p><a href="/oauthcallback/facebook">
+                <button type="button" class="social-button facebook">
+                    <span class="social-button__icon facebook">
+                        <img src="/Site/views/shared/image/facebook-logo.png" width="22">
+                    </span>
+                    <span class="social-button__text facebook">Sign in with Facebook</span>
+                </button>
+            </a></p>
             <form id="login-loginForm" action="/app/login_check" method="post"
                   accept-charset="utf-8" name="loginForm" novalidate>
                 <div class="form-group">

--- a/src/angular-app/bellows/apps/public/login/login.scss
+++ b/src/angular-app/bellows/apps/public/login/login.scss
@@ -1,8 +1,63 @@
 /* form styling */
 #form-container .page-header h1 {
-    margin-left: 0; 
+    margin-left: 0;
 }
 
 #form-container #forgot_password {
     margin-left: 10px;
 }
+
+.social-button {
+    height: 40px;
+    border-width: 0;
+
+    &.google { background: #4285f4; }
+    &.facebook { background: #4267B2; }
+
+    color: #737373;
+  //   border-radius: 5px;
+    white-space: nowrap;
+    box-shadow: 1px 1px 0px 1px rgba(0,0,0,0.05);
+    transition-property: background-color, box-shadow;
+    transition-duration: 150ms;
+    transition-timing-function: ease-in-out;
+    padding: 0;
+
+    &:focus,
+    &:hover {
+      box-shadow: 1px 4px 5px 1px rgba(0,0,0,0.1);
+    }
+
+    &:active {
+      background-color: #e5e5e5;
+      box-shadow: none;
+      transition-duration: 10ms;
+    }
+  }
+
+  .social-button__icon {
+    display: inline-block;
+    background: white;
+    vertical-align: middle;
+    padding: 8px 8px 8px 8px;
+    margin-left: 1px;
+    width: 38px;
+    height: 38px;
+    box-sizing: border-box;
+  }
+
+  .social-button__text {
+    display: inline-block;
+    vertical-align: middle;
+    &.google { padding: 0 42px 0 24px; }
+    &.facebook { padding: 0 24px; }
+
+    color: white;
+    font-size: 14px;
+    font-weight: bold;
+    font-family: 'Roboto',arial,sans-serif;
+  }
+
+  button.social-button ~ button.social-button {
+      margin-top: 8px;
+  }

--- a/src/angular-app/bellows/apps/public/oauth-signup/oauth-signup-app.component.ts
+++ b/src/angular-app/bellows/apps/public/oauth-signup/oauth-signup-app.component.ts
@@ -155,7 +155,11 @@ export class OAuthSignupAppController implements angular.IController {
     if (avatarRef) {
       if (avatarRef.startsWith('http')) {
         if (size) {
-          return avatarRef + '?sz=' + size;  // TODO: This will be different for Facebook
+          if (avatarRef.startsWith('https://graph.facebook.com')) {
+            return avatarRef + '?type=square&height=' + size;
+          } else {
+            return avatarRef + '?sz=' + size;
+          }
         } else {
           return avatarRef;
         }


### PR DESCRIPTION
The login buttons for Google and Facebook now have a consistent look and are compliant with each company's brand-use guidelines (e.g., we use the right shade of blue for each button). As a bonus, we also create the buttons with HTML and CSS instead of PNG images, which means their text can be translated.

Also, I noticed that Facebook avatar URLs were being incorrectly handled in the previous Facebook OAuth code, so I've fixed that. We now produce correct URLs for people's Facebook profile picture, and use that as our default avatar if someone signs up via Facebook OAuth (just like we do for Google OAuth).

Screenshot:

![login-with-facebook](https://user-images.githubusercontent.com/90762/62916075-0f078680-bdc1-11e9-8d4d-9accec954eb8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/762)
<!-- Reviewable:end -->
