### PR TITLE
Exclude site wide notices file from upload

### DIFF
--- a/upload-exclude.txt
+++ b/upload-exclude.txt
@@ -2,3 +2,4 @@
 /assets/**
 /js/lib/languageforge.js
 /js/lib/scriptureforge.js
+/site_wide_notices.json


### PR DESCRIPTION
* in src this is empty for testing. The file is only changed on the server so don't overwrite it on deploy upload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/782)
<!-- Reviewable:end -->
