### PR TITLE
Fix calling /api/v2/roles in LD API

### DIFF
--- a/docker/e2e-api/run.sh
+++ b/docker/e2e-api/run.sh
@@ -2,4 +2,6 @@
 
 cd /var/www/test/app
 php setupTestEnvironment.php localhost
+chmod -R g+w /var/www/html/assets /var/www/html/cache
+chown -R :www-data /var/www/html/assets /var/www/html/cache
 apache2-foreground

--- a/src/Api/Model/Shared/Command/LdapiCommands.php
+++ b/src/Api/Model/Shared/Command/LdapiCommands.php
@@ -68,8 +68,8 @@ class LdapiCommands
         return ($result === 'Manager');
     }
 
-    public static function getAllRoles($languageDepotUsername) {
-        return Ldapi::call($languageDepotUsername, 'get', self::ROLES_BASE_URL . self::URL_PART_GET_ALL);
+    public static function getAllRoles() {
+        return Ldapi::call(null, 'get', self::ROLES_BASE_URL . self::URL_PART_GET_ALL);
     }
 }
 

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -947,7 +947,7 @@ class Sf
         }
         if ($user->email) {
             $ldUsers = LdapiCommands::searchUsers('', $user->email);
-            if (count($ldUsers) == 1) {
+            if ($ldUsers && count($ldUsers) == 1) {
                 $username = $ldUsers[0]['username'];
                 if ($username) {
                     $user->languageDepotUsername = $username;
@@ -1004,7 +1004,7 @@ class Sf
     }
 
     public function ldapi_get_all_roles() {
-        return LdapiCommands::getAllRoles($this->get_ldapi_username());
+        return LdapiCommands::getAllRoles();
     }
 
     // ---------------------------------------------------------------

--- a/src/angular-app/bellows/core/api/roles.service.ts
+++ b/src/angular-app/bellows/core/api/roles.service.ts
@@ -13,6 +13,7 @@ export class RolesService {
   techSupport: IPromise<string>;
   static defaultContributorRole = 'Contributor';
   static defaultManagerRole = 'Manager';
+  static defaultTechSupportRole = 'LanguageDepotProgrammer';
   // get contributor(): IPromise<string {
   //   return this._contributor || RolesService.defaultContributorRole;
   // }
@@ -100,13 +101,13 @@ export class RolesService {
           }
         });
         if (!contributorFound) {
-          contributorD.reject('No contributor role found!');
+          contributorD.resolve(RolesService.defaultContributorRole);
         }
         if (!managerFound) {
-          managerD.reject('No manager role found!');
+          contributorD.resolve(RolesService.defaultManagerRole);
         }
         if (!techSupportFound) {
-          techSupportD.reject('No tech support role found!');
+          contributorD.resolve(RolesService.defaultTechSupportRole);
         }
         return result.data;
       } else {


### PR DESCRIPTION
Roles API call doesn't need authorization and shouldn't fail if there's no username available.

I haven't been able to prove that this works yet, due to multiple unrelated errors in E2E tests. **Update:** I think it's working now. Ready to be reviewed and merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/846)
<!-- Reviewable:end -->
