### PR TITLE
Fix bug where editing input systems could fail

### DIFF
--- a/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
@@ -318,7 +318,7 @@ export class ConfigurationFieldUnifiedViewModel {
         const multiTextLevelConfigField = levelConfigField as LexConfigMultiText;
         multiTextLevelConfigField.inputSystems = [];
         for (const inputSystemSettings of field.inputSystems) {
-          if (inputSystemSettings.isAllRowSelected) {
+          if (inputSystemSettings != null && inputSystemSettings.isAllRowSelected) {
             multiTextLevelConfigField.inputSystems.push(inputSystemSettings.tag);
           }
         }


### PR DESCRIPTION
In some cases, field.inputSystems could end up with at least one undefined value in field-unified-view-model.ts after many user edits. This change should fix that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/797)
<!-- Reviewable:end -->
