### PR TITLE
Custom user fonts on editor page entry list

### DIFF
--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -311,11 +311,7 @@ export class EditorDataService {
         );
     }
 
-    if (!meaning) {
-      return '[Empty]';
-    }
-
-    return meaning;
+    return meaning || '';
   }
 
   getSortableValue = (config: any, entry: any): string => {
@@ -385,11 +381,7 @@ export class EditorDataService {
       }
     }
 
-    if (!sortableValue) {
-      return '[Empty]';
-    }
-
-    return sortableValue;
+    return sortableValue || '';
   }
 
   private doFullRefresh(offset: number = 0): angular.IPromise<any> {
@@ -696,7 +688,12 @@ export class EditorDataService {
       value: this.getSortableValue(config, entry)
     }));
 
-    mapped.sort((a, b) => compare(a.value, b.value) * (reverse ? -1 : 1));
+    mapped.sort((a, b) =>
+                  compare(a.value, b.value) *
+                  (reverse ? -1 : 1) *
+                  // if one is an empty string and the other is not, reverse order so empty string will be sorted down
+                  ((a.value === '') !== (b.value === '') ? -1 : 1)
+                );
 
     return mapped.map(el => list[el.index]);
   }

--- a/src/angular-app/languageforge/lexicon/core/lexicon-utility.service.ts
+++ b/src/angular-app/languageforge/lexicon/core/lexicon-utility.service.ts
@@ -138,20 +138,13 @@ export class LexiconUtilityService extends UtilityService {
   }
 
   private static getField(globalConfig: LexiconConfig, node: any, fieldName: string, languageTag: string): string {
-    let result = '';
-    let field;
     if (node[fieldName]) {
-      const inputSystem = globalConfig.inputSystems[languageTag];
-      field = node[fieldName][languageTag];
+      const field = node[fieldName][languageTag];
       if (!LexiconUtilityService.isAudio(languageTag) && field != null && field.value != null && field.value !== '') {
-        if (inputSystem && inputSystem.cssFontFamily && inputSystem.cssFontFamily !== '') {
-          result = '<span style="font-family: ' + inputSystem.cssFontFamily + '">' + field.value + '</span>';
-        } else {
-          result = field.value;
-        }
+        return field.value;
       }
     }
-    return result;
+    return '';
   }
 
   private static getDefinition(globalConfig: LexiconConfig, config: LexConfigFieldList, sense: LexSense): string {

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -355,6 +355,8 @@ dc-entry .card {
   .listItemSecondary {
     z-index: 2;
     font-size: 0.8em;
+  }
+  .listItemPrimary, .listItemSecondary {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -82,9 +82,9 @@
                                          title="{{$ctrl.getCompactItemListOverlay(entry)}}"
                                          data-ng-repeat="entry in $ctrl.visibleEntries track by entry.id" data-ng-click="$ctrl.editEntry(entry.id)">
                                         <div dir="auto" class="listItemPrimary" data-ng-bind-html="$ctrl.getPrimaryListItemForDisplay(entry)"
-                                             data-ng-style="{ 'font-family': $ctrl.getFontFamilyForPrimaryListItemForDisplay() }"></div>
+                                             data-ng-style="{ 'font-family': $ctrl.getFontFamilyForPrimaryListItemForDisplay(entry) }"></div>
                                         <div dir="auto" class="listItemSecondary" data-ng-bind-html="$ctrl.getSecondaryListItemForDisplay(entry)"
-                                             data-ng-style="{ 'font-family': $ctrl.getFontFamilyForSecondaryListItemForDisplay() }"></div>
+                                             data-ng-style="{ 'font-family': $ctrl.getFontFamilyForSecondaryListItemForDisplay(entry) }"></div>
                                     </div>
                                 </div>
                             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -81,8 +81,10 @@
                                          data-ng-class="{selected: entry.id == $ctrl.currentEntry.id, listItemHasComment: $ctrl.getEntryCommentCount(entry.id) > 0}"
                                          title="{{$ctrl.getCompactItemListOverlay(entry)}}"
                                          data-ng-repeat="entry in $ctrl.visibleEntries track by entry.id" data-ng-click="$ctrl.editEntry(entry.id)">
-                                        <div dir="auto" class="listItemPrimary" data-ng-bind-html="$ctrl.getPrimaryListItemForDisplay(entry)"></div>
-                                        <div dir="auto" class="listItemSecondary" data-ng-bind-html="$ctrl.getSecondaryListItemForDisplay(entry)"></div>
+                                        <div dir="auto" class="listItemPrimary" data-ng-bind-html="$ctrl.getPrimaryListItemForDisplay(entry)"
+                                             data-ng-style="{ 'font-family': $ctrl.getFontFamilyForPrimaryListItemForDisplay() }"></div>
+                                        <div dir="auto" class="listItemSecondary" data-ng-bind-html="$ctrl.getSecondaryListItemForDisplay(entry)"
+                                             data-ng-style="{ 'font-family': $ctrl.getFontFamilyForSecondaryListItemForDisplay() }"></div>
                                     </div>
                                 </div>
                             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -5,7 +5,12 @@ import {ApplicationHeaderService} from '../../../bellows/core/application-header
 import {HelpHeroService} from '../../../bellows/core/helphero.service';
 import {ModalService} from '../../../bellows/core/modal/modal.service';
 import {NoticeService} from '../../../bellows/core/notice/notice.service';
-import {EditorDataService, LabeledOption, SortOption, FilterOption} from '../../../bellows/core/offline/editor-data.service';
+import {
+  EditorDataService,
+  FilterOption,
+  LabeledOption,
+  SortOption
+} from '../../../bellows/core/offline/editor-data.service';
 import {LexiconCommentService} from '../../../bellows/core/offline/lexicon-comments.service';
 import {SessionService} from '../../../bellows/core/session.service';
 import {InterfaceConfig} from '../../../bellows/shared/model/interface-config.model';
@@ -25,8 +30,8 @@ import {
   LexiconConfig
 } from '../shared/model/lexicon-config.model';
 import {LexiconProject} from '../shared/model/lexicon-project.model';
-import {FieldControl} from './field/field-control.model';
 import {LexOptionList} from '../shared/model/option-list.model';
+import {FieldControl} from './field/field-control.model';
 
 class Show {
   more: () => void;
@@ -595,8 +600,21 @@ export class LexiconEditorController implements angular.IController {
     return this.highlightMatches(this.getSortableValue(this.lecConfig, entry));
   }
 
+  getFontFamilyForPrimaryListItemForDisplay() {
+    // FIXME this is not always accurate, given the complexity in get EditorDataService#getSortableValue
+    return this.lecConfig.inputSystems[
+      (this.lecConfig.entry.fields.lexeme as LexConfigMultiText).inputSystems[0]
+    ].cssFontFamily;
+  }
+
   getSecondaryListItemForDisplay(entry: LexEntry): string {
     return this.highlightMatches(this.getMeaningForDisplay(this.lecConfig, entry));
+  }
+
+  getFontFamilyForSecondaryListItemForDisplay() {
+    return this.lecConfig.inputSystems[
+      ((this.lecConfig.entry.fields.senses as LexConfigFieldList).fields.gloss as LexConfigMultiText).inputSystems[0]
+    ].cssFontFamily;
   }
 
   highlightMatches(text: string) {
@@ -621,10 +639,8 @@ export class LexiconEditorController implements angular.IController {
   }
 
   getCompactItemListOverlay(entry: LexEntry): string {
-    let title;
-    let subtitle;
-    title = this.getWordForDisplay(entry);
-    subtitle = this.getMeaningForDisplay(this.lecConfig, entry);
+    const title = this.getWordForDisplay(entry);
+    const subtitle = this.getMeaningForDisplay(this.lecConfig, entry);
     if (title.length > 19 || subtitle.length > 25) {
       return title + '         ' + subtitle;
     } else {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -597,10 +597,11 @@ export class LexiconEditorController implements angular.IController {
   }
 
   getPrimaryListItemForDisplay(entry: LexEntry) {
-    return this.highlightMatches(this.getSortableValue(this.lecConfig, entry));
+    return this.highlightMatches(this.getSortableValue(this.lecConfig, entry)) || '[Empty]';
   }
 
-  getFontFamilyForPrimaryListItemForDisplay() {
+  getFontFamilyForPrimaryListItemForDisplay(entry: LexEntry) {
+    if (!this.getSortableValue(this.lecConfig, entry)) return '';
     // FIXME this is not always accurate, given the complexity in get EditorDataService#getSortableValue
     return this.lecConfig.inputSystems[
       (this.lecConfig.entry.fields.lexeme as LexConfigMultiText).inputSystems[0]
@@ -608,10 +609,11 @@ export class LexiconEditorController implements angular.IController {
   }
 
   getSecondaryListItemForDisplay(entry: LexEntry): string {
-    return this.highlightMatches(this.getMeaningForDisplay(this.lecConfig, entry));
+    return this.highlightMatches(this.getMeaningForDisplay(this.lecConfig, entry)) || '[Empty]';
   }
 
-  getFontFamilyForSecondaryListItemForDisplay() {
+  getFontFamilyForSecondaryListItemForDisplay(entry: LexEntry) {
+    if (!this.getMeaningForDisplay(this.lecConfig, entry)) return '';
     return this.lecConfig.inputSystems[
       ((this.lecConfig.entry.fields.senses as LexConfigFieldList).fields.gloss as LexConfigMultiText).inputSystems[0]
     ].cssFontFamily;
@@ -619,7 +621,7 @@ export class LexiconEditorController implements angular.IController {
 
   highlightMatches(text: string) {
     let filterText = this.entryListModifiers.filterText();
-    if (!filterText || text === '[Empty]') return text;
+    if (!filterText) return text;
 
     // FIXME this assumes the uppercase length of a string is the same as its lowercase, which is not necessarily true
     //  e.g. 'ß'.length !== 'ß'.toUpperCase().length

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
@@ -1,7 +1,7 @@
 <div class="dc-rendered-entryContainer" data-ng-hide="$ctrl.hideIfEmpty && !$ctrl.entry.word">
     <span class="dc-rendered-word" data-ng-bind-html="$ctrl.entry.word"></span>
     <span class="dc-rendered-senseContainer" data-ng-repeat="sense in $ctrl.entry.senses track by $index">
-        <span dir="ltr" data-ng-if="$ctrl.entry.senses.length !== 1" class="notranslate dc-rendered-senseNumber">{{$index + 1}})</span>
+        <span dir="ltr" data-ng-if="$ctrl.entry.senses.length !== 1" class="notranslate dc-rendered-senseNumber">{{$index + 1}}</span>
         <span class="dc-rendered-partOfSpeech" data-ng-bind-html="sense.partOfSpeech"></span>
         <span class="dc-rendered-definition" data-ng-bind-html="sense.meaning"></span>
         <span class="dc-rendered-exampleContainer" data-ng-repeat="example in sense.examples track by $index">


### PR DESCRIPTION
- User-specified fonts applied to entry list on editor page
- Word/lexeme now truncated with ellipsis (this could be controversial, but I think it's better than the current behavior of wrapping and pushing the second line out of the way).
- String values are not set to "[Empty]" if their use is anything other than immediately being displayed in the UI. This means if a value is empty, we pass around the empty string, and only convert it to "[Empty]" for display in the UI.

![Screenshot from 2019-09-13 22-21-56](https://user-images.githubusercontent.com/6140710/64902417-f0710580-d674-11e9-8550-ce20d562a361.png)

This does not change how `dc-rendered` works, which is responsible for both the entry preview, and the entry list on the list page. I've started some work on that and made good progress. It was clear, however, that it would take significantly more work, so I wanted to get this PR out there as a start. Also, @megahirt, if I recall, when we last about this you were suggesting that we may want to leave the rendered entry alone for now, and the important part was the list on the editor page. I don't think it will take a huge amount of time, but didn't want to attack it before you had a chance to comment.

Tip: Viewing commits one at a time will probably make it significantly easier to understand than trying to take everything in at once.

E2e tests are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/777)
<!-- Reviewable:end -->
