### PR TITLE
Fix blank comments panel when coming from entry list

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -215,6 +215,7 @@ export class LexiconEditorController implements angular.IController {
   returnToList(): void {
     this.saveCurrentEntry();
     this.setCurrentEntry();
+    this.hideRightPanelWithoutAnimation();
     this.$state.go('editor.list', {
       sortBy: this.$state.params.sortBy,
       filterText: this.$state.params.filterText,
@@ -716,6 +717,12 @@ export class LexiconEditorController implements angular.IController {
       }, delay, 1);
     }
   }
+
+  hideRightPanelWithoutAnimation = (): void => {
+    this.rightPanelVisible = false;
+    this.control.rightPanelVisible = this.rightPanelVisible;
+    this.setCommentContext('');
+}
 
   setCommentContext = (contextGuid: string): void => {
     this.commentContext.contextGuid = contextGuid;


### PR DESCRIPTION
If the user navigated back to the entry list while having the comments panel (or the recent-activity panel) open, coming back from the entry list to an entry would leave a blank space where the comments panel is supposed to be, and it would be impossible to show the comments panel by clicking on the Comments button.

The root cause was that going back to the entry list did not hide the right panel, which meant that `this.rightPanelVisible` was still true inside the editor controller. But most of the controller code assumes that `this.rightPanelVisible` starts out false (as it's set by the constructor). In particular, this means that the `showRightPanel()` function was misbehaving: it saw that `this.rightPanelVisible` was true, so it assumed that there must be an element with the `.panel-visible` CSS class. (This would be *either* the comments view *or* the activity log). But in fact, the `.panel-visible` CSS class is only ever assigned when `this.rightPanelVisible` goes from false to true. So the absence of that CSS class was causing `document.querySelector('.panel-visible')` to return `null`, which in turn was causing this bug.

Fixes LF-262.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/764)
<!-- Reviewable:end -->
