### PR TITLE
Use API token for new Language Depot API

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -961,6 +961,11 @@ gulp.task('build-productionConfig', function () {
     facebookClientSecret = 'facebookClientSecret';
   }
 
+  var languageDepotApiToken = process.env.LANGUAGE_DEPOT_API_TOKEN;
+  if (languageDepotApiToken === undefined) {
+    languageDepotApiToken = 'languageDepotApiToken';
+  }
+
   var gatherWordsClientId = process.env.GATHERWORDS_CLIENT_ID;
   if (gatherWordsClientId === undefined) {
     gatherWordsClientId = 'gatherWordsClientId';
@@ -1003,6 +1008,10 @@ gulp.task('build-productionConfig', function () {
       demand: false,
       default: facebookClientSecret,
       type: 'string' })
+    .option('languageDepotApiToken', {
+      demand: false,
+      default: languageDepotApiToken,
+      type: 'string' })
     .option('gatherWordsClientId', {
       demand: false,
       default: gatherWordsClientId,
@@ -1040,6 +1049,9 @@ gulp.task('build-productionConfig', function () {
     .pipe(replace(
       /(define\('FACEBOOK_CLIENT_SECRET', ').*;$/m,
       '$1' + params.facebookClientSecret + '\');'))
+    .pipe(replace(
+      /(define\('LANGUAGE_DEPOT_API_TOKEN', ').*;$/m,
+      '$1' + params.languageDepotApiToken + '\');'))
     .pipe(replace(
       /(define\('GATHERWORDS_CLIENT_ID', ').*;$/m,
       '$1' + params.gatherWordsClientId + '\');'))

--- a/src/Api/Model/Languageforge/Lexicon/Command/SendReceiveCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/SendReceiveCommands.php
@@ -85,8 +85,10 @@ class SendReceiveCommands
         $client = new Client(['handler' => $handler]);
 
         $url = 'https://admin.languagedepot.org/api/user/'.$username.'/projects';
-        $postData = ['json' => ['password' => $password],
-                     'headers' => ['Authorization' => 'Bearer ' . LANGUAGE_DEPOT_API_TOKEN]];
+        $postData = [
+            'json' => ['password' => $password],
+            'headers' => ['Authorization' => 'Bearer ' . LANGUAGE_DEPOT_API_TOKEN]
+        ];
 
         $tryCounter = 1;
         while ($tryCounter <= 5) {

--- a/src/Api/Model/Languageforge/Lexicon/Command/SendReceiveCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/SendReceiveCommands.php
@@ -85,7 +85,8 @@ class SendReceiveCommands
         $client = new Client(['handler' => $handler]);
 
         $url = 'https://admin.languagedepot.org/api/user/'.$username.'/projects';
-        $postData = ['json' => ['password' => $password]];
+        $postData = ['json' => ['password' => $password],
+                     'headers' => ['Authorization' => 'Bearer ' . LANGUAGE_DEPOT_API_TOKEN]];
 
         $tryCounter = 1;
         while ($tryCounter <= 5) {

--- a/src/config.php
+++ b/src/config.php
@@ -75,6 +75,10 @@ if (! defined('FACEBOOK_CLIENT_SECRET')) {
     define('FACEBOOK_CLIENT_SECRET', 'facebookClientSecret');
 }
 
+if (! defined('LANGUAGE_DEPOT_API_TOKEN')) {
+    define('LANGUAGE_DEPOT_API_TOKEN', 'not-a-secret');
+}
+
 if (! defined('GATHERWORDS_CLIENT_ID')) {
     define('GATHERWORDS_CLIENT_ID', 'gatherWordsClientId');
 }

--- a/src/config.php.fortest
+++ b/src/config.php.fortest
@@ -78,6 +78,10 @@ if (! defined('FACEBOOK_CLIENT_SECRET')) {
     define('FACEBOOK_CLIENT_SECRET', 'facebookClientSecret');
 }
 
+if (! defined('LANGUAGE_DEPOT_API_TOKEN')) {
+    define('LANGUAGE_DEPOT_API_TOKEN', 'not-a-secret');
+}
+
 if (! defined('GATHERWORDS_CLIENT_ID')) {
     define('GATHERWORDS_CLIENT_ID', 'gatherWordsClientId');
 }

--- a/src/config.php.live
+++ b/src/config.php.live
@@ -75,6 +75,10 @@ if (! defined('FACEBOOK_CLIENT_SECRET')) {
     define('FACEBOOK_CLIENT_SECRET', 'facebookClientSecret');
 }
 
+if (! defined('LANGUAGE_DEPOT_API_TOKEN')) {
+    define('LANGUAGE_DEPOT_API_TOKEN', 'not-a-secret');
+}
+
 if (! defined('GATHERWORDS_CLIENT_ID')) {
     define('GATHERWORDS_CLIENT_ID', 'gatherWordsClientId');
 }

--- a/test/php/TestConfig.php
+++ b/test/php/TestConfig.php
@@ -31,6 +31,8 @@ define('SF_TESTPROJECT2',     'Test Project2');
 define('SF_TESTPROJECTCODE2', 'testcode2');
 define('BCRYPT_COST', 7);
 
+define('LANGUAGE_DEPOT_API_TOKEN', 'not-a-secret');
+
 global $WEBSITE;
 $WEBSITE = Website::get('languageforge.localhost');
 


### PR DESCRIPTION
It does no harm to send an Authorization: Bearer token to an API endpoint that's not expecting it, so we can put this into place in LF first and then add the API token requirement to the Language Depot API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/799)
<!-- Reviewable:end -->
