### PR TITLE
Fix reset password part of E2E traversal test

### DIFF
--- a/test/app/bellows/reset-forgotten-password.e2e-spec.ts
+++ b/test/app/bellows/reset-forgotten-password.e2e-spec.ts
@@ -1,12 +1,12 @@
 import {browser, ExpectedConditions} from 'protractor';
 
-import {BellowsForgotPasswordPage} from '../shared/forgot-password.page';
-import {BellowsLoginPage} from '../shared/login.page';
-import {PageHeader} from '../shared/page-header.element';
-import {BellowsResetPasswordPage} from '../shared/reset-password.page';
+import {BellowsForgotPasswordPage} from './shared/forgot-password.page';
+import {BellowsLoginPage} from './shared/login.page';
+import {PageHeader} from './shared/page-header.element';
+import {BellowsResetPasswordPage} from './shared/reset-password.page';
 
 describe('Bellows E2E Reset Forgotten Password app', () => {
-  const constants = require('../../testConstants.json');
+  const constants = require('./../testConstants.json');
   const header = new PageHeader();
   const loginPage = new BellowsLoginPage();
   const resetPasswordPage = new BellowsResetPasswordPage();

--- a/test/app/bellows/signup.e2e-spec.ts
+++ b/test/app/bellows/signup.e2e-spec.ts
@@ -1,10 +1,10 @@
 import {browser, ExpectedConditions} from 'protractor';
 
-import {BellowsLoginPage} from '../shared/login.page';
-import {SignupPage} from '../shared/signup.page';
+import {BellowsLoginPage} from './shared/login.page';
+import {SignupPage} from './shared/signup.page';
 
 describe('Bellows E2E Signup app', () => {
-  const constants = require('../../testConstants.json');
+  const constants = require('./../testConstants.json');
   const page = new SignupPage();
   const loginPage = new BellowsLoginPage();
 


### PR DESCRIPTION
The failure on the reset password part of the E2E traversal test is because the traversal test is designed to be run first, before anything else, but the test locator logic is running tests in subdirectories before it runs tests in the parent directory, so that the test/app/bellows/bellows-traversal.e2e-spec.ts test is running *after* the test/app/bellows/reset-forgotten-password.e2e-spec.ts test. The bellows-traversal test needs to run first. Moving the reset-forgotten-password test into the parent directory fixes this issue.

This doesn't fix all the E2E tests, but we at least have fewer failures after this PR than before the PR. :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/837)
<!-- Reviewable:end -->
