### PR TITLE
Input system tag, not name, in comment.regarding

### DIFF
--- a/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
+++ b/src/angular-app/bellows/core/offline/lexicon-comments.service.ts
@@ -54,7 +54,7 @@ export class LexiconCommentService {
               contextGuid = comment.contextGuid;
             } else {
               contextGuid = comment.regarding.field +
-                (comment.regarding.inputSystemAbbreviation ? '.' + comment.regarding.inputSystemAbbreviation : '');
+                (comment.regarding.inputSystem ? '.' + comment.regarding.inputSystem : '');
               if (fieldConfig != null && fieldConfig.type === 'multioptionlist') {
                 contextGuid += '#' + comment.regarding.fieldValue;
               }

--- a/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.component.ts
@@ -46,7 +46,7 @@ export class LexCommentsViewController implements angular.IController {
       this.newComment.contextGuid = contextGuid;
       if (inputSystemTag) {
         this.newComment.regarding.fieldValue = LexCommentsViewController.getFieldValue(model, inputSystemTag);
-        this.newComment.regarding.inputSystem = this.control.config.inputSystems[inputSystemTag].languageName;
+        this.newComment.regarding.inputSystem = inputSystemTag;
         this.newComment.regarding.inputSystemAbbreviation =
           this.control.config.inputSystems[inputSystemTag].abbreviation;
       } else if (multioptionValue) {


### PR DESCRIPTION
This is a revival of the **bugfix/regarding-inputsystem-should-be-tag** branch, which had suffered code rot over the years and which I'm about to delete. Some of its fixes had been applied since it was created, but two fixes in that branch had never gotten applied, so I'm reviving them here.

Before merging this PR, I need to investigate the state of comments in the Mongo database on live, to see how many of them (if any) suffered from this bug where the input system *name* ("English") was inserted in the `comment.regarding` field, where the *tag* ("en") should be. The effect of that bug would be that the link between the comment and the thing it's commenting about gets lost and the UI can't render the comment bubble in the right place (e.g., it'll try to render on the "English" part of the Notes field, but the Notes field has an "en" part, which doesn't match). If there are any places where this bug actually showed up, I'll have to write a migration script to apply this fix to the database as well as to the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/809)
<!-- Reviewable:end -->
