### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -12,7 +12,7 @@
             <nav class="navbar navbar-expand navbar-dark align-items-stretch">
                 <span class="navbar-brand d-md-inline-block mr-auto">
                     <img class="navbar-logo" src="/Site/views/languageforge/theme/default/image/lf_logo_medium.png">
-                    <a class="" href="/">{{ app.website.name }}</a>
+                    <a class="website-title" href="/">{{ app.website.name }}</a>
                 </span>
                 <ul class="nav navbar-nav">
                     <!-- <li class="nav-item">

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -302,9 +302,11 @@ dc-entry .card {
         }
     }
     .lexiconItemListContainer {
+      margin-bottom: 15px;
+      @include media-breakpoint-up(sm) {
         height: 460px;
         overflow: auto;
-        margin-bottom: 15px;
+        }
     }
     .lexiconListItem.active {
         cursor: default;

--- a/src/angular-app/languageforge/lexicon/lexicon-app.component.html
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.component.html
@@ -1,4 +1,4 @@
-<div class="content container-fluid" data-ng-cloak dir="{{$ctrl.interfaceConfig.direction}}">
+<div class="content" data-ng-cloak dir="{{$ctrl.interfaceConfig.direction}}">
 
     <sil-notices></sil-notices>
     <div data-ui-view></div>

--- a/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
@@ -162,11 +162,10 @@ export class LexiconAppController implements angular.IController {
     Offline.options.checks = { xhr: { url: '/offlineCheck.txt' } };
 
     // Set the page's Language Forge title, font size, and nav's background color
-    function setTitle(text: string, fontSize: string, backgroundColor: string): void {
-      const title = document.querySelector('nav .navbar-brand') as HTMLElement;
-      title.textContent = text;
-      title.style.fontSize = fontSize;
-      (document.querySelector('nav.navbar') as HTMLElement).style.backgroundColor = backgroundColor;
+    function setTitle(text: string, backgroundColorA: string, backgroundColorB: string): void {
+      (document.querySelector('nav .navbar-brand .website-title') as HTMLElement).textContent = text;
+      (document.querySelectorAll('nav.navbar')[0] as HTMLElement).style.backgroundColor = backgroundColorA;
+      (document.querySelectorAll('nav.navbar-expand')[1] as HTMLElement).style.backgroundColor = backgroundColorB;
     }
 
     let offlineMessageId: string;
@@ -183,7 +182,7 @@ export class LexiconAppController implements angular.IController {
     });
 
     Offline.on('down', () => {
-      setTitle('Language Forge Offline', '0.8em', '#555');
+      setTitle('Language Forge Offline', '#555', '#777');
       offlineMessageId = this.notice.push(this.notice.ERROR, 'You are offline. Some features are not available', null,
         true, 5 * 1000);
       this.online = false;


### PR DESCRIPTION
(I've mostly moved over to SF, but I can't do much until I get a Paratext account verified. I felt like I was at a stand-still, so I swung back to LF to grab some low-hanging fruit).

These two screenshots show all the changes (though they're not all related).

When offline:
- Font size is now correct
- All of header fades to gray
- Logo isn't lost

On mobile:
- There isn't a scrollbar for the entries anymore (this can't be seen in the screenshots). It's still present on any size larger than Bootstrap's `xs` (extra small).
- There's less padding on the sides

For some reason GitHub is showing the two screenshots at a slightly different size, so if other stuff looks visually different, that's probably why.

Before | After
-----|-----
![languageforge localhost_app_lexicon_5d4c70712fe7a930335cbf62_(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/6140710/62983556-c3270280-bdfd-11e9-8c86-b43c4ea41e02.png) | ![languageforge localhost_app_lexicon_5d4c70712fe7a930335cbf62_(iPhone 6_7_8)](https://user-images.githubusercontent.com/6140710/62983557-c3bf9900-bdfd-11e9-842e-bcb486258ee9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/763)
<!-- Reviewable:end -->
