### PR TITLE
Convert some E2E tests to be async

### DIFF
--- a/test/app/bellows/bellows-traversal.e2e-spec.ts
+++ b/test/app/bellows/bellows-traversal.e2e-spec.ts
@@ -22,67 +22,67 @@ describe('Bellows E2E Page Traversal', () => {
   const siteAdminPage = new SiteAdminPage();
   const userProfilePage = new SfUserProfilePage();
 
-  it('Explore signup page' , () => {
-    BellowsLoginPage.logout();
-    SignupPage.get();
-    signupPage.emailInput.clear();
-    signupPage.nameInput.clear();
-    signupPage.passwordInput.clear();
-    signupPage.captcha.blueSquareButton.click();
-    signupPage.captcha.yellowCircleButton.click();
-    signupPage.captcha.redTriangleButton.click();
+  it('Explore signup page' , async () => {
+    await BellowsLoginPage.logout();
+    await SignupPage.get();
+    await signupPage.emailInput.clear();
+    await signupPage.nameInput.clear();
+    await signupPage.passwordInput.clear();
+    await signupPage.captcha.blueSquareButton.click();
+    await signupPage.captcha.yellowCircleButton.click();
+    await signupPage.captcha.redTriangleButton.click();
   });
 
-  it('Explore forgot password page', () => {
-    BellowsForgotPasswordPage.get();
-    forgotPasswordPage.usernameInput.clear();
-    forgotPasswordPage.submitButton.click();
+  it('Explore forgot password page', async () => {
+    await BellowsForgotPasswordPage.get();
+    await forgotPasswordPage.usernameInput.clear();
+    await forgotPasswordPage.submitButton.click();
   });
 
-  it('Explore reset password page', () => {
-    BellowsResetPasswordPage.get(constants.resetPasswordKey);
-    resetPasswordPage.passwordInput.clear();
-    resetPasswordPage.confirmPasswordInput.clear();
-    resetPasswordPage.resetButton.click();
+  it('Explore reset password page', async () => {
+    await BellowsResetPasswordPage.get(constants.resetPasswordKey);
+    await resetPasswordPage.passwordInput.clear();
+    await resetPasswordPage.confirmPasswordInput.clear();
+    await resetPasswordPage.resetButton.click();
   });
 
-  it('Explore login page', () => {
-    BellowsLoginPage.get();
-    loginPage.loginAsAdmin();
+  it('Explore login page', async () => {
+    await BellowsLoginPage.get();
+    await loginPage.loginAsAdmin();
   });
 
-  it('Explore change password page', () => {
-    changePasswordPage.get();
-    changePasswordPage.password.clear();
-    changePasswordPage.confirm.clear();
-    changePasswordPage.submitButton.click();
+  it('Explore change password page', async () => {
+    await changePasswordPage.get();
+    await changePasswordPage.password.clear();
+    await changePasswordPage.confirm.clear();
+    await changePasswordPage.submitButton.click();
   });
 
-  it('Explore activity page', () => {
-    activityPage.get();
-    activityPage.activitiesList.count();
+  it('Explore activity page', async () => {
+    await activityPage.get();
+    await activityPage.activitiesList.count();
   });
 
-  it('Explore project page', () => {
-    projectsPage.get();
-    projectsPage.projectsList.count();
-    projectsPage.projectNames.count();
-    projectsPage.projectTypes.count();
-    projectsPage.createBtn.click();
+  it('Explore project page', async () => {
+    await projectsPage.get();
+    await projectsPage.projectsList.count();
+    await projectsPage.projectNames.count();
+    await projectsPage.projectTypes.count();
+    await projectsPage.createBtn.click();
   });
 
-  it('Explore site admin page', () => {
-    siteAdminPage.get();
-    siteAdminPage.tabs.archivedProjects.click();
-    siteAdminPage.archivedProjectsTab.republishButton.click();
-    siteAdminPage.archivedProjectsTab.deleteButton.click();
-    siteAdminPage.archivedProjectsTab.projectsList.count();
+  it('Explore site admin page', async () => {
+    await siteAdminPage.get();
+    await siteAdminPage.tabs.archivedProjects.click();
+    await siteAdminPage.archivedProjectsTab.republishButton.click();
+    await siteAdminPage.archivedProjectsTab.deleteButton.click();
+    await siteAdminPage.archivedProjectsTab.projectsList.count();
   });
 
-  it('Explore user profile page', () => {
-    userProfilePage.get();
-    userProfilePage.activitiesList.count();
-    userProfilePage.tabs.aboutMe.click();
-    userProfilePage.tabs.myAccount.click();
+  it('Explore user profile page', async () => {
+    await userProfilePage.get();
+    await userProfilePage.activitiesList.count();
+    await userProfilePage.tabs.aboutMe.click();
+    await userProfilePage.tabs.myAccount.click();
   });
 });

--- a/test/app/bellows/reset-forgotten-password.e2e-spec.ts
+++ b/test/app/bellows/reset-forgotten-password.e2e-spec.ts
@@ -12,116 +12,116 @@ describe('Bellows E2E Reset Forgotten Password app', () => {
   const resetPasswordPage = new BellowsResetPasswordPage();
   const forgotPasswordPage = new BellowsForgotPasswordPage();
 
-  it('with expired reset key routes to login with warning', () => {
-    BellowsLoginPage.logout();
-    BellowsResetPasswordPage.get(constants.expiredPasswordKey);
-    browser.wait(ExpectedConditions.visibilityOf(loginPage.errors.get(0)), constants.conditionTimeout);
-    expect<any>(loginPage.username.isDisplayed()).toBe(true);
-    expect<any>(loginPage.infoMessages.count()).toBe(0);
-    expect<any>(loginPage.errors.count()).toBe(1);
-    expect<any>(loginPage.errors.first().getText()).toContain('expired');
+  it('with expired reset key routes to login with warning', async () => {
+    await BellowsLoginPage.logout();
+    await BellowsResetPasswordPage.get(constants.expiredPasswordKey);
+    await browser.wait(ExpectedConditions.visibilityOf(loginPage.errors.get(0)), constants.conditionTimeout);
+    expect<boolean>(await loginPage.username.isDisplayed()).toBe(true);
+    expect<number>(await loginPage.infoMessages.count()).toBe(0);
+    expect<number>(await loginPage.errors.count()).toBe(1);
+    expect<string>(await loginPage.errors.first().getText()).toContain('expired');
 
     // clear errors so that afterEach appFrame error check doesn't fail, see project-settings.e2e-spec.js
-    browser.refresh();
-    expect<any>(loginPage.errors.count()).toBe(0);
+    await browser.refresh();
+    expect<number>(await loginPage.errors.count()).toBe(0);
   });
 
   describe('for Forgot Password request', () => {
 
-    it('can navigate to request page', () => {
-      loginPage.forgotPasswordLink.click();
-      browser.wait(ExpectedConditions.stalenessOf(loginPage.forgotPasswordLink), constants.conditionTimeout);
-      browser.wait(ExpectedConditions.visibilityOf(forgotPasswordPage.usernameInput), constants.conditionTimeout);
-      expect<any>(forgotPasswordPage.usernameInput.isDisplayed()).toBe(true);
+    it('can navigate to request page', async () => {
+      await loginPage.forgotPasswordLink.click();
+      await browser.wait(ExpectedConditions.stalenessOf(loginPage.forgotPasswordLink), constants.conditionTimeout);
+      await browser.wait(ExpectedConditions.visibilityOf(forgotPasswordPage.usernameInput), constants.conditionTimeout);
+      expect<boolean>(await forgotPasswordPage.usernameInput.isDisplayed()).toBe(true);
     });
 
-    it('cannot request for non-existent user', () => {
-      BellowsForgotPasswordPage.get();
-      expect<any>(forgotPasswordPage.infoMessages.count()).toBe(0);
-      expect<any>(forgotPasswordPage.errors.count()).toBe(0);
-      forgotPasswordPage.usernameInput.sendKeys(constants.unusedUsername);
-      forgotPasswordPage.submitButton.click();
-      browser.wait(ExpectedConditions.visibilityOf(forgotPasswordPage.errors.get(0)), constants.conditionTimeout);
-      expect<any>(forgotPasswordPage.errors.count()).toBe(1);
-      expect<any>(forgotPasswordPage.errors.first().getText()).toContain('User not found');
+    it('cannot request for non-existent user', async () => {
+      await BellowsForgotPasswordPage.get();
+      expect<number>(await forgotPasswordPage.infoMessages.count()).toBe(0);
+      expect<number>(await forgotPasswordPage.errors.count()).toBe(0);
+      await forgotPasswordPage.usernameInput.sendKeys(constants.unusedUsername);
+      await forgotPasswordPage.submitButton.click();
+      await browser.wait(ExpectedConditions.visibilityOf(forgotPasswordPage.errors.get(0)), constants.conditionTimeout);
+      expect<number>(await forgotPasswordPage.errors.count()).toBe(1);
+      expect<string>(await forgotPasswordPage.errors.first().getText()).toContain('User not found');
       forgotPasswordPage.usernameInput.clear();
 
       // clear errors so that afterEach appFrame error check doesn't fail, see project-settings.e2e-spec.js
-      browser.refresh();
-      expect<any>(forgotPasswordPage.errors.count()).toBe(0);
+      await browser.refresh();
+      expect<number>(await forgotPasswordPage.errors.count()).toBe(0);
     });
 
-    it('can submit request', () => {
-      forgotPasswordPage.usernameInput.sendKeys(constants.expiredUsername);
-      forgotPasswordPage.submitButton.click();
-      expect<any>(forgotPasswordPage.errors.count()).toBe(0);
+    it('can submit request', async () => {
+      await forgotPasswordPage.usernameInput.sendKeys(constants.expiredUsername);
+      await forgotPasswordPage.submitButton.click();
+      expect<number>(await forgotPasswordPage.errors.count()).toBe(0);
       browser.wait(ExpectedConditions.stalenessOf(resetPasswordPage.confirmPasswordInput), constants.conditionTimeout);
       browser.wait(ExpectedConditions.visibilityOf(loginPage.infoMessages.get(0)), constants.conditionTimeout);
-      expect<any>(loginPage.username.isDisplayed()).toBe(true);
-      expect<any>(loginPage.errors.count()).toBe(0);
-      expect<any>(loginPage.infoMessages.count()).toBe(1);
-      expect<any>(loginPage.infoMessages.first().getText()).toContain('email sent');
+      expect<boolean>(await loginPage.username.isDisplayed()).toBe(true);
+      expect<number>(await loginPage.errors.count()).toBe(0);
+      expect<number>(await loginPage.infoMessages.count()).toBe(1);
+      expect<string>(await loginPage.infoMessages.first().getText()).toContain('email sent');
     });
 
   });
 
   describe('for Reset Password', () => {
 
-    it('with valid reset key routes reset page', () => {
-      BellowsResetPasswordPage.get(constants.resetPasswordKey);
-      expect<any>(resetPasswordPage.confirmPasswordInput.isDisplayed()).toBe(true);
-      expect<any>(resetPasswordPage.errors.count()).toBe(0);
-      expect<any>(loginPage.infoMessages.count()).toBe(0);
+    it('with valid reset key routes reset page', async () => {
+      await BellowsResetPasswordPage.get(constants.resetPasswordKey);
+      await expect<boolean>(await resetPasswordPage.confirmPasswordInput.isDisplayed()).toBe(true);
+      await expect<number>(await resetPasswordPage.errors.count()).toBe(0);
+      await expect<number>(await loginPage.infoMessages.count()).toBe(0);
     });
 
-    it('refuses to allow form submission if the confirm input does not match', () => {
-      resetPasswordPage.passwordInput.sendKeys(constants.passwordValid);
-      resetPasswordPage.confirmPasswordInput.sendKeys(constants.passwordTooShort);
-      expect<any>(resetPasswordPage.resetButton.isEnabled()).toBe(false);
-      resetPasswordPage.passwordInput.clear();
-      resetPasswordPage.confirmPasswordInput.clear();
+    it('refuses to allow form submission if the confirm input does not match', async () => {
+      await resetPasswordPage.passwordInput.sendKeys(constants.passwordValid);
+      await resetPasswordPage.confirmPasswordInput.sendKeys(constants.passwordTooShort);
+      expect<boolean>(await resetPasswordPage.resetButton.isEnabled()).toBe(false);
+      await resetPasswordPage.passwordInput.clear();
+      await resetPasswordPage.confirmPasswordInput.clear();
     });
 
-    it('allows form submission if the confirm input matches', () => {
-      resetPasswordPage.passwordInput.sendKeys(constants.passwordValid);
-      resetPasswordPage.confirmPasswordInput.sendKeys(constants.passwordValid);
-      expect<any>(resetPasswordPage.resetButton.isEnabled()).toBe(true);
-      resetPasswordPage.passwordInput.clear();
-      resetPasswordPage.confirmPasswordInput.clear();
+    it('allows form submission if the confirm input matches', async () => {
+      await resetPasswordPage.passwordInput.sendKeys(constants.passwordValid);
+      await resetPasswordPage.confirmPasswordInput.sendKeys(constants.passwordValid);
+      expect<boolean>(await resetPasswordPage.resetButton.isEnabled()).toBe(true);
+      await resetPasswordPage.passwordInput.clear();
+      await resetPasswordPage.confirmPasswordInput.clear();
     });
 
-    it('should not allow a password less than 7 characters', () => {
-      resetPasswordPage.passwordInput.sendKeys(constants.passwordTooShort);
-      resetPasswordPage.confirmPasswordInput.sendKeys(constants.passwordTooShort);
-      expect<any>(resetPasswordPage.resetButton.isEnabled()).toBe(false);
-      resetPasswordPage.passwordInput.clear();
-      resetPasswordPage.confirmPasswordInput.clear();
+    it('should not allow a password less than 7 characters', async () => {
+      await resetPasswordPage.passwordInput.sendKeys(constants.passwordTooShort);
+      await resetPasswordPage.confirmPasswordInput.sendKeys(constants.passwordTooShort);
+      expect<boolean>(await resetPasswordPage.resetButton.isEnabled()).toBe(false);
+      await resetPasswordPage.passwordInput.clear();
+      await resetPasswordPage.confirmPasswordInput.clear();
     });
 
-    it('successfully change user\'s password', () => {
-      BellowsResetPasswordPage.get(constants.resetPasswordKey);
-      resetPasswordPage.passwordInput.sendKeys(constants.resetPassword);
-      resetPasswordPage.confirmPasswordInput.sendKeys(constants.resetPassword);
-      resetPasswordPage.resetButton.click();
+    it('successfully change user\'s password', async () => {
+      await BellowsResetPasswordPage.get(constants.resetPasswordKey);
+      await resetPasswordPage.passwordInput.sendKeys(constants.resetPassword);
+      await resetPasswordPage.confirmPasswordInput.sendKeys(constants.resetPassword);
+      await resetPasswordPage.resetButton.click();
 
       // browser.wait(ExpectedConditions.stalenessOf(resetPasswordPage.confirmPasswordInput),
       //   constants.conditionTimeout);
       // 'stalenessOf' occasionally failed with
       // WebDriverError: javascript error: document unloaded while waiting for result
-      browser.sleep(100);
-      browser.wait(ExpectedConditions.visibilityOf(loginPage.infoMessages.get(0)), constants.conditionTimeout);
-      expect<any>(loginPage.username.isDisplayed()).toBe(true);
-      expect<any>(loginPage.form.isPresent()).toBe(true);
-      expect<any>(loginPage.infoMessages.count()).toBe(1);
-      expect<any>(loginPage.infoMessages.first().getText()).toContain('password has been reset');
-      expect<any>(loginPage.errors.count()).toBe(0);
+      await browser.sleep(100);
+      await browser.wait(ExpectedConditions.visibilityOf(loginPage.infoMessages.get(0)), constants.conditionTimeout);
+      expect<boolean>(await loginPage.username.isDisplayed()).toBe(true);
+      expect<boolean>(await loginPage.form.isPresent()).toBe(true);
+      expect<number>(await loginPage.infoMessages.count()).toBe(1);
+      expect<string>(await loginPage.infoMessages.first().getText()).toContain('password has been reset');
+      expect<number>(await loginPage.errors.count()).toBe(0);
     });
 
-    it('successfully login after password change', () => {
-      BellowsLoginPage.get();
-      loginPage.login(constants.resetUsername, constants.resetPassword);
-      expect<any>(header.loginButton.isPresent()).toBe(false);
-      expect<any>(header.myProjects.button.isDisplayed()).toBe(true);
+    it('successfully login after password change', async () => {
+      await BellowsLoginPage.get();
+      await loginPage.login(constants.resetUsername, constants.resetPassword);
+      expect<boolean>(await header.loginButton.isPresent()).toBe(false);
+      expect<boolean>(await header.myProjects.button.isDisplayed()).toBe(true);
     });
 
   });

--- a/test/app/bellows/shared/activity.page.ts
+++ b/test/app/bellows/shared/activity.page.ts
@@ -10,15 +10,15 @@ export class SfActivityPage {
 
   // Navigate to the Activity page
   get() {
-    browser.get(browser.baseUrl + this.activityURL);
+    return browser.get(browser.baseUrl + this.activityURL);
   }
 
   clickOnAllActivity() {
-    this.filterByUser.element(by.css('option:nth-child(1)')).click();
+    return this.filterByUser.element(by.css('option:nth-child(1)')).click();
   }
 
   clickOnShowOnlyMyActivity() {
-    this.filterByUser.element(by.css('option:nth-child(2)')).click();
+    return this.filterByUser.element(by.css('option:nth-child(2)')).click();
   }
 
   // Returns the number of items in the activity list
@@ -43,7 +43,7 @@ export class SfActivityPage {
   // Prints the entire activity list
   //noinspection JSUnusedGlobalSymbols
   printActivitiesNames() {
-    (this.activitiesList).each((names: ElementFinder) => {
+    return (this.activitiesList).each((names: ElementFinder) => {
       names.getText().then(console.log);
     });
   }

--- a/test/app/bellows/shared/change-password.page.ts
+++ b/test/app/bellows/shared/change-password.page.ts
@@ -4,9 +4,9 @@ export class BellowsChangePasswordPage {
   conditionTimeout: number = 3000;
 
   // TODO: this will likely change when we refactor the display of notifications - cjh 2014-06
-  get() {
-    browser.get(browser.baseUrl + '/app/changepassword');
-    browser.wait(ExpectedConditions.visibilityOf(this.password), this.conditionTimeout);
+  async get() {
+    await browser.get(browser.baseUrl + '/app/changepassword');
+    return browser.wait(ExpectedConditions.visibilityOf(this.password), this.conditionTimeout);
   }
 
   password = element(by.id('change-password-input'));

--- a/test/app/bellows/shared/forgot-password.page.ts
+++ b/test/app/bellows/shared/forgot-password.page.ts
@@ -2,7 +2,7 @@ import {browser, by, element} from 'protractor';
 
 export class BellowsForgotPasswordPage {
   static get() {
-    browser.get(browser.baseUrl + '/auth/forgot_password');
+    return browser.get(browser.baseUrl + '/auth/forgot_password');
   }
 
   form = element(by.id('forgot-password-form'));

--- a/test/app/bellows/shared/login.page.ts
+++ b/test/app/bellows/shared/login.page.ts
@@ -4,7 +4,7 @@ export class BellowsLoginPage {
   private readonly constants = require('../../testConstants');
 
   static get() {
-    browser.get(browser.baseUrl + '/auth/login');
+    return browser.get(browser.baseUrl + '/auth/login');
   }
 
   form = element(by.id('login-loginForm'));
@@ -16,43 +16,43 @@ export class BellowsLoginPage {
   submit     = element(by.id('login-submit'));
   lexiconLoading = element(by.id('loadingMessage'));
 
-  login(username: string, password: string) {
-    browser.get(browser.baseUrl + '/auth/logout');
+  async login(username: string, password: string) {
+    await browser.get(browser.baseUrl + '/auth/logout');
 
-    BellowsLoginPage.get();
-    this.username.sendKeys(username);
-    this.password.sendKeys(password);
-    this.submit.click();
-    browser.wait(ExpectedConditions.not(ExpectedConditions.urlContains('/auth/login')),
+    await BellowsLoginPage.get();
+    await this.username.sendKeys(username);
+    await this.password.sendKeys(password);
+    await this.submit.click();
+    await browser.wait(ExpectedConditions.not(ExpectedConditions.urlContains('/auth/login')),
       this.constants.conditionTimeout);
-    browser.wait(ExpectedConditions.invisibilityOf(this.lexiconLoading), this.constants.conditionTimeout);
+    return browser.wait(ExpectedConditions.invisibilityOf(this.lexiconLoading), this.constants.conditionTimeout);
   }
 
   loginAsAdmin() {
-    this.login(this.constants.adminEmail, this.constants.adminPassword);
+    return this.login(this.constants.adminEmail, this.constants.adminPassword);
   }
 
   loginAsManager() {
-    this.login(this.constants.managerEmail, this.constants.managerPassword);
+    return this.login(this.constants.managerEmail, this.constants.managerPassword);
   }
 
   loginAsUser() {
-    this.login(this.constants.memberEmail, this.constants.memberPassword);
+    return this.login(this.constants.memberEmail, this.constants.memberPassword);
   }
 
   loginAsMember = this.loginAsUser;
 
   loginAsSecondUser() {
-    this.login(this.constants.member2Email, this.constants.member2Password);
+    return this.login(this.constants.member2Email, this.constants.member2Password);
   }
 
   loginAsSecondMember = this.loginAsSecondUser;
 
   loginAsObserver() {
-    this.login(this.constants.observerEmail, this.constants.observerPassword);
+    return this.login(this.constants.observerEmail, this.constants.observerPassword);
   }
 
   static logout() {
-    browser.get(browser.baseUrl + '/auth/logout');
+    return browser.get(browser.baseUrl + '/auth/logout');
   }
 }

--- a/test/app/bellows/shared/projects.page.ts
+++ b/test/app/bellows/shared/projects.page.ts
@@ -8,7 +8,7 @@ export class ProjectsPage {
 
   url = '/app/projects';
   get() {
-    browser.get(browser.baseUrl + this.url);
+    return browser.get(browser.baseUrl + this.url);
   }
 
   testProjectName = 'Test Project';
@@ -43,7 +43,7 @@ export class ProjectsPage {
   }
 
   clickOnProject(projectName: string) {
-    this.findProject(projectName).then((projectRow: any) => {
+    return this.findProject(projectName).then((projectRow: any) => {
       const projectLink = projectRow.element(by.css('a'));
       projectLink.getAttribute('href').then((url: string) => {
         browser.get(url);
@@ -56,9 +56,9 @@ export class ProjectsPage {
     element(by.id('userManagementLink')) : element(by.id('dropdown-project-settings'));
 
   addUserToProject(projectName: any, usersName: string, roleText: string) {
-    this.findProject(projectName).then((projectRow: any) => {
+    return this.findProject(projectName).then(async (projectRow: any) => {
       const projectLink = projectRow.element(by.css('a'));
-      projectLink.getAttribute('href').then((href: string) => {
+      await projectLink.getAttribute('href').then((href: string) => {
         const results = /app\/lexicon\/([0-9a-fA-F]+)\//.exec(href);
         expect(results).not.toBeNull();
         expect(results.length).toBeGreaterThan(1);
@@ -66,21 +66,21 @@ export class ProjectsPage {
         UserManagementPage.get(projectId);
       });
 
-      browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.addMembersBtn), Utils.conditionTimeout);
-      this.userManagementPage.addMembersBtn.click();
-      browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.userNameInput), Utils.conditionTimeout);
-      this.userManagementPage.userNameInput.sendKeys(usersName);
+      await browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.addMembersBtn), Utils.conditionTimeout);
+      await this.userManagementPage.addMembersBtn.click();
+      await browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.userNameInput), Utils.conditionTimeout);
+      await this.userManagementPage.userNameInput.sendKeys(usersName);
 
-      this.utils.findRowByText(this.userManagementPage.typeaheadItems, usersName).then((item: any) => {
+      await this.utils.findRowByText(this.userManagementPage.typeaheadItems, usersName).then((item: any) => {
         item.click();
       });
 
       // This should be unique no matter what
-      this.userManagementPage.newMembersDiv.element(by.id('addUserButton')).click();
+      await this.userManagementPage.newMembersDiv.element(by.id('addUserButton')).click();
 
       // Now set the user to member or manager, as needed
       let foundUserRow: any;
-      this.userManagementPage.projectMemberRows.map((row: any) => {
+      await this.userManagementPage.projectMemberRows.map((row: any) => {
         const nameColumn = row.element(by.binding('user.username'));
         nameColumn.getText().then((text: string) => {
           if (text === usersName) {
@@ -94,7 +94,7 @@ export class ProjectsPage {
         }
       });
 
-      this.get(); // After all is finished, reload projects page
+      return this.get(); // After all is finished, reload projects page
     });
   }
 

--- a/test/app/bellows/shared/reset-password.page.ts
+++ b/test/app/bellows/shared/reset-password.page.ts
@@ -1,8 +1,8 @@
 import {browser, by, element} from 'protractor';
 
 export class BellowsResetPasswordPage {
-  static get(resetPasswordKey: string): void {
-    browser.get(browser.baseUrl + '/auth/reset_password/' + resetPasswordKey);
+  static get(resetPasswordKey: string) {
+    return browser.get(browser.baseUrl + '/auth/reset_password/' + resetPasswordKey);
   }
 
   form = element(by.id('reset-password-form'));

--- a/test/app/bellows/shared/signup.page.ts
+++ b/test/app/bellows/shared/signup.page.ts
@@ -2,11 +2,11 @@ import {browser, by, element} from 'protractor';
 
 export class SignupPage {
   static get() {
-    browser.get(browser.baseUrl + '/public/signup');
+    return browser.get(browser.baseUrl + '/public/signup');
   }
 
   static getPrefilledEmail(email: string) {
-    browser.get(browser.baseUrl + '/public/signup#!/?e=' + encodeURIComponent(email));
+    return browser.get(browser.baseUrl + '/public/signup#!/?e=' + encodeURIComponent(email));
   }
 
   signupForm = element(by.id('signupForm'));
@@ -28,9 +28,9 @@ export class SignupPage {
     yellowCircleButton: this.captchaDiv.element(by.id('captcha1')),
     redTriangleButton: this.captchaDiv.element(by.id('captcha2')),
 
-    setInvalidCaptcha: () => {
-      this.captcha.blueSquareButton.click();
-      this.captcha.expectedItemName.getText().then((result: string) => {
+    setInvalidCaptcha: async () => {
+      await this.captcha.blueSquareButton.click();
+      return this.captcha.expectedItemName.getText().then((result: string) => {
         if (result === 'Blue Square') {
           element(by.id('pui-captcha')).element(by.id('captcha1')).click();
         }
@@ -38,18 +38,15 @@ export class SignupPage {
     },
 
     setValidCaptcha: () => {
-      this.captcha.expectedItemName.getText().then((result: string) => {
+      return this.captcha.expectedItemName.getText().then((result: string) => {
         const captchaDiv = element(by.id('pui-captcha'));
         switch (result) {
           case 'Blue Square' :
-            captchaDiv.element(by.id('captcha0')).click();
-            break;
+            return captchaDiv.element(by.id('captcha0')).click();
           case 'Yellow Circle' :
-            captchaDiv.element(by.id('captcha1')).click();
-            break;
+            return captchaDiv.element(by.id('captcha1')).click();
           case 'Red Triangle' :
-            captchaDiv.element(by.id('captcha2')).click();
-            break;
+            return captchaDiv.element(by.id('captcha2')).click();
         }
       });
     }

--- a/test/app/bellows/shared/site-admin.page.ts
+++ b/test/app/bellows/shared/site-admin.page.ts
@@ -7,7 +7,7 @@ export class SiteAdminPage {
   url = browser.baseUrl + '/app/siteadmin';
   get() {
     // todo: refactor this to be a click recipe (as a user would click on the menu to navigate)
-    browser.get(this.url);
+    return browser.get(this.url);
   }
 
   activePane = element(by.css('div.tab-pane.active'));
@@ -24,7 +24,7 @@ export class SiteAdminPage {
     setCheckbox: (row: number, value: boolean) => {
       const projectRow = this.archivedProjectsTab.projectsList.get(row);
       const rowCheckbox = projectRow.element(by.css('input[type="checkbox"]'));
-      this.util.setCheckbox(rowCheckbox, value);
+      return this.util.setCheckbox(rowCheckbox, value);
     }
   };
 
@@ -45,11 +45,11 @@ export class SiteAdminPage {
   passwordInput = element(by.model('record.password'));
 
   //noinspection JSUnusedGlobalSymbols
-  clearForm() {
-    this.usernameInput.clear();
-    this.nameInput.clear();
-    this.emailInput.clear();
-    this.passwordInput.clear();
+  async clearForm() {
+    await this.usernameInput.clear();
+    await this.nameInput.clear();
+    await this.emailInput.clear();
+    return this.passwordInput.clear();
 
     // this.activeCheckbox.clear();
   }

--- a/test/app/bellows/shared/user-profile.page.ts
+++ b/test/app/bellows/shared/user-profile.page.ts
@@ -8,19 +8,19 @@ export class SfUserProfilePage {
 
   // Navigate to the MyProfile page (defaults to My Account tab)
   get() {
-    browser.get(browser.baseUrl + this.userProfileURL);
+    return browser.get(browser.baseUrl + this.userProfileURL);
   }
 
   // Navigate to the MyProfile -> My Account page
   getMyAccount() {
-    this.get();
+    return this.get();
   }
 
   // Navigate to the MyProfile -> About Me page
-  getAboutMe() {
-    this.get();
-    this.tabs.aboutMe.click();
-    browser.wait(ExpectedConditions.visibilityOf(this.aboutMeTab.fullName), Utils.conditionTimeout);
+  async getAboutMe() {
+    await this.get();
+    await this.tabs.aboutMe.click();
+    return browser.wait(ExpectedConditions.visibilityOf(this.aboutMeTab.fullName), Utils.conditionTimeout);
   }
 
   tabs = {
@@ -52,33 +52,33 @@ export class SfUserProfilePage {
     saveBtn:          element(by.id('saveBtn')),
 
     selectColor: (newColor: string|RegExp) => {
-      Utils.clickDropdownByValue(this.myAccountTab.avatarColor, newColor);
+      return Utils.clickDropdownByValue(this.myAccountTab.avatarColor, newColor);
     },
     selectShape: (newShape: string|RegExp) => {
-      Utils.clickDropdownByValue(this.myAccountTab.avatarShape, newShape);
+      return Utils.clickDropdownByValue(this.myAccountTab.avatarShape, newShape);
     },
-    updateEmail: (newEmail: string) => {
-      browser.wait(ExpectedConditions.visibilityOf(this.myAccountTab.emailInput), Utils.conditionTimeout);
-      this.myAccountTab.emailInput.sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
-      this.myAccountTab.emailInput.sendKeys(newEmail);
+    updateEmail: async (newEmail: string) => {
+      await browser.wait(ExpectedConditions.visibilityOf(this.myAccountTab.emailInput), Utils.conditionTimeout);
+      await this.myAccountTab.emailInput.sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
+      await this.myAccountTab.emailInput.sendKeys(newEmail);
 
       // click another field to force validation
-      this.myAccountTab.username.click();
+      return this.myAccountTab.username.click();
     },
-    updateUsername: (newUsername: string) => {
-      browser.wait(ExpectedConditions.visibilityOf(this.myAccountTab.username), Utils.conditionTimeout);
-      this.myAccountTab.username.sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
-      this.myAccountTab.username.sendKeys(newUsername);
+    updateUsername: async (newUsername: string) => {
+      await browser.wait(ExpectedConditions.visibilityOf(this.myAccountTab.username), Utils.conditionTimeout);
+      await this.myAccountTab.username.sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
+      await this.myAccountTab.username.sendKeys(newUsername);
 
       // click another field to force validation
-      this.myAccountTab.emailInput.click();
+      return this.myAccountTab.emailInput.click();
     },
-    updateMobilePhone: (newPhone: string) => {
-      browser.wait(ExpectedConditions.visibilityOf(this.myAccountTab.mobilePhoneInput), Utils.conditionTimeout);
-      this.myAccountTab.mobilePhoneInput.sendKeys(newPhone);
+    updateMobilePhone: async (newPhone: string) => {
+      await browser.wait(ExpectedConditions.visibilityOf(this.myAccountTab.mobilePhoneInput), Utils.conditionTimeout);
+      return this.myAccountTab.mobilePhoneInput.sendKeys(newPhone);
     },
     updateContactPreference() {
-      this.bothBtn.click();
+      return this.bothBtn.click();
     }
   };
 
@@ -88,18 +88,18 @@ export class SfUserProfilePage {
     gender:   element(by.id('gender')),
     saveBtn:  element(by.id('saveBtn')),
 
-    updateFullName: (newFullName: string) => {
-      browser.wait(ExpectedConditions.visibilityOf(this.aboutMeTab.fullName), Utils.conditionTimeout);
-      this.aboutMeTab.fullName.sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
-      this.aboutMeTab.fullName.sendKeys(newFullName);
+    updateFullName: async (newFullName: string) => {
+      await browser.wait(ExpectedConditions.visibilityOf(this.aboutMeTab.fullName), Utils.conditionTimeout);
+      await this.aboutMeTab.fullName.sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
+      return this.aboutMeTab.fullName.sendKeys(newFullName);
     },
-    updateAge: (newAge: string) => {
-      browser.wait(ExpectedConditions.visibilityOf(this.aboutMeTab.age), Utils.conditionTimeout);
-      this.aboutMeTab.age.sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
-      this.aboutMeTab.age.sendKeys(newAge);
+    updateAge: async (newAge: string) => {
+      await browser.wait(ExpectedConditions.visibilityOf(this.aboutMeTab.age), Utils.conditionTimeout);
+      await this.aboutMeTab.age.sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
+      return this.aboutMeTab.age.sendKeys(newAge);
     },
     updateGender: (newGender: string) => {
-      Utils.clickDropdownByValue(this.aboutMeTab.gender, newGender);
+      return Utils.clickDropdownByValue(this.aboutMeTab.gender, newGender);
     }
   };
 }

--- a/test/app/bellows/shared/utils.ts
+++ b/test/app/bellows/shared/utils.ts
@@ -10,7 +10,7 @@ export class Utils {
   setCheckbox(checkboxElement: ElementFinder, value: boolean) {
     // Ensure a checkbox element will be either checked (true) or unchecked (false), regardless of
     // what its current value is
-    checkboxElement.isSelected().then((checked: boolean) => {
+    return checkboxElement.isSelected().then((checked: boolean) => {
       if (checked !== value) {
         checkboxElement.click();
       }
@@ -24,7 +24,7 @@ export class Utils {
 
   static clickDropdownByValue(dropdownElement: ElementFinder, value: string|RegExp) {
     // Select an element of the dropdown based on its value (its text)
-    Utils.findDropdownByValue(dropdownElement, value).click();
+    return Utils.findDropdownByValue(dropdownElement, value).click();
   }
 
   findRowByFunc(elementArray: ElementArrayFinder, searchFunc: (rowText: string) => boolean): Promise<ElementFinder> {
@@ -62,7 +62,7 @@ export class Utils {
    * @param textString - string of text to set the value to
    */
   static sendText(elem: ElementFinder, textString: string) {
-    browser.executeScript('arguments[0].value = arguments[1];', elem.getWebElement(), textString);
+    return browser.executeScript('arguments[0].value = arguments[1];', elem.getWebElement(), textString);
   }
 
   //noinspection JSUnusedGlobalSymbols
@@ -97,23 +97,23 @@ export class Utils {
     }
   };
 
-  static checkModalTextMatches(expectedText: string) {
+  static async checkModalTextMatches(expectedText: string) {
     const modalBody = element(by.css('.modal-body'));
 
-    browser.wait(ExpectedConditions.visibilityOf(modalBody), Utils.conditionTimeout);
-    expect(modalBody.getText()).toMatch(expectedText);
+    await browser.wait(ExpectedConditions.visibilityOf(modalBody), Utils.conditionTimeout);
+    return expect(modalBody.getText()).toMatch(expectedText);
   }
 
-  static clickModalButton(buttonText: string) {
+  static async clickModalButton(buttonText: string) {
     const button = element(by.css('.modal-footer')).element(by.partialButtonText(buttonText));
 
-    browser.wait(ExpectedConditions.visibilityOf(button), Utils.conditionTimeout);
-    browser.wait(ExpectedConditions.elementToBeClickable(button), Utils.conditionTimeout);
-    button.click();
+    await browser.wait(ExpectedConditions.visibilityOf(button), Utils.conditionTimeout);
+    await browser.wait(ExpectedConditions.elementToBeClickable(button), Utils.conditionTimeout);
+    return button.click();
   }
 
   static clickBreadcrumb(breadcrumbTextOrRegex: string|RegExp) {
-    element(by.cssContainingText('.breadcrumb > li', breadcrumbTextOrRegex)).click();
+    return element(by.cssContainingText('.breadcrumb > li', breadcrumbTextOrRegex)).click();
   }
 
   static parent(child: ElementFinder) {
@@ -139,7 +139,7 @@ export class Utils {
   }
 
   static scrollTop() {
-    browser.executeScript('window.scroll(0,0)');
+    return browser.executeScript('window.scroll(0,0)');
   }
 
   static isAllCheckboxes(elementArray: ElementArrayFinder, state: boolean = true) {


### PR DESCRIPTION
bellows-traversal.e2e-spec.ts and reset-forgotten-password.e2e-spec.ts and all their helper code (the various page proxy classes they use) are now completely async, which should (once we can comfirm E2E tests are working) help reduce the number of browser.wait() calls we have to make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/836)
<!-- Reviewable:end -->
