### PR TITLE
Display warning message for Internet Explorer

### DIFF
--- a/src/Site/Controller/Base.php
+++ b/src/Site/Controller/Base.php
@@ -188,11 +188,7 @@ class Base
     protected function isIE(string $userAgent)
     {
         // Internet Explorer 11 does not report itself as MSIE but does have Trident in the user agent string
-        if (strpos($userAgent, 'MSIE') || strpos($userAgent, 'Trident')) {
-            return true;
-        } else {
-            return false;
-        }
+        return (bool)(strpos($userAgent, 'MSIE') || strpos($userAgent, 'Trident'));
     }
 
     protected function getThemePath($theme = "") {

--- a/src/Site/Controller/Base.php
+++ b/src/Site/Controller/Base.php
@@ -27,6 +27,7 @@ class Base
         $this->data['version'] = VERSION;
         $this->data['useMinifiedJs'] = USE_MINIFIED_JS;
         $this->data['http_host'] = $_SERVER['HTTP_HOST'];
+        $this->data['isIE'] = $this->isIE($_SERVER['HTTP_USER_AGENT'] ?? '');
 
         $this->data['jsFiles'] = [];
         $this->data['jsNotMinifiedFiles'] = [];
@@ -178,6 +179,20 @@ class Base
     protected function isLoggedIn(Application $app)
     {
         return $app['security.authorization_checker']->isGranted('IS_AUTHENTICATED_REMEMBERED');
+    }
+
+    /**
+     * @param string $userAgent
+     * @return bool
+     */
+    protected function isIE(string $userAgent)
+    {
+        // Internet Explorer 11 does not report itself as MSIE but does have Trident in the user agent string
+        if (strpos($userAgent, 'MSIE') || strpos($userAgent, 'Trident')) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     protected function getThemePath($theme = "") {

--- a/src/Site/Controller/Base.php
+++ b/src/Site/Controller/Base.php
@@ -27,7 +27,6 @@ class Base
         $this->data['version'] = VERSION;
         $this->data['useMinifiedJs'] = USE_MINIFIED_JS;
         $this->data['http_host'] = $_SERVER['HTTP_HOST'];
-        $this->data['isIE'] = $this->isIE($_SERVER['HTTP_USER_AGENT'] ?? '');
 
         $this->data['jsFiles'] = [];
         $this->data['jsNotMinifiedFiles'] = [];
@@ -179,16 +178,6 @@ class Base
     protected function isLoggedIn(Application $app)
     {
         return $app['security.authorization_checker']->isGranted('IS_AUTHENTICATED_REMEMBERED');
-    }
-
-    /**
-     * @param string $userAgent
-     * @return bool
-     */
-    protected function isIE(string $userAgent)
-    {
-        // Internet Explorer 11 does not report itself as MSIE but does have Trident in the user agent string
-        return (bool)(strpos($userAgent, 'MSIE') || strpos($userAgent, 'Trident'));
     }
 
     protected function getThemePath($theme = "") {

--- a/src/Site/views/shared/page/angular-app.html.twig
+++ b/src/Site/views/shared/page/angular-app.html.twig
@@ -2,6 +2,13 @@
 
 {% block content %}
     <div id="app-container">
+        {% if isIE %}
+            <div id="ie-alert" class="alert alert-danger">
+                It looks like you're using Internet Explorer.<br/>
+                This website is not designed for Internet Explorer, and some things may not work as expected.<br/>
+                Please use a different browser (such as <a href="https://www.microsoft.com/en-us/windows/microsoft-edge">Microsoft Edge</a>, <a href="https://google.com/chrome">Google Chrome</a>, or <a href="https://mozilla.org/firefox">Mozilla Firefox</a>) to browse this site.
+            </div>
+        {% endif %}
         {% include appFolder~'/'~appName~'.html' %}
     </div>
 

--- a/src/Site/views/shared/page/angular-app.html.twig
+++ b/src/Site/views/shared/page/angular-app.html.twig
@@ -2,13 +2,6 @@
 
 {% block content %}
     <div id="app-container">
-        {% if isIE %}
-            <div id="ie-alert" class="alert alert-danger">
-                It looks like you're using Internet Explorer.<br/>
-                This website is not designed for Internet Explorer, and some things may not work as expected.<br/>
-                Please use a different browser (such as <a href="https://www.microsoft.com/en-us/windows/microsoft-edge">Microsoft Edge</a>, <a href="https://google.com/chrome">Google Chrome</a>, or <a href="https://mozilla.org/firefox">Mozilla Firefox</a>) to browse this site.
-            </div>
-        {% endif %}
         {% include appFolder~'/'~appName~'.html' %}
     </div>
 

--- a/src/angular-app/bellows/apps/activity/activity-app.component.ts
+++ b/src/angular-app/bellows/apps/activity/activity-app.component.ts
@@ -2,11 +2,14 @@ import * as angular from 'angular';
 
 import {ApplicationHeaderService} from '../../core/application-header.service';
 import {BreadcrumbService} from '../../core/breadcrumbs/breadcrumb.service';
+import {BrowserCheckService} from '../../core/browser-check.service';
 
 export class ActivityAppController implements angular.IController {
   static $inject = ['breadcrumbService',
+    'browserCheckService',
     'applicationHeaderService'];
   constructor(private breadcrumbService: BreadcrumbService,
+              private browserCheckService: BrowserCheckService,
               private applicationHeaderService: ApplicationHeaderService) { }
 
   $onInit(): void {
@@ -14,6 +17,7 @@ export class ActivityAppController implements angular.IController {
       {label: 'Activity'}
     ]);
     this.applicationHeaderService.setPageName('Activity');
+    this.browserCheckService.warnIfIE();
   }
 }
 

--- a/src/angular-app/bellows/apps/activity/activity-app.module.ts
+++ b/src/angular-app/bellows/apps/activity/activity-app.module.ts
@@ -3,6 +3,7 @@ import 'angular-moment-picker/dist/angular-moment-picker.css';
 import 'angular-moment-picker/dist/angular-moment-picker.js';
 
 import {BreadcrumbModule} from '../../core/breadcrumbs/breadcrumb.module';
+import {BrowserCheckModule} from '../../core/browser-check.service';
 import {CoreModule} from '../../core/core.module';
 import {ActivityAppComponent} from './activity-app.component';
 import {ActivityContainerComponent} from './activity-container.component';
@@ -13,7 +14,8 @@ export const ActivityAppModule = angular
     'ui.bootstrap',
     'moment-picker',
     CoreModule,
-    BreadcrumbModule
+    BreadcrumbModule,
+    BrowserCheckModule
   ])
   .component('activityApp', ActivityAppComponent)
   .component('activityContainer', ActivityContainerComponent)

--- a/src/angular-app/bellows/apps/changepassword/change-password-app.component.ts
+++ b/src/angular-app/bellows/apps/changepassword/change-password-app.component.ts
@@ -3,6 +3,7 @@ import * as angular from 'angular';
 import { UserService } from '../../core/api/user.service';
 import { ApplicationHeaderService } from '../../core/application-header.service';
 import { BreadcrumbService } from '../../core/breadcrumbs/breadcrumb.service';
+import { BrowserCheckService } from '../../core/browser-check.service';
 import { NoticeService } from '../../core/notice/notice.service';
 import { SessionService } from '../../core/session.service';
 
@@ -12,9 +13,11 @@ export class ChangePasswordAppController implements angular.IController {
 
   static $inject = ['userService', 'sessionService',
                     'silNoticeService', 'breadcrumbService',
+                    'browserCheckService',
                     'applicationHeaderService'];
   constructor(private userService: UserService, private sessionService: SessionService,
               private notice: NoticeService, private breadcrumbService: BreadcrumbService,
+              private browserCheckService: BrowserCheckService,
               private applicationHeaderService: ApplicationHeaderService) {}
 
   $onInit() {
@@ -22,6 +25,7 @@ export class ChangePasswordAppController implements angular.IController {
       { label: 'Change Your Password' }
     ]);
     this.applicationHeaderService.setPageName('Change Your Password');
+    this.browserCheckService.warnIfIE();
   }
 
   updatePassword() {

--- a/src/angular-app/bellows/apps/changepassword/change-password-app.module.ts
+++ b/src/angular-app/bellows/apps/changepassword/change-password-app.module.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 import {BreadcrumbModule} from '../../core/breadcrumbs/breadcrumb.module';
+import {BrowserCheckModule} from '../../core/browser-check.service';
 import {CoreModule} from '../../core/core.module';
 import {NoticeModule} from '../../core/notice/notice.module';
 import {PuiUtilityModule} from '../../shared/utils/pui-utils.module';
@@ -8,7 +9,7 @@ import {ChangePasswordAppComponent} from './change-password-app.component';
 
 export const ChangePasswordAppModule = angular
   .module('changepassword', ['ui.bootstrap', 'ui.validate', 'zxcvbn', CoreModule,
-    NoticeModule, PuiUtilityModule, BreadcrumbModule
+    NoticeModule, PuiUtilityModule, BreadcrumbModule, BrowserCheckModule
   ])
   .component('changePasswordApp', ChangePasswordAppComponent)
   .name;

--- a/src/angular-app/bellows/apps/projects/projects-app.component.ts
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.ts
@@ -3,6 +3,7 @@ import * as angular from 'angular';
 import { ProjectService } from '../../core/api/project.service';
 import { ApplicationHeaderService } from '../../core/application-header.service';
 import { BreadcrumbService } from '../../core/breadcrumbs/breadcrumb.service';
+import { BrowserCheckService } from '../../core/browser-check.service';
 import { HelpHeroService } from '../../core/helphero.service';
 import { NoticeService } from '../../core/notice/notice.service';
 import { SessionService } from '../../core/session.service';
@@ -28,11 +29,13 @@ export class ProjectsAppController implements angular.IController {
   static $inject = ['$window', 'projectService',
                     'sessionService', 'silNoticeService',
                     'breadcrumbService',
+                    'browserCheckService',
                     'applicationHeaderService',
                     'helpHeroService'];
   constructor(private $window: angular.IWindowService, private projectService: ProjectService,
               private sessionService: SessionService, private notice: NoticeService,
               private breadcrumbService: BreadcrumbService,
+              private browserCheckService: BrowserCheckService,
               private applicationHeaderService: ApplicationHeaderService,
               private readonly helpHeroService: HelpHeroService) { }
 
@@ -44,6 +47,7 @@ export class ProjectsAppController implements angular.IController {
           href: '/app/projects',
           label: 'My Projects'
         }]);
+    this.browserCheckService.warnIfIE();
 
     this.sessionService.getSession().then(session => {
       this.rights.canEditProjects =

--- a/src/angular-app/bellows/apps/projects/projects-app.module.ts
+++ b/src/angular-app/bellows/apps/projects/projects-app.module.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 import {BreadcrumbModule} from '../../core/breadcrumbs/breadcrumb.module';
+import {BrowserCheckModule} from '../../core/browser-check.service';
 import {CoreModule} from '../../core/core.module';
 import {NoticeModule} from '../../core/notice/notice.module';
 import {ListViewModule} from '../../shared/list-view.component';
@@ -15,7 +16,8 @@ export const ProjectsAppModule = angular
     ListViewModule,
     NoticeModule,
     PuiUtilityModule,
-    BreadcrumbModule
+    BreadcrumbModule,
+    BrowserCheckModule
   ])
   .component('projectsApp', ProjectsAppComponent)
   .service('helpHeroService', HelpHeroService)

--- a/src/angular-app/bellows/apps/public/login/login-app.component.ts
+++ b/src/angular-app/bellows/apps/public/login/login-app.component.ts
@@ -1,12 +1,14 @@
 import * as angular from 'angular';
 
+import {BrowserCheckService} from '../../../core/browser-check.service';
 import { NoticeService } from '../../../core/notice/notice.service';
 
 export class LoginAppController implements angular.IController {
-  static $inject = ['silNoticeService'];
-  constructor(private notice: NoticeService) { }
+  static $inject = ['silNoticeService', 'browserCheckService'];
+  constructor(private notice: NoticeService, private browserCheckService: BrowserCheckService) { }
 
   $onInit() {
+    this.browserCheckService.warnIfIE();
     (document.querySelector('input[name="_username"]') as HTMLElement).focus();
   }
 }

--- a/src/angular-app/bellows/apps/public/login/login-app.module.ts
+++ b/src/angular-app/bellows/apps/public/login/login-app.module.ts
@@ -1,11 +1,13 @@
 import * as angular from 'angular';
 
+import {BrowserCheckModule} from '../../../core/browser-check.service';
 import {CoreModule} from '../../../core/core.module';
 import {LoginAppComponent} from './login-app.component';
 
 export const LoginAppModule = angular
   .module('login', [
     'ui.bootstrap',
+    BrowserCheckModule,
     CoreModule
   ])
   .component('loginApp', LoginAppComponent)

--- a/src/angular-app/bellows/apps/public/oauth-signup/oauth-signup-app.component.ts
+++ b/src/angular-app/bellows/apps/public/oauth-signup/oauth-signup-app.component.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 import { UserService } from '../../../core/api/user.service';
+import { BrowserCheckService } from '../../../core/browser-check.service';
 import { SessionService } from '../../../core/session.service';
 import { User } from '../../../shared/model/user.model';
 
@@ -28,9 +29,11 @@ export class OAuthSignupAppController implements angular.IController {
   hostname: string;
 
   static $inject = ['$scope', '$location', '$window',
+    'browserCheckService',
     'userService', 'sessionService'];
   constructor(private $scope: any, private $location: angular.ILocationService,
               private $window: angular.IWindowService,
+              private browserCheckService: BrowserCheckService,
               private userService: UserService, private sessionService: SessionService) {}
 
   $onInit() {
@@ -56,6 +59,8 @@ export class OAuthSignupAppController implements angular.IController {
         this.$window.location.href = '/app/projects';
       }
     });
+
+    this.browserCheckService.warnIfIE();
 
     // TODO: This is duplicated from the userprofile app. Should refactor avatar stuff into separate library.
     this.dropdown.avatarColors = [

--- a/src/angular-app/bellows/apps/public/oauth-signup/oauth-signup-app.module.ts
+++ b/src/angular-app/bellows/apps/public/oauth-signup/oauth-signup-app.module.ts
@@ -1,9 +1,10 @@
 import * as angular from 'angular';
 
+import { BrowserCheckModule } from '../../../core/browser-check.service';
 import { CoreModule } from '../../../core/core.module';
 import { OAuthSignupAppComponent } from './oauth-signup-app.component';
 
 export const OAuthSignupAppModule = angular
-    .module('oauth-signup', ['ui.bootstrap', CoreModule])
+    .module('oauth-signup', ['ui.bootstrap', CoreModule, BrowserCheckModule])
     .component('oauthSignupApp', OAuthSignupAppComponent)
     .name;

--- a/src/angular-app/bellows/apps/public/reset_password/reset-password-app.module.ts
+++ b/src/angular-app/bellows/apps/public/reset_password/reset-password-app.module.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 import { UserService } from '../../../core/api/user.service';
+import { BrowserCheckModule, BrowserCheckService } from '../../../core/browser-check.service';
 import { CoreModule } from '../../../core/core.module';
 import { UserWithPassword } from '../../../shared/model/user-password.model';
 
@@ -11,13 +12,15 @@ export class ResetPasswordController implements angular.IController {
 
   private forgotPasswordKey: string;
 
-  static $inject = ['$location', '$window', 'userService'];
+  static $inject = ['$location', '$window', 'browserCheckService', 'userService'];
   constructor(private $location: angular.ILocationService, private $window: angular.IWindowService,
+              private browserCheckService: BrowserCheckService,
               private userService: UserService) {}
 
   $onInit() {
     const absUrl = this.$location.absUrl();
     const appName = '/reset_password/';
+    this.browserCheckService.warnIfIE();
     this.forgotPasswordKey = absUrl.substring(absUrl.indexOf(appName) + appName.length);
   }
 
@@ -36,6 +39,6 @@ export class ResetPasswordController implements angular.IController {
 }
 
 export const ResetPasswordAppModule = angular
-  .module('reset_password', ['ui.bootstrap', CoreModule])
+  .module('reset_password', ['ui.bootstrap', CoreModule, BrowserCheckModule])
   .controller('ResetPasswordCtrl', ResetPasswordController)
   .name;

--- a/src/angular-app/bellows/apps/public/signup/signup-app.component.ts
+++ b/src/angular-app/bellows/apps/public/signup/signup-app.component.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 import {UserService} from '../../../core/api/user.service';
+import {BrowserCheckService} from '../../../core/browser-check.service';
 import {SessionService} from '../../../core/session.service';
 import {CaptchaData} from '../../../shared/model/captcha.model';
 import {UserWithPassword} from '../../../shared/model/user-password.model';
@@ -31,14 +32,18 @@ export class SignupAppController implements angular.IController {
 
   static $inject = ['$scope', '$location',
     '$window',
+    'browserCheckService',
     'userService', 'sessionService'];
   constructor(private readonly $scope: any, private readonly $location: angular.ILocationService,
               private readonly $window: angular.IWindowService,
+              private browserCheckService: BrowserCheckService,
               private readonly userService: UserService, private readonly sessionService: SessionService) {}
 
   $onInit() {
     this.record.id = '';
     this.record.password = '';
+
+    this.browserCheckService.warnIfIE();
 
     (document.querySelector('input[name="name"]') as HTMLElement).focus();
 

--- a/src/angular-app/bellows/apps/public/signup/signup-app.module.ts
+++ b/src/angular-app/bellows/apps/public/signup/signup-app.module.ts
@@ -1,5 +1,6 @@
 import * as angular from 'angular';
 
+import {BrowserCheckModule} from '../../../core/browser-check.service';
 import {CoreModule} from '../../../core/core.module';
 import {CaptchaModule} from '../../../shared/captcha.component';
 import {SignupAppComponent} from './signup-app.component';
@@ -8,6 +9,7 @@ export const ResetPasswordAppModule = angular
   .module('signup', [
     'ui.bootstrap',
     'zxcvbn',
+    BrowserCheckModule,
     CoreModule,
     CaptchaModule
   ])

--- a/src/angular-app/bellows/apps/siteadmin/site-admin-app.module.ts
+++ b/src/angular-app/bellows/apps/siteadmin/site-admin-app.module.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 import {BreadcrumbModule} from '../../core/breadcrumbs/breadcrumb.module';
+import {BrowserCheckModule} from '../../core/browser-check.service';
 import {CoreModule} from '../../core/core.module';
 import {NoticeModule} from '../../core/notice/notice.module';
 import {ListViewModule} from '../../shared/list-view.component';
@@ -19,7 +20,8 @@ export const SiteAdminAppModule = angular
     TypeAheadModule,
     NoticeModule,
     PuiUtilityModule,
-    BreadcrumbModule
+    BreadcrumbModule,
+    BrowserCheckModule
   ])
   .component('siteAdminApp', SiteAdminComponent)
   .component('siteAdminUsers', SiteAdminUsersComponent)

--- a/src/angular-app/bellows/apps/siteadmin/site-admin.component.ts
+++ b/src/angular-app/bellows/apps/siteadmin/site-admin.component.ts
@@ -2,12 +2,15 @@ import * as angular from 'angular';
 
 import {ApplicationHeaderService} from '../../core/application-header.service';
 import {BreadcrumbService} from '../../core/breadcrumbs/breadcrumb.service';
+import {BrowserCheckService} from '../../core/browser-check.service';
 
 export class SiteAdminAppController implements angular.IController {
 
   static $inject = ['breadcrumbService',
+                    'browserCheckService',
                     'applicationHeaderService'];
   constructor(private breadcrumbService: BreadcrumbService,
+              private browserCheckService: BrowserCheckService,
               private applicationHeaderService: ApplicationHeaderService) { }
 
   $onInit() {
@@ -15,6 +18,7 @@ export class SiteAdminAppController implements angular.IController {
       { label: 'Site Administration' }
     ]);
     this.applicationHeaderService.setPageName('Site Administration');
+    this.browserCheckService.warnIfIE();
   }
 
 }

--- a/src/angular-app/bellows/apps/translate/editor/editor.component.ts
+++ b/src/angular-app/bellows/apps/translate/editor/editor.component.ts
@@ -3,6 +3,7 @@ import { ProgressStatus, TrainResultCode } from 'machine';
 import Quill, { DeltaStatic, RangeStatic } from 'quill';
 import Worker from 'worker-loader?name=document-cache.worker.js&publicPath=/dist/!./document-cache.worker';
 
+import { BrowserCheckService } from '../../../core/browser-check.service';
 import { ModalService } from '../../../core/modal/modal.service';
 import { NoticeService } from '../../../core/notice/notice.service';
 import { DocumentsOfflineCacheService } from '../../../core/offline/documents-offline-cache.service';
@@ -44,12 +45,14 @@ export class TranslateEditorController implements angular.IController {
   private readonly documentCacheWorker: Worker;
 
   static $inject = ['$window', '$scope',
+    'browserCheckService',
     '$q', 'machineService',
     'metricService', 'modalService',
     'silNoticeService', 'realTimeService',
     'translateProjectApi', 'utilService',
     'translateSendReceiveService'];
   constructor(private readonly $window: angular.IWindowService, private readonly $scope: angular.IScope,
+              private readonly browserCheckService: BrowserCheckService,
               private readonly $q: angular.IQService, private readonly machine: MachineService,
               private readonly metricService: MetricService, private readonly modal: ModalService,
               private readonly notice: NoticeService, private readonly realTime: RealTimeService,
@@ -65,6 +68,7 @@ export class TranslateEditorController implements angular.IController {
   }
 
   $onInit(): void {
+    this.browserCheckService.warnIfIE();
     this.source = new SourceDocumentEditor(this.$q, this.machine, this.realTime);
     this.target = new TargetDocumentEditor(this.$q, this.machine, this.realTime, this.metricService, this.$window);
     // noinspection JSUnusedLocalSymbols

--- a/src/angular-app/bellows/apps/translate/editor/editor.module.ts
+++ b/src/angular-app/bellows/apps/translate/editor/editor.module.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 import uiRouter from 'angular-ui-router';
 
+import { BrowserCheckModule } from '../../../core/browser-check.service';
 import { CoreModule } from '../../../core/core.module';
 import { PuiUtilityModule } from '../../../shared/utils/pui-utils.module';
 import { TranslateCoreModule } from '../core/translate-core.module';
@@ -11,7 +12,7 @@ import { RealTimeService } from './realtime.service';
 
 export const TranslateEditorModule = angular
   .module('translateEditorModule', [uiRouter, 'ui.bootstrap', CoreModule,
-    TranslateCoreModule, QuillModule, PuiUtilityModule])
+    BrowserCheckModule, TranslateCoreModule, QuillModule, PuiUtilityModule])
   .component('translateEditor', TranslateEditorComponent)
   .service('metricService', MetricService)
   .service('realTimeService', RealTimeService)

--- a/src/angular-app/bellows/apps/translate/new-project/translate-new-project.controller.ts
+++ b/src/angular-app/bellows/apps/translate/new-project/translate-new-project.controller.ts
@@ -1,5 +1,6 @@
 import * as angular from 'angular';
 
+import { BrowserCheckService } from '../../../core/browser-check.service';
 import { InputSystemsService } from '../../../core/input-systems/input-systems.service';
 import { LinkService } from '../../../core/link.service';
 import { NoticeService } from '../../../core/notice/notice.service';
@@ -56,6 +57,7 @@ export class TranslateNewProjectController implements angular.IController {
   static $inject = ['$scope', '$state',
     '$q', '$window',
     'sessionService', 'silNoticeService',
+    'browserCheckService',
     'translateProjectApi', 'linkService',
     'machineService',
     'translateSendReceiveService',
@@ -64,6 +66,7 @@ export class TranslateNewProjectController implements angular.IController {
   constructor(private readonly $scope: angular.IScope, private readonly $state: angular.ui.IStateService,
               private readonly $q: angular.IQService, private readonly $window: angular.IWindowService,
               private readonly sessionService: SessionService, private readonly notice: NoticeService,
+              private readonly browserCheckService: BrowserCheckService,
               private readonly projectApi: TranslateProjectService, private readonly linkService: LinkService,
               private readonly machine: MachineService,
               private readonly translateSendReceiveService: TranslateSendReceiveService,
@@ -84,6 +87,8 @@ export class TranslateNewProjectController implements angular.IController {
         }
       }
     });
+
+    this.browserCheckService.warnIfIE();
 
     this.newProject = {} as NewProject;
     this.newProject.config = new TranslateConfig();

--- a/src/angular-app/bellows/apps/translate/new-project/translate-new-project.module.ts
+++ b/src/angular-app/bellows/apps/translate/new-project/translate-new-project.module.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 import uiRouter from 'angular-ui-router';
 
+import {BrowserCheckModule} from '../../../core/browser-check.service';
 import {CoreModule} from '../../../core/core.module';
 import {InputSystemsModule} from '../../../core/input-systems/input-systems.service';
 import {PuiUtilityModule} from '../../../shared/utils/pui-utils.module';
@@ -13,6 +14,7 @@ export const TranslateNewProjectModule = angular.module('translate-new-project',
     uiRouter,
     'ngFileUpload',
     CoreModule,
+    BrowserCheckModule,
     PuiUtilityModule,
     InputSystemsModule,
     TranslateCoreModule,

--- a/src/angular-app/bellows/apps/translate/settings/settings.component.ts
+++ b/src/angular-app/bellows/apps/translate/settings/settings.component.ts
@@ -1,5 +1,6 @@
 import * as angular from 'angular';
 
+import { BrowserCheckService } from '../../../core/browser-check.service';
 import { NoticeService } from '../../../core/notice/notice.service';
 import { TranslateProjectService } from '../core/translate-project.service';
 import { TranslateRights } from '../core/translate-rights.service';
@@ -17,10 +18,16 @@ export class TranslateSettingsController implements angular.IController {
   project: TranslateProject;
 
   static $inject = ['$scope', '$interval',
+    'browserCheckService',
     'silNoticeService', 'translateProjectApi'
   ];
   constructor(private $scope: angular.IScope, private $interval: angular.IIntervalService,
+              private browserCheckService: BrowserCheckService,
               private notice: NoticeService, private projectApi: TranslateProjectService) {}
+
+  $onInit() {
+    this.browserCheckService.warnIfIE();
+  }
 
   $onChanges(changes: any) {
     if (changes.tscProject.isFirstChange()) {

--- a/src/angular-app/bellows/apps/translate/settings/settings.module.ts
+++ b/src/angular-app/bellows/apps/translate/settings/settings.module.ts
@@ -2,6 +2,7 @@ import * as angular from 'angular';
 import 'angularjs-slider';
 import 'angularjs-slider/dist/rzslider.css';
 
+import {BrowserCheckModule} from '../../../core/browser-check.service';
 import {CoreModule} from '../../../core/core.module';
 import {NoticeModule} from '../../../core/notice/notice.module';
 import {ArchiveProjectModule} from '../../../shared/archive-project.component';
@@ -17,6 +18,7 @@ export const TranslateSettingsModule = angular
     'rzModule',
     'ui.bootstrap',
     CoreModule,
+    BrowserCheckModule,
     ArchiveProjectModule,
     DeleteProjectModule,
     ListViewModule,

--- a/src/angular-app/bellows/apps/translate/translate-app.component.ts
+++ b/src/angular-app/bellows/apps/translate/translate-app.component.ts
@@ -1,5 +1,6 @@
 import * as angular from 'angular';
 
+import { BrowserCheckService } from '../../core/browser-check.service';
 import { SessionService } from '../../core/session.service';
 import { TranslateProjectService } from './core/translate-project.service';
 import { TranslateRights, TranslateRightsService } from './core/translate-rights.service';
@@ -13,10 +14,12 @@ export class TranslateAppController implements angular.IController {
   interfaceConfig: any;
 
   static $inject = ['$state', 'sessionService',
+    'browserCheckService',
     'translateRightsService',
     'translateProjectApi', '$q'
   ];
   constructor(private $state: angular.ui.IStateService, private sessionService: SessionService,
+              private browserCheckService: BrowserCheckService,
               private rightsService: TranslateRightsService,
               private projectApi: TranslateProjectService, private $q: angular.IQService) {}
 
@@ -42,6 +45,7 @@ export class TranslateAppController implements angular.IController {
       this.interfaceConfig.placementToSide = 'left';
       this.interfaceConfig.placementNormal = 'right';
     });
+    this.browserCheckService.warnIfIE();
   }
 
   get showSync(): boolean {

--- a/src/angular-app/bellows/apps/translate/translate-app.module.ts
+++ b/src/angular-app/bellows/apps/translate/translate-app.module.ts
@@ -2,6 +2,7 @@ import * as angular from 'angular';
 import uiRouter from 'angular-ui-router';
 
 import { ApiService } from '../../core/api/api.service';
+import { BrowserCheckModule } from '../../core/browser-check.service';
 import { CoreModule } from '../../core/core.module';
 import { TranslateCoreModule } from './core/translate-core.module';
 import { TranslateEditorModule } from './editor/editor.module';
@@ -14,6 +15,7 @@ export const TranslateAppModule = angular
     uiRouter,
     'ui.bootstrap',
     'ngSanitize',
+    BrowserCheckModule,
     CoreModule,
     TranslateCoreModule,
     TranslateEditorModule,

--- a/src/angular-app/bellows/apps/usermanagement/user-management-app.component.ts
+++ b/src/angular-app/bellows/apps/usermanagement/user-management-app.component.ts
@@ -4,6 +4,7 @@ import { LexiconProjectService } from '../../../languageforge/lexicon/core/lexic
 import { ProjectService } from '../../core/api/project.service';
 import { ApplicationHeaderService } from '../../core/application-header.service';
 import { BreadcrumbService } from '../../core/breadcrumbs/breadcrumb.service';
+import { BrowserCheckService } from '../../core/browser-check.service';
 import { HelpHeroService } from '../../core/helphero.service';
 import { SessionService } from '../../core/session.service';
 
@@ -40,9 +41,10 @@ export class UserManagementAppController implements angular.IController {
   };
 
   static $inject = ['$location', 'projectService', 'sessionService', 'applicationHeaderService',
-                    'breadcrumbService', 'lexProjectService', 'helpHeroService'];
+                    'browserCheckService', 'breadcrumbService', 'lexProjectService', 'helpHeroService'];
   constructor(private $location: angular.ILocationService, private projectService: ProjectService,
               private sessionService: SessionService, private applicationHeaderService: ApplicationHeaderService,
+              private browserCheckService: BrowserCheckService,
               private breadcrumbService: BreadcrumbService, private lexProjectService: LexiconProjectService,
               private readonly helpHeroService: HelpHeroService) { }
 
@@ -56,6 +58,8 @@ export class UserManagementAppController implements angular.IController {
     if (this.roles.length === 0) {
       this.queryUserList();
     }
+
+    this.browserCheckService.warnIfIE();
 
     this.sessionService.getSession().then(session => {
       this.rights.remove = session.hasProjectRight(this.sessionService.domain.USERS,

--- a/src/angular-app/bellows/apps/usermanagement/user-management-app.module.ts
+++ b/src/angular-app/bellows/apps/usermanagement/user-management-app.module.ts
@@ -3,6 +3,7 @@ import uiRouter from 'angular-ui-router';
 
 import {LexiconCoreModule} from '../../../languageforge/lexicon/core/lexicon-core.module';
 import {BreadcrumbModule} from '../../core/breadcrumbs/breadcrumb.module';
+import {BrowserCheckModule} from '../../core/browser-check.service';
 import {CoreModule} from '../../core/core.module';
 import {NoticeModule} from '../../core/notice/notice.module';
 import {ListViewModule} from '../../shared/list-view.component';
@@ -20,6 +21,7 @@ export const UserManagementAppModule = angular
     ListViewModule,
     TypeAheadModule,
     BreadcrumbModule,
+    BrowserCheckModule,
     LexiconCoreModule
   ])
   .component('userManagementApp', UserManagementAppComponent)

--- a/src/angular-app/bellows/apps/userprofile/user-profile-app.component.ts
+++ b/src/angular-app/bellows/apps/userprofile/user-profile-app.component.ts
@@ -3,6 +3,7 @@ import * as angular from 'angular';
 import {UserService} from '../../core/api/user.service';
 import {ApplicationHeaderService} from '../../core/application-header.service';
 import {BreadcrumbService} from '../../core/breadcrumbs/breadcrumb.service';
+import {BrowserCheckService} from '../../core/browser-check.service';
 import {ModalService} from '../../core/modal/modal.service';
 import {NoticeService} from '../../core/notice/notice.service';
 import {UtilityService} from '../../core/utility.service';
@@ -34,10 +35,12 @@ export class UserProfileAppController implements angular.IController {
   static $inject = ['$scope', '$window',
     'userService', 'modalService', 'silNoticeService',
     'breadcrumbService',
+    'browserCheckService',
     'applicationHeaderService'];
   constructor(private $scope: UserProfileAppControllerScope, private $window: angular.IWindowService,
               private userService: UserService, private modalService: ModalService, private notice: NoticeService,
               private breadcrumbService: BreadcrumbService,
+              private browserCheckService: BrowserCheckService,
               private applicationHeaderService: ApplicationHeaderService) {}
 
   $onInit(): void {
@@ -56,6 +59,8 @@ export class UserProfileAppController implements angular.IController {
         this.user.avatar_shape = null;
       }
     });
+
+    this.browserCheckService.warnIfIE();
 
     this.loadUser(); // load the user data right away
 

--- a/src/angular-app/bellows/apps/userprofile/user-profile-app.module.ts
+++ b/src/angular-app/bellows/apps/userprofile/user-profile-app.module.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 import {BreadcrumbModule} from '../../core/breadcrumbs/breadcrumb.module';
+import {BrowserCheckModule} from '../../core/browser-check.service';
 import {CoreModule} from '../../core/core.module';
 import {NoticeModule} from '../../core/notice/notice.module';
 import {InternationalTelephoneInputModule} from './international-telephone-input.directive';
@@ -10,6 +11,7 @@ export const UserProfileAppModule = angular
   .module('userprofile', [
     'ui.bootstrap',
     BreadcrumbModule,
+    BrowserCheckModule,
     CoreModule,
     NoticeModule,
     InternationalTelephoneInputModule

--- a/src/angular-app/bellows/core/browser-check.service.ts
+++ b/src/angular-app/bellows/core/browser-check.service.ts
@@ -1,0 +1,27 @@
+import * as angular from 'angular';
+
+import { NoticeModule } from './notice/notice.module';
+import { NoticeService } from './notice/notice.service';
+import { UtilityService } from './utility.service';
+
+export class BrowserCheckService {
+  static $inject: string[] = ['silNoticeService'];
+  static message: string = 'It looks like you\'re using Internet Explorer. ' +
+  'This website is not designed for Internet Explorer, and some things may not work as expected. ' +
+  'Please use a different browser (such as <a href="https://www.microsoft.com/windows/microsoft-edge">Edge</a>, ' +
+  '<a href="https://mozilla.org/firefox">Firefox</a>, or <a href="https://google.com/chrome">Chrome</a>) ' +
+  'to browse this site.';
+
+  constructor(private noticeService: NoticeService) { }
+
+  warnIfIE() {
+    if (UtilityService.isIE(window.navigator.userAgent)) {
+      this.noticeService.push(this.noticeService.ERROR, BrowserCheckService.message);
+    }
+  }
+}
+
+export const BrowserCheckModule = angular
+  .module('browserCheckModule', [NoticeModule])
+  .service('browserCheckService', BrowserCheckService)
+  .name;

--- a/src/angular-app/bellows/core/utility.service.ts
+++ b/src/angular-app/bellows/core/utility.service.ts
@@ -28,6 +28,10 @@ export class UtilityService {
     return tagAudioPattern.test(tag);
   }
 
+  static isIE(userAgent: string): boolean {
+    return /MSIE|Trident/.test(userAgent);
+  }
+
   /**
    * Copy array retaining any references to the target.
    */

--- a/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
@@ -1,5 +1,6 @@
 import * as angular from 'angular';
 
+import {BrowserCheckService} from '../../bellows/core/browser-check.service';
 import {HelpHeroService} from '../../bellows/core/helphero.service';
 import {NoticeService} from '../../bellows/core/notice/notice.service';
 import {InterfaceConfig} from '../../bellows/shared/model/interface-config.model';
@@ -30,6 +31,7 @@ export class LexiconAppController implements angular.IController {
   static $inject = ['$scope', '$location',
     '$q',
     'silNoticeService', 'lexConfigService',
+    'browserCheckService',
     'lexProjectService',
     'lexEditorDataService',
     'lexRightsService',
@@ -38,6 +40,7 @@ export class LexiconAppController implements angular.IController {
   constructor(private readonly $scope: angular.IScope, private readonly $location: angular.ILocationService,
               private readonly $q: angular.IQService,
               private readonly notice: NoticeService, private readonly configService: LexiconConfigService,
+              private readonly browserCheckService: BrowserCheckService,
               private readonly lexProjectService: LexiconProjectService,
               private readonly editorService: LexiconEditorDataService,
               private readonly rightsService: LexiconRightsService,
@@ -46,6 +49,8 @@ export class LexiconAppController implements angular.IController {
 
   $onInit(): void {
     let finishedPreloading = false;
+
+    this.browserCheckService.warnIfIE();
 
     this.$q.all([this.rightsService.getRights(), this.configService.getEditorConfig()])
       .then(([rights, editorConfig]) => {

--- a/src/angular-app/languageforge/lexicon/lexicon-app.module.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.module.ts
@@ -3,6 +3,7 @@ import 'angular-sanitize';
 import uiRouter from 'angular-ui-router';
 
 import {ApiService} from '../../bellows/core/api/api.service';
+import {BrowserCheckModule} from '../../bellows/core/browser-check.service';
 import {CoreModule} from '../../bellows/core/core.module';
 import {LexiconCoreModule} from './core/lexicon-core.module';
 import {LexiconEditorModule} from './editor/editor.module';
@@ -16,6 +17,7 @@ export const LexiconAppModule = angular
     uiRouter,
     'ngSanitize',
     CoreModule,
+    BrowserCheckModule,
     LexiconCoreModule,
     LexiconEditorModule,
     LexiconSettingsModule

--- a/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.component.ts
+++ b/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.component.ts
@@ -3,6 +3,7 @@ import * as angular from 'angular';
 import {ProjectService} from '../../../bellows/core/api/project.service';
 import {ApplicationHeaderService} from '../../../bellows/core/application-header.service';
 import {BreadcrumbService} from '../../../bellows/core/breadcrumbs/breadcrumb.service';
+import {BrowserCheckService} from '../../../bellows/core/browser-check.service';
 import {LinkService} from '../../../bellows/core/link.service';
 import {NoticeService} from '../../../bellows/core/notice/notice.service';
 import {SessionService} from '../../../bellows/core/session.service';
@@ -60,6 +61,7 @@ export class LexiconNewProjectController implements angular.IController {
     '$state', '$window',
     'applicationHeaderService',
     'breadcrumbService', 'sessionService',
+    'browserCheckService',
     'silNoticeService', 'linkService',
     'projectService',
     'lexProjectService',
@@ -70,6 +72,7 @@ export class LexiconNewProjectController implements angular.IController {
               readonly $state: angular.ui.IStateService, private readonly $window: angular.IWindowService,
               private readonly applicationHeaderService: ApplicationHeaderService,
               private readonly breadcrumbService: BreadcrumbService, readonly sessionService: SessionService,
+              private readonly browserCheckService: BrowserCheckService,
               readonly notice: NoticeService, private readonly linkService: LinkService,
               readonly projectService: ProjectService,
               private readonly lexProjectService: LexiconProjectService,
@@ -105,6 +108,7 @@ export class LexiconNewProjectController implements angular.IController {
       label: 'New Project'
     }]);
     this.applicationHeaderService.setPageName('Start or join a Web Dictionary Project');
+    this.browserCheckService.warnIfIE();
 
     // ----- Step 2: Send Receive Clone -----
 

--- a/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.module.ts
+++ b/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.module.ts
@@ -2,6 +2,7 @@ import * as angular from 'angular';
 import uiRouter from 'angular-ui-router';
 
 import {BreadcrumbModule} from '../../../bellows/core/breadcrumbs/breadcrumb.module';
+import {BrowserCheckModule} from '../../../bellows/core/browser-check.service';
 import {CoreModule} from '../../../bellows/core/core.module';
 import {MockModule} from '../../../bellows/shared/mock.module';
 import {SelectLanguageModule} from '../../../bellows/shared/select-language.component';
@@ -32,6 +33,7 @@ export const LexiconNewProjectModule = angular
     uiRouter,
     'ngFileUpload',
     CoreModule,
+    BrowserCheckModule,
     BreadcrumbModule,
     PuiUtilityModule,
     SelectLanguageModule,


### PR DESCRIPTION
We have seen many Javascript errors in Bugsnag caused by IE 11 not being up-to-date with modern Javascript features. `Array.includes` is one of them, which was recently fixed by https://github.com/sillsdev/web-languageforge/pull/755, but there are others: IE 11 doesn't support `String.prototype.normalize()`, for example. We have two choices: we could add polyfills for all the different things that IE 11 doesn't support, which would be chasing a moving target since we never test with IE. Or, since we have already decided that we don't support IE (since Edge is available), we can just inform the user that Internet Explorer is not supported and ask them to use a better browser.

This PR makes the latter choice. We should probably have a discussion about whether that's the right choice before merging it. We can also discuss the wording of the error message we want to present.

To test this on a Linux box where Internet Explorer isn't available, you can edit `Base.php` and change the `isIE` regex to look for the strings "Chrome" or "Firefox" instead of "MSIE" or "Trident". This will let you experience what an IE-using user would see.

Sample of what the warning looks like below; note there is no "close" box. This is intentional, so that the warning shows up on every Angular page until they switch to a better browser:

![ie-warning](https://user-images.githubusercontent.com/90762/63089326-aadff080-bf81-11e9-8c21-26f64f37b7e6.png)

And how the warning looks on the login page:

![ie-warning](https://user-images.githubusercontent.com/90762/63088733-fabdb800-bf7f-11e9-9723-b76902da5549.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/765)
<!-- Reviewable:end -->
