### PR TITLE
Fix CSV Insights and add command-line wrapper

### DIFF
--- a/scripts/tools/csvInsights.php
+++ b/scripts/tools/csvInsights.php
@@ -1,0 +1,13 @@
+#!/usr/bin/php -q
+
+<?php
+
+require_once('../scriptsConfig.php');
+
+use Api\Model\Shared\Dto\ProjectInsightsDto;
+use Api\Library\Shared\Website;
+
+(php_sapi_name() == 'cli') or die('this script must be run on the command-line');
+
+ProjectInsightsDto::csvInsightsToFile(Website::get('languageforge.org'), 'languageforge.csv');
+ProjectInsightsDto::csvInsightsToFile(Website::get('scriptureforge.org'), 'scriptureforge.csv');


### PR DESCRIPTION
This PR fixes the CSV insights function based upon actual usage with production data.  This PR is for master.  The insights have already been fixed via a hotfix on sf/live.  Additionally, this adds a command line wrapper script to run the CSV insights directly on the command-line without a web interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/787)
<!-- Reviewable:end -->
