### PR TITLE
Make user list robust against missing projects

### DIFF
--- a/src/Api/Model/Shared/Command/UserCommands.php
+++ b/src/Api/Model/Shared/Command/UserCommands.php
@@ -179,7 +179,9 @@ class UserCommands
                 $projectIds = $item['projects'];
                 $list->entries[$key]['projects'] = [];
                 foreach ($projectIds as $id) {
-                    $list->entries[$key]['projects'][] = $projectList[(string)$id];
+                    if (array_key_exists((string)$id, $projectList)) {
+                        $list->entries[$key]['projects'][] = $projectList[(string)$id];
+                    }
                 }
             }
         }


### PR DESCRIPTION
When the site admin tries to list users, if there is even one user who was in a deleted project but somehow that project was not removed from their membership list, the user list fails to load. This change makes it just ignore that missing project when loading the user list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/801)
<!-- Reviewable:end -->
