### PR TITLE
[PR to another branch] Improvements to the sharing dialog

### DIFF
--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.html
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.html
@@ -4,7 +4,7 @@
     <label>via: </label>
     <input type="email" class="form-control" placeholder="Email" ng-model="$ctrl.inviteEmail">
     <button type="button" class="btn btn-primary"
-            ng-click="$ctrl.sendEmailInvite()">
+            ng-click="$ctrl.sendEmailInvite()" data-ng-disabled="$ctrl.inviteEmailDisabled()">
       <i class="fa fa-paper-plane"></i>
     </button>
     <role-dropdown class="sm-no-margin"

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.html
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.html
@@ -31,7 +31,7 @@
                     ng-if="$ctrl.currentUserIsManager"
                     target="'reusable_invite_link'"
                     roles="$ctrl.reusableInviteLinkRoles"
-                    selected-role="$ctrl.project.inviteToken.defaultRole"
+                    selected-role="$ctrl.getInviteRole()"
                     on-role-changed="$ctrl.onRoleChanged($event)"></role-dropdown>
     </div>
   </div>

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.ts
@@ -22,9 +22,7 @@ export class InviteMemberFormController implements angular.IController {
   static $inject = ['projectService', 'sessionService', 'userService'];
   constructor(private readonly projectService: ProjectService,
               private readonly sessionService: SessionService,
-              private readonly userService: UserService) { }
-
-  $onInit(): void {
+              private readonly userService: UserService) {
 
     this.emailInviteRoles = [
       LexRoles.MANAGER,
@@ -94,6 +92,10 @@ export class InviteMemberFormController implements angular.IController {
         });
       }
     }
