### PR TITLE
Ensure picklists can cope with missing input items

### DIFF
--- a/src/angular-app/bellows/shared/pick-list-editor.module.ts
+++ b/src/angular-app/bellows/shared/pick-list-editor.module.ts
@@ -15,6 +15,16 @@ export class PickListEditorController implements angular.IController {
 
   private isDeletable: { [key: string]: boolean } = {};
 
+  $onChanges(changes: angular.IOnChangesObject): void {
+    // Ensure this.items is always an array even if it was missing in the input data
+    const itemsChangeObj = changes.items as angular.IChangesObject<Item[]>;
+    if (itemsChangeObj != null) {
+      if (itemsChangeObj.currentValue == null) {
+        this.items = [];
+      }
+    }
+  }
+
   pickAddItem(): void {
     if (this.newValue) {
       const key = PickListEditorController.keyFromValue(this.newValue);


### PR DESCRIPTION
If the items array for an option list is missing in Mongo (because it was empty and the DB code stripped it out), ensure that the picklist component gets an empty array in this.items instead of undefined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/798)
<!-- Reviewable:end -->
