### PR TITLE
Fix LF-372: parse inline LIFT ranges right

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Import/LiftDecoder.php
+++ b/src/Api/Model/Languageforge/Lexicon/Import/LiftDecoder.php
@@ -382,7 +382,9 @@ class LiftDecoder
             throw new \Exception("'" . $sxeNode->getName() . "' is not a gloss");
         }
         $inputSystemTag = \Normalizer::normalize((string) $sxeNode['lang']);
-        $multiText->form($inputSystemTag, (string) $sxeNode->{'text'});
+        // Some LIFT files can have multiple <gloss> elements which are supposed to be separated by a semicolon-space
+        // pair, so we use appendForm() here instead of form(). 2019-09 RM
+        $multiText->appendForm($inputSystemTag, (string) $sxeNode->{'text'}, '; ');
 
         $this->project->addInputSystem($inputSystemTag);
         if (isset($inputSystems)) {

--- a/src/Api/Model/Languageforge/Lexicon/Import/LiftImport.php
+++ b/src/Api/Model/Languageforge/Lexicon/Import/LiftImport.php
@@ -79,34 +79,39 @@ class LiftImport
             // Read LIFT ranges in the header of the LIFT file
             if ($reader->nodeType == \XMLReader::ELEMENT && $reader->localName == 'range') {
                 $node = $reader->expand();
+                $range = null;
+                $rangeImportNodeError = null;
                 $rangeId = $node->attributes->getNamedItem('id')->textContent;
-                $rangeHref = $node->attributes->getNamedItem('href')->textContent;
-                $hrefPath = parse_url($rangeHref, PHP_URL_PATH);
-                $rangeFilename = basename($hrefPath);
-                $rangeFilePath = null;
-                $rangeImportNodeError = new LiftRangeImportNodeError(LiftRangeImportNodeError::FILE, $rangeFilename);
-                if (! array_key_exists($rangeFilename, $liftRangeFiles)) {
-                    // Haven't parsed the .lift-ranges file yet. We'll assume it is alongside the .lift file.
-                    $rangeFilePath = $liftFolderPath . "/" . $rangeFilename;
-                    if (file_exists($rangeFilePath)) {
-                        $sxeNode = simplexml_load_file($rangeFilePath);
-                        $parsedRanges = $liftRangeDecoder->decode($sxeNode);
-                        $liftRanges = array_merge($liftRanges, $parsedRanges);
-                        $liftRangeFiles[] = $rangeFilename;
-                    } else {
-                        // Range file was NOT found in alongside the .lift file
-                        $rangeImportNodeError->addRangeFileNotFound(basename($liftFilePath));
+                $rangeHrefAttr = $node->attributes->getNamedItem('href');
+                if ($rangeHrefAttr) {
+                    $rangeHref = $rangeHrefAttr->textContent;
+                    $hrefPath = parse_url($rangeHref, PHP_URL_PATH);
+                    $rangeFilename = basename($hrefPath);
+                    $rangeFilePath = null;
+                    $rangeImportNodeError = new LiftRangeImportNodeError(LiftRangeImportNodeError::FILE, $rangeFilename);
+                    if (! array_key_exists($rangeFilename, $liftRangeFiles)) {
+                        // Haven't parsed the .lift-ranges file yet. We'll assume it is alongside the .lift file.
+                        $rangeFilePath = $liftFolderPath . "/" . $rangeFilename;
+                        if (file_exists($rangeFilePath)) {
+                            $sxeNode = simplexml_load_file($rangeFilePath);
+                            $parsedRanges = $liftRangeDecoder->decode($sxeNode);
+                            $liftRanges = array_merge($liftRanges, $parsedRanges);
+                            $liftRangeFiles[] = $rangeFilename;
+                        } else {
+                            // Range file was NOT found in alongside the .lift file
+                            $rangeImportNodeError->addRangeFileNotFound(basename($liftFilePath));
+                        }
                     }
-                }
 
-                // pull out the referenced range
-                if (isset($liftRanges[$rangeId])) {
-                    $range = $liftRanges[$rangeId];
-                } else {
-                    $range = null;
-                    if (file_exists($rangeFilePath)) {
-                        // Range was NOT found in referenced .lift-ranges file after parsing it
-                        $rangeImportNodeError->addRangeNotFound($rangeId);
+                    // pull out the referenced range
+                    if (isset($liftRanges[$rangeId])) {
+                        $range = $liftRanges[$rangeId];
+                    } else {
+                        $range = null;
+                        if (file_exists($rangeFilePath)) {
+                            // Range was NOT found in referenced .lift-ranges file after parsing it
+                            $rangeImportNodeError->addRangeNotFound($rangeId);
+                        }
                     }
                 }
 
@@ -117,7 +122,7 @@ class LiftImport
                     $liftRanges[$rangeId] = $range;
                 }
 
-                if ($rangeImportNodeError->hasErrors()) {
+                if (isset($rangeImportNodeError) && $rangeImportNodeError->hasErrors()) {
                     $this->liftImportNodeError->addSubnodeError($rangeImportNodeError);
                 }
             }

--- a/src/Api/Model/Languageforge/Lexicon/LexMultiText.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexMultiText.php
@@ -25,6 +25,17 @@ class LexMultiText extends MapOf
         }
     }
 
+    public function appendForm($inputSystem, $value, $separator = '; ')
+    {
+        if (array_key_exists($inputSystem, $this)) {
+            $oldValue = $this[$inputSystem]->value;
+            $newValue = $oldValue . $separator . $value;
+            $this[$inputSystem]->value($newValue);
+        } else {
+            $this[$inputSystem] = new LexValue($value);
+        }
+    }
+
     /**
      * @param string $inputSystem
      * @return boolean


### PR DESCRIPTION
LiftImport needs to be able to cope with a `<range>` element that doesn't have an `href` attribute, but defines the range inline. Our current code had an assumption that there will always be an `href` attribute, but the LIFT spec (as defined by the RelaxNG schema) [lists `href` as optional](https://github.com/sillsdev/libpalaso/blob/18f9433cdf2808bc0f362eef9ae38e6c8706c8ca/SIL.Lift/Validation/lift-0.13.rng#L537). The code already knows how to parse `<range>` elements defined inline, we just need to make sure we don't assume the presence of an optional attribute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/778)
<!-- Reviewable:end -->
