### PR TITLE
Fix E2E tests of projects page

### DIFF
--- a/test/app/bellows/shared/projects.page.ts
+++ b/test/app/bellows/shared/projects.page.ts
@@ -58,11 +58,13 @@ export class ProjectsPage {
   addUserToProject(projectName: any, usersName: string, roleText: string) {
     this.findProject(projectName).then((projectRow: any) => {
       const projectLink = projectRow.element(by.css('a'));
-      projectLink.click();
-      browser.wait(ExpectedConditions.visibilityOf(this.settingsBtn), Utils.conditionTimeout);
-      this.settingsBtn.click();
-      browser.wait(ExpectedConditions.visibilityOf(this.userManagementLink), Utils.conditionTimeout);
-      this.userManagementLink.click();
+      projectLink.getAttribute('href').then((href: string) => {
+        const results = /app\/lexicon\/([0-9a-fA-F]+)\//.exec(href);
+        expect(results).not.toBeNull();
+        expect(results.length).toBeGreaterThan(1);
+        const projectId = results[1];
+        UserManagementPage.get(projectId);
+      });
 
       browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.addMembersBtn), Utils.conditionTimeout);
       this.userManagementPage.addMembersBtn.click();
@@ -108,12 +110,14 @@ export class ProjectsPage {
   removeUserFromProject(projectName: string, userName: string) {
     this.findProject(projectName).then((projectRow: any) => {
       const projectLink = projectRow.element(by.css('a'));
-      projectLink.click();
-
-      browser.wait(ExpectedConditions.visibilityOf(this.settingsBtn), Utils.conditionTimeout);
-      this.settingsBtn.click();
-      browser.wait(ExpectedConditions.visibilityOf(this.userManagementLink), Utils.conditionTimeout);
-      this.userManagementLink.click();
+      projectLink.getAttribute('href').then((href: string) => {
+        const results = /app\/lexicon\/([0-9a-fA-F]+)\//.exec(href);
+        expect(results).not.toBeNull();
+        expect(results.length).toBeGreaterThan(1);
+        const projectId = results[1];
+        UserManagementPage.get(projectId);
+      });
+      browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.addMembersBtn), Utils.conditionTimeout);
 
       let userFilter: any;
       let projectMemberRows: any;

--- a/test/app/bellows/shared/user-management.page.ts
+++ b/test/app/bellows/shared/user-management.page.ts
@@ -1,9 +1,9 @@
-import { browser, element, by, ElementFinder, ElementArrayFinder, protractor } from "protractor";
-import { Utils } from "./utils";
+import { browser, by, element, ElementArrayFinder, ElementFinder, protractor } from 'protractor';
+import { Utils } from './utils';
 
 export class UserManagementPage {
   static get(projectId: string) {
-    browser.get(browser.baseUrl + '/app/usermanagement' + projectId );
+    browser.get(browser.baseUrl + '/app/usermanagement/' + projectId );
   }
 
   addMembersBtn = element(by.id('addMembersButton'));


### PR DESCRIPTION
This is not a good long-term fix since it exercises an app (the user management app) which we no longer expose to the user in our UI and so we'll probably remove it at some point. But in the short term, it gets the E2E tests passing again. In the long term, we should change the `addUserToProject` implementation to use the user's email address and enter it in the new "Share With Others" dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/775)
<!-- Reviewable:end -->
