### PR TITLE
remove remnants of deploy_archive submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,3 @@
 [submodule "deploy/roles/ansible-role-apache"]
 	path = deploy/roles/apache_config
 	url = https://github.com/saygoweb/ansible-role-apache.git
-[submodule "deploy_archive/roles/apache_config"]
-    path = deploy_archive/roles/apache_config
-	url = https://github.com/saygoweb/ansible-role-apache.git
-[submodule "deploy_archive/roles_common"]
-    path = deploy_archive/roles_common
-	url = https://github.com/sillsdev/ops-ansible-common-roles


### PR DESCRIPTION
This PR finishes removing the submodule deploy_archive so that you don't get git checkout errors like this:
![image](https://user-images.githubusercontent.com/3444521/108922555-e032c780-7669-11eb-9898-5d7ffb7a65b4.png)

Alas, you will likely also need to remove a few [submodule] lines from your .git/config pertaining to deploy_archive.

Sorry about the mess.  When I remove the deploy/ submodule, I'll try and get it all in one go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/835)
<!-- Reviewable:end -->