+  }
+
+  getInviteRole() {
+    return this.reusableInviteLinkRoles.find(role => role.key === this.project.inviteToken.defaultRole);
   }
 
 }

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.ts
@@ -61,11 +61,13 @@ export class InviteMemberFormController implements angular.IController {
   }
 
   sendEmailInvite() {
-    if (this.inviteEmail) {
-      this.userService.sendInvite(this.inviteEmail, this.emailInviteRole.key).then(() => {
-        if (this.onSendEmailInvite) this.onSendEmailInvite();
-      });
-    }
+    this.userService.sendInvite(this.inviteEmail, this.emailInviteRole.key).then(() => {
+      if (this.onSendEmailInvite) this.onSendEmailInvite();
+    });
+  }
+
+  inviteEmailDisabled() {
+    return !/^\S+@\S+\.\S+$/.test(this.inviteEmail);
   }
 
   onRoleChanged($event: {roleDetail: RoleDetail, target: any}) {

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.html
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.html
@@ -3,7 +3,7 @@
     uib-dropdown-toggle>
     <i class="fa fa-{{ $ctrl.selectedRoleDetail.icon }}"></i> <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu modal-dropdown" uib-dropdown-menu role="menu" aria-labelledby="single-button">
+  <ul class="dropdown-menu dropdown-menu-right modal-dropdown" uib-dropdown-menu role="menu" aria-labelledby="single-button">
     <li class="dropdown-item" role="menuitem"
       ng-repeat="roleDetail in $ctrl.roleDetails">
       <div ng-click="$ctrl.selectRoleDetail(roleDetail)">

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.html
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.html
@@ -3,16 +3,14 @@
     uib-dropdown-toggle>
     <i class="fa fa-{{ $ctrl.selectedRoleDetail.icon }}"></i> <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu dropdown-menu-right modal-dropdown" uib-dropdown-menu role="menu" aria-labelledby="single-button">
-    <li class="dropdown-item" role="menuitem"
-      ng-repeat="roleDetail in $ctrl.roleDetails">
-      <div ng-click="$ctrl.selectRoleDetail(roleDetail)">
-          {{ roleDetail.description }} <i class="fa fa-check" ng-show="$ctrl.selectedRoleDetail == roleDetail"></i>
-      </div>
-    </li>
+  <div class="dropdown-menu dropdown-menu-right modal-dropdown" uib-dropdown-menu role="menu" aria-labelledby="single-button">
+    <a href class="dropdown-item" role="menuitem" ng-repeat="roleDetail in $ctrl.roleDetails" ng-click="$ctrl.selectRoleDetail(roleDetail)">
+      <i class="fa fa-{{ roleDetail.icon }}"></i>
+      {{ roleDetail.description }} <i class="fa fa-check" ng-show="$ctrl.selectedRoleDetail == roleDetail"></i>
+    </a>
     <div class="dropdown-divider" ng-if="$ctrl.allowDelete"></div>
     <li class="dropdown-item" role="menuitem" ng-if="$ctrl.allowDelete">
       <div ng-click="$ctrl.onDeleteTarget({$event: {target: $ctrl.target}})" class="text-danger">remove</div>
     </li>
-  </ul>
+  </div>
 </div>

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.ts
@@ -28,59 +28,40 @@ export class RoleDropdownController implements angular.IController {
   static $inject = ['$scope'];
   constructor(private readonly $scope: angular.IScope) { }
 
-  $onInit(): void {
-    if (!this.roleDetails) this.buildRoleDetails();
-    this.selectedRole = this.selectedRole || this.roles[this.roles.length - 1];
-  }
-
   $onChanges(changes: any): void {
+    if (changes.roles) this.buildRoleDetails();
+
     if (changes.selectedRole) {
-      if (!this.roleDetails) this.buildRoleDetails();
-      this.selectedRoleDetail = this.roleDetails.find(p => p.role.key === (this.selectedRole.key || this.selectedRole));
+      if (!this.selectedRole) this.selectedRole = this.roles[this.roles.length - 1];
+      this.selectedRoleDetail = this.roleDetails.find(p => p.role.key === this.selectedRole.key);
     }
   }
 
   buildRoleDetails(): void {
-    this.roleDetails = [];
-    this.roles.forEach(role => {
-      switch (role) {
-        case LexRoles.MANAGER:
-          this.roleDetails.push({
-            role,
-            description: 'can manage',
-            icon: 'vcard'
-          });
-          break;
-        case LexRoles.CONTRIBUTOR:
-          this.roleDetails.push({
-            role,
-            description: 'can edit',
-            icon: 'pencil'
-          });
-          break;
-        case LexRoles.OBSERVER_WITH_COMMENT:
-            this.roleDetails.push({
-              role,
-              description: 'can comment',
-              icon: 'comment'
-            });
-            break;
-        case LexRoles.OBSERVER:
-            this.roleDetails.push({
-              role,
-              description: 'can view',
-              icon: 'eye'
-            });
-            break;
-        case LexRoles.NONE:
-            this.roleDetails.push({
-              role,
-              description: 'disable',
-              icon: 'ban'
-            });
-            break;
+    const allRoleDetails = [{
+        role: LexRoles.MANAGER,
+        description: 'can manage',
+        icon: 'vcard'
+      }, {
+        role: LexRoles.CONTRIBUTOR,
+        description: 'can edit',
+        icon: 'pencil'
+      }, {
+        role: LexRoles.OBSERVER_WITH_COMMENT,
+        description: 'can comment',
+        icon: 'comment'
+      }, {
+        role: LexRoles.OBSERVER,
+        description: 'can view',
+        icon: 'eye'
+      }, {
+        role: LexRoles.NONE,
+        description: 'disable',
+        icon: 'ban'
       }
-    });
+    ];
+
+    this.roleDetails = allRoleDetails.filter(roleDetail => this.roles.includes(roleDetail.role));
   }
 
   selectRoleDetail(roleDetail: RoleDetail): void {

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/share-with-others.scss
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/share-with-others.scss
@@ -20,7 +20,7 @@
   align-items: center;
 
   input[type=text], input[type=email], input[type=password] {
-    flex-grow: 1;
+    min-width: 0; // necessary in Firefox for small screens
   }
 
   > *:not(:last-child) {


### PR DESCRIPTION
I've made some changes to the sharing dialog that hasn't been merged into master yet. As such I am setting the base for this PR to `feature/sharingDialog`. Whether actually merging into that branch is the best strategy I leave to others to decide. It could be merged into master after merging that one, or something else.

### Changes
- Previously only part of each menu item in the role dropdown was clickable, and the cursor wasn’t a hand. I’ve changed it to use an `<a>` tag, which solves both of these problems and makes them act like the other menus we have.
- I added the leftmost icons to the menu. Previously these icons showed only in the button part of the dropdown, after an item was selected. This change is a little more debatable (nothing was actually wrong before), but it was a very easy change, and I think it helps to create the mental connection between the options and the icon that is shown once the dropdown is closed. 
![Screenshot from 2019-08-20 11-49-10](https://user-images.githubusercontent.com/6140710/63362922-a11f0a00-c340-11e9-9cdd-c690a1c54aa4.png)
 - The button to send an email invite is now disabled until the email is something like `a@a.a`. Previously it was enabled all the time, but would only send a request to the server if it wasn’t the empty string. This is a very permissive regex that accepts any non-whitespace characters for the main parts of the email (technically email addresses can sometimes have spaces, and don’t have to have dots, but that hardly seems like something we’re likely to encounter).
- Menus are now left-aligned, which is especially important on small screens, where previously they were sticking out of the viewport. The current version is in a screenshot above. Here's how they were before:
![Screenshot from 2019-08-20 11-18-22](https://user-images.githubusercontent.com/6140710/63361681-8d72a400-c33e-11e9-8ff4-9c5dae37524b.png)
- The email input was not shrinking on small screens in Firefox like it should. Now it works in both Chromium and Firefox. The screenshot shows how it was before.
![Screenshot from 2019-08-20 11-45-50](https://user-images.githubusercontent.com/6140710/63362610-1e964a80-c340-11e9-9a37-57dc3bb329b1.png)
- There was an error in the console, as well as some UI issues, due to the invite link not having a default role (this might only show up on some projects). I believe I've successfully fixed that bug.

### TODO

- The share button needs to not exist on the my projects page, or anywhere else it doesn't belong. I'm not sure that this is reproducible 100% of the time (for a short time I couldn't reproduce it, but now I can't not reproduce it).
![Screenshot from 2019-08-20 11-55-51](https://user-images.githubusercontent.com/6140710/63363416-87ca8d80-c341-11e9-9963-7f3a01b473b9.png)
- The "Allow others to share" option needs a lot more clarification. Clearly managers can always share, so this applies to those who can edit, comment, or view. What privilege level do those they share with receive? Clearly they shouldn't be able to share above their own privilege level. However it works, I think it needs to be spelled out clearly. If the invite link is enabled, we might also want to add "*Users with the invite link will always be able to share it with others.*"
![Screen Shot 2019-08-20 at 11 58 09](https://user-images.githubusercontent.com/6140710/63363550-d2e4a080-c341-11e9-9c6b-4cd096202c6e.png)
- Currently it's possible to allow users joining by link to join as managers. I think we should seriously consider whether this should be an option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/774)
<!-- Reviewable:end -->
