### PR TITLE
Fix flaky comment pane E2E test

### DIFF
--- a/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
@@ -124,11 +124,16 @@ describe('Lexicon E2E Editor Comments', () => {
     editorPage.comment.bubbles.first.click();
     browser.wait(ExpectedConditions.invisibilityOf(editorPage.commentDiv), constants.conditionTimeout);
     expect<any>(editorPage.commentDiv.getAttribute('class')).not.toContain('panel-visible');
+    // Hiding the comments panel triggers an animation (in hideRightPanel() in editor.component.ts) that uses
+    // Angular's $interval() to animate hiding the panel, taking 1500 ms on large screens, or 500 ms on small ones.
+    // Since it uses $interval(), the animation isn't disabled during our test run. Also, only AFTER the animation
+    // completes will control.rightPanelVisible be set to false. But the 'panel-visible' attribute is removed
+    // BEFORE the animation begins, so our browser.wait() call returns 1500 ms too soon. Which means we have to
+    // wait for the animation to complete before subsequent tests will be ready to run. - 2019-08 RM
+    browser.sleep(1500 + 250);  // Extra 250 ms for paranoia
   });
 
   it('comments panel: show all comments', () => {
-    // ToDo: investigate why this was needed to be added after editor.js changed to TS - IJH 2018-05
-    browser.sleep(1000);
     editorPage.edit.toCommentsLink.click();
     browser.wait(ExpectedConditions.visibilityOf(editorPage.commentDiv), constants.conditionTimeout);
     expect<any>(editorPage.commentDiv.getAttribute('class')).toContain('panel-visible');


### PR DESCRIPTION
One comment-pane E2E test was flaky because of some details of how the comments pane is animated. They're explained in a comment in the PR, so I won't repeat it here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/768)
<!-- Reviewable:end -->
