### PR TITLE
Fix bug where entryListModifiers.sortBy is null

### DIFF
--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -19,26 +19,36 @@ import {CommentsOfflineCacheService} from './comments-offline-cache.service';
 import {EditorOfflineCacheService} from './editor-offline-cache.service';
 import {LexiconCommentService} from './lexicon-comments.service';
 
-class FilterOption {
-  label?: string;
-  level?: string;
-  type?: string;
-  value?: string;
+export interface LabeledOption {
+  label: string;
+}
+
+export interface SortOption extends LabeledOption {
+  label: string;
+  value: string;
+}
+
+export interface FilterOption extends LabeledOption {
   inputSystem?: string;
+  key: string;
+  label: string;
+  level?: string;
+  type: string;
+  value: string;
 }
 
 class EntryListModifiers {
-  sortBy = {
+  sortBy: SortOption = {
     label: 'Default',
     value: 'default'
   };
-  sortOptions: any[] = [];
+  sortOptions: SortOption[] = [];
   sortReverse = false;
   filterBy: {
     text: string;
     option: FilterOption;
   } = null;
-  filterOptions: any[] = [];
+  filterOptions: FilterOption[] = [];
   filterType = 'isNotEmpty';
 
   filterText = () => this.filterBy && this.filterBy.text || '';

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -5,7 +5,7 @@ import {ApplicationHeaderService} from '../../../bellows/core/application-header
 import {HelpHeroService} from '../../../bellows/core/helphero.service';
 import {ModalService} from '../../../bellows/core/modal/modal.service';
 import {NoticeService} from '../../../bellows/core/notice/notice.service';
-import {EditorDataService} from '../../../bellows/core/offline/editor-data.service';
+import {EditorDataService, LabeledOption, SortOption, FilterOption} from '../../../bellows/core/offline/editor-data.service';
 import {LexiconCommentService} from '../../../bellows/core/offline/lexicon-comments.service';
 import {SessionService} from '../../../bellows/core/session.service';
 import {InterfaceConfig} from '../../../bellows/shared/model/interface-config.model';
@@ -27,20 +27,6 @@ import {
 import {LexiconProject} from '../shared/model/lexicon-project.model';
 import {FieldControl} from './field/field-control.model';
 import {LexOptionList} from '../shared/model/option-list.model';
-
-class SortOption {
-  label: string;
-  value: string;
-}
-
-class FilterOption {
-  inputSystem?: string;
-  key: string;
-  label: string;
-  level?: string;
-  type: string;
-  value: string;
-}
 
 class Show {
   more: () => void;
@@ -251,8 +237,10 @@ export class LexiconEditorController implements angular.IController {
       clear(); // remove the watcher
 
       if (this.$state.params.sortBy) {
-        this.entryListModifiers.sortBy =
-        this.findSelectedFilter(this.entryListModifiers.sortOptions, this.$state.params.sortBy);
+        const sortBy = this.findSelectedFilter(this.entryListModifiers.sortOptions, this.$state.params.sortBy);
+        if (sortBy) {
+          this.entryListModifiers.sortBy = sortBy;
+        }
       }
       this.entryListModifiers.sortReverse = this.$state.params.sortReverse === 'true';
 
@@ -917,7 +905,7 @@ export class LexiconEditorController implements angular.IController {
     });
   }
 
-  private findSelectedFilter(collections: any[], params: string) {
+  private findSelectedFilter<T extends LabeledOption>(collections: T[], params: string) : T {
     if (collections && params) return collections.filter(item => item.label === params)[0];
   }
 


### PR DESCRIPTION
It is often happening that there's an invalid `sortBy` parameter in the URL, and our code currently assumes that the URL parameter will always be found in the sort options; when that wasn't happening, the `findSelectedFilter` function was returning null or undefined. Now we check the result first, and only assign it to `entryListModifiers.sortBy` if it is valid.

This passes E2E tests once PR #768 has been merged, and should fix LF-258, LF-259, and LF-283.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/772)
<!-- Reviewable:end -->
