### PR TITLE
Fix extra params in e2e-ui/run.sh

### DIFF
--- a/docker/e2e-ui/run.sh
+++ b/docker/e2e-ui/run.sh
@@ -17,7 +17,7 @@ attach_debugger () {
 
 attach_debugger &
 cd /data
-gulp test-e2e-doTest --webserverHost e2e ${@:2}
+gulp test-e2e-doTest --webserverHost e2e "$@"
 STATUS=$?
 
 exit $STATUS


### PR DESCRIPTION
The run.sh file in docker/e2e-ui was originally designed to pass in the name of the site (sf for Scripture Forge, lf for Language Forge, etc) as its first parameter, so it was designed to swallow its first parameter and pass any later parameters on to the Gulp task, for things like `--specs=change-password`. Now that we're no longer calling it with the site name, we no longer need to strip the first parameter.

Also added quotation marks around the `$@` usage so that spaces won't be dropped: see https://www.grymoire.com/Unix/Sh.html#uh-42 for why.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/843)
<!-- Reviewable:end -->
