### PR TITLE
[cherry-pick to lf-live] Use user-specified fonts on lexicon editor page

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -85,7 +85,7 @@
                         <div class="col d-none d-md-block">
                             <div id="compactEntryListContainer" class="lexiconItemListContainer" data-pui-when-scrolled="$ctrl.show.more()">
                                 <div class="list-group">
-                                    <div id="entryId_{{entry.id}}" class="list-group-item lexiconListItemCompact"
+                                    <div id="entryId_{{entry.id}}" class="list-group-item lexiconListItemCompact user-fonts"
                                          data-ng-class="{selected: entry.id == $ctrl.currentEntry.id, listItemHasComment: $ctrl.getEntryCommentCount(entry.id) > 0}"
                                          title="{{$ctrl.getCompactItemListOverlay(entry)}}"
                                          data-ng-repeat="entry in $ctrl.visibleEntries track by entry.id" data-ng-click="$ctrl.editEntry(entry.id)">

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
@@ -1,4 +1,4 @@
-<div class="dc-rendered-entryContainer" id="entryContainer" data-ng-hide="$ctrl.hideIfEmpty && !$ctrl.entry.word">
+<div class="dc-rendered-entryContainer user-fonts" id="entryContainer" data-ng-hide="$ctrl.hideIfEmpty && !$ctrl.entry.word">
     <span class="dc-rendered-word" data-ng-bind-html="$ctrl.entry.word"></span>
     <span class="dc-rendered-senseContainer" data-ng-repeat="sense in $ctrl.entry.senses track by $index">
         <span dir="ltr" data-ng-hide="$ctrl.entry.senses.length === 1" class="notranslate dc-rendered-senseNumber">{{$index + 1}})</span>

--- a/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.component.ts
@@ -60,12 +60,14 @@ export class LexiconAppController implements angular.IController {
               this.users = users;
             }
             this.setupConfig(rights, editorConfig);
+            this.setUpCustomFonts();
             finishedPreloading = true;
           }).then(() => { // end of path "B" -- user can edit
             if (finishedPreloading && !this.finishedLoading) this.postLoad();
           });
         } else {
           this.setupConfig(rights, editorConfig);
+          this.setUpCustomFonts();
           finishedPreloading = true;
         }
 
@@ -88,6 +90,29 @@ export class LexiconAppController implements angular.IController {
     });
 
     this.setupOffline();
+  }
+
+  setUpCustomFonts() {
+    const fontFamily = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, '
+                   + '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
+    if (fontFamily !== window.getComputedStyle(document.body).fontFamily) {
+      console.warn('Default fonts may have changed and need to be updated here.');
+    }
+
+    const div = document.createElement('div');
+    const inputSystems = this.editorConfig.inputSystems;
+    const userFonts = Object.keys(inputSystems).map(key => inputSystems[key].cssFontFamily)
+                  .filter(font => {
+                    // ensure it's a valid font value so a single invalid font won't affect other fonts
+                    div.style.fontFamily = font;
+                    return div.style.fontFamily !== '';
+                  }).map(font => `"${font}"`).join(', ');
+
+    const style = document.createElement('style');
+    document.head.appendChild(style);
+    const sheet = style.sheet as any;
+    sheet.insertRule('.user-fonts {font-family: ' + fontFamily + ';}', 0);
+    sheet.rules[0].style.setProperty('font-family', fontFamily + (userFonts ? ', ' + userFonts : ''));
   }
 
   $onDestroy(): void {


### PR DESCRIPTION
This is a companion pull request to #770. Comments and discussion should occur there, unless it relates to the cherry-pick to `lf-live`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/771)
<!-- Reviewable:end -->
