### PR TITLE
Handle rearranged items (senses, examples, etc.) in Mongo

### DIFF
--- a/test/php/model/shared/mapper/mongo/MongoMapperArrayTest.php
+++ b/test/php/model/shared/mapper/mongo/MongoMapperArrayTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Api\Model\Shared\Mapper\MongoMapper;
+use PHPUnit\Framework\TestCase;
+
+class MongoMapperArrayTest extends TestCase
+{
+    private function doTest($oldData, $newData, $key, $expected, $msg) {
+        $actual = MongoMapper::detectMoved($oldData, $newData, $key);
+        $this->assertEquals($expected, $actual, $msg);
+    }
+
+    public function testDetectMoved_BasicScenario_ReturnsExpectedResult()
+    {
+        $oldData = [["id" => "abc", "data" => "foo"], ["id" => "def", "data" => "bar"]];
+        $newData = [["id" => "def", "data" => "bar"], ["id" => "abc", "data" => "new foo"]];
+        $key = "id";
+
+        $expected = ["abc" => ["oldPos" => 0, "newPos" => 1], "def" => ["oldPos" => 1, "newPos" => 0]];
+        $this->doTest($oldData, $newData, $key, $expected, "Basic test failed");
+    }
+
+    public function testDetectMoved_OneItemDeleted_ReturnsNullForNewPos()
+    {
+        $oldData = [["id" => "abc", "data" => "foo"], ["id" => "def", "data" => "bar"]];
+        $newData = [["id" => "def", "data" => "bar"]];
+        $key = "id";
+
+        $expected = ["abc" => ["oldPos" => 0, "newPos" => null], "def" => ["oldPos" => 1, "newPos" => 0]];
+        $this->doTest($oldData, $newData, $key, $expected, "Deleting an item should produce null in newPos");
+    }
+
+    public function testDetectMoved_OneItemAdded_ReturnsNullForOldPos()
+    {
+        $oldData = [["id" => "abc", "data" => "foo"]];
+        $newData = [["id" => "def", "data" => "bar"], ["id" => "abc", "data" => "new foo"]];
+        $key = "id";
+
+        $expected = ["abc" => ["oldPos" => 0, "newPos" => 1], "def" => ["oldPos" => null, "newPos" => 0]];
+        $this->doTest($oldData, $newData, $key, $expected, "Adding an item should produce null in oldPos");
+    }
+}


### PR DESCRIPTION
WIP which was waiting until we would upgrade the live server to Mongo 3.6, because [the positional-update operators](https://docs.mongodb.com/manual/reference/operator/update/positional-filtered/) (new in Mongo 3.6) would be necessary for the rest of the work. That's happened by now, so work can resume on this feature at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/811)
<!-- Reviewable:end -->
