### PR TITLE
Ignore Javascript errors from outdated browsers

### DIFF
--- a/src/angular-app/bellows/core/exception-handling.service.ts
+++ b/src/angular-app/bellows/core/exception-handling.service.ts
@@ -56,6 +56,15 @@ export class ExceptionHandlingService {
       return;
     }
 
+    // Silence errors coming from out-of-date browser versions
+    // So far we've only seen errors from Chrome version 30, but if other old
+    // browser versions trigger errors, they can be added below as well
+    const userAgent = navigator.userAgent;
+    if (userAgent.indexOf('Chrome/30') >= 0) {
+      // Outdated browser: don't submit error to Bugsnag
+      return;
+    }
+
     this.bugsnagClient.notify(exception, {
       beforeSend: report => {
         if (this.metadata != null) {


### PR DESCRIPTION
Draft PR until I've checked Bugsnag; I'll either mark it ready for review or close it depending on what I find. See below for details.

We have (or had in the past) one user with device with an outdated browser (Chrome Mobile 30), which was sending a lot of Bugsnag reports about Javascript features that that browser doesn't implement because it's so old (e.g., the Array.includes function). These reports aren't actually bugs and we won't do anything about them, so we should ignore them and not send them to Bugsnag to reduce how much Bugsnap spam we're receiving. **If,** that is, that same user is still using that device with the old browser. Once I've had a chance to look through our Bugsnag reports, I'll either mark this PR as ready for review if that device is still spamming us with Bugsnag reports, or I'll close this PR if that device has gone away and we no longer have to deal with Chrome Mobile 30 any longer (which would be great news).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/810)
<!-- Reviewable:end -->
