### PR TITLE
Add SF tech support role

### DIFF
--- a/src/Api/Model/Scriptureforge/Sfchecks/SfchecksRoles.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/SfchecksRoles.php
@@ -56,6 +56,9 @@ class SfchecksRoles extends ProjectRoles
         $rights[] = Domain::USERS + Operation::VIEW;
         self::grantAllOnDomain($rights, Domain::TEMPLATES);
         self::$_rights[self::MANAGER] = $rights;
+
+        // Tech support (same as manager)
+        self::$_rights[self::TECH_SUPPORT] = $rights;
     }
 
     private static $_rights;

--- a/src/angular-app/scriptureforge/sfchecks/project/project-settings.controller.ts
+++ b/src/angular-app/scriptureforge/sfchecks/project/project-settings.controller.ts
@@ -491,6 +491,7 @@ export const SfChecksProjectSettingsModule = angular
     $scope.roles = [
           { key: 'contributor', name: 'Contributor' },
           { key: 'project_manager', name: 'Manager' },
+          { key: 'tech_support', name: 'Tech Support'}
       ];
 
     $scope.onRoleChange = function onRoleChange(user: User): void {


### PR DESCRIPTION
This is an attempt to get the current master shippable to Scripture Forge. If there are other issues that would prevent master from shipping to SF, I'm not aware of them.

There are 7 e2e test failures on SF, and quite a bit more on LF. I haven't investigated extremely carefully, but some of them are caused by the change from the user management app to the share dialog. I'm not aware that anything is actually broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/779)
<!-- Reviewable:end -->
