### PR TITLE
Fix User Management E2E tests

### DIFF
--- a/src/angular-app/bellows/core/navbar.controller.ts
+++ b/src/angular-app/bellows/core/navbar.controller.ts
@@ -66,7 +66,9 @@ export class NavbarController implements angular.IController {
         }
       }
       if (this.project) {
-        this.currentUserIsProjectManager = session.data.userProjectRole === ProjectRoles.MANAGER.key;
+        this.currentUserIsProjectManager =
+          (session.data.userProjectRole === ProjectRoles.MANAGER.key) ||
+          (session.data.userProjectRole === ProjectRoles.TECH_SUPPORT.key);
         this.displayShareButton =
           (this.currentUserIsProjectManager || (this.project.allowSharing && this.session.data.userIsProjectMember));
       }

--- a/test/app/bellows/shared/user-management.page.ts
+++ b/test/app/bellows/shared/user-management.page.ts
@@ -1,9 +1,25 @@
 import { browser, by, element, ElementArrayFinder, ElementFinder, protractor } from 'protractor';
+import { ProjectsPage } from './projects.page';
 import { Utils } from './utils';
 
 export class UserManagementPage {
   static get(projectId: string) {
     browser.get(browser.baseUrl + '/app/usermanagement/' + projectId );
+  }
+
+  static getByProjectName(projectName: string) {
+    const projectsPage = new ProjectsPage();
+    projectsPage.get();
+    return projectsPage.findProject(projectName).then((projectRow: ElementFinder) => {
+      const projectLink = projectRow.element(by.css('a'));
+      return projectLink.getAttribute('href').then((href: string) => {
+        const results = /app\/lexicon\/([0-9a-fA-F]+)\//.exec(href);
+        expect(results).not.toBeNull();
+        expect(results.length).toBeGreaterThan(1);
+        const projectId = results[1];
+        UserManagementPage.get(projectId);
+      });
+    });
   }
 
   addMembersBtn = element(by.id('addMembersButton'));

--- a/test/app/bellows/user-management.e2e-spec.ts
+++ b/test/app/bellows/user-management.e2e-spec.ts
@@ -26,78 +26,64 @@ describe('Bellows E2E User Management App', () => {
       projectRow.element(by.id('techSupportButton')).click();
     });
 
-    // Assert admin is Tech Support
-    projectsPage.clickOnProject(constants.otherProjectName);
-    browser.wait(ExpectedConditions.visibilityOf(projectsPage.settingsBtn), Utils.conditionTimeout);
-    projectsPage.settingsBtn.click();
-    projectsPage.userManagementLink.click();
-    browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
-
-    userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      const selector = row.element(by.css('select'));
-      expect<any>(selector.isEnabled()).toBe(true);
-      selector.element(by.css('option[selected=selected]')).getText().then( text => {
-        expect<any>(text).toBe('Tech Support');
+    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
+      browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+      userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+        const selector = row.element(by.css('select'));
+        expect<any>(selector.isEnabled()).toBe(true);
+        selector.element(by.css('option[selected=selected]')).getText().then( text => {
+          expect<any>(text).toBe('Tech Support');
+        });
       });
     });
   });
 
   it('Other user cannot assign Tech Support user\'s role', () => {
     loginPage.loginAsManager();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.otherProjectName);
-
-    browser.wait(ExpectedConditions.visibilityOf(projectsPage.settingsBtn), Utils.conditionTimeout);
-    projectsPage.settingsBtn.click();
-    projectsPage.userManagementLink.click();
-    browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
-
-    userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      const selector = row.element(by.css('select'));
-      expect<any>(selector.isEnabled()).toBe(false);
-      selector.element(by.css('option[selected=selected]')).getText().then( text => {
-        expect<any>(text).toBe('Tech Support');
+    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
+      browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+      userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+        const selector = row.element(by.css('select'));
+        expect<any>(selector.isEnabled()).toBe(false);
+        selector.element(by.css('option[selected=selected]')).getText().then( text => {
+          expect<any>(text).toBe('Tech Support');
+        });
       });
     });
+
   });
 
   it('Tech Support user can assign their own role', () => {
     loginPage.loginAsAdmin();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.otherProjectName);
-
-    browser.wait(ExpectedConditions.visibilityOf(projectsPage.settingsBtn), Utils.conditionTimeout);
-    projectsPage.settingsBtn.click();
-    projectsPage.userManagementLink.click();
-    userManagementPage.changeUserRole(constants.adminUsername, 'Manager');
-
-    browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
-    userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      const selector = row.element(by.css('select'));
-      expect<any>(selector.isEnabled()).toBe(true);
-      selector.element(by.css('option[selected=selected]')).getText().then( text => {
-        expect<any>(text).toBe('Manager');
+    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
+      browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+      userManagementPage.changeUserRole(constants.adminUsername, 'Manager');
+    });
+    // Now verify
+    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
+      browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+      userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+        const selector = row.element(by.css('select'));
+        expect<any>(selector.isEnabled()).toBe(true);
+        selector.element(by.css('option[selected=selected]')).getText().then( text => {
+          expect<any>(text).toBe('Manager');
+        });
       });
     });
   });
 
   it('User cannot assign member to Tech Support role', () => {
     loginPage.loginAsManager();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.otherProjectName);
+    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
 
-    browser.wait(ExpectedConditions.visibilityOf(projectsPage.settingsBtn), Utils.conditionTimeout);
-    projectsPage.settingsBtn.click();
-    projectsPage.userManagementLink.click();
-    browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
-
-    userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-      row.element(by.css('select')).getText().then( text => {
-        expect<any>(text).toContain('Manager');
-        expect<any>(text).toContain('Contributor');
-        expect<any>(text).toContain('Observer');
-        expect<any>(text).toContain('Observer with comment');
-        expect<any>(text).not.toContain('Tech Support');
+      userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+        row.element(by.css('select')).getText().then( text => {
+          expect<any>(text).toContain('Manager');
+          expect<any>(text).toContain('Contributor');
+          expect<any>(text).toContain('Observer');
+          expect<any>(text).toContain('Observer with comment');
+          expect<any>(text).not.toContain('Tech Support');
+        });
       });
     });
   });


### PR DESCRIPTION
As with PR #775, this is not an ideal solution since we're exercising a UI element that will probably be removed in the future. But this makes all unit tests green again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/776)
<!-- Reviewable:end -->
