### PR TITLE
Fix recent users count in project stats

### DIFF
--- a/src/Api/Model/Shared/Dto/ProjectInsightsDto.php
+++ b/src/Api/Model/Shared/Dto/ProjectInsightsDto.php
@@ -85,7 +85,7 @@ class ProjectInsightsDto
             if (array_key_exists('userRef', $event)) {
                 $userId = (string) $event['userRef'];
                 $users[$userId] = array_key_exists($userId, $users) ? $users[$userId] + 1 : 1;
-                if (date_create($event['date']) > date_create()->modify('-180 days')) {
+                if ($event['date']->toDateTime() > date_create()->modify('-180 days')) {
                     $recentUsers[$userId] = true;
                 };
             }


### PR DESCRIPTION
Previously the date object was being constructed with `date_create($event['date'])`.

This always returned false because the format was incorrect. The result was that the number of recent users reported was always 0.

Once this is merged we should also cherry-pick it to sf-live.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/792)
<!-- Reviewable:end -->
