### PR TITLE
fix PHP PPA errors

### DIFF
--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -21,7 +21,7 @@
         id: 14AA40EC0831756756D7F66C4F4EA0AAE5267A6C
     - name: Add PHP{{php_version}} ppa
       apt_repository:
-        repo: "deb http://ppa.launchpad.net/ondrej/php/ubuntu {{base_distribution_release}} Release"
+        repo: "deb http://ppa.launchpad.net/ondrej/php/ubuntu {{base_distribution_release}} main"
         state: present
     - name: add Mongo apt key
       apt_key:

--- a/deploy/playbook_bionic.yml
+++ b/deploy/playbook_bionic.yml
@@ -15,6 +15,10 @@
   vars_files:
     - "vars/config_{{config}}.yml"
   pre_tasks:
+    - name: Add PHP apt key
+      apt_key:
+        keyserver: hkp://keyserver.ubuntu.com:80
+        id: 14AA40EC0831756756D7F66C4F4EA0AAE5267A6C
     - name: Add PHP{{php_version}} ppa
       apt_repository:
         repo: "deb http://ppa.launchpad.net/ondrej/php/ubuntu {{base_distribution_release}} Release"


### PR DESCRIPTION
This PR adds the apt key for the PHP PPA and change the repo to "main" instead of "release" - this should make the ansible script run successfully now.

A short and simple fix that took several hours to get right.  Sometimes that's how it goes.  I won't merge this PR yet until I have successfully run through the whole setup...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/812)
<!-- Reviewable:end -->
