### PR TITLE
Update PHP live config to have Facebook client ID and secret

### DIFF
--- a/src/config.php.fortest
+++ b/src/config.php.fortest
@@ -70,6 +70,14 @@ if (! defined('GOOGLE_CLIENT_SECRET')) {
     define('GOOGLE_CLIENT_SECRET', 'googleClientSecret');
 }
 
+if (! defined('FACEBOOK_CLIENT_ID')) {
+    define('FACEBOOK_CLIENT_ID', 'facebookClientId');
+}
+
+if (! defined('FACEBOOK_CLIENT_SECRET')) {
+    define('FACEBOOK_CLIENT_SECRET', 'facebookClientSecret');
+}
+
 if (! defined('GATHERWORDS_CLIENT_ID')) {
     define('GATHERWORDS_CLIENT_ID', 'gatherWordsClientId');
 }

--- a/src/config.php.live
+++ b/src/config.php.live
@@ -67,6 +67,14 @@ if (! defined('GOOGLE_CLIENT_SECRET')) {
     define('GOOGLE_CLIENT_SECRET', 'googleClientSecret');
 }
 
+if (! defined('FACEBOOK_CLIENT_ID')) {
+    define('FACEBOOK_CLIENT_ID', 'facebookClientId');
+}
+
+if (! defined('FACEBOOK_CLIENT_SECRET')) {
+    define('FACEBOOK_CLIENT_SECRET', 'facebookClientSecret');
+}
+
 if (! defined('GATHERWORDS_CLIENT_ID')) {
     define('GATHERWORDS_CLIENT_ID', 'gatherWordsClientId');
 }


### PR DESCRIPTION
The lines needed in the config for Facebook login were added in 65fdc3b03eec4d28e679e08fff16edf4ebec549b, but only in `config.php`, not `config.php.live`. The result was that when the e2e tests finished running, `config.php` had been modified.

@rmunn, should they also be added to `config.php.fortest`?

Wouldn't it be "more correct" for them to be named `config.live.php` and `config.fortest.php`? At the very least editors would (probably) automatically detect it as PHP, whereas right now VS Code renders them as plain text files. I'm guessing the reason `config.php.fortest` ends with `fortest` is because `.test` would have caused the file to be treated incorrectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/773)
<!-- Reviewable:end -->
