### PR TITLE
Use user-specified fonts on lexicon editor page

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -77,7 +77,7 @@
                         <div class="col d-none d-md-block">
                             <div id="compactEntryListContainer" class="lexiconItemListContainer" data-pui-when-scrolled="$ctrl.show.more()">
                                 <div class="list-group">
-                                    <div id="entryId_{{entry.id}}" class="list-group-item lexiconListItemCompact"
+                                    <div id="entryId_{{entry.id}}" class="list-group-item lexiconListItemCompact user-fonts"
                                          data-ng-class="{selected: entry.id == $ctrl.currentEntry.id, listItemHasComment: $ctrl.getEntryCommentCount(entry.id) > 0}"
                                          title="{{$ctrl.getCompactItemListOverlay(entry)}}"
                                          data-ng-repeat="entry in $ctrl.visibleEntries track by entry.id" data-ng-click="$ctrl.editEntry(entry.id)">

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
@@ -1,4 +1,4 @@
-<div class="dc-rendered-entryContainer" data-ng-hide="$ctrl.hideIfEmpty && !$ctrl.entry.word">
+<div class="dc-rendered-entryContainer user-fonts" data-ng-hide="$ctrl.hideIfEmpty && !$ctrl.entry.word">
     <span class="dc-rendered-word" data-ng-bind-html="$ctrl.entry.word"></span>
     <span class="dc-rendered-senseContainer" data-ng-repeat="sense in $ctrl.entry.senses track by $index">
         <span dir="ltr" data-ng-if="$ctrl.entry.senses.length !== 1" class="notranslate dc-rendered-senseNumber">{{$index + 1}})</span>

--- a/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
@@ -60,12 +60,14 @@ export class LexiconAppController implements angular.IController {
               this.users = users;
             }
             this.setupConfig(rights, editorConfig);
+            this.setUpCustomFonts();
             finishedPreloading = true;
           }).then(() => { // end of path "B" -- user can edit
             if (finishedPreloading && !this.finishedLoading) this.postLoad();
           });
         } else {
           this.setupConfig(rights, editorConfig);
+          this.setUpCustomFonts();
           finishedPreloading = true;
         }
 
@@ -88,6 +90,29 @@ export class LexiconAppController implements angular.IController {
     });
 
     this.setupOffline();
+  }
+
+  setUpCustomFonts() {
+    const fontFamily = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, '
+                   + '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
+    if (fontFamily !== window.getComputedStyle(document.body).fontFamily) {
+      console.warn('Default fonts may have changed and need to be updated here.');
+    }
+
+    const div = document.createElement('div');
+    const inputSystems = this.editorConfig.inputSystems;
+    const userFonts = Object.keys(inputSystems).map(key => inputSystems[key].cssFontFamily)
+                  .filter(font => {
+                    // ensure it's a valid font value so a single invalid font won't affect other fonts
+                    div.style.fontFamily = font;
+                    return div.style.fontFamily !== '';
+                  }).map(font => `"${font}"`).join(', ');
+
+    const style = document.createElement('style');
+    document.head.appendChild(style);
+    const sheet = style.sheet as any;
+    sheet.insertRule('.user-fonts {font-family: ' + fontFamily + ';}', 0);
+    sheet.rules[0].style.setProperty('font-family', fontFamily + (userFonts ? ', ' + userFonts : ''));
   }
 
   $onDestroy(): void {


### PR DESCRIPTION
This PR applies the user-specified fonts to elements that render lexical entries. They are already applied to inputs for the lexical editor, but there are some places where unrendered characters can still occur:

![](https://user-images.githubusercontent.com/6140710/63195959-070a4980-c042-11e9-9637-8dff1ededded.png)


The methodology is slightly hackish, but I think it really is a reasonable solution. Rather than aplly a font face by setting `style="..."` on each element that may contain lexical data, a `user-fonts` class is put on all elements that may need a custom font, and then a `<style>` element is added that applies a font face to all `.user-fonts` elements.

The main alternative I can think of is applying the style directly to each element. This is a little more complicated, as font metadata has to be passed to each part of the application that handles rendering of lexical data.

Our current default font is `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"`.

The font family this would apply to each `.user-fonts` element is `<that default font>, "user font for input system 1", "user font for input system 2"`, etc. This way most characters are still rendered with the same fonts, regardless of user settings, but it falls back to the user specified font when the other fonts cannot render it.

- Input systems with no custom font are skipped
- If a syntactically invalid font name is supplied, it is ignored
- I'm fairly confident this successfully avoids allowing CSS injection
- E2e tests are passing (except for errors caused by missing images on the login page, but those errors can be worked around, and then everything passes).

There's a companion pull request (#771) that is a cherry-pick of this commit to `lf-live`, as requested by @megahirt. Comments and discussion should be on this pull request, unless they directly relate to the cherry-pick to `lf-live`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/770)
<!-- Reviewable:end -->
