### PR TITLE
Fix blank project page for Tech Support role

### DIFF
--- a/src/angular-app/languageforge/lexicon/core/lexicon-config.service.ts
+++ b/src/angular-app/languageforge/lexicon/core/lexicon-config.service.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 import {SessionService} from '../../../bellows/core/session.service';
+import {ProjectRoles} from '../../../bellows/shared/model/project.model';
 import {LexMultiText} from '../shared/model/lex-multi-text.model';
 import {LexValue} from '../shared/model/lex-value.model';
 import {
@@ -44,13 +45,18 @@ export class LexiconConfigService {
       } else {
         // fallback to role-based field config
         fieldsConfig = config.roleViews[role];
+        // further fallback for projects that don't have anything configured for the Tech Support role
+        if (fieldsConfig == null && role === ProjectRoles.TECH_SUPPORT.key) {
+          fieldsConfig = config.roleViews[ProjectRoles.MANAGER.key];
+        }
       }
 
-      this.removeDisabledConfigFields(config.entry, fieldsConfig);
-      this.removeDisabledConfigFields((config.entry.fields.senses as LexConfigFieldList), fieldsConfig);
-      this.removeDisabledConfigFields(((config.entry.fields.senses as LexConfigFieldList).fields.examples as
-        LexConfigFieldList), fieldsConfig);
-
+      if (fieldsConfig != null) {
+        this.removeDisabledConfigFields(config.entry, fieldsConfig);
+        this.removeDisabledConfigFields((config.entry.fields.senses as LexConfigFieldList), fieldsConfig);
+        this.removeDisabledConfigFields(((config.entry.fields.senses as LexConfigFieldList).fields.examples as
+          LexConfigFieldList), fieldsConfig);
+      }
       return config;
     }));
   }


### PR DESCRIPTION
Many projects don't have anything configured for the Tech Support role, since it was newly added, so those projects end up throwing an exception in the filter() call in removeDisabledConfigFields. And since the filter didn't return true, all fields end up being stripped out. The Tech Support role is supposed to have the same rights as a project manager, so if it's looked for and not found, we give manager rights.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/808)
<!-- Reviewable:end -->
