### PR TITLE
Disable x button in IE/Edge inputs

### DIFF
--- a/src/Site/views/shared/_global.scss
+++ b/src/Site/views/shared/_global.scss
@@ -341,3 +341,7 @@ pui-tab {
 .flex-no-grow {
     flex: 0 0 auto;
 }
+
+input::-ms-clear {
+  display: none;
+}


### PR DESCRIPTION
Edge and IE have an x button to clear text inputs. Since we implement our own we don't want theirs.

![edge](https://user-images.githubusercontent.com/6140710/63189962-32d20300-c033-11e9-85f6-66224cf8b606.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/769)
<!-- Reviewable:end -->
