### PR TITLE
Fix most async problems in E2E tests

### DIFF
--- a/test/app/bellows/project-settings.e2e-spec.ts
+++ b/test/app/bellows/project-settings.e2e-spec.ts
@@ -11,17 +11,17 @@ describe('Bellows E2E Project Settings app', () => {
   const projectsPage = new ProjectsPage();
   const settingsPage = new BellowsProjectSettingsPage();
 
-  it('Normal user cannot access projectSettings to a project of which the user is a member', () => {
-    loginPage.loginAsMember();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
-    expect<any>(settingsPage.settingsMenuLink.getAttribute('class')).not.toContain('app-settings-available');
+  it('Normal user cannot access projectSettings to a project of which the user is a member', async () => {
+    await loginPage.loginAsMember();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
+    expect<string>(await settingsPage.settingsMenuLink.getAttribute('class')).not.toContain('app-settings-available');
   });
 
-  it('System Admin can manage project', () => {
-    loginPage.loginAsAdmin();
-    settingsPage.get(constants.testProjectName);
-    expect<any>(settingsPage.noticeList.count()).toBe(0);
+  it('System Admin can manage project', async () => {
+    await loginPage.loginAsAdmin();
+    await settingsPage.get(constants.testProjectName);
+    expect<number>(await settingsPage.noticeList.count()).toBe(0);
 
     // Archive tab currently disabled
     /*
@@ -29,20 +29,20 @@ describe('Bellows E2E Project Settings app', () => {
     expect(managementPage.archiveTab.archiveButton.isDisplayed()).toBe(true);
     expect(managementPage.archiveTab.archiveButton.isEnabled()).toBe(true);
     */
-    browser.wait(ExpectedConditions.elementToBeClickable(settingsPage.tabs.remove), constants.conditionTimeout);
-    browser.actions().mouseMove(settingsPage.tabs.remove).click().perform();
-    // settingsPage.tabs.remove.click();
-    browser.wait(ExpectedConditions.visibilityOf(settingsPage.deleteTab.deleteButton), constants.conditionTimeout);
-    expect<any>(settingsPage.deleteTab.deleteButton.isDisplayed()).toBe(true);
-    expect<any>(settingsPage.deleteTab.deleteButton.isEnabled()).toBe(false);
+    await browser.wait(ExpectedConditions.visibilityOf(settingsPage.tabs.remove), constants.conditionTimeout);
+    // await browser.actions().mouseMove(settingsPage.tabs.remove).click().perform();
+    await settingsPage.tabs.remove.click();
+    // await browser.wait(ExpectedConditions.visibilityOf(settingsPage.deleteTab.deleteButton), constants.conditionTimeout);
+    expect<boolean>(await settingsPage.deleteTab.deleteButton.isDisplayed()).toBe(true);
+    expect<boolean>(await settingsPage.deleteTab.deleteButton.isEnabled()).toBe(false);
   });
 
-  it('confirm Manager is not owner of test project', () => {
-    loginPage.loginAsManager();
-    settingsPage.get(constants.testProjectName);
-    settingsPage.tabs.project.click();
-    expect<any>(settingsPage.projectTab.projectOwner.isDisplayed()).toBe(true);
-    expect(settingsPage.projectTab.projectOwner.getText())
+  it('confirm Manager is not owner of test project', async () => {
+    await loginPage.loginAsManager();
+    await settingsPage.get(constants.testProjectName);
+    await settingsPage.tabs.project.click();
+    expect<any>(await settingsPage.projectTab.projectOwner.isDisplayed()).toBe(true);
+    expect(await settingsPage.projectTab.projectOwner.getText())
       .not.toContain(constants.managerUsername);
   });
 
@@ -53,35 +53,38 @@ describe('Bellows E2E Project Settings app', () => {
   });
   */
 
-  it('Manager cannot view delete tab if not owner', () => {
-    expect<any>(settingsPage.tabs.remove.isPresent()).toBe(false);
+  it('Manager cannot view delete tab if not owner', async () => {
+    expect<any>(await settingsPage.tabs.remove.isPresent()).toBe(false);
   });
 
-  it('confirm Manager is owner of fourth project', () => {
-    loginPage.loginAsManager();
-    settingsPage.get(constants.fourthProjectName);
-    settingsPage.tabs.project.click();
-    expect<any>(settingsPage.projectTab.projectOwner.isDisplayed()).toBe(true);
-    expect(settingsPage.projectTab.projectOwner.getText()).toContain(constants.managerUsername);
+  it('confirm Manager is owner of fourth project', async () => {
+    await loginPage.loginAsManager();
+    await settingsPage.get(constants.fourthProjectName);
+    await settingsPage.tabs.project.click();
+    expect<any>(await settingsPage.projectTab.projectOwner.isDisplayed()).toBe(true);
+    expect(await settingsPage.projectTab.projectOwner.getText()).toContain(constants.managerUsername);
   });
 
   // For Jamaican Psalms, only system admins can delete projects.
   // Project Manager is an ordinary user, so this test is ignored for Jamaican Psalms
-  it('Manager can delete if owner', () => {
+  it('Manager can delete if owner', async () => {
     if (!browser.baseUrl.startsWith('http://jamaicanpsalms') && !browser.baseUrl.startsWith('https://jamaicanpsalms')) {
-      loginPage.loginAsManager();
-      settingsPage.get(constants.fourthProjectName);
-      expect<any>(settingsPage.noticeList.count()).toBe(0);
-      settingsPage.tabs.remove.click();
-      browser.wait(ExpectedConditions.visibilityOf(settingsPage.deleteTab.deleteButton), constants.conditionTimeout);
-      expect<any>(settingsPage.deleteTab.deleteButton.isDisplayed()).toBe(true);
-      expect<any>(settingsPage.deleteTab.deleteButton.isEnabled()).toBe(false);
-      settingsPage.deleteTab.deleteBoxText.sendKeys('DELETE');
-      expect<any>(settingsPage.deleteTab.deleteButton.isEnabled()).toBe(true);
-      settingsPage.deleteTab.deleteButton.click();
-      Utils.clickModalButton('Delete');
-      projectsPage.get();
-      expect<any>(projectsPage.projectsList.count()).toBe(3);
+      await loginPage.loginAsManager();
+      await projectsPage.get();
+      expect<any>(await projectsPage.projectsList.count()).toBe(4);
+      await settingsPage.get(constants.fourthProjectName);
+      expect<any>(await settingsPage.noticeList.count()).toBe(0);
+      await settingsPage.tabs.remove.click();
+      await browser.wait(ExpectedConditions.visibilityOf(settingsPage.deleteTab.deleteButton), constants.conditionTimeout);
+      expect<any>(await settingsPage.deleteTab.deleteButton.isDisplayed()).toBe(true);
+      expect<any>(await settingsPage.deleteTab.deleteButton.isEnabled()).toBe(false);
+      await settingsPage.deleteTab.deleteBoxText.sendKeys('DELETE');
+      expect<any>(await settingsPage.deleteTab.deleteButton.isEnabled()).toBe(true);
+      await settingsPage.deleteTab.deleteButton.click();
+      await Utils.clickModalButton('Delete');
+      // await browser.wait(() => false, constants.conditionTimeout * 10);
+      await projectsPage.get();
+      expect<any>(await projectsPage.projectsList.count()).toBe(3);
     }
   });
 

--- a/test/app/bellows/projects.e2e-spec.ts
+++ b/test/app/bellows/projects.e2e-spec.ts
@@ -14,88 +14,88 @@ describe('Bellows E2E Projects List app', () => {
 
   describe('for Normal User', () => {
 
-    it('should list the project of which the user is a member', () => {
-      loginPage.loginAsMember();
-      projectsPage.get();
-      expect(projectsPage.projectNames.get(0).getText()).toBe(constants.testProjectName);
+    it('should list the project of which the user is a member', async () => {
+      await loginPage.loginAsMember();
+      await projectsPage.get();
+      expect(await projectsPage.projectNames.get(0).getText()).toBe(constants.testProjectName);
     });
 
-    it('should not list projects the user is not a member of', () => {
-      projectsPage.get();
-      expect<any>(projectsPage.projectsList.count()).toBe(1);
+    it('should not list projects the user is not a member of', async () => {
+      await projectsPage.get();
+      expect<any>(await projectsPage.projectsList.count()).toBe(1);
     });
 
-    it('can list two projects of which the user is a member', () => {
-      loginPage.loginAsAdmin();
-      projectsPage.get();
-      browser.wait(ExpectedConditions.visibilityOf(projectsPage.createBtn), constants.conditionTimeout);
-      projectsPage.addMemberToProject(constants.otherProjectName, constants.memberName);
-      loginPage.loginAsMember();
-      projectsPage.get();
-      browser.wait(ExpectedConditions.visibilityOf(projectsPage.createBtn), constants.conditionTimeout);
-      expect<any>(projectsPage.projectsList.count()).toBe(2);
+    it('can list two projects of which the user is a member', async () => {
+      await loginPage.loginAsAdmin();
+      await projectsPage.get();
+      await browser.wait(ExpectedConditions.visibilityOf(projectsPage.createBtn), constants.conditionTimeout);
+      await projectsPage.addMemberToProject(constants.otherProjectName, constants.memberName);
+      await loginPage.loginAsMember();
+      await projectsPage.get();
+      await browser.wait(ExpectedConditions.visibilityOf(projectsPage.createBtn), constants.conditionTimeout);
+      expect<any>(await projectsPage.projectsList.count()).toBe(2);
     });
   });
 
   // Two helper functions to avoid duplicating the same checks in admin test below
-  const shouldProjectBeLinked = (projectName: string, projectRow: ElementFinder, bool: boolean) => {
-    expect<any>(projectRow.element(by.cssContainingText('a', projectName)).isDisplayed()).toBe(bool);
+  const shouldProjectBeLinked = async (projectName: string, projectRow: ElementFinder, bool: boolean) => {
+    expect<any>(await projectRow.element(by.cssContainingText('a', projectName)).isDisplayed()).toBe(bool);
   };
 
-  const shouldProjectHaveButtons = (projectRow: ElementFinder, bool: boolean) => {
+  const shouldProjectHaveButtons = async (projectRow: ElementFinder, bool: boolean) => {
     const addAsTechSupportBtn = projectRow.element(by.id('techSupportButton'));
-    expect<any>(addAsTechSupportBtn.isDisplayed()).toBe(bool);
+    expect<any>(await addAsTechSupportBtn.isDisplayed()).toBe(bool);
   };
 
   describe('for System Admin User', () => {
 
-    it('should list all projects', () => {
-      loginPage.loginAsAdmin();
-      projectsPage.get();
-      expect(projectsPage.projectsList.count()).toBeGreaterThan(0);
+    it('should list all projects', async () => {
+      await loginPage.loginAsAdmin();
+      await projectsPage.get();
+      expect(await projectsPage.projectsList.count()).toBeGreaterThan(0);
 
       // Check that the test project is around
-      projectsPage.findProject(constants.testProjectName).then((projectRow: ElementFinder) => {
-        shouldProjectBeLinked(constants.testProjectName, projectRow, true);
+      return projectsPage.findProject(constants.testProjectName).then((projectRow: ElementFinder) => {
+        return shouldProjectBeLinked(constants.testProjectName, projectRow, true);
       });
     });
 
-    it('should show add and delete buttons', () => {
+    it('should show add and delete buttons', async () => {
       // projectsPage.createBtn.getOuterHtml().then(console.log);
-      expect(projectsPage.createBtn.isDisplayed()).toBeTruthy();
+      expect(await projectsPage.createBtn.isDisplayed()).toBeTruthy();
     });
 
-    it('should allow the admin to add themselves to the project as member or manager', () => {
+    it('should allow the admin to add themselves to the project as member or manager', async () => {
 
       // First remove the admin from the project (must be a project admin is not the owner of)
-      loginPage.loginAsManager();
-      projectsPage.get();
+      await loginPage.loginAsManager();
+      await projectsPage.get();
 
       // The admin should not see "Add myself to project" buttons when he's already a project member
       // or manager, and the project name should be a clickable link
-      projectsPage.findProject(constants.otherProjectName).then((projectRow: ElementFinder) => {
-        shouldProjectBeLinked(constants.otherProjectName, projectRow, true);
-        shouldProjectHaveButtons(projectRow, false);
+      await projectsPage.findProject(constants.otherProjectName).then(async (projectRow: ElementFinder) => {
+        await shouldProjectBeLinked(constants.otherProjectName, projectRow, true);
+        return shouldProjectHaveButtons(projectRow, false);
       });
 
-      projectsPage.removeUserFromProject(constants.otherProjectName, constants.adminUsername);
-      loginPage.loginAsAdmin();
-      projectsPage.get();
+      await projectsPage.removeUserFromProject(constants.otherProjectName, constants.adminUsername);
+      await loginPage.loginAsAdmin();
+      await projectsPage.get();
 
       // Now the admin should have "Add myself to project" buttons
       // And the project name should NOT be a clickable link
-      projectsPage.findProject(constants.otherProjectName).then((projectRow: ElementFinder) => {
-        shouldProjectBeLinked(constants.otherProjectName, projectRow, false);
-        shouldProjectHaveButtons(projectRow, true);
+      await projectsPage.findProject(constants.otherProjectName).then(async (projectRow: ElementFinder) => {
+        await shouldProjectBeLinked(constants.otherProjectName, projectRow, false);
+        await shouldProjectHaveButtons(projectRow, true);
 
         // Now add the admin back to the project
-        projectRow.element(by.id('techSupportButton')).click();
+        return projectRow.element(by.id('techSupportButton')).click();
       });
 
       // And the buttons should go away after one of them is clicked
-      projectsPage.findProject(constants.otherProjectName).then((projectRow: ElementFinder) => {
-        shouldProjectBeLinked(constants.otherProjectName, projectRow, true);
-        shouldProjectHaveButtons(projectRow, false);
+      return projectsPage.findProject(constants.otherProjectName).then(async (projectRow: ElementFinder) => {
+        await shouldProjectBeLinked(constants.otherProjectName, projectRow, true);
+        return shouldProjectHaveButtons(projectRow, false);
       });
     });
 
@@ -103,29 +103,26 @@ describe('Bellows E2E Projects List app', () => {
 
   describe('Lexicon E2E Project Access', () => {
 
-    it('Admin added to project when accessing without membership', () => {
-      loginPage.loginAsManager();
-      browser.getCurrentUrl().then(url => {
-        projectNameLabel.getText().then( projectName => {
-          projectsPage.get();
-          browser.wait(ExpectedConditions.visibilityOf(projectsPage.createBtn), constants.conditionTimeout);
-          projectsPage.removeUserFromProject(projectName, constants.adminUsername);
-          loginPage.loginAsAdmin();
-          browser.get(url);
-          browser.wait(ExpectedConditions.visibilityOf(editorPage.browseDiv), constants.conditionTimeout);
-          expect<any>(editorPage.browseDiv.isPresent()).toBe(true);
-        });
-      });
+    it('Admin added to project when accessing without membership', async () => {
+      await loginPage.loginAsManager();
+      const url = await browser.getCurrentUrl();
+      const projectName = await projectNameLabel.getText();
+      await projectsPage.get();
+      await browser.wait(ExpectedConditions.visibilityOf(projectsPage.createBtn), constants.conditionTimeout);
+      await projectsPage.removeUserFromProject(projectName, constants.adminUsername);
+      await loginPage.loginAsAdmin();
+      await browser.get(url);
+      await browser.wait(ExpectedConditions.visibilityOf(editorPage.browseDiv), constants.conditionTimeout);
+      expect<any>(await editorPage.browseDiv.isPresent()).toBe(true);
     });
 
-    it('User redirected to projects app when accessing without membership', () => {
-        loginPage.loginAsManager();
-        browser.getCurrentUrl().then(url => {
-          loginPage.loginAsSecondUser();
-          browser.get(url);
-          browser.wait(ExpectedConditions.visibilityOf(projectsPage.createBtn), constants.conditionTimeout);
-          expect<any>(projectsPage.createBtn.isPresent()).toBe(true);
-        });
+    it('User redirected to projects app when accessing without membership', async () => {
+      await loginPage.loginAsManager();
+      const url = await browser.getCurrentUrl();
+      await loginPage.loginAsSecondUser();
+      await browser.get(url);
+      await browser.wait(ExpectedConditions.visibilityOf(projectsPage.createBtn), constants.conditionTimeout);
+      expect<any>(await projectsPage.createBtn.isPresent()).toBe(true);
     });
 
   });

--- a/test/app/bellows/shared/project-settings.page.ts
+++ b/test/app/bellows/shared/project-settings.page.ts
@@ -10,13 +10,13 @@ export class BellowsProjectSettingsPage {
   projectSettingsLink = element(by.id('dropdown-project-settings'));
 
   // Get the projectSettings for project projectName
-  get(projectName: string) {
-    this.projectsPage.get();
-    this.projectsPage.clickOnProject(projectName);
-    browser.wait(ExpectedConditions.visibilityOf(this.settingsMenuLink), this.conditionTimeout);
-    this.settingsMenuLink.click();
-    browser.wait(ExpectedConditions.visibilityOf(this.projectSettingsLink), this.conditionTimeout);
-    this.projectSettingsLink.click();
+  async get(projectName: string) {
+    await this.projectsPage.get();
+    await this.projectsPage.clickOnProject(projectName);
+    await browser.wait(ExpectedConditions.visibilityOf(this.settingsMenuLink), this.conditionTimeout);
+    await this.settingsMenuLink.click();
+    await browser.wait(ExpectedConditions.visibilityOf(this.projectSettingsLink), this.conditionTimeout);
+    return this.projectSettingsLink.click();
   }
 
   noticeList = element.all(by.repeater('notice in $ctrl.notices()'));

--- a/test/app/bellows/shared/projects.page.ts
+++ b/test/app/bellows/shared/projects.page.ts
@@ -100,38 +100,38 @@ export class ProjectsPage {
 
   //noinspection JSUnusedGlobalSymbols
   addManagerToProject(projectName: string, usersName: string) {
-    this.addUserToProject(projectName, usersName, 'Manager');
+    return this.addUserToProject(projectName, usersName, 'Manager');
   }
 
   addMemberToProject(projectName: string, usersName: string) {
-    this.addUserToProject(projectName, usersName, 'Contributor');
+    return this.addUserToProject(projectName, usersName, 'Contributor');
   }
 
   removeUserFromProject(projectName: string, userName: string) {
-    this.findProject(projectName).then((projectRow: any) => {
+    return this.findProject(projectName).then(async (projectRow: any) => {
       const projectLink = projectRow.element(by.css('a'));
-      projectLink.getAttribute('href').then((href: string) => {
+      await projectLink.getAttribute('href').then((href: string) => {
         const results = /app\/lexicon\/([0-9a-fA-F]+)\//.exec(href);
         expect(results).not.toBeNull();
         expect(results.length).toBeGreaterThan(1);
         const projectId = results[1];
-        UserManagementPage.get(projectId);
+        return UserManagementPage.get(projectId);
       });
-      browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.addMembersBtn), Utils.conditionTimeout);
+      await browser.wait(ExpectedConditions.visibilityOf(this.userManagementPage.addMembersBtn), Utils.conditionTimeout);
 
       let userFilter: any;
       let projectMemberRows: any;
       userFilter = element(by.model('$ctrl.userFilter'));
-      userFilter.sendKeys(userName);
+      await userFilter.sendKeys(userName);
       projectMemberRows = element.all(by.repeater('user in $ctrl.list.visibleUsers'));
 
-      const foundUserRow = projectMemberRows.first();
+      const foundUserRow = await projectMemberRows.first();
       const rowCheckbox = foundUserRow.element(by.css('input[type="checkbox"]'));
-      this.utils.setCheckbox(rowCheckbox, true);
+      await this.utils.setCheckbox(rowCheckbox, true);
       const removeMembersBtn = element(by.id('remove-members-button'));
-      removeMembersBtn.click();
+      await removeMembersBtn.click();
 
-      this.get(); // After all is finished, reload projects page
+      return this.get(); // After all is finished, reload projects page
     });
   }
 }

--- a/test/app/bellows/shared/user-management.page.ts
+++ b/test/app/bellows/shared/user-management.page.ts
@@ -4,12 +4,12 @@ import { Utils } from './utils';
 
 export class UserManagementPage {
   static get(projectId: string) {
-    browser.get(browser.baseUrl + '/app/usermanagement/' + projectId );
+    return browser.get(browser.baseUrl + '/app/usermanagement/' + projectId );
   }
 
-  static getByProjectName(projectName: string) {
+  static async getByProjectName(projectName: string) {
     const projectsPage = new ProjectsPage();
-    projectsPage.get();
+    await projectsPage.get();
     return projectsPage.findProject(projectName).then((projectRow: ElementFinder) => {
       const projectLink = projectRow.element(by.css('a'));
       return projectLink.getAttribute('href').then((href: string) => {
@@ -17,7 +17,7 @@ export class UserManagementPage {
         expect(results).not.toBeNull();
         expect(results.length).toBeGreaterThan(1);
         const projectId = results[1];
-        UserManagementPage.get(projectId);
+        return UserManagementPage.get(projectId);
       });
     });
   }
@@ -30,10 +30,10 @@ export class UserManagementPage {
   userNameInput = this.newMembersDiv.element(by.id('typeaheadInput'));
 
   changeUserRole(userName: string, roleText: string) {
-    this.getUserRow(userName).then( (row: ElementFinder) => {
+    return this.getUserRow(userName).then( (row: ElementFinder) => {
       if (row) {
         const select = row.element(by.css('select'));
-        Utils.clickDropdownByValue(select, roleText);
+        return Utils.clickDropdownByValue(select, roleText);
       }
     });
   }

--- a/test/app/bellows/signup.e2e-spec.ts
+++ b/test/app/bellows/signup.e2e-spec.ts
@@ -8,125 +8,121 @@ describe('Bellows E2E Signup app', () => {
   const page = new SignupPage();
   const loginPage = new BellowsLoginPage();
 
-  it('setup and contains a user form', () => {
-    BellowsLoginPage.logout();
-    SignupPage.get();
+  it('setup and contains a user form', async () => {
+    await BellowsLoginPage.logout();
+    await SignupPage.get();
     expect(page.signupForm).toBeDefined();
   });
 
-  it('can verify required information filled', () => {
-    SignupPage.get();
-    expect<any>(page.signupButton.isEnabled()).toBe(false);
-    page.emailInput.sendKeys(constants.unusedEmail);
-    page.nameInput.sendKeys(constants.unusedName);
-    page.passwordInput.sendKeys(constants.passwordValid);
-    page.captcha.setInvalidCaptcha();
-    expect<any>(page.signupButton.isEnabled()).toBe(true);
+  it('can verify required information filled', async () => {
+    await SignupPage.get();
+    expect<any>(await page.signupButton.isEnabled()).toBe(false);
+    await page.emailInput.sendKeys(constants.unusedEmail);
+    await page.nameInput.sendKeys(constants.unusedName);
+    await page.passwordInput.sendKeys(constants.passwordValid);
+    await page.captcha.setInvalidCaptcha();
+    expect<any>(await page.signupButton.isEnabled()).toBe(true);
   });
 
-  it('cannot submit if email is invalid', () => {
-    page.emailInput.clear();
-    page.emailInput.sendKeys(constants.emailNoAt);
-    page.captcha.setInvalidCaptcha();
-    expect<any>(page.emailInvalid.isDisplayed()).toBe(true);
-    expect<any>(page.signupButton.isEnabled()).toBe(false);
+  it('cannot submit if email is invalid', async () => {
+    await page.emailInput.clear();
+    await page.emailInput.sendKeys(constants.emailNoAt);
+    await page.captcha.setInvalidCaptcha();
+    expect<any>(await page.emailInvalid.isDisplayed()).toBe(true);
+    expect<any>(await page.signupButton.isEnabled()).toBe(false);
   });
 
-  it('cannot submit if password is weak', () => {
-    page.emailInput.clear();
-    page.emailInput.sendKeys(constants.unusedEmail);
-    expect<any>(page.signupButton.isEnabled()).toBe(true);
-    page.passwordInput.clear();
-    page.passwordInput.sendKeys(constants.passwordTooShort);
-    page.captcha.setInvalidCaptcha();
-    expect<any>(page.passwordIsWeak.isDisplayed()).toBe(true);
-    expect<any>(page.signupButton.isEnabled()).toBe(false);
+  it('cannot submit if password is weak', async () => {
+    await page.emailInput.clear();
+    await page.emailInput.sendKeys(constants.unusedEmail);
+    expect<any>(await page.signupButton.isEnabled()).toBe(true);
+    await page.passwordInput.clear();
+    await page.passwordInput.sendKeys(constants.passwordTooShort);
+    await page.captcha.setInvalidCaptcha();
+    expect<any>(await page.passwordIsWeak.isDisplayed()).toBe(true);
+    expect<any>(await page.signupButton.isEnabled()).toBe(false);
   });
 
-  it('can submit if password not weak', () => {
-    page.passwordInput.clear();
-    page.passwordInput.sendKeys(constants.passwordValid);
-    page.captcha.setInvalidCaptcha();
-    expect<any>(page.passwordIsWeak.isDisplayed()).toBe(false);
-    expect<any>(page.signupButton.isEnabled()).toBe(true);
+  it('can submit if password not weak', async () => {
+    await page.passwordInput.clear();
+    await page.passwordInput.sendKeys(constants.passwordValid);
+    await page.captcha.setInvalidCaptcha();
+    expect<any>(await page.passwordIsWeak.isDisplayed()).toBe(false);
+    expect<any>(await page.signupButton.isEnabled()).toBe(true);
   });
 
-  it('can submit if password is showing and not weak', () => {
-    page.showPassword.click();
-    page.captcha.setInvalidCaptcha();
-    expect<any>(page.passwordIsWeak.isDisplayed()).toBe(false);
-    expect<any>(page.signupButton.isEnabled()).toBe(true);
+  it('can submit if password is showing and not weak', async () => {
+    await page.showPassword.click();
+    await page.captcha.setInvalidCaptcha();
+    expect<any>(await page.passwordIsWeak.isDisplayed()).toBe(false);
+    expect<any>(await page.signupButton.isEnabled()).toBe(true);
   });
 
-  it('cannot submit if captcha not selected', () => {
-    SignupPage.get();
-    page.emailInput.sendKeys(constants.unusedEmail);
-    page.nameInput.sendKeys(constants.unusedName);
-    page.passwordInput.sendKeys(constants.passwordValid);
-    expect<any>(page.signupButton.isEnabled()).toBe(false);
+  it('cannot submit if captcha not selected', async () => {
+    await SignupPage.get();
+    await page.emailInput.sendKeys(constants.unusedEmail);
+    await page.nameInput.sendKeys(constants.unusedName);
+    await page.passwordInput.sendKeys(constants.passwordValid);
+    expect<any>(await page.signupButton.isEnabled()).toBe(false);
   });
 
-  it('can submit a user registration request and captcha is invalid', () => {
-    SignupPage.get();
-    page.emailInput.sendKeys(constants.unusedEmail);
-    page.nameInput.sendKeys(constants.unusedName);
-    page.passwordInput.sendKeys(constants.passwordValid);
-    page.captcha.setInvalidCaptcha();
-    page.signupButton.click();
-    expect<any>(page.captchaInvalid.isDisplayed()).toBe(true);
+  it('can submit a user registration request and captcha is invalid', async () => {
+    await SignupPage.get();
+    await page.emailInput.sendKeys(constants.unusedEmail);
+    await page.nameInput.sendKeys(constants.unusedName);
+    await page.passwordInput.sendKeys(constants.passwordValid);
+    await page.captcha.setInvalidCaptcha();
+    await page.signupButton.click();
+    expect<any>(await page.captchaInvalid.isDisplayed()).toBe(true);
   });
 
-  it('finds the admin user (case insensitive) already exists', () => {
-    SignupPage.get();
-    page.emailInput.sendKeys(constants.adminEmail.toUpperCase());
-    page.nameInput.sendKeys(constants.unusedName);
-    page.passwordInput.sendKeys(constants.passwordValid);
-    page.captcha.setValidCaptcha();
-    expect<any>(page.signupButton.isEnabled()).toBe(true);
-    page.signupButton.click();
-    expect<any>(page.emailTaken.isDisplayed()).toBe(true);
+  it('finds the admin user (case insensitive) already exists', async () => {
+    await SignupPage.get();
+    await page.emailInput.sendKeys(constants.adminEmail.toUpperCase());
+    await page.nameInput.sendKeys(constants.unusedName);
+    await page.passwordInput.sendKeys(constants.passwordValid);
+    await page.captcha.setValidCaptcha();
+    expect<any>(await page.signupButton.isEnabled()).toBe(true);
+    await page.signupButton.click();
+    expect<any>(await page.emailTaken.isDisplayed()).toBe(true);
   });
 
-  it('can prefill email address that can\'t be changed', () => {
-    SignupPage.getPrefilledEmail(constants.unusedEmail);
-    expect<any>(page.emailInput.isEnabled()).toBe(false);
+  it('can prefill email address that can\'t be changed', async () => {
+    await SignupPage.getPrefilledEmail(constants.unusedEmail);
+    expect<any>(await page.emailInput.isEnabled()).toBe(false);
   });
 
-  it('can prefill email address that already exists', () => {
-    SignupPage.getPrefilledEmail(constants.adminEmail);
-    page.nameInput.sendKeys(constants.unusedName);
-    page.passwordInput.sendKeys(constants.passwordValid);
-    page.captcha.setValidCaptcha();
-    page.signupButton.click();
-    expect<any>(page.emailTaken.isDisplayed()).toBe(true);
+  it('can prefill email address that already exists', async () => {
+    await SignupPage.getPrefilledEmail(constants.adminEmail);
+    await page.nameInput.sendKeys(constants.unusedName);
+    await page.passwordInput.sendKeys(constants.passwordValid);
+    await page.captcha.setValidCaptcha();
+    await page.signupButton.click();
+    expect<any>(await page.emailTaken.isDisplayed()).toBe(true);
   });
 
-  it('can signup a new user', () => {
-    SignupPage.get();
-    page.emailInput.sendKeys(constants.unusedEmail);
-    page.nameInput.sendKeys(constants.unusedName);
-    page.passwordInput.sendKeys(constants.passwordValid);
-    page.captcha.setValidCaptcha();
-    expect<any>(page.signupButton.isEnabled()).toBe(true);
-    page.signupButton.click();
+  it('can signup a new user', async () => {
+    await SignupPage.get();
+    await page.emailInput.sendKeys(constants.unusedEmail);
+    await page.nameInput.sendKeys(constants.unusedName);
+    await page.passwordInput.sendKeys(constants.passwordValid);
+    await page.captcha.setValidCaptcha();
+    expect<any>(await page.signupButton.isEnabled()).toBe(true);
+    await page.signupButton.click();
 
     // added to stop intermittent error
     // "Failed: javascript error: document unloaded while waiting for result"
-    browser.wait(ExpectedConditions.urlContains('projects'), constants.conditionTimeout);
+    await browser.wait(ExpectedConditions.urlContains('projects'), constants.conditionTimeout);
 
     // Verify new user logged in and redirected to projects page
-    browser.getCurrentUrl().then(() => {
-      expect(browser.getCurrentUrl()).toContain('/app/projects');
-    });
+    expect(await browser.getCurrentUrl()).toContain('/app/projects');
   });
 
-  it('redirects to projects page if already logged in', () => {
-    BellowsLoginPage.logout();
-    loginPage.loginAsUser();
-    SignupPage.get();
-    browser.wait(ExpectedConditions.urlContains('projects'), constants.conditionTimeout);
-    browser.getCurrentUrl().then(() => {
-      expect(browser.getCurrentUrl()).toContain('/app/projects');
-    });
+  it('redirects to projects page if already logged in', async () => {
+    await BellowsLoginPage.logout();
+    await loginPage.loginAsUser();
+    await SignupPage.get();
+    await browser.wait(ExpectedConditions.urlContains('projects'), constants.conditionTimeout);
+    expect(await browser.getCurrentUrl()).toContain('/app/projects');
   });
 });

--- a/test/app/bellows/user-management.e2e-spec.ts
+++ b/test/app/bellows/user-management.e2e-spec.ts
@@ -12,40 +12,40 @@ describe('Bellows E2E User Management App', () => {
   const projectsPage = new ProjectsPage();
   const userManagementPage = new UserManagementPage();
 
-  it('Can add admin as Tech Support', () => {
+  it('Can add admin as Tech Support', async () => {
     // Remove admin from Other Project for Testing
-    loginPage.loginAsManager();
-    projectsPage.get();
-    projectsPage.removeUserFromProject(constants.otherProjectName, constants.adminUsername);
+    await loginPage.loginAsManager();
+    await projectsPage.get();
+    await projectsPage.removeUserFromProject(constants.otherProjectName, constants.adminUsername);
 
-    loginPage.loginAsAdmin();
-    projectsPage.get();
+    await loginPage.loginAsAdmin();
+    await projectsPage.get();
 
     // Click "+ Tech Support" button
-    projectsPage.findProject(constants.otherProjectName).then((projectRow: ElementFinder) => {
-      projectRow.element(by.id('techSupportButton')).click();
+    await projectsPage.findProject(constants.otherProjectName).then((projectRow: ElementFinder) => {
+      return projectRow.element(by.id('techSupportButton')).click();
     });
 
-    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
-      browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
-      userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+    return UserManagementPage.getByProjectName(constants.otherProjectName).then(async () => {
+      await browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+      return userManagementPage.getUserRow(constants.adminUsername).then(async (row: ElementFinder) => {
         const selector = row.element(by.css('select'));
-        expect<any>(selector.isEnabled()).toBe(true);
-        selector.element(by.css('option[selected=selected]')).getText().then( text => {
+        expect<any>(await selector.isEnabled()).toBe(true);
+        return selector.element(by.css('option[selected=selected]')).getText().then( text => {
           expect<any>(text).toBe('Tech Support');
         });
       });
     });
   });
 
-  it('Other user cannot assign Tech Support user\'s role', () => {
-    loginPage.loginAsManager();
-    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
-      browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
-      userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+  it('Other user cannot assign Tech Support user\'s role', async () => {
+    await loginPage.loginAsManager();
+    return UserManagementPage.getByProjectName(constants.otherProjectName).then(async () => {
+      await browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+      return userManagementPage.getUserRow(constants.adminUsername).then(async (row: ElementFinder) => {
         const selector = row.element(by.css('select'));
-        expect<any>(selector.isEnabled()).toBe(false);
-        selector.element(by.css('option[selected=selected]')).getText().then( text => {
+        expect<any>(await selector.isEnabled()).toBe(false);
+        return selector.element(by.css('option[selected=selected]')).getText().then( text => {
           expect<any>(text).toBe('Tech Support');
         });
       });
@@ -53,38 +53,34 @@ describe('Bellows E2E User Management App', () => {
 
   });
 
-  it('Tech Support user can assign their own role', () => {
-    loginPage.loginAsAdmin();
-    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
-      browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
-      userManagementPage.changeUserRole(constants.adminUsername, 'Manager');
+  it('Tech Support user can assign their own role', async () => {
+    await loginPage.loginAsAdmin();
+    await UserManagementPage.getByProjectName(constants.otherProjectName).then(async () => {
+      await browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+      return userManagementPage.changeUserRole(constants.adminUsername, 'Manager');
     });
     // Now verify
-    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
-      browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
-      userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
+    return UserManagementPage.getByProjectName(constants.otherProjectName).then(async () => {
+      await browser.wait(ExpectedConditions.visibilityOf(userManagementPage.projectMemberRows.first()), Utils.conditionTimeout);
+      userManagementPage.getUserRow(constants.adminUsername).then(async (row: ElementFinder) => {
         const selector = row.element(by.css('select'));
-        expect<any>(selector.isEnabled()).toBe(true);
-        selector.element(by.css('option[selected=selected]')).getText().then( text => {
+        expect<any>(await selector.isEnabled()).toBe(true);
+        return selector.element(by.css('option[selected=selected]')).getText().then( text => {
           expect<any>(text).toBe('Manager');
         });
       });
     });
   });
 
-  it('User cannot assign member to Tech Support role', () => {
-    loginPage.loginAsManager();
-    UserManagementPage.getByProjectName(constants.otherProjectName).then(() => {
-
-      userManagementPage.getUserRow(constants.adminUsername).then( (row: ElementFinder) => {
-        row.element(by.css('select')).getText().then( text => {
-          expect<any>(text).toContain('Manager');
-          expect<any>(text).toContain('Contributor');
-          expect<any>(text).toContain('Observer');
-          expect<any>(text).toContain('Observer with comment');
-          expect<any>(text).not.toContain('Tech Support');
-        });
-      });
-    });
+  it('User cannot assign member to Tech Support role', async () => {
+    await loginPage.loginAsManager();
+    await UserManagementPage.getByProjectName(constants.otherProjectName);
+    const row = await userManagementPage.getUserRow(constants.adminUsername) as ElementFinder;
+    const text = await row.element(by.css('select')).getText();
+    expect<string>(text).toContain('Manager');
+    expect<string>(text).toContain('Contributor');
+    expect<string>(text).toContain('Observer');
+    expect<string>(text).toContain('Observer with comment');
+    expect<string>(text).not.toContain('Tech Support');
   });
 });

--- a/test/app/bellows/user-profile.e2e-spec.ts
+++ b/test/app/bellows/user-profile.e2e-spec.ts
@@ -46,145 +46,145 @@ describe('Bellows E2E User Profile app', () => {
     }
 
     function logInAsRole() {
-      if (expectedUsername === constants.memberUsername) loginPage.loginAsMember();
-      else if (expectedUsername === constants.managerUsername) loginPage.loginAsManager();
+      if (expectedUsername === constants.memberUsername) return loginPage.loginAsMember();
+      else if (expectedUsername === constants.managerUsername) return loginPage.loginAsManager();
     }
 
     // Perform activity E2E tests according to the different roles
     describe('Running as: ' + expectedUsername, () => {
-      it('Logging in', () => {
-        logInAsRole();
+      it('Logging in', async () => {
+        await logInAsRole();
       });
 
-      it('Verify initial "My Account" settings created from setupTestEnvironment.php', () => {
-        userProfile.getMyAccount();
+      it('Verify initial "My Account" settings created from setupTestEnvironment.php', async () => {
+        await userProfile.getMyAccount();
 
-        expect(userProfile.myAccountTab.username.getAttribute('value')).toEqual(expectedUsername);
-        expect(userProfile.myAccountTab.avatar.getAttribute('src')).toContain(constants.avatar);
-        expect<any>(userProfile.myAccountTab.avatarColor.$('option:checked').getText())
+        expect(await userProfile.myAccountTab.username.getAttribute('value')).toEqual(expectedUsername);
+        expect(await userProfile.myAccountTab.avatar.getAttribute('src')).toContain(constants.avatar);
+        expect<string>(await userProfile.myAccountTab.avatarColor.$('option:checked').getText())
           .toBe('Select a Color...');
-        expect<any>(userProfile.myAccountTab.avatarShape.$('option:checked').getText())
+        expect<string>(await userProfile.myAccountTab.avatarShape.$('option:checked').getText())
           .toBe('Choose an animal...');
-        expect<any>(userProfile.myAccountTab.mobilePhoneInput.getAttribute('value')).toEqual('');
-        expect(userProfile.myAccountTab.emailBtn.isSelected());
+        expect<string>(await userProfile.myAccountTab.mobilePhoneInput.getAttribute('value')).toEqual('');
+        expect(await userProfile.myAccountTab.emailBtn.isSelected());
       });
 
-      it('Verify initial "About Me" settings created from setupTestEnvironment.php', () => {
-        userProfile.getAboutMe();
+      it('Verify initial "About Me" settings created from setupTestEnvironment.php', async () => {
+        await userProfile.getAboutMe();
 
         const expectedAge: string = '';
         const expectedGender: string = '';
 
-        expect<any>(userProfile.aboutMeTab.fullName.getAttribute('value')).toEqual(expectedFullname);
-        expect<any>(userProfile.aboutMeTab.age.getAttribute('value')).toEqual(expectedAge);
-        expect<any>(userProfile.aboutMeTab.gender.$('option:checked').getText()).toBe(expectedGender);
+        expect<string>(await userProfile.aboutMeTab.fullName.getAttribute('value')).toEqual(expectedFullname);
+        expect<string>(await userProfile.aboutMeTab.age.getAttribute('value')).toEqual(expectedAge);
+        expect<string>(await userProfile.aboutMeTab.gender.$('option:checked').getText()).toBe(expectedGender);
       });
 
-      it('Update and store "My Account" settings', () => {
-        userProfile.getMyAccount();
+      it('Update and store "My Account" settings', async () => {
+        await userProfile.getMyAccount();
 
         // Change profile except username
 
-        userProfile.myAccountTab.updateEmail(newEmail);
+        await userProfile.myAccountTab.updateEmail(newEmail);
 
         // Ensure "Blue" won't match "Steel Blue", etc.
-        userProfile.myAccountTab.selectColor(new RegExp('^' + newColor + '$'));
-        userProfile.myAccountTab.selectShape(newShape);
+        await userProfile.myAccountTab.selectColor(new RegExp('^' + newColor + '$'));
+        await userProfile.myAccountTab.selectShape(newShape);
 
-        userProfile.myAccountTab.updateMobilePhone(newMobilePhone);
+        await userProfile.myAccountTab.updateMobilePhone(newMobilePhone);
 
         // Modify contact preference
-        userProfile.myAccountTab.bothBtn.click();
+        await userProfile.myAccountTab.bothBtn.click();
 
         // Change Password tested in changepassword e2e
 
         // Submit updated profile
-        userProfile.myAccountTab.saveBtn.click();
+        await userProfile.myAccountTab.saveBtn.click();
       });
 
-      it('Verify that new profile settings persisted', () => {
-        browser.refresh();
-        browser.wait(ExpectedConditions.visibilityOf(userProfile.myAccountTab.emailInput), constants.conditionTimeout);
+      it('Verify that new profile settings persisted', async () => {
+        await browser.refresh();
+        await browser.wait(ExpectedConditions.visibilityOf(userProfile.myAccountTab.emailInput), constants.conditionTimeout);
 
         // Verify values.
-        expect<any>(userProfile.myAccountTab.emailInput.getAttribute('value')).toEqual(newEmail);
-        expect<any>(userProfile.myAccountTab.avatar.getAttribute('src')).toContain(expectedAvatar);
-        expect<any>(userProfile.myAccountTab.avatarColor.$('option:checked').getText()).toBe(newColor);
-        expect<any>(userProfile.myAccountTab.avatarShape.$('option:checked').getText()).toBe(newShape);
-        expect<any>(userProfile.myAccountTab.mobilePhoneInput.getAttribute('value')).toEqual(newMobilePhone);
-        expect(userProfile.myAccountTab.bothBtn.isSelected());
+        expect<any>(await userProfile.myAccountTab.emailInput.getAttribute('value')).toEqual(newEmail);
+        expect<any>(await userProfile.myAccountTab.avatar.getAttribute('src')).toContain(expectedAvatar);
+        expect<any>(await userProfile.myAccountTab.avatarColor.$('option:checked').getText()).toBe(newColor);
+        expect<any>(await userProfile.myAccountTab.avatarShape.$('option:checked').getText()).toBe(newShape);
+        expect<any>(await userProfile.myAccountTab.mobilePhoneInput.getAttribute('value')).toEqual(newMobilePhone);
+        expect(await userProfile.myAccountTab.bothBtn.isSelected());
 
         // Restore email address
-        userProfile.myAccountTab.updateEmail(originalEmail);
-        userProfile.myAccountTab.saveBtn.click().then(() => {
-          browser.refresh();
-          browser.wait(ExpectedConditions.visibilityOf(userProfile.myAccountTab.emailInput),
+        await userProfile.myAccountTab.updateEmail(originalEmail);
+        await userProfile.myAccountTab.saveBtn.click().then(async () => {
+          await browser.refresh();
+          await browser.wait(ExpectedConditions.visibilityOf(userProfile.myAccountTab.emailInput),
           constants.conditionTimeout);
         });
 
-        expect<any>(userProfile.myAccountTab.emailInput.getAttribute('value')).toEqual(originalEmail);
+        expect<any>(await userProfile.myAccountTab.emailInput.getAttribute('value')).toEqual(originalEmail);
       });
 
-      it('Update and store different username. Login with new credentials', () => {
+      it('Update and store different username. Login with new credentials', async () => {
         // Change email
-        userProfile.myAccountTab.updateEmail(newEmail);
+        await userProfile.myAccountTab.updateEmail(newEmail);
 
         // Change to taken username
-        userProfile.myAccountTab.updateUsername(constants.observerUsername);
-        browser.wait(ExpectedConditions.visibilityOf(userProfile.myAccountTab.usernameTaken),
+        await userProfile.myAccountTab.updateUsername(constants.observerUsername);
+        await browser.wait(ExpectedConditions.visibilityOf(userProfile.myAccountTab.usernameTaken),
           constants.conditionTimeout);
-        expect<any>(userProfile.myAccountTab.usernameTaken.isDisplayed()).toBe(true);
-        expect<any>(userProfile.myAccountTab.saveBtn.isEnabled()).toBe(false);
+        expect<any>(await userProfile.myAccountTab.usernameTaken.isDisplayed()).toBe(true);
+        expect<any>(await userProfile.myAccountTab.saveBtn.isEnabled()).toBe(false);
 
         // Change to new username
-        userProfile.myAccountTab.updateUsername(newUsername);
-        expect<any>(userProfile.myAccountTab.usernameTaken.isDisplayed()).toBe(false);
+        await userProfile.myAccountTab.updateUsername(newUsername);
+        expect<any>(await userProfile.myAccountTab.usernameTaken.isDisplayed()).toBe(false);
 
         // Save, Cancel the confirmation modal
-        expect<any>(userProfile.myAccountTab.saveBtn.isEnabled()).toBe(true);
-        userProfile.myAccountTab.saveBtn.click();
-        Utils.clickModalButton('Cancel');
-        browser.wait(ExpectedConditions.elementToBeClickable(userProfile.myAccountTab.saveBtn));
+        expect<any>(await userProfile.myAccountTab.saveBtn.isEnabled()).toBe(true);
+        await userProfile.myAccountTab.saveBtn.click();
+        await Utils.clickModalButton('Cancel');
+        await browser.wait(ExpectedConditions.elementToBeClickable(userProfile.myAccountTab.saveBtn));
 
-        browser.refresh();
+        await browser.refresh();
 
         // Confirm email not changed
-        browser.wait(ExpectedConditions.visibilityOf(userProfile.myAccountTab.emailInput), constants.conditionTimeout);
-        browser.wait(ExpectedConditions.elementToBeClickable(userProfile.myAccountTab.saveBtn));
-        Utils.scrollTop();
-        expect<any>(userProfile.myAccountTab.emailInput.getAttribute('value')).toEqual(originalEmail);
+        await browser.wait(ExpectedConditions.visibilityOf(userProfile.myAccountTab.emailInput), constants.conditionTimeout);
+        await browser.wait(ExpectedConditions.elementToBeClickable(userProfile.myAccountTab.saveBtn));
+        await Utils.scrollTop();
+        expect<any>(await userProfile.myAccountTab.emailInput.getAttribute('value')).toEqual(originalEmail);
 
         // Change to new username
-        userProfile.myAccountTab.updateUsername(newUsername);
-        expect<any>(userProfile.myAccountTab.usernameTaken.isDisplayed()).toBe(false);
+        await userProfile.myAccountTab.updateUsername(newUsername);
+        expect<any>(await userProfile.myAccountTab.usernameTaken.isDisplayed()).toBe(false);
 
         // Save changes
-        expect<any>(userProfile.myAccountTab.saveBtn.isEnabled()).toBe(true);
-        userProfile.myAccountTab.saveBtn.click();
+        expect<any>(await userProfile.myAccountTab.saveBtn.isEnabled()).toBe(true);
+        await userProfile.myAccountTab.saveBtn.click();
 
-        Utils.clickModalButton('Save changes');
-        Utils.waitForNewAngularPage('login');
-        browser.wait(ExpectedConditions.visibilityOf(loginPage.username), constants.conditionTimeout);
-        expect<any>(loginPage.infoMessages.count()).toBe(1);
-        expect(loginPage.infoMessages.first().getText()).toContain('Username changed. Please login.');
+        await Utils.clickModalButton('Save changes');
+        await Utils.waitForNewAngularPage('login');
+        await browser.wait(ExpectedConditions.visibilityOf(loginPage.username), constants.conditionTimeout);
+        expect<any>(await loginPage.infoMessages.count()).toBe(1);
+        expect(await loginPage.infoMessages.first().getText()).toContain('Username changed. Please login.');
       });
 
-      it('Login with new username and revert to original username', () => {
+      it('Login with new username and revert to original username', async () => {
         // user is automatically logged out and taken to login page when username is changed
-        loginPage.login(newUsername, password);
+        await loginPage.login(newUsername, password);
 
-        userProfile.getMyAccount();
-        expect<any>(userProfile.myAccountTab.username.getAttribute('value')).toEqual(newUsername);
-        userProfile.myAccountTab.updateUsername(expectedUsername);
-        userProfile.myAccountTab.saveBtn.click();
-        Utils.clickModalButton('Save changes');
-        BellowsLoginPage.get();
+        await userProfile.getMyAccount();
+        expect<any>(await userProfile.myAccountTab.username.getAttribute('value')).toEqual(newUsername);
+        await userProfile.myAccountTab.updateUsername(expectedUsername);
+        await userProfile.myAccountTab.saveBtn.click();
+        await Utils.clickModalButton('Save changes');
+        await BellowsLoginPage.get();
       });
 
-      it('Update and store "About Me" settings', () => {
-        logInAsRole();
+      it('Update and store "About Me" settings', async () => {
+        await logInAsRole();
 
-        userProfile.getAboutMe();
+        await userProfile.getAboutMe();
 
         // New user profile to put in
         let newFullName: string;
@@ -205,21 +205,21 @@ describe('Bellows E2E User Profile app', () => {
         }
 
         // Modify About me
-        userProfile.aboutMeTab.updateFullName(newFullName);
+        await userProfile.aboutMeTab.updateFullName(newFullName);
 
-        userProfile.aboutMeTab.updateAge(newAge);
-        userProfile.aboutMeTab.updateGender(newGender);
+        await userProfile.aboutMeTab.updateAge(newAge);
+        await userProfile.aboutMeTab.updateGender(newGender);
 
         // Submit updated profile
-        userProfile.aboutMeTab.saveBtn.click();
-        expect<any>(userProfile.aboutMeTab.fullName.getAttribute('value')).toEqual(newFullName);
+        await userProfile.aboutMeTab.saveBtn.click();
+        expect<any>(await userProfile.aboutMeTab.fullName.getAttribute('value')).toEqual(newFullName);
 
         // Verify values.  Browse to different URL first to force new page load
-        userProfile.getAboutMe();
+        await userProfile.getAboutMe();
 
-        expect<any>(userProfile.aboutMeTab.fullName.getAttribute('value')).toEqual(newFullName);
-        expect<any>(userProfile.aboutMeTab.age.getAttribute('value')).toEqual(newAge);
-        expect<any>(userProfile.aboutMeTab.gender.$('option:checked').getText()).toBe(newGender);
+        expect<any>(await userProfile.aboutMeTab.fullName.getAttribute('value')).toEqual(newFullName);
+        expect<any>(await userProfile.aboutMeTab.age.getAttribute('value')).toEqual(newAge);
+        expect<any>(await userProfile.aboutMeTab.gender.$('option:checked').getText()).toBe(newGender);
       });
     });
   });

--- a/test/app/languageforge/lexicon-traversal.e2e-spec.ts
+++ b/test/app/languageforge/lexicon-traversal.e2e-spec.ts
@@ -18,106 +18,106 @@ describe('Lexicon E2E Page Traversal', () => {
   const editorPage = new EditorPage();
 
   describe('Explore configuration page', () => {
-    it('Unified tab', () => {
-      loginPage.loginAsAdmin();
-      configurationPage.get();
-      configurationPage.tabs.unified.click();
-      configurationPage.unifiedPane.inputSystem.addGroupButton.click();
-      browser.$('body').sendKeys(protractor.Key.ESCAPE);
-      browser.wait(
+    it('Unified tab', async () => {
+      await loginPage.loginAsAdmin();
+      await configurationPage.get();
+      await configurationPage.tabs.unified.click();
+      await configurationPage.unifiedPane.inputSystem.addGroupButton.click();
+      await browser.$('body').sendKeys(protractor.Key.ESCAPE);
+      await browser.wait(
         ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.inputSystem.addInputSystemButton),
         constants.conditionTimeout);
-      configurationPage.unifiedPane.inputSystem.addInputSystemButton.click();
-      browser.$('body').sendKeys(protractor.Key.ESCAPE);
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.tabs.unified), constants.conditionTimeout);
-      configurationPage.tabs.unified.click();
-      configurationPage.unifiedPane.entry.addGroupButton.click();
-      browser.$('body').sendKeys(protractor.Key.ESCAPE);
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.entry.addCustomEntryButton),
+      await configurationPage.unifiedPane.inputSystem.addInputSystemButton.click();
+      await browser.$('body').sendKeys(protractor.Key.ESCAPE);
+      await browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.tabs.unified), constants.conditionTimeout);
+      await configurationPage.tabs.unified.click();
+      await configurationPage.unifiedPane.entry.addGroupButton.click();
+      await browser.$('body').sendKeys(protractor.Key.ESCAPE);
+      await browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.entry.addCustomEntryButton),
         constants.conditionTimeout);
-      configurationPage.unifiedPane.entry.addCustomEntryButton.click();
-      browser.$('body').sendKeys(protractor.Key.ESCAPE);
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.sense.addGroupButton),
+      await configurationPage.unifiedPane.entry.addCustomEntryButton.click();
+      await browser.$('body').sendKeys(protractor.Key.ESCAPE);
+      await browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.sense.addGroupButton),
         constants.conditionTimeout);
-      configurationPage.unifiedPane.hiddenIfEmptyCheckbox('Citation Form').click();
-      configurationPage.unifiedPane.fieldSpecificButton('Citation Form').click();
-      configurationPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox('Citation Form', 1).click();
-      configurationPage.unifiedPane.fieldSpecificButton('Citation Form').click();
-      configurationPage.unifiedPane.sense.addGroupButton.click();
-      browser.$('body').sendKeys(protractor.Key.ESCAPE);
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.sense.addCustomSenseButton),
+      await configurationPage.unifiedPane.hiddenIfEmptyCheckbox('Citation Form').click();
+      await configurationPage.unifiedPane.fieldSpecificButton('Citation Form').click();
+      await configurationPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox('Citation Form', 1).click();
+      await configurationPage.unifiedPane.fieldSpecificButton('Citation Form').click();
+      await configurationPage.unifiedPane.sense.addGroupButton.click();
+      await browser.$('body').sendKeys(protractor.Key.ESCAPE);
+      await browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.sense.addCustomSenseButton),
         constants.conditionTimeout);
-      configurationPage.unifiedPane.sense.addCustomSenseButton.click();
-      browser.$('body').sendKeys(protractor.Key.ESCAPE);
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.example.addGroupButton),
+      await configurationPage.unifiedPane.sense.addCustomSenseButton.click();
+      await browser.$('body').sendKeys(protractor.Key.ESCAPE);
+      await browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.example.addGroupButton),
         constants.conditionTimeout);
-      configurationPage.unifiedPane.hiddenIfEmptyCheckbox('Pictures').click();
-      configurationPage.unifiedPane.fieldSpecificButton('Pictures').click();
-      configurationPage.unifiedPane.sense.fieldSpecificInputSystemCheckbox('Pictures', 1).click();
-      configurationPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox('Pictures').click();
-      configurationPage.unifiedPane.fieldSpecificButton('Pictures').click();
-      configurationPage.unifiedPane.example.addGroupButton.click();
-      browser.$('body').sendKeys(protractor.Key.ESCAPE);
-      browser.wait(
+      await configurationPage.unifiedPane.hiddenIfEmptyCheckbox('Pictures').click();
+      await configurationPage.unifiedPane.fieldSpecificButton('Pictures').click();
+      await configurationPage.unifiedPane.sense.fieldSpecificInputSystemCheckbox('Pictures', 1).click();
+      await configurationPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox('Pictures').click();
+      await configurationPage.unifiedPane.fieldSpecificButton('Pictures').click();
+      await configurationPage.unifiedPane.example.addGroupButton.click();
+      await browser.$('body').sendKeys(protractor.Key.ESCAPE);
+      await browser.wait(
         ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.example.addCustomExampleButton),
         constants.conditionTimeout);
-      configurationPage.unifiedPane.example.addCustomExampleButton.click();
-      browser.$('body').sendKeys(protractor.Key.ESCAPE);
-      browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.tabs.unified), constants.conditionTimeout);
-      configurationPage.unifiedPane.hiddenIfEmptyCheckbox('Translation').click();
-      configurationPage.unifiedPane.fieldSpecificButton('Translation').click();
-      configurationPage.unifiedPane.example.fieldSpecificInputSystemCheckbox('Translation', 0).click();
-      configurationPage.unifiedPane.fieldSpecificButton('Translation').click();
+      await configurationPage.unifiedPane.example.addCustomExampleButton.click();
+      await browser.$('body').sendKeys(protractor.Key.ESCAPE);
+      await browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.tabs.unified), constants.conditionTimeout);
+      await configurationPage.unifiedPane.hiddenIfEmptyCheckbox('Translation').click();
+      await configurationPage.unifiedPane.fieldSpecificButton('Translation').click();
+      await configurationPage.unifiedPane.example.fieldSpecificInputSystemCheckbox('Translation', 0).click();
+      await configurationPage.unifiedPane.fieldSpecificButton('Translation').click();
     });
 
-    it('Input Systems tab', () => {
-      configurationPage.tabs.inputSystems.click();
-      configurationPage.inputSystemsPane.moreButton.click();
+    it('Input Systems tab', async () => {
+      await configurationPage.tabs.inputSystems.click();
+      await configurationPage.inputSystemsPane.moreButton.click();
     });
 
-    it('Option List tab', () => {
-      configurationPage.tabs.optionlists.click();
+    it('Option List tab', async () => {
+      await configurationPage.tabs.optionlists.click();
       // There is no model of option list tab - Mark W 2018-01-14
     });
   });
 
   describe('Explore editor page', () => {
-    it('Edit view', () => {
-      projectsPage.get();
-      projectsPage.clickOnProject(constants.testProjectName);
-      editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-      editorPage.noticeList.count();
-      editorPage.edit.entriesList.count();
-      editorPage.edit.senses.count();
+    it('Edit view', async () => {
+      await projectsPage.get();
+      await projectsPage.clickOnProject(constants.testProjectName);
+      await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+      await editorPage.noticeList.count();
+      await editorPage.edit.entriesList.count();
+      await editorPage.edit.senses.count();
     });
 
-    it('Comments view', () => {
-      editorPage.edit.toCommentsLink.click();
-      editorPage.comment.commentsList.count();
+    it('Comments view', async () => {
+      await editorPage.edit.toCommentsLink.click();
+      await editorPage.comment.commentsList.count();
     });
   });
 
-  it('Explore new lex project page', () => {
-    NewLexProjectPage.get();
-    newLexProjectPage.noticeList.count();
+  it('Explore new lex project page', async () => {
+    await NewLexProjectPage.get();
+    await newLexProjectPage.noticeList.count();
   });
 
-  it('Explore project settings page', () => {
-    projectSettingsPage.get(constants.testProjectName);
-    projectSettingsPage.tabs.project.click();
+  it('Explore project settings page', async () => {
+    await projectSettingsPage.get(constants.testProjectName);
+    await projectSettingsPage.tabs.project.click();
   });
 
-  // it('Explore project settings page', () => {
-  //  projectSettingsPage.get(constants.testProjectName);
-  //  projectSettingsPage.noticeList.count();
-  //  projectSettingsPage.tabDivs.count();
-  //  projectSettingsPage.tabs.project.click();
-  //  projectSettingsPage.tabs.remove.click();
+  // it('Explore project settings page', async () => {
+  //  await projectSettingsPage.get(constants.testProjectName);
+  //  await projectSettingsPage.noticeList.count();
+  //  await projectSettingsPage.tabDivs.count();
+  //  await projectSettingsPage.tabs.project.click();
+  //  await projectSettingsPage.tabs.remove.click();
   // });
 
   // TODO this is an lf-specific view
-  // it('Explore user management page', function() {
-  //   userManagementPage.get();
+  // it('Explore user management page', async function() {
+  //   await userManagementPage.get();
   //   // TODO click on things
   // });
 });

--- a/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
@@ -11,137 +11,137 @@ describe('Lexicon E2E Editor Comments', () => {
   const projectsPage = new ProjectsPage();
   const editorPage = new EditorPage();
 
-  it('setup: login, click on test project', () => {
-    loginPage.loginAsManager();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
+  it('setup: login, click on test project', async () => {
+    await loginPage.loginAsManager();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
   });
 
-  it('browse page has correct word count', () => {
+  it('browse page has correct word count', async () => {
     // flaky assertion, also test/app/languageforge/lexicon/editor/e2e/editor-entry.spec.js:20
-    expect<any>(editorPage.browse.entriesList.count()).toEqual(editorPage.browse.getEntryCount());
-    expect<any>(editorPage.browse.getEntryCount()).toBe(3);
+    expect<any>(await editorPage.browse.entriesList.count()).toEqual(await editorPage.browse.getEntryCount());
+    expect<any>(await editorPage.browse.getEntryCount()).toBe(3);
   });
 
-  it('click on first word', () => {
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+  it('click on first word', async () => {
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
   });
 
   it('click first comment bubble, type in a comment, add text to another part of the entry, ' +
-    'submit comment to appear on original field', () => {
-      editorPage.comment.bubbles.first.click();
-      editorPage.comment.newComment.textarea.sendKeys('First comment on this word.');
-      editorPage.edit.getMultiTextInputs('Definition').first().sendKeys('change value - ');
-      editorPage.comment.newComment.postBtn.click();
+    'submit comment to appear on original field', async () => {
+      await editorPage.comment.bubbles.first.click();
+      await editorPage.comment.newComment.textarea.sendKeys('First comment on this word.');
+      await editorPage.edit.getMultiTextInputs('Definition').first().sendKeys('change value - ');
+      await editorPage.comment.newComment.postBtn.click();
     });
 
-  it('comments panel: check that comment shows up', () => {
+  it('comments panel: check that comment shows up', async () => {
     const comment = editorPage.comment.getComment(0);
-    expect<any>(comment.contextGuid.getAttribute('textContent')).toEqual('lexeme.th'); // flaky
+    expect<any>(await comment.contextGuid.getAttribute('textContent')).toEqual('lexeme.th'); // flaky
 
     // Earlier tests modify the avatar and name of the manager user; don't check those
-    expect<any>(comment.score.getText()).toEqual('0 Likes');
-    expect<any>(comment.plusOne.isPresent()).toBe(true);
-    expect<any>(comment.content.getText()).toEqual('First comment on this word.');
-    expect<any>(comment.date.getText()).toMatch(/ago|in a few seconds/);
+    expect<any>(await comment.score.getText()).toEqual('0 Likes');
+    expect<any>(await comment.plusOne.isPresent()).toBe(true);
+    expect<any>(await comment.content.getText()).toEqual('First comment on this word.');
+    expect<any>(await comment.date.getText()).toMatch(/ago|in a few seconds/);
   });
 
-  it('comments panel: add comment to another part of the entry', () => {
+  it('comments panel: add comment to another part of the entry', async () => {
     const definitionField = editorPage.edit.getMultiTextInputs('Definition').first();
-    definitionField.clear();
-    definitionField.sendKeys(
+    await definitionField.clear();
+    await definitionField.sendKeys(
       constants.testEntry1.senses[0].definition.en.value
     );
-    editorPage.comment.bubbles.second.click();
-    editorPage.comment.newComment.textarea.clear();
-    editorPage.comment.newComment.textarea.sendKeys('Second comment.');
-    editorPage.comment.newComment.postBtn.click();
+    await editorPage.comment.bubbles.second.click();
+    await editorPage.comment.newComment.textarea.clear();
+    await editorPage.comment.newComment.textarea.sendKeys('Second comment.');
+    await editorPage.comment.newComment.postBtn.click();
   });
 
-  it('comments panel: check that second comment shows up', () => {
+  it('comments panel: check that second comment shows up', async () => {
     const comment = editorPage.comment.getComment(-1);
-    expect<any>(comment.wholeComment.isPresent()).toBe(true);
+    expect<any>(await comment.wholeComment.isPresent()).toBe(true);
 
     // Earlier tests modify the avatar and name of the manager user; don't check those
-    expect<any>(comment.score.getText()).toEqual('0 Likes');
-    expect<any>(comment.plusOne.isPresent()).toBe(true);
-    expect<any>(comment.content.getText()).toEqual('Second comment.');
-    expect<any>(comment.date.getText()).toMatch(/ago|in a few seconds/);
+    expect<any>(await comment.score.getText()).toEqual('0 Likes');
+    expect<any>(await comment.plusOne.isPresent()).toBe(true);
+    expect<any>(await comment.content.getText()).toEqual('Second comment.');
+    expect<any>(await comment.date.getText()).toMatch(/ago|in a few seconds/);
   });
 
-  it('comments panel: check regarding value is hidden when the field value matches', () => {
+  it('comments panel: check regarding value is hidden when the field value matches', async () => {
     const comment = editorPage.comment.getComment(-1);
     const updateText = 'update -';
 
     // Make sure it is hidden
-    expect<any>(comment.regarding.container.isDisplayed()).toBe(false);
+    expect<any>(await comment.regarding.container.isDisplayed()).toBe(false);
 
     // Change the field value and then make sure it appears
-    editorPage.edit.getMultiTextInputs('Definition').first().sendKeys(updateText);
-    expect<any>(comment.regarding.container.isDisplayed()).toBe(true);
+    await editorPage.edit.getMultiTextInputs('Definition').first().sendKeys(updateText);
+    expect<any>(await comment.regarding.container.isDisplayed()).toBe(true);
 
     // Make sure the regarding value matches what was originally there
     const word    = constants.testEntry1.senses[0].definition.en.value;
-    expect<any>(comment.regarding.fieldValue.getText()).toEqual(word);
+    expect<any>(await comment.regarding.fieldValue.getText()).toEqual(word);
     // Restore original value of Definition to not distort other tests
     for (let i = 0; i < updateText.length; i++) {
-      editorPage.edit.getMultiTextInputs('Definition').first().sendKeys(protractor.Key.BACK_SPACE);
+      await editorPage.edit.getMultiTextInputs('Definition').first().sendKeys(protractor.Key.BACK_SPACE);
     }
 
     // old stuff
     // This comment should have a "regarding" section
   });
 
-  it('comments panel: click +1 button on first comment', () => {
+  it('comments panel: click +1 button on first comment', async () => {
     const comment = editorPage.comment.getComment(0);
-    editorPage.comment.bubbles.first.click();
+    await editorPage.comment.bubbles.first.click();
 
     // Should be clickable
-    expect(comment.plusOneActive.getAttribute('data-ng-click')).not.toBe(null);
-    comment.plusOneActive.click();
-    expect<any>(comment.score.getText()).toEqual('1 Like');
+    expect(await comment.plusOneActive.getAttribute('data-ng-click')).not.toBe(null);
+    await comment.plusOneActive.click();
+    expect<any>(await comment.score.getText()).toEqual('1 Like');
     });
 
-  it('comments panel: +1 button disabled after clicking', () => {
+  it('comments panel: +1 button disabled after clicking', async () => {
     const comment = editorPage.comment.getComment(0);
-    expect<any>(comment.plusOneInactive.isDisplayed()).toBe(true);
+    expect<any>(await comment.plusOneInactive.isDisplayed()).toBe(true);
 
     // Should NOT be clickable
-    expect<any>(comment.plusOneInactive.getAttribute('data-ng-click')).toBe(null);
-    expect<any>(comment.score.getText()).toEqual('1 Like'); // Should not change from previous test
+    expect<any>(await comment.plusOneInactive.getAttribute('data-ng-click')).toBe(null);
+    expect<any>(await comment.score.getText()).toEqual('1 Like'); // Should not change from previous test
   });
 
-  it('comments panel: refresh returns to comment', () => {
+  it('comments panel: refresh returns to comment', async () => {
     const comment = editorPage.comment.getComment(0);
-    browser.refresh();
-    browser.wait(ExpectedConditions.visibilityOf(editorPage.comment.bubbles.first), constants.conditionTimeout);
-    editorPage.comment.bubbles.first.click();
-    browser.wait(ExpectedConditions.visibilityOf(editorPage.commentDiv), constants.conditionTimeout);
-    expect<any>(comment.content.getText()).toEqual('First comment on this word.');
+    await browser.refresh();
+    await browser.wait(ExpectedConditions.visibilityOf(editorPage.comment.bubbles.first), constants.conditionTimeout);
+    await editorPage.comment.bubbles.first.click();
+    await browser.wait(ExpectedConditions.visibilityOf(editorPage.commentDiv), constants.conditionTimeout);
+    expect<any>(await comment.content.getText()).toEqual('First comment on this word.');
   });
 
-  it('comments panel: close comments panel clicking on bubble', () => {
-    editorPage.comment.bubbles.first.click();
-    browser.wait(ExpectedConditions.invisibilityOf(editorPage.commentDiv), constants.conditionTimeout);
-    expect<any>(editorPage.commentDiv.getAttribute('class')).not.toContain('panel-visible');
+  it('comments panel: close comments panel clicking on bubble', async () => {
+    await editorPage.comment.bubbles.first.click();
+    await browser.wait(ExpectedConditions.invisibilityOf(editorPage.commentDiv), constants.conditionTimeout);
+    expect<any>(await editorPage.commentDiv.getAttribute('class')).not.toContain('panel-visible');
     // Hiding the comments panel triggers an animation (in hideRightPanel() in editor.component.ts) that uses
     // Angular's $interval() to animate hiding the panel, taking 1500 ms on large screens, or 500 ms on small ones.
     // Since it uses $interval(), the animation isn't disabled during our test run. Also, only AFTER the animation
     // completes will control.rightPanelVisible be set to false. But the 'panel-visible' attribute is removed
     // BEFORE the animation begins, so our browser.wait() call returns 1500 ms too soon. Which means we have to
     // wait for the animation to complete before subsequent tests will be ready to run. - 2019-08 RM
-    browser.sleep(1500 + 250);  // Extra 250 ms for paranoia
+    await browser.sleep(1500 + 250);  // Extra 250 ms for paranoia
   });
 
-  it('comments panel: show all comments', () => {
-    editorPage.edit.toCommentsLink.click();
+  it('comments panel: show all comments', async () => {
+    await editorPage.edit.toCommentsLink.click();
     browser.wait(ExpectedConditions.visibilityOf(editorPage.commentDiv), constants.conditionTimeout);
-    expect<any>(editorPage.commentDiv.getAttribute('class')).toContain('panel-visible');
+    expect<any>(await editorPage.commentDiv.getAttribute('class')).toContain('panel-visible');
   });
 
-  it('comments panel: close all comments clicking on main comments button', () => {
-    editorPage.edit.toCommentsLink.click();
-    browser.wait(ExpectedConditions.invisibilityOf(editorPage.commentDiv), constants.conditionTimeout);
-    expect<any>(editorPage.commentDiv.getAttribute('class')).not.toContain('panel-visible');
+  it('comments panel: close all comments clicking on main comments button', async () => {
+    await editorPage.edit.toCommentsLink.click();
+    await browser.wait(ExpectedConditions.invisibilityOf(editorPage.commentDiv), constants.conditionTimeout);
+    expect<any>(await editorPage.commentDiv.getAttribute('class')).not.toContain('panel-visible');
   });
 });

--- a/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
@@ -19,413 +19,413 @@ describe('Lexicon E2E Editor List and Entry', () => {
 
   const lexemeLabel = 'Word';
 
-  it('setup: login, click on test project', () => {
-    loginPage.loginAsManager();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
+  it('setup: login, click on test project', async () => {
+    await loginPage.loginAsManager();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
   });
 
-  it('browse page has correct word count', () => {
+  it('browse page has correct word count', async () => {
     // flaky assertion
-    expect(editorPage.browse.entriesList.count()).toEqual(editorPage.browse.getEntryCount());
-    expect<any>(editorPage.browse.getEntryCount()).toBe(3);
+    expect(await editorPage.browse.entriesList.count()).toEqual(await editorPage.browse.getEntryCount());
+    expect<any>(await editorPage.browse.getEntryCount()).toBe(3);
   });
 
-  it('search function works correctly', () => {
-    editorPage.browse.search.input.sendKeys('asparagus');
-    expect<any>(editorPage.browse.search.getMatchCount()).toBe(1);
-    editorPage.browse.search.clearBtn.click();
-    editorPage.browse.search.input.sendKeys('Asparagus');
-    expect<any>(editorPage.browse.search.getMatchCount()).toBe(1);
-    editorPage.browse.search.clearBtn.click();
+  it('search function works correctly', async () => {
+    await editorPage.browse.search.input.sendKeys('asparagus');
+    expect<any>(await editorPage.browse.search.getMatchCount()).toBe(1);
+    await editorPage.browse.search.clearBtn.click();
+    await editorPage.browse.search.input.sendKeys('Asparagus');
+    expect<any>(await editorPage.browse.search.getMatchCount()).toBe(1);
+    await editorPage.browse.search.clearBtn.click();
   });
 
-  it('refresh returns to list view', () => {
-    browser.refresh();
-    expect<any>(editorPage.browse.getEntryCount()).toBe(3);
+  it('refresh returns to list view', async () => {
+    await browser.refresh();
+    expect<any>(await editorPage.browse.getEntryCount()).toBe(3);
   });
 
-  it('click on first word', () => {
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+  it('click on first word', async () => {
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
   });
 
-  it('refresh returns to entry view', () => {
-    expect(editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
-    browser.refresh();
-    expect(editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
+  it('refresh returns to entry view', async () => {
+    expect(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
+    await browser.refresh();
+    expect(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
   });
 
-  it('edit page has correct word count', () => {
-    expect(editorPage.edit.entriesList.count()).toEqual(editorPage.edit.getEntryCount());
-    expect<any>(editorPage.edit.getEntryCount()).toBe(3);
+  it('edit page has correct word count', async () => {
+    expect(await editorPage.edit.entriesList.count()).toEqual(await editorPage.edit.getEntryCount());
+    expect<any>(await editorPage.edit.getEntryCount()).toBe(3);
   });
 
-  it('word 1: edit page has correct definition, part of speech', () => {
-    expect<any>(editorUtil.getFieldValues('Definition')).toEqual([
+  it('word 1: edit page has correct definition, part of speech', async () => {
+    expect<any>(await editorUtil.getFieldValues('Definition')).toEqual([
       { en: constants.testEntry1.senses[0].definition.en.value }
     ]);
-    expect<any>(editorUtil.getFieldValues('Part of Speech')).toEqual([
+    expect<any>(await editorUtil.getFieldValues('Part of Speech')).toEqual([
       editorUtil.expandPartOfSpeech(constants.testEntry1.senses[0].partOfSpeech.value)
     ]);
   });
 
-  it('dictionary citation reflects lexeme form', () => {
-    expect(editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme.th.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme['th-fonipa'].value);
-    expect(editorPage.edit.renderedDiv.getText()).not.toContain('citation form');
+  it('dictionary citation reflects lexeme form', async () => {
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme.th.value);
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme['th-fonipa'].value);
+    expect(await editorPage.edit.renderedDiv.getText()).not.toContain('citation form');
   });
 
-  it('add citation form as visible field', () => {
-    configPage.get();
-    configPage.tabs.unified.click();
-    util.setCheckbox(configPage.unifiedPane.hiddenIfEmptyCheckbox('Citation Form'), false);
-    configPage.applyButton.click();
-    Utils.clickBreadcrumb(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+  it('add citation form as visible field', async () => {
+    await configPage.get();
+    await configPage.tabs.unified.click();
+    await util.setCheckbox(configPage.unifiedPane.hiddenIfEmptyCheckbox('Citation Form'), false);
+    await configPage.applyButton.click();
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
   });
 
-  it('citation form field overrides lexeme form in dictionary citation view', () => {
-    editorPage.edit.showHiddenFields();
+  it('citation form field overrides lexeme form in dictionary citation view', async () => {
+    await editorPage.edit.showHiddenFields();
     const citationFormMultiTextInputs = editorPage.edit.getMultiTextInputs('Citation Form');
-    editorPage.edit.selectElement.sendKeys(citationFormMultiTextInputs.first(), 'citation form');
-    expect(editorPage.edit.renderedDiv.getText()).toContain('citation form');
-    expect(editorPage.edit.renderedDiv.getText()).not.toContain(constants.testEntry1.lexeme.th.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme['th-fonipa'].value);
-    editorPage.edit.selectElement.clear(citationFormMultiTextInputs.first());
-    expect(editorPage.edit.renderedDiv.getText()).not.toContain('citation form');
-    expect(editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme.th.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme['th-fonipa'].value);
-    editorPage.edit.hideHiddenFields();
+    await editorPage.edit.selectElement.sendKeys(citationFormMultiTextInputs.first(), 'citation form');
+    expect(await editorPage.edit.renderedDiv.getText()).toContain('citation form');
+    expect(await editorPage.edit.renderedDiv.getText()).not.toContain(constants.testEntry1.lexeme.th.value);
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme['th-fonipa'].value);
+    await editorPage.edit.selectElement.clear(citationFormMultiTextInputs.first());
+    expect(await editorPage.edit.renderedDiv.getText()).not.toContain('citation form');
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme.th.value);
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(constants.testEntry1.lexeme['th-fonipa'].value);
+    await editorPage.edit.hideHiddenFields();
   });
 
-  it('one picture and caption is present', () => {
-    expect(editorPage.edit.pictures.getFileName(0))
+  it('one picture and caption is present', async () => {
+    expect(await editorPage.edit.pictures.getFileName(0))
       .toContain('_' + constants.testEntry1.senses[0].pictures[0].fileName);
-    expect(editorPage.edit.pictures.getCaption(0))
+    expect(await editorPage.edit.pictures.getCaption(0))
       .toEqual({ en: constants.testEntry1.senses[0].pictures[0].caption.en.value });
   });
 
-  it('file upload drop box is displayed when Add Picture is clicked', () => {
-    expect<any>(editorPage.edit.pictures.addPictureLink.isPresent()).toBe(true);
-    expect<any>(editorPage.edit.pictures.addDropBox.isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.pictures.addCancelButton.isDisplayed()).toBe(false);
+  it('file upload drop box is displayed when Add Picture is clicked', async () => {
+    expect<any>(await editorPage.edit.pictures.addPictureLink.isPresent()).toBe(true);
+    expect<any>(await editorPage.edit.pictures.addDropBox.isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.pictures.addCancelButton.isDisplayed()).toBe(false);
 
     // fix problem with protractor not scrolling to element before click
-    browser.driver.executeScript('arguments[0].scrollIntoView();',
+    await browser.driver.executeScript('arguments[0].scrollIntoView();',
       editorPage.edit.pictures.addPictureLink.getWebElement());
-    editorPage.edit.pictures.addPictureLink.click();
-    expect<any>(editorPage.edit.pictures.addPictureLink.isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.pictures.addDropBox.isDisplayed()).toBe(true);
+    await editorPage.edit.pictures.addPictureLink.click();
+    expect<any>(await editorPage.edit.pictures.addPictureLink.isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.pictures.addDropBox.isDisplayed()).toBe(true);
   });
 
-  it('file upload drop box is not displayed when Cancel Adding Picture is clicked', () => {
-    expect<any>(editorPage.edit.pictures.addCancelButton.isDisplayed()).toBe(true);
-    editorPage.edit.pictures.addCancelButton.click();
-    expect<any>(editorPage.edit.pictures.addPictureLink.isPresent()).toBe(true);
-    expect<any>(editorPage.edit.pictures.addDropBox.isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.pictures.addCancelButton.isDisplayed()).toBe(false);
+  it('file upload drop box is not displayed when Cancel Adding Picture is clicked', async () => {
+    expect<any>(await editorPage.edit.pictures.addCancelButton.isDisplayed()).toBe(true);
+    await editorPage.edit.pictures.addCancelButton.click();
+    expect<any>(await editorPage.edit.pictures.addPictureLink.isPresent()).toBe(true);
+    expect<any>(await editorPage.edit.pictures.addDropBox.isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.pictures.addCancelButton.isDisplayed()).toBe(false);
   });
 
-  it('change config to show Pictures and hide captions', () => {
-    configPage.get();
-    configPage.tabs.unified.click();
-    util.setCheckbox(configPage.unifiedPane.hiddenIfEmptyCheckbox('Pictures'), false);
-    configPage.unifiedPane.fieldSpecificButton('Pictures').click();
-    util.setCheckbox(configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox('Pictures'), true);
-    configPage.applyButton.click();
+  it('change config to show Pictures and hide captions', async () => {
+    await configPage.get();
+    await configPage.tabs.unified.click();
+    await util.setCheckbox(configPage.unifiedPane.hiddenIfEmptyCheckbox('Pictures'), false);
+    await configPage.unifiedPane.fieldSpecificButton('Pictures').click();
+    await util.setCheckbox(configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox('Pictures'), true);
+    await configPage.applyButton.click();
   });
 
-  it('caption is hidden when empty if "Hidden if empty" is set in config', () => {
-    Utils.clickBreadcrumb(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    editorPage.edit.hideHiddenFields();
-    expect<any>(editorPage.edit.pictures.captions.first().isDisplayed()).toBe(true);
-    editorPage.edit.selectElement.clear(editorPage.edit.pictures.captions.first());
-    expect<any>(editorPage.edit.pictures.captions.count()).toBe(0);
+  it('caption is hidden when empty if "Hidden if empty" is set in config', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.edit.hideHiddenFields();
+    expect<any>(await editorPage.edit.pictures.captions.first().isDisplayed()).toBe(true);
+    await editorPage.edit.selectElement.clear(editorPage.edit.pictures.captions.first());
+    expect<any>(await editorPage.edit.pictures.captions.count()).toBe(0);
   });
 
-  it('change config to show Pictures and show captions', () => {
-    configPage.get();
-    configPage.tabs.unified.click();
-    util.setCheckbox(configPage.unifiedPane.hiddenIfEmptyCheckbox('Pictures'), false);
-    configPage.unifiedPane.fieldSpecificButton('Pictures').click();
-    util.setCheckbox(configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox('Pictures'), false);
-    configPage.applyButton.click();
+  it('change config to show Pictures and show captions', async () => {
+    await configPage.get();
+    await configPage.tabs.unified.click();
+    await util.setCheckbox(configPage.unifiedPane.hiddenIfEmptyCheckbox('Pictures'), false);
+    await configPage.unifiedPane.fieldSpecificButton('Pictures').click();
+    await util.setCheckbox(configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox('Pictures'), false);
+    await configPage.applyButton.click();
   });
 
-  it('when caption is empty, it is visible if "Hidden if empty" is cleared in config', () => {
-    Utils.clickBreadcrumb(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    expect<any>(editorPage.edit.pictures.captions.first().isDisplayed()).toBe(true);
+  it('when caption is empty, it is visible if "Hidden if empty" is cleared in config', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    expect<any>(await editorPage.edit.pictures.captions.first().isDisplayed()).toBe(true);
   });
 
-  it('picture is removed when Delete is clicked', () => {
-    expect<any>(editorPage.edit.pictures.images.first().isPresent()).toBe(true);
-    expect<any>(editorPage.edit.pictures.removeImages.first().isPresent()).toBe(true);
-    editorPage.edit.pictures.removeImages.first().click();
-    Utils.clickModalButton('Delete Picture');
-    expect<any>(editorPage.edit.pictures.images.count()).toBe(0);
+  it('picture is removed when Delete is clicked', async () => {
+    expect<any>(await editorPage.edit.pictures.images.first().isPresent()).toBe(true);
+    expect<any>(await editorPage.edit.pictures.removeImages.first().isPresent()).toBe(true);
+    await editorPage.edit.pictures.removeImages.first().click();
+    await Utils.clickModalButton('Delete Picture');
+    expect<any>(await editorPage.edit.pictures.images.count()).toBe(0);
   });
 
-  it('change config to hide Pictures and hide captions', () => {
-    configPage.get();
-    configPage.tabs.unified.click();
-    util.setCheckbox(configPage.unifiedPane.hiddenIfEmptyCheckbox('Pictures'), true);
-    configPage.unifiedPane.fieldSpecificButton('Pictures').click();
-    util.setCheckbox(configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox('Pictures'), true);
-    configPage.applyButton.click();
+  it('change config to hide Pictures and hide captions', async () => {
+    await configPage.get();
+    await configPage.tabs.unified.click();
+    await util.setCheckbox(configPage.unifiedPane.hiddenIfEmptyCheckbox('Pictures'), true);
+    await configPage.unifiedPane.fieldSpecificButton('Pictures').click();
+    await util.setCheckbox(configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox('Pictures'), true);
+    await configPage.applyButton.click();
   });
 
-  it('while Show Hidden Fields has not been clicked, Pictures field is hidden', () => {
-    Utils.clickBreadcrumb(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    expect<any>(editorPage.edit.getFields('Pictures').count()).toBe(0);
-    editorPage.edit.showHiddenFields();
-    expect<any>(editorPage.edit.pictures.list.isPresent()).toBe(true);
-    editorPage.edit.hideHiddenFields();
-    expect<any>(editorPage.edit.getFields('Pictures').count()).toBe(0);
+  it('while Show Hidden Fields has not been clicked, Pictures field is hidden', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    expect<any>(await editorPage.edit.getFields('Pictures').count()).toBe(0);
+    await editorPage.edit.showHiddenFields();
+    expect<any>(await editorPage.edit.pictures.list.isPresent()).toBe(true);
+    await editorPage.edit.hideHiddenFields();
+    expect<any>(await editorPage.edit.getFields('Pictures').count()).toBe(0);
   });
 
-  it('audio Input System is present, playable and has "more" control (manager)', () => {
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).count()).toEqual(1);
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().getAttribute('class')).toContain('fa-play');
-    expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isEnabled()).toBe(true);
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isEnabled()).toBe(true);
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+  it('audio Input System is present, playable and has "more" control (manager)', async () => {
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).count()).toEqual(1);
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().getAttribute('class')).toContain('fa-play');
+    expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isEnabled()).toBe(true);
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isEnabled()).toBe(true);
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
   });
 
-  it('file upload drop box is displayed when Upload is clicked', () => {
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(false);
-    editorPage.edit.audio.moreControls(lexemeLabel).first().click();
-    editorPage.edit.audio.moreUpload(lexemeLabel, 0).click();
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(true);
+  it('file upload drop box is displayed when Upload is clicked', async () => {
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+    await editorPage.edit.audio.moreControls(lexemeLabel).first().click();
+    await editorPage.edit.audio.moreUpload(lexemeLabel, 0).click();
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(true);
   });
 
-  it('file upload drop box is not displayed when Cancel Uploading Audio is clicked', () => {
-    expect<any>(editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(true);
-    editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().click();
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+  it('file upload drop box is not displayed when Cancel Uploading Audio is clicked', async () => {
+    expect<any>(await editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(true);
+    await editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().click();
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(false);
   });
 
-  it('click on second word (found by definition)', () => {
-    editorPage.edit.findEntryByDefinition(constants.testEntry2.senses[0].definition.en.value).click();
+  it('click on second word (found by definition)', async () => {
+    await editorPage.edit.findEntryByDefinition(constants.testEntry2.senses[0].definition.en.value).click();
   });
 
-  it('word 2: audio Input System is not playable but has "upload" button (manager)', () => {
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().isPresent()).toBe(false);
-    expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isPresent()).toBe(false);
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isEnabled()).toBe(true);
-    expect<any>(editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+  it('word 2: audio Input System is not playable but has "upload" button (manager)', async () => {
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().isPresent()).toBe(false);
+    expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isPresent()).toBe(false);
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isEnabled()).toBe(true);
+    expect<any>(await editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
   });
 
-  it('login as member, click on first word', () => {
-    loginPage.loginAsMember();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+  it('login as member, click on first word', async () => {
+    await loginPage.loginAsMember();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
   });
 
-  it('audio Input System is present, playable and has "more" control (member)', () => {
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).count()).toEqual(1);
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().getAttribute('class')).toContain('fa-play');
-    expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isEnabled()).toBe(true);
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isEnabled()).toBe(true);
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+  it('audio Input System is present, playable and has "more" control (member)', async () => {
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).count()).toEqual(1);
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().getAttribute('class')).toContain('fa-play');
+    expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isEnabled()).toBe(true);
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isEnabled()).toBe(true);
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
   });
 
-  it('click on second word (found by definition)', () => {
-    editorPage.edit.findEntryByDefinition(constants.testEntry2.senses[0].definition.en.value)
+  it('click on second word (found by definition)', async () => {
+    await editorPage.edit.findEntryByDefinition(constants.testEntry2.senses[0].definition.en.value)
       .click();
   });
 
-  it('word 2: audio Input System is not playable but has "upload" button (member)', () => {
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().isPresent()).toBe(false);
-    expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isPresent()).toBe(false);
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isEnabled()).toBe(true);
-    expect<any>(editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+  it('word 2: audio Input System is not playable but has "upload" button (member)', async () => {
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().isPresent()).toBe(false);
+    expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isPresent()).toBe(false);
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isEnabled()).toBe(true);
+    expect<any>(await editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
   });
 
-  it('login as observer, click on first word', () => {
-    loginPage.loginAsObserver();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+  it('login as observer, click on first word', async () => {
+    await loginPage.loginAsObserver();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
   });
 
-  it('audio Input System is playable but does not have "more" control (observer)', () => {
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).count()).toEqual(1);
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().getAttribute('class')).toContain('fa-play');
-    expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isEnabled()).toBe(true);
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
+  it('audio Input System is playable but does not have "more" control (observer)', async () => {
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).count()).toEqual(1);
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().getAttribute('class')).toContain('fa-play');
+    expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isEnabled()).toBe(true);
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
   });
 
-  it('click on second word (found by definition)', () => {
-    editorPage.edit.findEntryByDefinition(constants.testEntry2.senses[0].definition.en.value).click();
+  it('click on second word (found by definition)', async () => {
+    await editorPage.edit.findEntryByDefinition(constants.testEntry2.senses[0].definition.en.value).click();
   });
 
   it('word 2: audio Input System is not playable and does not have "upload" button (observer)',
-    () => {
-      expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().isPresent()).toBe(false);
-      expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isPresent()).toBe(false);
-      expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
-      expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
-      expect<any>(editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+    async () => {
+      expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().isPresent()).toBe(false);
+      expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isPresent()).toBe(false);
+      expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(false);
+      expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+      expect<any>(await editorPage.edit.audio.downloadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
     });
 
-  it('login as manager, click on first word', () => {
-    loginPage.loginAsManager();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+  it('login as manager, click on first word', async () => {
+    await loginPage.loginAsManager();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
   });
 
-  it('can delete audio Input System', () => {
-    expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
-    editorPage.edit.audio.moreControls(lexemeLabel).first().click();
-    editorPage.edit.audio.moreDelete(lexemeLabel, 0).click();
-    Utils.clickModalButton('Delete Audio');
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
+  it('can delete audio Input System', async () => {
+    expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
+    await editorPage.edit.audio.moreControls(lexemeLabel).first().click();
+    await editorPage.edit.audio.moreDelete(lexemeLabel, 0).click();
+    await Utils.clickModalButton('Delete Audio');
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
   });
 
-  it('file upload drop box is displayed when Upload is clicked', () => {
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(false);
-    editorPage.edit.audio.uploadButtons(lexemeLabel).first().click();
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(true);
+  it('file upload drop box is displayed when Upload is clicked', async () => {
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+    await editorPage.edit.audio.uploadButtons(lexemeLabel).first().click();
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(true);
   });
 
-  it('file upload drop box is not displayed when Cancel Uploading Audio is clicked', () => {
-    expect<any>(editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(true);
-    editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().click();
-    expect<any>(editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
-    expect<any>(editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(false);
-    expect<any>(editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(false);
+  it('file upload drop box is not displayed when Cancel Uploading Audio is clicked', async () => {
+    expect<any>(await editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(true);
+    await editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().click();
+    expect<any>(await editorPage.edit.audio.uploadButtons(lexemeLabel).first().isDisplayed()).toBe(true);
+    expect<any>(await editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(false);
+    expect<any>(await editorPage.edit.audio.uploadCancelButtons(lexemeLabel).first().isDisplayed()).toBe(false);
   });
 
-  describe('Mock file upload', () => {
+  describe('Mock file upload', async () => {
 
-    it('can\'t upload a non-audio file', () => {
-      expect<any>(editorPage.noticeList.count()).toBe(0);
-      editorPage.edit.audio.uploadButtons(lexemeLabel).first().click();
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.enableButton.click();
-      expect(editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileNameInput.isDisplayed()).toBe(true);
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileNameInput
+    it('can\'t upload a non-audio file', async () => {
+      expect<any>(await editorPage.noticeList.count()).toBe(0);
+      await editorPage.edit.audio.uploadButtons(lexemeLabel).first().click();
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.enableButton.click();
+      expect(await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileNameInput.isDisplayed()).toBe(true);
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileNameInput
         .sendKeys(constants.testMockPngUploadFile.name);
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileSizeInput
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileSizeInput
         .sendKeys(constants.testMockPngUploadFile.size);
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.uploadButton.click();
-      expect<any>(editorPage.noticeList.count()).toBe(1);
-      expect<any>(editorPage.noticeList.first().getText()).toContain(constants.testMockPngUploadFile.name +
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.uploadButton.click();
+      expect<any>(await editorPage.noticeList.count()).toBe(1);
+      expect<any>(await editorPage.noticeList.first().getText()).toContain(constants.testMockPngUploadFile.name +
           ' is not an allowed audio file. Ensure the file is');
-      expect<any>(editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(true);
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileNameInput.clear();
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileSizeInput.clear();
-      editorPage.firstNoticeCloseButton.click();
+      expect<any>(await editorPage.edit.audio.uploadDropBoxes(lexemeLabel).first().isDisplayed()).toBe(true);
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileNameInput.clear();
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileSizeInput.clear();
+      await editorPage.firstNoticeCloseButton.click();
     });
 
-    it('can upload an audio file', () => {
-      expect<any>(editorPage.noticeList.count()).toBe(0);
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileNameInput
+    it('can upload an audio file', async () => {
+      expect<any>(await editorPage.noticeList.count()).toBe(0);
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileNameInput
         .sendKeys(constants.testMockMp3UploadFile.name);
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileSizeInput
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.fileSizeInput
         .sendKeys(constants.testMockMp3UploadFile.size);
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.uploadButton.click();
-      editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.enableButton.click();
-      expect<any>(editorPage.noticeList.count()).toBe(1);
-      expect<any>(editorPage.noticeList.first().getText()).toContain('File uploaded successfully');
-      expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().isDisplayed()).toBe(true);
-      expect<any>(editorPage.edit.audio.playerIcons(lexemeLabel).first().getAttribute('class')).toContain('fa-play');
-      expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isDisplayed()).toBe(true);
-      expect<any>(editorPage.edit.audio.players(lexemeLabel).first().isEnabled()).toBe(true);
-      expect<any>(editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.uploadButton.click();
+      await editorPage.edit.audio.control(lexemeLabel, 0).mockUpload.enableButton.click();
+      expect<any>(await editorPage.noticeList.count()).toBe(1);
+      expect<any>(await editorPage.noticeList.first().getText()).toContain('File uploaded successfully');
+      expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().isDisplayed()).toBe(true);
+      expect<any>(await editorPage.edit.audio.playerIcons(lexemeLabel).first().getAttribute('class')).toContain('fa-play');
+      expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isDisplayed()).toBe(true);
+      expect<any>(await editorPage.edit.audio.players(lexemeLabel).first().isEnabled()).toBe(true);
+      expect<any>(await editorPage.edit.audio.moreControls(lexemeLabel).first().isDisplayed()).toBe(true);
     });
 
   });
 
-  it('click on second word (found by definition)', () => {
-    editorPage.edit.findEntryByDefinition(constants.testEntry2.senses[0].definition.en.value).click();
+  it('click on second word (found by definition)', async () => {
+    await editorPage.edit.findEntryByDefinition(constants.testEntry2.senses[0].definition.en.value).click();
   });
 
-  it('word 2: edit page has correct definition, part of speech', () => {
-    expect<any>(editorUtil.getFieldValues('Definition')).toEqual([
+  it('word 2: edit page has correct definition, part of speech', async () => {
+    expect<any>(await editorUtil.getFieldValues('Definition')).toEqual([
       { en: constants.testEntry2.senses[0].definition.en.value }
     ]);
-    expect<any>(editorUtil.getFieldValues('Part of Speech')).toEqual([
+    expect<any>(await editorUtil.getFieldValues('Part of Speech')).toEqual([
       editorUtil.expandPartOfSpeech(constants.testEntry2.senses[0].partOfSpeech.value)
     ]);
   });
 
-  it('setup: click on word with multiple definitions (found by lexeme)', () => {
-    editorPage.edit.findEntryByLexeme(constants.testMultipleMeaningEntry1.lexeme.th.value).click();
+  it('setup: click on word with multiple definitions (found by lexeme)', async () => {
+    await editorPage.edit.findEntryByLexeme(constants.testMultipleMeaningEntry1.lexeme.th.value).click();
 
     // fix problem with protractor not scrolling to element before click
-    browser.driver.executeScript('arguments[0].scrollIntoView();',
+    await browser.driver.executeScript('arguments[0].scrollIntoView();',
       editorPage.edit.senses.first().getWebElement());
-    editorPage.edit.senses.first().click();
+    await editorPage.edit.senses.first().click();
   });
 
-  it('dictionary citation reflects example sentences and translations', () => {
-    expect(editorPage.edit.renderedDiv.getText()).toContain(
+  it('dictionary citation reflects example sentences and translations', async () => {
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(
       constants.testMultipleMeaningEntry1.senses[0].examples[0].sentence.th.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(
       constants.testMultipleMeaningEntry1.senses[0].examples[0].translation.en.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(
       constants.testMultipleMeaningEntry1.senses[0].examples[1].sentence.th.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(
       constants.testMultipleMeaningEntry1.senses[0].examples[1].translation.en.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(
       constants.testMultipleMeaningEntry1.senses[1].examples[0].sentence.th.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(
       constants.testMultipleMeaningEntry1.senses[1].examples[0].translation.en.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(
       constants.testMultipleMeaningEntry1.senses[1].examples[1].sentence.th.value);
-    expect(editorPage.edit.renderedDiv.getText()).toContain(
+    expect(await editorPage.edit.renderedDiv.getText()).toContain(
       constants.testMultipleMeaningEntry1.senses[1].examples[1].translation.en.value);
   });
 
   it('word with multiple definitions: edit page has correct definitions, parts of speech',
-  () => {
-    expect<any>(editorUtil.getFieldValues('Definition')).toEqual([
+  async () => {
+    expect<any>(await editorUtil.getFieldValues('Definition')).toEqual([
       { en: constants.testMultipleMeaningEntry1.senses[0].definition.en.value },
       { en: constants.testMultipleMeaningEntry1.senses[1].definition.en.value }
     ]);
-    expect<any>(editorUtil.getFieldValues('Part of Speech')).toEqual([
+    expect<any>(await editorUtil.getFieldValues('Part of Speech')).toEqual([
       editorUtil.expandPartOfSpeech(constants.testMultipleMeaningEntry1.senses[0].partOfSpeech.value),
       editorUtil.expandPartOfSpeech(constants.testMultipleMeaningEntry1.senses[1].partOfSpeech.value)
     ]);
   });
 
-  it('word with multiple meanings: edit page has correct example sentences, translations', () => {
-    expect<any>(editorUtil.getFieldValues('Sentence')).toEqual([
+  it('word with multiple meanings: edit page has correct example sentences, translations', async () => {
+    expect<any>(await editorUtil.getFieldValues('Sentence')).toEqual([
       { th: constants.testMultipleMeaningEntry1.senses[0].examples[0].sentence.th.value },
       { th: constants.testMultipleMeaningEntry1.senses[0].examples[1].sentence.th.value },
       { th: constants.testMultipleMeaningEntry1.senses[1].examples[0].sentence.th.value },
       { th: constants.testMultipleMeaningEntry1.senses[1].examples[1].sentence.th.value }
     ]);
-    expect<any>(editorUtil.getFieldValues('Translation')).toEqual([
+    expect<any>(await editorUtil.getFieldValues('Translation')).toEqual([
       { en: constants.testMultipleMeaningEntry1.senses[0].examples[0].translation.en.value },
       { en: constants.testMultipleMeaningEntry1.senses[0].examples[1].translation.en.value },
       { en: constants.testMultipleMeaningEntry1.senses[1].examples[0].translation.en.value },
@@ -433,171 +433,171 @@ describe('Lexicon E2E Editor List and Entry', () => {
     ]);
   });
 
-  it('while Show Hidden Fields has not been clicked, hidden fields are hidden if they are empty', () => {
-    expect<any>(editorPage.edit.getFields('Semantics Note').count()).toBe(0);
-    expect<any>(editorPage.edit.getOneField('General Note').isPresent()).toBe(true);
-    editorPage.edit.showHiddenFields();
-    expect<any>(editorPage.edit.getOneField('Semantics Note').isPresent()).toBe(true);
-    expect<any>(editorPage.edit.getOneField('General Note').isPresent()).toBe(true);
+  it('while Show Hidden Fields has not been clicked, hidden fields are hidden if they are empty', async () => {
+    expect<any>(await editorPage.edit.getFields('Semantics Note').count()).toBe(0);
+    expect<any>(await editorPage.edit.getOneField('General Note').isPresent()).toBe(true);
+    await editorPage.edit.showHiddenFields();
+    expect<any>(await editorPage.edit.getOneField('Semantics Note').isPresent()).toBe(true);
+    expect<any>(await editorPage.edit.getOneField('General Note').isPresent()).toBe(true);
   });
 
-  it('word with multiple meanings: edit page has correct general notes, sources', () => {
-    expect<any>(editorUtil.getFieldValues('General Note')).toEqual([
+  it('word with multiple meanings: edit page has correct general notes, sources', async () => {
+    expect<any>(await editorUtil.getFieldValues('General Note')).toEqual([
       { en: constants.testMultipleMeaningEntry1.senses[0].generalNote.en.value },
       { en: constants.testMultipleMeaningEntry1.senses[1].generalNote.en.value }
     ]);
 
     // First item is empty Etymology Source, now that View Settings all default to visible. IJH
-    expect<any>(editorUtil.getFieldValues('Source')).toEqual([
+    expect<any>(await editorUtil.getFieldValues('Source')).toEqual([
       { en: constants.testMultipleMeaningEntry1.senses[0].source.en.value },
       { en: constants.testMultipleMeaningEntry1.senses[1].source.en.value }
     ]);
   });
 
-  it('senses can be reordered and deleted', () => {
-    editorPage.edit.sense.actionMenus.first().click();
-    editorPage.edit.sense.moveDown.first().click();
-    expect<any>(editorUtil.getFieldValues('Definition')).toEqual([
+  it('senses can be reordered and deleted', async () => {
+    await editorPage.edit.sense.actionMenus.first().click();
+    await editorPage.edit.sense.moveDown.first().click();
+    expect<any>(await editorUtil.getFieldValues('Definition')).toEqual([
       { en: constants.testMultipleMeaningEntry1.senses[1].definition.en.value },
       { en: constants.testMultipleMeaningEntry1.senses[0].definition.en.value }
     ]);
   });
 
-  it('back to browse page, create new word', () => {
-    editorPage.edit.toListLink.click();
-    editorPage.browse.newWordBtn.click();
+  it('back to browse page, create new word', async () => {
+    await editorPage.edit.toListLink.click();
+    await editorPage.browse.newWordBtn.click();
   });
 
-  it('check that word count is still correct', () => {
-    expect(editorPage.edit.entriesList.count()).toEqual(editorPage.edit.getEntryCount());
-    expect<any>(editorPage.edit.getEntryCount()).toEqual(4);
+  it('check that word count is still correct', async () => {
+    expect(await editorPage.edit.entriesList.count()).toEqual(await editorPage.edit.getEntryCount());
+    expect<any>(await editorPage.edit.getEntryCount()).toEqual(4);
   });
 
-  it('modify new word', () => {
+  it('modify new word', async () => {
     const word = constants.testEntry3.lexeme.th.value;
     const definition = constants.testEntry3.senses[0].definition.en.value;
-    editorPage.edit.getMultiTextInputs(lexemeLabel).first().sendKeys(word);
-    editorPage.edit.getMultiTextInputs('Definition').first().sendKeys(definition);
-    Utils.clickDropdownByValue(editorPage.edit.getOneField('Part of Speech').element(by.css('select')),
+    await editorPage.edit.getMultiTextInputs(lexemeLabel).first().sendKeys(word);
+    await editorPage.edit.getMultiTextInputs('Definition').first().sendKeys(definition);
+    await Utils.clickDropdownByValue(await editorPage.edit.getOneField('Part of Speech').element(by.css('select')),
       new RegExp('Noun \\(n\\)'));
-    Utils.scrollTop();
+      await Utils.scrollTop();
   });
 
-  it('autosaves changes', () => {
-    browser.refresh();
-    browser.wait(ExpectedConditions.visibilityOf(editorPage.edit.fields.last()));
-    editorPage.edit.getMultiTextInputs(lexemeLabel).first().getAttribute('value').then(text => {
-      editorPage.edit.getMultiTextInputs(lexemeLabel).first().sendKeys('a');
-      browser.refresh();
-      browser.wait(ExpectedConditions.visibilityOf(editorPage.edit.fields.last()));
-      expect<any>(editorPage.edit.getMultiTextInputs(lexemeLabel).first().getAttribute('value')).toEqual(text + 'a');
-      editorPage.edit.getMultiTextInputs(lexemeLabel).first().sendKeys(protractor.Key.BACK_SPACE);
+  it('autosaves changes', async () => {
+    await browser.refresh();
+    await browser.wait(ExpectedConditions.visibilityOf(await editorPage.edit.fields.last()));
+    await editorPage.edit.getMultiTextInputs(lexemeLabel).first().getAttribute('value').then(async text => {
+      await editorPage.edit.getMultiTextInputs(lexemeLabel).first().sendKeys('a');
+      await browser.refresh();
+      await browser.wait(ExpectedConditions.visibilityOf(await editorPage.edit.fields.last()));
+      expect<any>(await editorPage.edit.getMultiTextInputs(lexemeLabel).first().getAttribute('value')).toEqual(text + 'a');
+      await editorPage.edit.getMultiTextInputs(lexemeLabel).first().sendKeys(protractor.Key.BACK_SPACE);
     });
   });
 
-  it('new word is visible in edit page', () => {
-    editorPage.edit.search.input.sendKeys(constants.testEntry3.senses[0].definition.en.value);
-    expect<any>(editorPage.edit.search.getMatchCount()).toBe(1);
-    editorPage.edit.search.clearBtn.click();
+  it('new word is visible in edit page', async () => {
+    await editorPage.edit.search.input.sendKeys(constants.testEntry3.senses[0].definition.en.value);
+    expect<any>(await editorPage.edit.search.getMatchCount()).toBe(1);
+    await editorPage.edit.search.clearBtn.click();
   });
 
-  it('check that Semantic Domain field is visible (for view settings test later)', () => {
-      expect(editorPage.edit.getOneField('Semantic Domain').isPresent()).toBeTruthy();
+  it('check that Semantic Domain field is visible (for view settings test later)', async () => {
+      expect(await editorPage.edit.getOneField('Semantic Domain').isPresent()).toBeTruthy();
     });
 
-  describe('Configuration check', () => {
+  describe('Configuration check', async () => {
     const englishISIndex = 3;
 
-    it('Word has only "th", "tipa" and "taud" visible', () => {
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(3);
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
+    it('Word has only "th", "tipa" and "taud" visible', async () => {
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(3);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
     });
 
-    it('make "en" input system visible for "Word" field', () => {
-      configPage.get();
-      configPage.tabs.unified.click();
-      configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
-      util.setCheckbox(
+    it('make "en" input system visible for "Word" field', async () => {
+      await configPage.get();
+      await configPage.tabs.unified.click();
+      await configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
+      await util.setCheckbox(
         configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, englishISIndex), true);
-      configPage.applyButton.click();
-      Utils.clickBreadcrumb(constants.testProjectName);
-      editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+      await configPage.applyButton.click();
+      await Utils.clickBreadcrumb(constants.testProjectName);
+      await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
     });
 
-    it('Word has "th", "tipa", "taud" and "en" visible', () => {
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(4);
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(3).getText()).toEqual('en');
+    it('Word has "th", "tipa", "taud" and "en" visible', async () => {
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(4);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(3).getText()).toEqual('en');
     });
 
-    it('make "en" input system invisible for "Word" field', () => {
-      configPage.get();
-      configPage.tabs.unified.click();
-      configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
-      util.setCheckbox(
+    it('make "en" input system invisible for "Word" field', async () => {
+      await configPage.get();
+      await configPage.tabs.unified.click();
+      await configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
+      await util.setCheckbox(
         configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, englishISIndex), false);
-      configPage.applyButton.click();
-      Utils.clickBreadcrumb(constants.testProjectName);
-      editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+      await configPage.applyButton.click();
+      await Utils.clickBreadcrumb(constants.testProjectName);
+      await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
     });
 
-    it('Word has only "th", "tipa" and "taud" visible', () => {
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(3);
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
-      expect<any>(editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
+    it('Word has only "th", "tipa" and "taud" visible', async () => {
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(3);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
     });
 
   });
 
-  it('first entry is selected if entryId unknown', () => {
-    editorPage.edit.findEntryByLexeme(constants.testEntry3.lexeme.th.value).click();
-    EditorPage.getProjectIdFromUrl().then(projectId => {
-      EditorPage.get(projectId, '_unknown_id_1234');
+  it('first entry is selected if entryId unknown', async () => {
+    await editorPage.edit.findEntryByLexeme(constants.testEntry3.lexeme.th.value).click();
+    await EditorPage.getProjectIdFromUrl().then(projectId => {
+      return EditorPage.get(projectId, '_unknown_id_1234');
     });
 
-    expect(editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
+    expect(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
   });
 
-  it('URL entry id changes with entry', () => {
-    const entry1Id = EditorPage.getEntryIdFromUrl();
+  it('URL entry id changes with entry', async () => {
+    const entry1Id = await EditorPage.getEntryIdFromUrl();
     expect(entry1Id).toMatch(/[0-9a-z_]{6,24}/);
-    editorPage.edit.findEntryByLexeme(constants.testEntry3.lexeme.th.value).click();
-    expect(editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry3.lexeme.th.value);
-    const entry3Id = EditorPage.getEntryIdFromUrl();
+    await editorPage.edit.findEntryByLexeme(constants.testEntry3.lexeme.th.value).click();
+    expect(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry3.lexeme.th.value);
+    const entry3Id = await EditorPage.getEntryIdFromUrl();
     expect(entry3Id).toMatch(/[0-9a-z_]{6,24}/);
     expect(entry1Id).not.toEqual(entry3Id);
-    editorPage.edit.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    expect(editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
-    expect(EditorPage.getEntryIdFromUrl()).not.toEqual(entry3Id);
+    await editorPage.edit.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    expect(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
+    expect(await EditorPage.getEntryIdFromUrl()).not.toEqual(entry3Id);
   });
 
-  it('new word is visible in browse page', () => {
-    editorPage.edit.toListLink.click();
-    editorPage.browse.search.input.sendKeys(constants.testEntry3.senses[0].definition.en.value);
-    expect<any>(editorPage.browse.search.getMatchCount()).toBe(1);
-    editorPage.browse.search.clearBtn.click();
+  it('new word is visible in browse page', async () => {
+    await editorPage.edit.toListLink.click();
+    await editorPage.browse.search.input.sendKeys(constants.testEntry3.senses[0].definition.en.value);
+    expect<any>(await editorPage.browse.search.getMatchCount()).toBe(1);
+    await editorPage.browse.search.clearBtn.click();
   });
 
-  it('check that word count is still correct in browse page', () => {
-    expect(editorPage.browse.entriesList.count()).toEqual(editorPage.browse.getEntryCount());
-    expect<any>(editorPage.browse.getEntryCount()).toBe(4);
+  it('check that word count is still correct in browse page', async () => {
+    expect(await editorPage.browse.entriesList.count()).toEqual(await editorPage.browse.getEntryCount());
+    expect<any>(await editorPage.browse.getEntryCount()).toBe(4);
   });
 
-  it('remove new word to restore original word count', () => {
-    editorPage.browse.findEntryByLexeme(constants.testEntry3.lexeme.th.value).click();
-    editorPage.edit.actionMenu.click();
-    editorPage.edit.deleteMenuItem.click();
-    expect<any>(editorPage.modal.modalBodyText.getText()).toContain(constants.testEntry3.lexeme.th.value);
-    Utils.clickModalButton('Delete Entry');
-    expect<any>(editorPage.edit.getEntryCount()).toBe(3);
+  it('remove new word to restore original word count', async () => {
+    await editorPage.browse.findEntryByLexeme(constants.testEntry3.lexeme.th.value).click();
+    await editorPage.edit.actionMenu.click();
+    await editorPage.edit.deleteMenuItem.click();
+    expect<any>(await editorPage.modal.modalBodyText.getText()).toContain(constants.testEntry3.lexeme.th.value);
+    await Utils.clickModalButton('Delete Entry');
+    expect<any>(await editorPage.edit.getEntryCount()).toBe(3);
   });
 
-  it('previous entry is selected after delete', () => {
-    expect(editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
+  it('previous entry is selected after delete', async () => {
+    expect(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
   });
 });

--- a/test/app/languageforge/lexicon/lexicon-new-project.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/lexicon-new-project.e2e-spec.ts
@@ -13,205 +13,205 @@ describe('Lexicon E2E New Project wizard app', () => {
   const page = new NewLexProjectPage();
   const CHECK_PAUSE = 1000;
 
-  it('admin can get to wizard', () => {
-    loginPage.loginAsAdmin();
-    NewLexProjectPage.get();
-    expect(page.newLexProjectForm).toBeDefined();
-    expect<any>(page.chooserPage.createButton.isDisplayed()).toBe(true);
+  it('admin can get to wizard', async () => {
+    await loginPage.loginAsAdmin();
+    await NewLexProjectPage.get();
+    expect(await page.newLexProjectForm).toBeDefined();
+    expect<any>(await page.chooserPage.createButton.isDisplayed()).toBe(true);
   });
 
-  it('manager can get to wizard', () => {
-    loginPage.loginAsManager();
-    NewLexProjectPage.get();
-    expect(page.newLexProjectForm).toBeDefined();
-    expect<any>(page.chooserPage.createButton.isDisplayed()).toBe(true);
+  it('manager can get to wizard', async () => {
+    await loginPage.loginAsManager();
+    await NewLexProjectPage.get();
+    expect(await page.newLexProjectForm).toBeDefined();
+    expect<any>(await page.chooserPage.createButton.isDisplayed()).toBe(true);
   });
 
-  it('setup: user login and page contains a form', () => {
-    loginPage.loginAsUser();
-    NewLexProjectPage.get();
-    expect(page.newLexProjectForm).toBeDefined();
-    expect<any>(page.chooserPage.createButton.isDisplayed()).toBe(true);
+  it('setup: user login and page contains a form', async () => {
+    await loginPage.loginAsUser();
+    await NewLexProjectPage.get();
+    expect(await page.newLexProjectForm).toBeDefined();
+    expect<any>(await page.chooserPage.createButton.isDisplayed()).toBe(true);
   });
 
   describe('Chooser page', () => {
 
-    it('cannot see Back or Next buttons', () => {
-      expect<any>(page.backButton.isDisplayed()).toBe(false);
-      expect<any>(page.nextButton.isDisplayed()).toBe(false);
-      page.formStatus.expectHasNoError();
+    it('cannot see Back or Next buttons', async () => {
+      expect<any>(await page.backButton.isDisplayed()).toBe(false);
+      expect<any>(await page.nextButton.isDisplayed()).toBe(false);
+      await page.formStatus.expectHasNoError();
     });
 
-    it('can create a new project', () => {
-      expect<any>(page.chooserPage.createButton.isEnabled()).toBe(true);
-      page.chooserPage.createButton.click();
-      expect<any>(page.namePage.projectNameInput.isDisplayed()).toBe(true);
+    it('can create a new project', async () => {
+      expect<any>(await page.chooserPage.createButton.isEnabled()).toBe(true);
+      await page.chooserPage.createButton.click();
+      expect<any>(await page.namePage.projectNameInput.isDisplayed()).toBe(true);
     });
 
-    it('can go back to Chooser page', () => {
-      expect<any>(page.backButton.isDisplayed()).toBe(true);
-      page.backButton.click();
-      expect<any>(page.chooserPage.sendReceiveButton.isDisplayed()).toBe(true);
+    it('can go back to Chooser page', async () => {
+      expect<any>(await page.backButton.isDisplayed()).toBe(true);
+      await page.backButton.click();
+      expect<any>(await page.chooserPage.sendReceiveButton.isDisplayed()).toBe(true);
     });
 
-    it('can select Send and Receive', () => {
-      expect<any>(page.chooserPage.sendReceiveButton.isEnabled()).toBe(true);
-      page.chooserPage.sendReceiveButton.click();
-      expect<any>(page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
+    it('can select Send and Receive', async () => {
+      expect<any>(await page.chooserPage.sendReceiveButton.isEnabled()).toBe(true);
+      await page.chooserPage.sendReceiveButton.click();
+      expect<any>(await page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
     });
 
-    it('can go back to Chooser page', () => {
-      expect<any>(page.backButton.isDisplayed()).toBe(true);
-      page.backButton.click();
-      expect<any>(page.chooserPage.sendReceiveButton.isDisplayed()).toBe(true);
+    it('can go back to Chooser page', async () => {
+      expect<any>(await page.backButton.isDisplayed()).toBe(true);
+      await page.backButton.click();
+      expect<any>(await page.chooserPage.sendReceiveButton.isDisplayed()).toBe(true);
     });
 
   });
 
   describe('Send Receive Credentials page', () => {
 
-    it('can get back to Send and Receive Credentials page', () => {
-      page.chooserPage.sendReceiveButton.click();
-      expect<any>(page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.loginInput.getAttribute('value')).toEqual(constants.memberUsername);
-      expect<any>(page.srCredentialsPage.passwordInput.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
+    it('can get back to Send and Receive Credentials page', async () => {
+      await page.chooserPage.sendReceiveButton.click();
+      expect<any>(await page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.loginInput.getAttribute('value')).toEqual(constants.memberUsername);
+      expect<any>(await page.srCredentialsPage.passwordInput.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
     });
 
-    it('cannot move on if Password is empty', () => {
-      page.formStatus.expectHasNoError();
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.nextButton.click();
-      expect<any>(page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
-      page.formStatus.expectContainsError('Password cannot be empty.');
+    it('cannot move on if Password is empty', async () => {
+      await page.formStatus.expectHasNoError();
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.nextButton.click();
+      expect<any>(await page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
+      await page.formStatus.expectContainsError('Password cannot be empty.');
     });
 
-    it('cannot move on if username is incorrect', () => {
+    it('cannot move on if username is incorrect', async () => {
       // passwordInvalid is, incredibly, an invalid password.
       // It's valid only in the sense that it follows the password rules
-      page.srCredentialsPage.passwordInput.sendKeys(constants.passwordValid);
-      browser.wait(ExpectedConditions.visibilityOf(page.srCredentialsPage.credentialsInvalid),
+      await page.srCredentialsPage.passwordInput.sendKeys(constants.passwordValid);
+      await browser.wait(ExpectedConditions.visibilityOf(page.srCredentialsPage.credentialsInvalid),
         constants.conditionTimeout);
-      expect<any>(page.srCredentialsPage.credentialsInvalid.isDisplayed()).toBe(true);
-      page.formStatus.expectHasNoError();
-      page.nextButton.click();
-      expect<any>(page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
-      page.formStatus.expectContainsError('The username or password isn\'t valid on LanguageDepot.org.');
+      expect<any>(await page.srCredentialsPage.credentialsInvalid.isDisplayed()).toBe(true);
+      await page.formStatus.expectHasNoError();
+      await page.nextButton.click();
+      expect<any>(await page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
+      await page.formStatus.expectContainsError('The username or password isn\'t valid on LanguageDepot.org.');
     });
 
-    it('can go back to Chooser page, user and pass preserved', () => {
-      expect<any>(page.backButton.isDisplayed()).toBe(true);
-      page.backButton.click();
-      expect<any>(page.chooserPage.sendReceiveButton.isDisplayed()).toBe(true);
-      page.chooserPage.sendReceiveButton.click();
-      expect<any>(page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
-      expect(page.srCredentialsPage.loginInput.getAttribute('value')).toEqual(constants.memberUsername);
-      expect(page.srCredentialsPage.passwordInput.getAttribute('value')).toEqual(constants.passwordValid);
-      page.srCredentialsPage.passwordInput.clear();
+    it('can go back to Chooser page, user and pass preserved', async () => {
+      expect<any>(await page.backButton.isDisplayed()).toBe(true);
+      await page.backButton.click();
+      expect<any>(await page.chooserPage.sendReceiveButton.isDisplayed()).toBe(true);
+      await page.chooserPage.sendReceiveButton.click();
+      expect<any>(await page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
+      expect(await page.srCredentialsPage.loginInput.getAttribute('value')).toEqual(constants.memberUsername);
+      expect(await page.srCredentialsPage.passwordInput.getAttribute('value')).toEqual(constants.passwordValid);
+      await page.srCredentialsPage.passwordInput.clear();
     });
 
-    it('cannot move on if Login is empty', () => {
-      page.srCredentialsPage.loginInput.clear();
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.nextButton.click();
-      expect<any>(page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
-      page.formStatus.expectContainsError('Login cannot be empty.');
+    it('cannot move on if Login is empty', async () => {
+      await page.srCredentialsPage.loginInput.clear();
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.nextButton.click();
+      expect<any>(await page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
+      await page.formStatus.expectContainsError('Login cannot be empty.');
     });
 
-    it('cannot move on if credentials are invalid', () => {
-      page.srCredentialsPage.loginInput.sendKeys(constants.srUsername);
-      page.srCredentialsPage.passwordInput.sendKeys(constants.passwordValid);
-      browser.wait(ExpectedConditions.visibilityOf(page.srCredentialsPage.credentialsInvalid),
+    it('cannot move on if credentials are invalid', async () => {
+      await page.srCredentialsPage.loginInput.sendKeys(constants.srUsername);
+      await page.srCredentialsPage.passwordInput.sendKeys(constants.passwordValid);
+      await browser.wait(ExpectedConditions.visibilityOf(page.srCredentialsPage.credentialsInvalid),
         constants.conditionTimeout);
-      expect<any>(page.srCredentialsPage.loginOk.isPresent()).toBe(false);
-      browser.wait(ExpectedConditions.visibilityOf(page.srCredentialsPage.credentialsInvalid),
+      expect<any>(await page.srCredentialsPage.loginOk.isPresent()).toBe(false);
+      await browser.wait(ExpectedConditions.visibilityOf(page.srCredentialsPage.credentialsInvalid),
         constants.conditionTimeout);
-      expect<any>(page.srCredentialsPage.credentialsInvalid.isDisplayed()).toBe(true);
-      page.formStatus.expectHasNoError();
-      page.nextButton.click();
-      expect<any>(page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
+      expect<any>(await page.srCredentialsPage.credentialsInvalid.isDisplayed()).toBe(true);
+      await page.formStatus.expectHasNoError();
+      await page.nextButton.click();
+      expect<any>(await page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.projectSelect().isPresent()).toBe(false);
     });
 
-    it('can move on when the credentials are valid', () => {
-      page.srCredentialsPage.passwordInput.clear();
-      page.srCredentialsPage.passwordInput.sendKeys(constants.srPassword);
-      browser.wait(ExpectedConditions.visibilityOf(page.srCredentialsPage.passwordOk), constants.conditionTimeout);
-      expect<any>(page.srCredentialsPage.loginOk.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.passwordOk.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.projectSelect().isDisplayed()).toBe(true);
-      page.formStatus.expectHasNoError();
+    it('can move on when the credentials are valid', async () => {
+      await page.srCredentialsPage.passwordInput.clear();
+      await page.srCredentialsPage.passwordInput.sendKeys(constants.srPassword);
+      await browser.wait(ExpectedConditions.visibilityOf(page.srCredentialsPage.passwordOk), constants.conditionTimeout);
+      expect<any>(await page.srCredentialsPage.loginOk.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.passwordOk.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.projectSelect().isDisplayed()).toBe(true);
+      await page.formStatus.expectHasNoError();
     });
 
-    it('cannot move on if no project is selected', () => {
-      page.nextButton.click();
-      expect<any>(page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
-      expect<any>(page.srCredentialsPage.projectSelect().isDisplayed()).toBe(true);
-      page.formStatus.expectContainsError('Please select a Project.');
+    it('cannot move on if no project is selected', async () => {
+      await page.nextButton.click();
+      expect<any>(await page.srCredentialsPage.loginInput.isDisplayed()).toBe(true);
+      expect<any>(await page.srCredentialsPage.projectSelect().isDisplayed()).toBe(true);
+      await page.formStatus.expectContainsError('Please select a Project.');
     });
 
-    it('cannot move on if not a manager of the project', () => {
-      Utils.clickDropdownByValue(page.srCredentialsPage.projectSelect(), 'mock-name2');
-      expect<any>(page.srCredentialsPage.projectNoAccess.isDisplayed()).toBe(true);
-      page.formStatus.expectContainsError('select a Project that you are the Manager of');
+    it('cannot move on if not a manager of the project', async () => {
+      await Utils.clickDropdownByValue(page.srCredentialsPage.projectSelect(), 'mock-name2');
+      expect<any>(await page.srCredentialsPage.projectNoAccess.isDisplayed()).toBe(true);
+      await page.formStatus.expectContainsError('select a Project that you are the Manager of');
     });
 
-    it('can move on when a managed project is selected', () => {
-      Utils.clickDropdownByValue(page.srCredentialsPage.projectSelect(), 'mock-name4');
-      expect<any>(page.srCredentialsPage.projectOk.isDisplayed()).toBe(true);
-      page.formStatus.expectHasNoError();
-      page.expectFormIsValid();
+    it('can move on when a managed project is selected', async () => {
+      await Utils.clickDropdownByValue(page.srCredentialsPage.projectSelect(), 'mock-name4');
+      expect<any>(await page.srCredentialsPage.projectOk.isDisplayed()).toBe(true);
+      await page.formStatus.expectHasNoError();
+      await page.expectFormIsValid();
     });
 
   });
 
   describe('Send Receive Verify page', () => {
 
-    it('can clone project', () => {
-      page.nextButton.click();
-      browser.wait(ExpectedConditions.visibilityOf(page.srClonePage.cloning), constants.conditionTimeout);
-      expect<any>(page.srClonePage.cloning.isDisplayed()).toBe(true);
+    it('can clone project', async () => {
+      await page.nextButton.click();
+      await browser.wait(ExpectedConditions.visibilityOf(page.srClonePage.cloning), constants.conditionTimeout);
+      expect<any>(await page.srClonePage.cloning.isDisplayed()).toBe(true);
     });
 
-    it('cannot move on while cloning', () => {
-      expect<any>(page.nextButton.isDisplayed()).toBe(false);
-      expect<any>(page.nextButton.isEnabled()).toBe(false);
-      page.expectFormIsNotValid();
+    it('cannot move on while cloning', async () => {
+      expect<any>(await page.nextButton.isDisplayed()).toBe(false);
+      expect<any>(await page.nextButton.isEnabled()).toBe(false);
+      await page.expectFormIsNotValid();
     });
 
   });
 
   describe('New Project Name page', () => {
 
-    it('can create a new project', () => {
-      NewLexProjectPage.get();
-      page.chooserPage.createButton.click();
-      expect<any>(page.namePage.projectNameInput.isPresent()).toBe(true);
+    it('can create a new project', async () => {
+      await NewLexProjectPage.get();
+      await page.chooserPage.createButton.click();
+      expect<any>(await page.namePage.projectNameInput.isPresent()).toBe(true);
     });
 
-    it('cannot move on if name is invalid', () => {
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.nextButton.click();
-      expect<any>(page.namePage.projectNameInput.isPresent()).toBe(true);
-      page.formStatus.expectContainsError('Project Name cannot be empty.');
+    it('cannot move on if name is invalid', async () => {
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.nextButton.click();
+      expect<any>(await page.namePage.projectNameInput.isPresent()).toBe(true);
+      await page.formStatus.expectContainsError('Project Name cannot be empty.');
     });
 
-    it('finds the test project already exists', () => {
-      page.namePage.projectNameInput.sendKeys(constants.testProjectName + Key.TAB);
-      browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeExists), constants.conditionTimeout);
-      expect<any>(page.namePage.projectCodeExists.isDisplayed()).toBe(true);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeOk.isPresent()).toBe(false);
-      expect(page.namePage.projectCodeInput.getAttribute('value')).toEqual(constants.testProjectCode);
-      page.formStatus.expectContainsError('Another project with code \'' + constants.testProjectCode +
+    it('finds the test project already exists', async () => {
+      await page.namePage.projectNameInput.sendKeys(constants.testProjectName + Key.TAB);
+      await browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeExists), constants.conditionTimeout);
+      expect<any>(await page.namePage.projectCodeExists.isDisplayed()).toBe(true);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeOk.isPresent()).toBe(false);
+      expect(await page.namePage.projectCodeInput.getAttribute('value')).toEqual(constants.testProjectCode);
+      await page.formStatus.expectContainsError('Another project with code \'' + constants.testProjectCode +
         '\' already exists.');
     });
 
-    it('with a cleared name does not show an error but is still invalid', () => {
+    it('with a cleared name does not show an error but is still invalid', async () => {
 
       /**
        * FIXME: added the following two lines so the test will work (previous error wasn't clearing)
@@ -219,225 +219,225 @@ describe('Lexicon E2E New Project wizard app', () => {
        * however is likely symptomatic of some funkiness with promises. IJH 2014-12
        */
 
-      page.namePage.projectNameInput.sendKeys('a' + Key.TAB);
-      page.namePage.projectNameInput.clear();
-      page.namePage.projectNameInput.sendKeys(Key.TAB);
-      browser.sleep(CHECK_PAUSE);
-      expect<any>(page.namePage.projectCodeExists.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeOk.isPresent()).toBe(false);
-      page.formStatus.expectHasNoError();
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.nextButton.click();
-      expect<any>(page.namePage.projectNameInput.isPresent()).toBe(true);
-      page.formStatus.expectContainsError('Project Name cannot be empty.');
+      await page.namePage.projectNameInput.sendKeys('a' + Key.TAB);
+      await page.namePage.projectNameInput.clear();
+      await page.namePage.projectNameInput.sendKeys(Key.TAB);
+      await browser.sleep(CHECK_PAUSE);
+      expect<any>(await page.namePage.projectCodeExists.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeOk.isPresent()).toBe(false);
+      await page.formStatus.expectHasNoError();
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.nextButton.click();
+      expect<any>(await page.namePage.projectNameInput.isPresent()).toBe(true);
+      await page.formStatus.expectContainsError('Project Name cannot be empty.');
     });
 
-    it('can verify that an unused project name is available', () => {
-      page.namePage.projectNameInput.sendKeys(constants.newProjectName + Key.TAB);
-      browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeOk),
+    it('can verify that an unused project name is available', async () => {
+      await page.namePage.projectNameInput.sendKeys(constants.newProjectName + Key.TAB);
+      await browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeOk),
         constants.conditionTimeout);
-      expect<any>(page.namePage.projectCodeOk.isDisplayed()).toBe(true);
-      expect<any>(page.namePage.projectCodeExists.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeInput.getAttribute('value')).toEqual(constants.newProjectCode);
-      page.formStatus.expectHasNoError();
+      expect<any>(await page.namePage.projectCodeOk.isDisplayed()).toBe(true);
+      expect<any>(await page.namePage.projectCodeExists.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeInput.getAttribute('value')).toEqual(constants.newProjectCode);
+      await page.formStatus.expectHasNoError();
     });
 
-    it('can not edit project code by default', () => {
-      expect<any>(page.namePage.projectCodeInput.isDisplayed()).toBe(false);
+    it('can not edit project code by default', async () => {
+      expect<any>(await page.namePage.projectCodeInput.isDisplayed()).toBe(false);
     });
 
-    it('can edit project code when enabled', () => {
-      expect<any>(page.namePage.editProjectCodeCheckbox.isDisplayed()).toBe(true);
-      util.setCheckbox(page.namePage.editProjectCodeCheckbox, true);
-      expect<any>(page.namePage.projectCodeInput.isDisplayed()).toBe(true);
-      page.namePage.projectCodeInput.clear();
-      page.namePage.projectCodeInput.sendKeys('changed_new_project');
-      page.namePage.projectNameInput.sendKeys(Key.TAB);     // trigger project code check
-      expect<any>(page.namePage.projectCodeInput.getAttribute('value')).toEqual('changed_new_project');
-      page.formStatus.expectHasNoError();
+    it('can edit project code when enabled', async () => {
+      expect<any>(await page.namePage.editProjectCodeCheckbox.isDisplayed()).toBe(true);
+      await util.setCheckbox(page.namePage.editProjectCodeCheckbox, true);
+      expect<any>(await page.namePage.projectCodeInput.isDisplayed()).toBe(true);
+      await page.namePage.projectCodeInput.clear();
+      await page.namePage.projectCodeInput.sendKeys('changed_new_project');
+      await page.namePage.projectNameInput.sendKeys(Key.TAB);     // trigger project code check
+      expect<any>(await page.namePage.projectCodeInput.getAttribute('value')).toEqual('changed_new_project');
+      await page.formStatus.expectHasNoError();
     });
 
-    it('project code cannot be empty; does not show an error but is still invalid', () => {
-      page.namePage.projectCodeInput.clear();
-      page.namePage.projectNameInput.sendKeys(Key.TAB);     // trigger project code check
-      browser.sleep(CHECK_PAUSE);
-      expect<any>(page.namePage.projectCodeExists.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeOk.isPresent()).toBe(false);
-      page.formStatus.expectHasNoError();
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.nextButton.click();
-      expect<any>(page.namePage.projectNameInput.isPresent()).toBe(true);
-      page.formStatus.expectContainsError('Project Code cannot be empty.');
+    it('project code cannot be empty; does not show an error but is still invalid', async () => {
+      await page.namePage.projectCodeInput.clear();
+      await page.namePage.projectNameInput.sendKeys(Key.TAB);     // trigger project code check
+      await browser.sleep(CHECK_PAUSE);
+      expect<any>(await page.namePage.projectCodeExists.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeOk.isPresent()).toBe(false);
+      await page.formStatus.expectHasNoError();
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.nextButton.click();
+      expect<any>(await page.namePage.projectNameInput.isPresent()).toBe(true);
+      await page.formStatus.expectContainsError('Project Code cannot be empty.');
     });
 
-    it('project code can be one character', () => {
-      page.namePage.projectCodeInput.clear();
-      page.namePage.projectCodeInput.sendKeys('a');
-      page.namePage.projectNameInput.sendKeys(Key.TAB);     // trigger project code check
-      browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeOk), constants.conditionTimeout);
-      expect<any>(page.namePage.projectCodeExists.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeOk.isDisplayed()).toBe(true);
-      page.formStatus.expectHasNoError();
+    it('project code can be one character', async () => {
+      await page.namePage.projectCodeInput.clear();
+      await page.namePage.projectCodeInput.sendKeys('a');
+      await page.namePage.projectNameInput.sendKeys(Key.TAB);     // trigger project code check
+      await browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeOk), constants.conditionTimeout);
+      expect<any>(await page.namePage.projectCodeExists.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeOk.isDisplayed()).toBe(true);
+      await page.formStatus.expectHasNoError();
     });
 
-    it('project code cannot be uppercase', () => {
-      page.namePage.projectCodeInput.clear();
-      page.namePage.projectCodeInput.sendKeys('A' + Key.TAB);
-      browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeAlphanumeric), constants.conditionTimeout);
-      expect<any>(page.namePage.projectCodeExists.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isDisplayed()).toBe(true);
-      expect<any>(page.namePage.projectCodeOk.isPresent()).toBe(false);
-      page.formStatus.expectHasNoError();
-      page.nextButton.click();
-      page.formStatus.expectContainsError('Project Code must begin with a letter');
-      page.namePage.projectCodeInput.clear();
-      page.namePage.projectCodeInput.sendKeys('aB' + Key.TAB);
-      browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeAlphanumeric), constants.conditionTimeout);
-      expect<any>(page.namePage.projectCodeExists.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isDisplayed()).toBe(true);
-      expect<any>(page.namePage.projectCodeOk.isPresent()).toBe(false);
-      page.formStatus.expectHasNoError();
-      page.nextButton.click();
-      page.formStatus.expectContainsError('Project Code must begin with a letter');
+    it('project code cannot be uppercase', async () => {
+      await page.namePage.projectCodeInput.clear();
+      await page.namePage.projectCodeInput.sendKeys('A' + Key.TAB);
+      await browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeAlphanumeric), constants.conditionTimeout);
+      expect<any>(await page.namePage.projectCodeExists.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isDisplayed()).toBe(true);
+      expect<any>(await page.namePage.projectCodeOk.isPresent()).toBe(false);
+      await page.formStatus.expectHasNoError();
+      await page.nextButton.click();
+      await page.formStatus.expectContainsError('Project Code must begin with a letter');
+      await page.namePage.projectCodeInput.clear();
+      await page.namePage.projectCodeInput.sendKeys('aB' + Key.TAB);
+      await browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeAlphanumeric), constants.conditionTimeout);
+      expect<any>(await page.namePage.projectCodeExists.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isDisplayed()).toBe(true);
+      expect<any>(await page.namePage.projectCodeOk.isPresent()).toBe(false);
+      await page.formStatus.expectHasNoError();
+      await page.nextButton.click();
+      await page.formStatus.expectContainsError('Project Code must begin with a letter');
     });
 
-    it('project code cannot start with a number', () => {
-      page.namePage.projectCodeInput.clear();
-      page.namePage.projectCodeInput.sendKeys('1' + Key.TAB);
-      browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeAlphanumeric), constants.conditionTimeout);
-      expect<any>(page.namePage.projectCodeExists.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isDisplayed()).toBe(true);
-      expect<any>(page.namePage.projectCodeOk.isPresent()).toBe(false);
-      page.formStatus.expectHasNoError();
-      page.nextButton.click();
-      page.formStatus.expectContainsError('Project Code must begin with a letter');
+    it('project code cannot start with a number', async () => {
+      await page.namePage.projectCodeInput.clear();
+      await page.namePage.projectCodeInput.sendKeys('1' + Key.TAB);
+      await browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeAlphanumeric), constants.conditionTimeout);
+      expect<any>(await page.namePage.projectCodeExists.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isDisplayed()).toBe(true);
+      expect<any>(await page.namePage.projectCodeOk.isPresent()).toBe(false);
+      await page.formStatus.expectHasNoError();
+      await page.nextButton.click();
+      await page.formStatus.expectContainsError('Project Code must begin with a letter');
     });
 
-    it('project code cannot use non-alphanumeric', () => {
-      page.namePage.projectCodeInput.clear();
-      page.namePage.projectCodeInput.sendKeys('a?' + Key.TAB);
-      browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeAlphanumeric), constants.conditionTimeout);
-      expect<any>(page.namePage.projectCodeExists.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isDisplayed()).toBe(true);
-      expect<any>(page.namePage.projectCodeOk.isPresent()).toBe(false);
-      page.formStatus.expectHasNoError();
-      page.nextButton.click();
-      page.formStatus.expectContainsError('Project Code must begin with a letter');
+    it('project code cannot use non-alphanumeric', async () => {
+      await page.namePage.projectCodeInput.clear();
+      await page.namePage.projectCodeInput.sendKeys('a?' + Key.TAB);
+      await browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeAlphanumeric), constants.conditionTimeout);
+      expect<any>(await page.namePage.projectCodeExists.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isDisplayed()).toBe(true);
+      expect<any>(await page.namePage.projectCodeOk.isPresent()).toBe(false);
+      await page.formStatus.expectHasNoError();
+      await page.nextButton.click();
+      await page.formStatus.expectContainsError('Project Code must begin with a letter');
     });
 
-    it('project code reverts to default when Edit-project-code is disabled', () => {
-      expect<any>(page.namePage.editProjectCodeCheckbox.isDisplayed()).toBe(true);
-      util.setCheckbox(page.namePage.editProjectCodeCheckbox, false);
-      expect<any>(page.namePage.projectCodeInput.isDisplayed()).toBe(false);
-      expect(page.namePage.projectCodeInput.getAttribute('value')).toEqual(constants.newProjectCode);
-      page.formStatus.expectHasNoError();
+    it('project code reverts to default when Edit-project-code is disabled', async () => {
+      expect<any>(await page.namePage.editProjectCodeCheckbox.isDisplayed()).toBe(true);
+      await util.setCheckbox(page.namePage.editProjectCodeCheckbox, false);
+      expect<any>(await page.namePage.projectCodeInput.isDisplayed()).toBe(false);
+      expect(await page.namePage.projectCodeInput.getAttribute('value')).toEqual(constants.newProjectCode);
+      await page.formStatus.expectHasNoError();
     });
 
-    it('can create project', () => {
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.expectFormIsValid();
-      page.nextButton.click();
-      expect<any>(page.namePage.projectNameInput.isPresent()).toBe(false);
-      expect<any>(page.initialDataPage.browseButton.isPresent()).toBe(true);
-      page.formStatus.expectHasNoError();
+    it('can create project', async () => {
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.expectFormIsValid();
+      await page.nextButton.click();
+      expect<any>(await page.namePage.projectNameInput.isPresent()).toBe(false);
+      expect<any>(await page.initialDataPage.browseButton.isPresent()).toBe(true);
+      await page.formStatus.expectHasNoError();
     });
 
   });
 
   describe('Initial Data page with upload', () => {
 
-    it('cannot see back button and defaults to uploading data', () => {
-      expect<any>(page.backButton.isDisplayed()).toBe(false);
-      expect<any>(page.initialDataPage.browseButton.isDisplayed()).toBe(true);
-      expect<any>(page.progressIndicatorStep3Label.getText()).toEqual('Verify');
-      page.expectFormIsNotValid();
-      page.formStatus.expectHasNoError();
+    it('cannot see back button and defaults to uploading data', async () => {
+      expect<any>(await page.backButton.isDisplayed()).toBe(false);
+      expect<any>(await page.initialDataPage.browseButton.isDisplayed()).toBe(true);
+      expect<any>(await page.progressIndicatorStep3Label.getText()).toEqual('Verify');
+      await page.expectFormIsNotValid();
+      await page.formStatus.expectHasNoError();
     });
 
     describe('Mock file upload', () => {
 
-      it('cannot upload large file', () => {
-        page.initialDataPage.mockUpload.enableButton.click();
-        expect<any>(page.initialDataPage.mockUpload.fileNameInput.isPresent()).toBe(true);
-        expect<any>(page.initialDataPage.mockUpload.fileNameInput.isDisplayed()).toBe(true);
-        page.initialDataPage.mockUpload.fileNameInput.sendKeys(constants.testMockZipImportFile.name);
-        page.initialDataPage.mockUpload.fileSizeInput.sendKeys(134217728);
-        expect<any>(page.noticeList.count()).toBe(0);
-        page.initialDataPage.mockUpload.uploadButton.click();
-        expect<any>(page.initialDataPage.browseButton.isDisplayed()).toBe(true);
-        expect<any>(page.verifyDataPage.entriesImported.isPresent()).toBe(false);
-        expect<any>(page.noticeList.count()).toBe(1);
-        expect<any>(page.noticeList.get(0).getText()).toContain('is too large. It must be smaller than');
-        page.formStatus.expectHasNoError();
-        page.initialDataPage.mockUpload.fileNameInput.clear();
-        page.initialDataPage.mockUpload.fileSizeInput.clear();
-        page.firstNoticeCloseButton.click();
+      it('cannot upload large file', async () => {
+        await page.initialDataPage.mockUpload.enableButton.click();
+        expect<any>(await page.initialDataPage.mockUpload.fileNameInput.isPresent()).toBe(true);
+        expect<any>(await page.initialDataPage.mockUpload.fileNameInput.isDisplayed()).toBe(true);
+        await page.initialDataPage.mockUpload.fileNameInput.sendKeys(constants.testMockZipImportFile.name);
+        await page.initialDataPage.mockUpload.fileSizeInput.sendKeys(134217728);
+        expect<any>(await page.noticeList.count()).toBe(0);
+        await page.initialDataPage.mockUpload.uploadButton.click();
+        expect<any>(await page.initialDataPage.browseButton.isDisplayed()).toBe(true);
+        expect<any>(await page.verifyDataPage.entriesImported.isPresent()).toBe(false);
+        expect<any>(await page.noticeList.count()).toBe(1);
+        expect<any>(await page.noticeList.get(0).getText()).toContain('is too large. It must be smaller than');
+        await page.formStatus.expectHasNoError();
+        await page.initialDataPage.mockUpload.fileNameInput.clear();
+        await page.initialDataPage.mockUpload.fileSizeInput.clear();
+        await page.firstNoticeCloseButton.click();
       });
 
-      it('cannot upload jpg', () => {
-        page.initialDataPage.mockUpload.fileNameInput.sendKeys(constants.testMockJpgImportFile.name);
-        page.initialDataPage.mockUpload.fileSizeInput.sendKeys(constants.testMockJpgImportFile.size);
-        expect<any>(page.noticeList.count()).toBe(0);
-        page.initialDataPage.mockUpload.uploadButton.click();
-        expect<any>(page.initialDataPage.browseButton.isDisplayed()).toBe(true);
-        expect<any>(page.verifyDataPage.entriesImported.isPresent()).toBe(false);
-        expect<any>(page.noticeList.count()).toBe(1);
-        expect(page.noticeList.get(0).getText()).toContain(constants.testMockJpgImportFile.name +
+      it('cannot upload jpg', async () => {
+        await page.initialDataPage.mockUpload.fileNameInput.sendKeys(constants.testMockJpgImportFile.name);
+        await page.initialDataPage.mockUpload.fileSizeInput.sendKeys(constants.testMockJpgImportFile.size);
+        expect<any>(await page.noticeList.count()).toBe(0);
+        await page.initialDataPage.mockUpload.uploadButton.click();
+        expect<any>(await page.initialDataPage.browseButton.isDisplayed()).toBe(true);
+        expect<any>(await page.verifyDataPage.entriesImported.isPresent()).toBe(false);
+        expect<any>(await page.noticeList.count()).toBe(1);
+        expect(await page.noticeList.get(0).getText()).toContain(constants.testMockJpgImportFile.name +
           ' is not an allowed compressed file. Ensure the file is');
-        page.formStatus.expectHasNoError();
-        page.initialDataPage.mockUpload.fileNameInput.clear();
-        page.initialDataPage.mockUpload.fileSizeInput.clear();
-        page.firstNoticeCloseButton.click();
+        await page.formStatus.expectHasNoError();
+        await page.initialDataPage.mockUpload.fileNameInput.clear();
+        await page.initialDataPage.mockUpload.fileSizeInput.clear();
+        await page.firstNoticeCloseButton.click();
       });
 
-      it('can upload zip file', () => {
-        page.initialDataPage.mockUpload.fileNameInput.sendKeys(constants.testMockZipImportFile.name);
-        page.initialDataPage.mockUpload.fileSizeInput.sendKeys(constants.testMockZipImportFile.size);
-        expect<any>(page.noticeList.count()).toBe(0);
-        page.initialDataPage.mockUpload.uploadButton.click();
-        expect<any>(page.verifyDataPage.entriesImported.isDisplayed()).toBe(true);
-        expect<any>(page.noticeList.count()).toBe(1);
-        expect(page.noticeList.get(0).getText()).toContain('Successfully imported ' +
+      it('can upload zip file', async () => {
+        await page.initialDataPage.mockUpload.fileNameInput.sendKeys(constants.testMockZipImportFile.name);
+        await page.initialDataPage.mockUpload.fileSizeInput.sendKeys(constants.testMockZipImportFile.size);
+        expect<any>(await page.noticeList.count()).toBe(0);
+        await page.initialDataPage.mockUpload.uploadButton.click();
+        expect<any>(await page.verifyDataPage.entriesImported.isDisplayed()).toBe(true);
+        expect<any>(await page.noticeList.count()).toBe(1);
+        expect(await page.noticeList.get(0).getText()).toContain('Successfully imported ' +
           constants.testMockZipImportFile.name);
-        page.formStatus.expectHasNoError();
+        await page.formStatus.expectHasNoError();
       });
 
     });
 
   });
 
-  describe('Verify Data page', () => {
+  describe('Verify Data await page', () => {
 
-    it('displays stats', () => {
-      expect<any>(page.verifyDataPage.title.getText()).toEqual('Verify Data');
-      expect<any>(page.verifyDataPage.entriesImported.getText()).toEqual('2');
-      page.formStatus.expectHasNoError();
+    it('displays stats', async () => {
+      expect<any>(await page.verifyDataPage.title.getText()).toEqual('Verify Data');
+      expect<any>(await page.verifyDataPage.entriesImported.getText()).toEqual('2');
+      await page.formStatus.expectHasNoError();
     });
 
     // regression avoidance test - should not redirect when button is clicked
-    it('displays non-critical errors', () => {
-      expect<any>(page.verifyDataPage.importErrors.isPresent()).toBe(true);
-      expect<any>(page.verifyDataPage.importErrors.isDisplayed()).toBe(false);
-      page.verifyDataPage.nonCriticalErrorsButton.click();
-      expect<any>(page.verifyDataPage.title.getText()).toEqual('Verify Data');
-      page.formStatus.expectHasNoError();
-      expect<any>(page.verifyDataPage.importErrors.isDisplayed()).toBe(true);
-      expect(page.verifyDataPage.importErrors.getText())
+    it('displays non-critical errors', async () => {
+      expect<any>(await page.verifyDataPage.importErrors.isPresent()).toBe(true);
+      expect<any>(await page.verifyDataPage.importErrors.isDisplayed()).toBe(false);
+      await page.verifyDataPage.nonCriticalErrorsButton.click();
+      expect<any>(await page.verifyDataPage.title.getText()).toEqual('Verify Data');
+      await page.formStatus.expectHasNoError();
+      expect<any>(await page.verifyDataPage.importErrors.isDisplayed()).toBe(true);
+      expect(await page.verifyDataPage.importErrors.getText())
         .toContain('range file \'TestProj.lift-ranges\' was not found');
-      page.verifyDataPage.nonCriticalErrorsButton.click();
-      browser.wait(ExpectedConditions.invisibilityOf(page.verifyDataPage.importErrors), constants.conditionTimeout);
-      expect<any>(page.verifyDataPage.importErrors.isDisplayed()).toBe(false);
+      await page.verifyDataPage.nonCriticalErrorsButton.click();
+      await browser.wait(ExpectedConditions.invisibilityOf(page.verifyDataPage.importErrors), constants.conditionTimeout);
+      expect<any>(await page.verifyDataPage.importErrors.isDisplayed()).toBe(false);
     });
 
-    it('can go to lexicon', () => {
-      expect<any>(page.nextButton.isDisplayed()).toBe(true);
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.expectFormIsValid();
-      page.nextButton.click();
+    it('can go to lexicon', async () => {
+      expect<any>(await page.nextButton.isDisplayed()).toBe(true);
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.expectFormIsValid();
+      await page.nextButton.click();
       expect<any>(editorPage.browse.getEntryCount()).toBe(2);
     });
 
@@ -445,94 +445,94 @@ describe('Lexicon E2E New Project wizard app', () => {
 
   describe('New Empty Project Name page', () => {
 
-    it('create: new empty project', () => {
-      NewLexProjectPage.get();
-      page.chooserPage.createButton.click();
-      page.namePage.projectNameInput.sendKeys(constants.emptyProjectName + Key.TAB);
-      browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeOk), constants.conditionTimeout);
-      expect<any>(page.namePage.projectCodeExists.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
-      expect<any>(page.namePage.projectCodeOk.isDisplayed()).toBe(true);
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
+    it('create: new empty project', async () => {
+      await NewLexProjectPage.get();
+      await page.chooserPage.createButton.click();
+      await page.namePage.projectNameInput.sendKeys(constants.emptyProjectName + Key.TAB);
+      await browser.wait(ExpectedConditions.visibilityOf(page.namePage.projectCodeOk), constants.conditionTimeout);
+      expect<any>(await page.namePage.projectCodeExists.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeAlphanumeric.isPresent()).toBe(false);
+      expect<any>(await page.namePage.projectCodeOk.isDisplayed()).toBe(true);
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
 
       // added sleep to ensure state is stable so the next test passes (expectFormIsNotValid)
-      browser.sleep(500);
-      page.nextButton.click();
-      expect<any>(page.namePage.projectNameInput.isPresent()).toBe(false);
-      expect<any>(page.initialDataPage.browseButton.isPresent()).toBe(true);
+      await browser.sleep(500);
+      await page.nextButton.click();
+      expect<any>(await page.namePage.projectNameInput.isPresent()).toBe(false);
+      expect<any>(await page.initialDataPage.browseButton.isPresent()).toBe(true);
     });
 
   });
 
   describe('Initial Data page skipping upload', () => {
 
-    it('can skip uploading data', () => {
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.expectFormIsNotValid();
-      page.nextButton.click();
-      expect<any>(page.primaryLanguagePage.selectButton.isPresent()).toBe(true);
+    it('can skip uploading data', async () => {
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.expectFormIsNotValid();
+      await page.nextButton.click();
+      expect<any>(await page.primaryLanguagePage.selectButton.isPresent()).toBe(true);
     });
 
   });
 
   describe('Primary Language page', () => {
 
-    it('can go back to initial data page (then forward again)', () => {
-      expect<any>(page.backButton.isDisplayed()).toBe(true);
-      expect<any>(page.backButton.isEnabled()).toBe(true);
-      page.backButton.click();
-      expect<any>(page.initialDataPage.browseButton.isDisplayed()).toBe(true);
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.expectFormIsNotValid();
-      page.nextButton.click();
-      expect<any>(page.primaryLanguagePage.selectButton.isPresent()).toBe(true);
-      expect<any>(page.backButton.isDisplayed()).toBe(true);
+    it('can go back to initial data page (then forward again)', async () => {
+      expect<any>(await page.backButton.isDisplayed()).toBe(true);
+      expect<any>(await page.backButton.isEnabled()).toBe(true);
+      await page.backButton.click();
+      expect<any>(await page.initialDataPage.browseButton.isDisplayed()).toBe(true);
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.expectFormIsNotValid();
+      await page.nextButton.click();
+      expect<any>(await page.primaryLanguagePage.selectButton.isPresent()).toBe(true);
+      expect<any>(await page.backButton.isDisplayed()).toBe(true);
     });
 
-    it('cannot move on if language is not selected', () => {
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.expectFormIsNotValid();
-      page.nextButton.click();
-      expect<any>(page.primaryLanguagePage.selectButton.isPresent()).toBe(true);
-      page.formStatus.expectContainsError('Please select a primary language for the project.');
+    it('cannot move on if language is not selected', async () => {
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.expectFormIsNotValid();
+      await page.nextButton.click();
+      expect<any>(await page.primaryLanguagePage.selectButton.isPresent()).toBe(true);
+      await page.formStatus.expectContainsError('Please select a primary language for the project.');
     });
 
-    it('can select language', () => {
-      expect<any>(page.primaryLanguagePage.selectButton.isEnabled()).toBe(true);
-      page.primaryLanguagePage.selectButtonClick();
-      expect<any>(page.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(true);
+    it('can select language', async () => {
+      expect<any>(await page.primaryLanguagePage.selectButton.isEnabled()).toBe(true);
+      await page.primaryLanguagePage.selectButtonClick();
+      expect<any>(await page.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(true);
     });
 
     describe('Select Language modal', () => {
 
-      it('can search, select and add language', () => {
-        page.modal.selectLanguage.searchLanguageInput.sendKeys(constants.searchLanguage + Key.ENTER);
-        expect<any>(page.modal.selectLanguage.languageRows.first().isPresent()).toBe(true);
+      it('can search, select and add language', async () => {
+        await page.modal.selectLanguage.searchLanguageInput.sendKeys(constants.searchLanguage + Key.ENTER);
+        expect<any>(await page.modal.selectLanguage.languageRows.first().isPresent()).toBe(true);
 
-        expect<any>(page.modal.selectLanguage.addButton.isPresent()).toBe(true);
-        expect<any>(page.modal.selectLanguage.addButton.isEnabled()).toBe(false);
-        page.modal.selectLanguage.languageRows.first().click();
-        expect<any>(page.modal.selectLanguage.addButton.isEnabled()).toBe(true);
-        expect<any>(page.modal.selectLanguage.addButton.getText()).toEqual('Add ' + constants.foundLanguage);
+        expect<any>(await page.modal.selectLanguage.addButton.isPresent()).toBe(true);
+        expect<any>(await page.modal.selectLanguage.addButton.isEnabled()).toBe(false);
+        await page.modal.selectLanguage.languageRows.first().click();
+        expect<any>(await page.modal.selectLanguage.addButton.isEnabled()).toBe(true);
+        expect<any>(await page.modal.selectLanguage.addButton.getText()).toEqual('Add ' + constants.foundLanguage);
 
-        page.modal.selectLanguage.addButton.click();
-        browser.wait(ExpectedConditions.stalenessOf(page.modal.selectLanguage.searchLanguageInput),
+        await page.modal.selectLanguage.addButton.click();
+        await browser.wait(ExpectedConditions.stalenessOf(page.modal.selectLanguage.searchLanguageInput),
           constants.conditionTimeout);
-        expect<any>(page.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(false);
+        expect<any>(await page.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(false);
       });
 
     });
 
-    it('can go to lexicon and primary language has changed', () => {
-      page.formStatus.expectHasNoError();
-      expect<any>(page.nextButton.isEnabled()).toBe(true);
-      page.expectFormIsValid();
-      page.nextButton.click();
-      browser.wait(ExpectedConditions.visibilityOf(editorPage.browse.noEntriesElem), constants.conditionTimeout);
-      expect<any>(editorPage.browse.noEntriesElem.isDisplayed()).toBe(true);
-      editorPage.browse.noEntriesNewWordBtn.click();
-      expect<any>(editorPage.edit.getEntryCount()).toBe(1);
-      expect<any>(editorPage.edit.getLexemesAsObject()).toEqual({ es: '' });
+    it('can go to lexicon and primary language has changed', async () => {
+      await page.formStatus.expectHasNoError();
+      expect<any>(await page.nextButton.isEnabled()).toBe(true);
+      await page.expectFormIsValid();
+      await page.nextButton.click();
+      await browser.wait(ExpectedConditions.visibilityOf(editorPage.browse.noEntriesElem), constants.conditionTimeout);
+      expect<any>(await editorPage.browse.noEntriesElem.isDisplayed()).toBe(true);
+      await editorPage.browse.noEntriesNewWordBtn.click();
+      expect<any>(await editorPage.edit.getEntryCount()).toBe(1);
+      expect<any>(await editorPage.edit.getLexemesAsObject()).toEqual({ es: '' });
     });
 
   });

--- a/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
@@ -14,82 +14,82 @@ describe('Lexicon E2E Configuration Fields', () => {
   const configPage = new ConfigurationPage();
   const util = new Utils();
 
-  it('setup: login as manager, select test project and first entry', () => {
-    loginPage.loginAsManager();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    expect(editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
+  it('setup: login as manager, select test project and first entry', async () => {
+    await loginPage.loginAsManager();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    expect(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
   });
 
-  it('check first entry for field order', () => {
-    editorPage.edit.showHiddenFields();
-    expect<any>(editorPage.edit.getFieldLabel(0).getText()).toEqual('Word');
-    expect<any>(editorPage.edit.getFieldLabel(1).getText()).toEqual('Citation Form');
-    expect<any>(editorPage.edit.getFieldLabel(2).getText()).toEqual('Pronunciation');
+  it('check first entry for field order', async () => {
+    await editorPage.edit.showHiddenFields();
+    expect<any>(await editorPage.edit.getFieldLabel(0).getText()).toEqual('Word');
+    expect<any>(await editorPage.edit.getFieldLabel(1).getText()).toEqual('Citation Form');
+    expect<any>(await editorPage.edit.getFieldLabel(2).getText()).toEqual('Pronunciation');
   });
 
-  it('check first entry for field-specific input systems', () => {
+  it('check first entry for field-specific input systems', async () => {
     const citationFormLabel = 'Citation Form';
     const scientificNameLabel = 'Scientific Name';
-    expect<any>(editorPage.edit.getMultiTextInputSystems(citationFormLabel).count()).toEqual(1);
-    expect<any>(editorPage.edit.getMultiTextInputSystems(citationFormLabel).get(0).getText()).toEqual('th');
-    expect<any>(editorPage.edit.getMultiTextInputSystems(scientificNameLabel).count()).toEqual(1);
-    expect<any>(editorPage.edit.getMultiTextInputSystems(scientificNameLabel).get(0).getText()).toEqual('en');
+    expect<any>(await editorPage.edit.getMultiTextInputSystems(citationFormLabel).count()).toEqual(1);
+    expect<any>(await editorPage.edit.getMultiTextInputSystems(citationFormLabel).get(0).getText()).toEqual('th');
+    expect<any>(await editorPage.edit.getMultiTextInputSystems(scientificNameLabel).count()).toEqual(1);
+    expect<any>(await editorPage.edit.getMultiTextInputSystems(scientificNameLabel).get(0).getText()).toEqual('en');
   });
 
-  it('can go to Configuration and select unified Fields tab', () => {
-    expect<any>(configPage.settingsMenuLink.isDisplayed()).toBe(true);
-    configPage.get();
-    expect<any>(configPage.applyButton.isDisplayed()).toBe(true);
-    expect<any>(configPage.applyButton.isEnabled()).toBe(false);
-    configPage.tabs.unified.click();
-    expect<any>(configPage.unifiedPane.inputSystem.addInputSystemButton.isDisplayed()).toBe(true);
-    expect<any>(configPage.unifiedPane.entry.addCustomEntryButton.isDisplayed()).toBe(true);
-    expect<any>(configPage.unifiedPane.sense.addCustomSenseButton.isDisplayed()).toBe(true);
-    expect<any>(configPage.unifiedPane.example.addCustomExampleButton.isDisplayed()).toBe(true);
+  it('can go to Configuration and select unified Fields tab', async () => {
+    expect<any>(await configPage.settingsMenuLink.isDisplayed()).toBe(true);
+    await configPage.get();
+    expect<any>(await configPage.applyButton.isDisplayed()).toBe(true);
+    expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
+    await configPage.tabs.unified.click();
+    expect<any>(await configPage.unifiedPane.inputSystem.addInputSystemButton.isDisplayed()).toBe(true);
+    expect<any>(await configPage.unifiedPane.entry.addCustomEntryButton.isDisplayed()).toBe(true);
+    expect<any>(await configPage.unifiedPane.sense.addCustomSenseButton.isDisplayed()).toBe(true);
+    expect<any>(await configPage.unifiedPane.example.addCustomExampleButton.isDisplayed()).toBe(true);
   });
 
-  it('check Apply button is enabled on changes', () => {
-    expect<any>(configPage.applyButton.isEnabled()).toBe(false);
-    configPage.unifiedPane.observerCheckbox('English').click();
-    expect<any>(configPage.applyButton.isEnabled()).toBe(true);
-    configPage.unifiedPane.resetInputSystemButton('observer').click();
-    expect<any>(configPage.applyButton.isEnabled()).toBe(false);
+  it('check Apply button is enabled on changes', async () => {
+    expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
+    await configPage.unifiedPane.observerCheckbox('English').click();
+    expect<any>(await configPage.applyButton.isEnabled()).toBe(true);
+    await configPage.unifiedPane.resetInputSystemButton('observer').click();
+    expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
   });
 
   describe('Field-Specific Settings', () => {
 
-    it('check sense POS has no field-specific settings', () => {
+    it('check sense POS has no field-specific settings', async () => {
       const rowLabel = new RegExp('^Part of Speech$');
-      expect<any>(configPage.unifiedPane.fieldSpecificButton(rowLabel).isPresent()).toBe(false);
+      expect<any>(await configPage.unifiedPane.fieldSpecificButton(rowLabel).isPresent()).toBe(false);
     });
 
-    it('check sense Pictures "Caption Hidden if Empty" field-specific setting', () => {
+    it('check sense Pictures "Caption Hidden if Empty" field-specific setting', async () => {
       const rowLabel = new RegExp('^Pictures$');
-      expect<any>(configPage.unifiedPane.fieldSpecificButton(rowLabel).isDisplayed()).toBe(true);
-      expect<any>(configPage.unifiedPane.fieldSpecificIcon(rowLabel).getAttribute('class'))
+      expect<any>(await configPage.unifiedPane.fieldSpecificButton(rowLabel).isDisplayed()).toBe(true);
+      expect<any>(await configPage.unifiedPane.fieldSpecificIcon(rowLabel).getAttribute('class'))
         .toEqual('fa fa-chevron-down');
-      configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
-      expect<any>(configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox(rowLabel).isDisplayed()).toBe(true);
-      configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
-      expect<any>(configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox(rowLabel).isPresent()).toBe(false);
+      await configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
+      expect<any>(await configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox(rowLabel).isDisplayed()).toBe(true);
+      await configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
+      expect<any>(await configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox(rowLabel).isPresent()).toBe(false);
     });
 
-    it('check sense field-specific settings', () => {
+    it('check sense field-specific settings', async () => {
       const rowLabel = new RegExp('^Scientific Name$');
-      expect<any>(configPage.unifiedPane.fieldSpecificButton(rowLabel).isDisplayed()).toBe(true);
-      expect<any>(configPage.unifiedPane.fieldSpecificIcon(rowLabel).getAttribute('class'))
+      expect<any>(await configPage.unifiedPane.fieldSpecificButton(rowLabel).isDisplayed()).toBe(true);
+      expect<any>(await configPage.unifiedPane.fieldSpecificIcon(rowLabel).getAttribute('class'))
         .toEqual('fa fa-chevron-down');
-      configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
-      expect<any>(configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox(rowLabel).isPresent()).toBe(false);
-      configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
-      expect<any>(configPage.unifiedPane.fieldSpecificIcon(rowLabel).getAttribute('class'))
+      await configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
+      expect<any>(await configPage.unifiedPane.fieldSpecificCaptionHiddenIfEmptyCheckbox(rowLabel).isPresent()).toBe(false);
+      await configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
+      expect<any>(await configPage.unifiedPane.fieldSpecificIcon(rowLabel).getAttribute('class'))
         .toEqual('fa fa-chevron-down');
-      configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
-      util.setCheckbox(configPage.unifiedPane.sense.fieldSpecificInputSystemCheckbox(rowLabel, 1), true);
-      expect<any>(configPage.unifiedPane.sense.fieldSpecificInputSystemCheckbox(rowLabel, 0).isSelected()).toBe(true);
-      expect<any>(configPage.unifiedPane.sense.fieldSpecificInputSystemCheckbox(rowLabel, 1).isSelected()).toBe(true);
+      await configPage.unifiedPane.fieldSpecificButton(rowLabel).click();
+      await util.setCheckbox(configPage.unifiedPane.sense.fieldSpecificInputSystemCheckbox(rowLabel, 1), true);
+      expect<any>(await configPage.unifiedPane.sense.fieldSpecificInputSystemCheckbox(rowLabel, 0).isSelected()).toBe(true);
+      expect<any>(await configPage.unifiedPane.sense.fieldSpecificInputSystemCheckbox(rowLabel, 1).isSelected()).toBe(true);
     });
 
   });
@@ -99,373 +99,373 @@ describe('Lexicon E2E Configuration Fields', () => {
     // row, and Utils.simulateDragDrop uses the middle of a row, then set the target to one row above where you want it.
     // IJH 2018-03
 
-    it('can reorder Input System rows', () => {
-      expect<any>(configPage.unifiedPane.inputSystem.rowLabel(0).getText()).toEqual('English');
-      expect<any>(configPage.unifiedPane.inputSystem.rowLabel(1).getText()).toEqual('Thai');
-      expect<any>(configPage.unifiedPane.inputSystem.rowLabel(2).getText()).toEqual('Thai (IPA)');
-      browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.inputSystem.rows().get(2).getWebElement(),
+    it('can reorder Input System rows', async () => {
+      expect<any>(await configPage.unifiedPane.inputSystem.rowLabel(0).getText()).toEqual('English');
+      expect<any>(await configPage.unifiedPane.inputSystem.rowLabel(1).getText()).toEqual('Thai');
+      expect<any>(await configPage.unifiedPane.inputSystem.rowLabel(2).getText()).toEqual('Thai (IPA)');
+      await browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.inputSystem.rows().get(2).getWebElement(),
         configPage.unifiedPane.inputSystem.rows().get(0).getWebElement());
-      expect<any>(configPage.unifiedPane.inputSystem.rowLabel(0).getText()).toEqual('English');
-      expect<any>(configPage.unifiedPane.inputSystem.rowLabel(1).getText()).toEqual('Thai (IPA)');
-      expect<any>(configPage.unifiedPane.inputSystem.rowLabel(2).getText()).toEqual('Thai');
+      expect<any>(await configPage.unifiedPane.inputSystem.rowLabel(0).getText()).toEqual('English');
+      expect<any>(await configPage.unifiedPane.inputSystem.rowLabel(1).getText()).toEqual('Thai (IPA)');
+      expect<any>(await configPage.unifiedPane.inputSystem.rowLabel(2).getText()).toEqual('Thai');
     });
 
-    it('can reorder Entry rows', () => {
-      expect<any>(configPage.unifiedPane.entry.rowLabel(0).getText()).toEqual('Word');
-      expect<any>(configPage.unifiedPane.entry.rowLabel(1).getText()).toEqual('Citation Form');
-      expect<any>(configPage.unifiedPane.entry.rowLabel(2).getText()).toEqual('Pronunciation');
-      browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.entry.rows().get(2).getWebElement(),
+    it('can reorder Entry rows', async () => {
+      expect<any>(await configPage.unifiedPane.entry.rowLabel(0).getText()).toEqual('Word');
+      expect<any>(await configPage.unifiedPane.entry.rowLabel(1).getText()).toEqual('Citation Form');
+      expect<any>(await configPage.unifiedPane.entry.rowLabel(2).getText()).toEqual('Pronunciation');
+      await browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.entry.rows().get(2).getWebElement(),
         configPage.unifiedPane.entry.rows().get(0).getWebElement());
-      expect<any>(configPage.unifiedPane.entry.rowLabel(0).getText()).toEqual('Word');
-      expect<any>(configPage.unifiedPane.entry.rowLabel(1).getText()).toEqual('Pronunciation');
-      expect<any>(configPage.unifiedPane.entry.rowLabel(2).getText()).toEqual('Citation Form');
+      expect<any>(await configPage.unifiedPane.entry.rowLabel(0).getText()).toEqual('Word');
+      expect<any>(await configPage.unifiedPane.entry.rowLabel(1).getText()).toEqual('Pronunciation');
+      expect<any>(await configPage.unifiedPane.entry.rowLabel(2).getText()).toEqual('Citation Form');
     });
 
-    it('check first entry for changed field order', () => {
-      expect<any>(configPage.applyButton.isEnabled()).toBe(true);
-      configPage.applyButton.click();
-      expect<any>(configPage.applyButton.isEnabled()).toBe(false);
-      Utils.clickBreadcrumb(constants.testProjectName);
-      editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-      editorPage.edit.showHiddenFields();
-      expect<any>(editorPage.edit.getFieldLabel(0).getText()).toEqual('Word');
-      expect<any>(editorPage.edit.getFieldLabel(1).getText()).toEqual('Pronunciation');
-      expect<any>(editorPage.edit.getFieldLabel(2).getText()).toEqual('Citation Form');
+    it('check first entry for changed field order', async () => {
+      expect<any>(await configPage.applyButton.isEnabled()).toBe(true);
+      await configPage.applyButton.click();
+      expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
+      await Utils.clickBreadcrumb(constants.testProjectName);
+      await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+      await editorPage.edit.showHiddenFields();
+      expect<any>(await editorPage.edit.getFieldLabel(0).getText()).toEqual('Word');
+      expect<any>(await editorPage.edit.getFieldLabel(1).getText()).toEqual('Pronunciation');
+      expect<any>(await editorPage.edit.getFieldLabel(2).getText()).toEqual('Citation Form');
     });
 
-    it('check first entry for changed field-specific input systems', () => {
+    it('check first entry for changed field-specific input systems', async () => {
       const citationFormLabel = 'Citation Form';
       const scientificNameLabel = 'Scientific Name';
-      expect<any>(editorPage.edit.getMultiTextInputSystems(citationFormLabel).count()).toEqual(1);
-      expect<any>(editorPage.edit.getMultiTextInputSystems(citationFormLabel).get(0).getText()).toEqual('th');
-      expect<any>(editorPage.edit.getMultiTextInputSystems(scientificNameLabel).count()).toEqual(2);
-      expect<any>(editorPage.edit.getMultiTextInputSystems(scientificNameLabel).get(0).getText()).toEqual('en');
-      expect<any>(editorPage.edit.getMultiTextInputSystems(scientificNameLabel).get(1).getText()).toEqual('th');
-      configPage.get();
-      configPage.tabs.unified.click();
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(citationFormLabel).count()).toEqual(1);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(citationFormLabel).get(0).getText()).toEqual('th');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(scientificNameLabel).count()).toEqual(2);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(scientificNameLabel).get(0).getText()).toEqual('en');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(scientificNameLabel).get(1).getText()).toEqual('th');
+      await configPage.get();
+      await configPage.tabs.unified.click();
     });
 
-    it('can reorder Entry rows back to how they were', () => {
-      browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.entry.rows().get(2).getWebElement(),
-        configPage.unifiedPane.entry.rows().get(0).getWebElement());
-      expect<any>(configPage.unifiedPane.entry.rowLabel(0).getText()).toEqual('Word');
-      expect<any>(configPage.unifiedPane.entry.rowLabel(1).getText()).toEqual('Citation Form');
-      expect<any>(configPage.unifiedPane.entry.rowLabel(2).getText()).toEqual('Pronunciation');
-      configPage.applyButton.click();
+    it('can reorder Entry rows back to how they were', async () => {
+      await browser.executeScript(Utils.simulateDragDrop, await configPage.unifiedPane.entry.rows().get(2).getWebElement(),
+        await configPage.unifiedPane.entry.rows().get(0).getWebElement());
+      expect<any>(await configPage.unifiedPane.entry.rowLabel(0).getText()).toEqual('Word');
+      expect<any>(await configPage.unifiedPane.entry.rowLabel(1).getText()).toEqual('Citation Form');
+      expect<any>(await configPage.unifiedPane.entry.rowLabel(2).getText()).toEqual('Pronunciation');
+      await configPage.applyButton.click();
     });
 
-    it('can reorder Sense rows', () => {
-      expect<any>(configPage.unifiedPane.sense.rowLabel(0).getText()).toEqual('Gloss');
-      expect<any>(configPage.unifiedPane.sense.rowLabel(1).getText()).toEqual('Definition');
-      expect<any>(configPage.unifiedPane.sense.rowLabel(2).getText()).toEqual('Pictures');
-      browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.sense.rows().get(2).getWebElement(),
+    it('can reorder Sense rows', async () => {
+      expect<any>(await configPage.unifiedPane.sense.rowLabel(0).getText()).toEqual('Gloss');
+      expect<any>(await configPage.unifiedPane.sense.rowLabel(1).getText()).toEqual('Definition');
+      expect<any>(await configPage.unifiedPane.sense.rowLabel(2).getText()).toEqual('Pictures');
+      await browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.sense.rows().get(2).getWebElement(),
         configPage.unifiedPane.sense.rows().get(0).getWebElement());
-      expect<any>(configPage.unifiedPane.sense.rowLabel(0).getText()).toEqual('Gloss');
-      expect<any>(configPage.unifiedPane.sense.rowLabel(1).getText()).toEqual('Pictures');
-      expect<any>(configPage.unifiedPane.sense.rowLabel(2).getText()).toEqual('Definition');
+      expect<any>(await configPage.unifiedPane.sense.rowLabel(0).getText()).toEqual('Gloss');
+      expect<any>(await configPage.unifiedPane.sense.rowLabel(1).getText()).toEqual('Pictures');
+      expect<any>(await configPage.unifiedPane.sense.rowLabel(2).getText()).toEqual('Definition');
     });
 
-    it('can reorder Example rows', () => {
-      expect<any>(configPage.unifiedPane.example.rowLabel(0).getText()).toEqual('Sentence');
-      expect<any>(configPage.unifiedPane.example.rowLabel(1).getText()).toEqual('Translation');
-      expect<any>(configPage.unifiedPane.example.rowLabel(2).getText()).toEqual('Reference');
-      browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.example.rows().get(2).getWebElement(),
+    it('can reorder Example rows', async () => {
+      expect<any>(await configPage.unifiedPane.example.rowLabel(0).getText()).toEqual('Sentence');
+      expect<any>(await configPage.unifiedPane.example.rowLabel(1).getText()).toEqual('Translation');
+      expect<any>(await configPage.unifiedPane.example.rowLabel(2).getText()).toEqual('Reference');
+      await browser.executeScript(Utils.simulateDragDrop, configPage.unifiedPane.example.rows().get(2).getWebElement(),
         configPage.unifiedPane.example.rows().get(0).getWebElement());
-      expect<any>(configPage.unifiedPane.example.rowLabel(0).getText()).toEqual('Sentence');
-      expect<any>(configPage.unifiedPane.example.rowLabel(1).getText()).toEqual('Reference');
-      expect<any>(configPage.unifiedPane.example.rowLabel(2).getText()).toEqual('Translation');
+      expect<any>(await configPage.unifiedPane.example.rowLabel(0).getText()).toEqual('Sentence');
+      expect<any>(await configPage.unifiedPane.example.rowLabel(1).getText()).toEqual('Reference');
+      expect<any>(await configPage.unifiedPane.example.rowLabel(2).getText()).toEqual('Translation');
     });
 
   });
 
   describe('Select All for Columns', () => {
 
-    it('can fully function "Select All" down the Input System observer column', () => {
+    it('can fully function "Select All" down the Input System observer column', async () => {
       const column = 'observer';
       const rowLabel = 'English';
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), false);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
         .toBe(false);
-      util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.observer, false);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.observer, false);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
         .toBe(false);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.observer, true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(true);
-      configPage.unifiedPane.resetInputSystemButton('observer').click();
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.observer, true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(true);
+      await configPage.unifiedPane.resetInputSystemButton('observer').click();
     });
 
-    it('can select and de-select all down the Input System commenter column', () => {
+    it('can select and de-select all down the Input System commenter column', async () => {
       const column = 'commenter';
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.commenter.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.commenter.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.commenter, false);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.commenter.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.commenter, false);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.commenter.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.commenter, true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.commenter.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.commenter, true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.commenter.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      configPage.unifiedPane.resetInputSystemButton('commenter').click();
+      await configPage.unifiedPane.resetInputSystemButton('commenter').click();
     });
 
-    it('can select and de-select all down the Input System contributor column', () => {
+    it('can select and de-select all down the Input System contributor column', async () => {
       const column = 'contributor';
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.contributor.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.contributor.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.contributor, false);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.contributor.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.contributor, false);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.contributor.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.contributor, true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.contributor.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.contributor, true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.contributor.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      configPage.unifiedPane.resetInputSystemButton('contributor').click();
+      await configPage.unifiedPane.resetInputSystemButton('contributor').click();
     });
 
-    it('can select and de-select all down the Input System manager column', () => {
+    it('can select and de-select all down the Input System manager column', async () => {
       const column = 'manager';
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.manager.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.manager.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.manager, false);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.manager.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.manager, false);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.manager.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.manager, true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.manager.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.manager, true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.manager.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      configPage.unifiedPane.resetInputSystemButton('manager').click();
+      await configPage.unifiedPane.resetInputSystemButton('manager').click();
     });
 
-    it('can de-select and select all down the entry observer column', () => {
+    it('can de-select and select all down the entry observer column', async () => {
       const column = 'observer';
-      expect<any>(configPage.unifiedPane.entry.selectAll.observer.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.entry.selectAll.observer.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.entry.selectAll.observer, false);
-      expect<any>(configPage.unifiedPane.entry.selectAll.observer.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.entry.selectAll.observer, false);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.observer.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.entry.selectAll.observer, true);
-      expect<any>(configPage.unifiedPane.entry.selectAll.observer.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.entry.selectAll.observer, true);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.observer.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can fully function "Select All" down the entry commenter column', () => {
+    it('can fully function "Select All" down the entry commenter column', async () => {
       const column = 'commenter';
       const rowLabel = new RegExp('^Location$');
-      expect<any>(configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.entry.selectAll.commenter, false);
-      expect<any>(configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
+      expect<any>(await configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.entry.selectAll.commenter, false);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), true);
-      util.setCheckbox(configPage.unifiedPane.entry.selectAll.commenter, true);
-      expect<any>(configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), true);
+      await util.setCheckbox(configPage.unifiedPane.entry.selectAll.commenter, true);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), false);
-      expect<any>(configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
         .toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
         .toBe(false);
-      util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.commenter.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can de-select and select all down the entry contributor column', () => {
+    it('can de-select and select all down the entry contributor column', async () => {
       const column = 'contributor';
-      expect<any>(configPage.unifiedPane.entry.selectAll.contributor.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.entry.selectAll.contributor.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.entry.selectAll.contributor, false);
-      expect<any>(configPage.unifiedPane.entry.selectAll.contributor.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.entry.selectAll.contributor, false);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.contributor.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.entry.selectAll.contributor, true);
-      expect<any>(configPage.unifiedPane.entry.selectAll.contributor.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.entry.selectAll.contributor, true);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.contributor.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can de-select and select all down the entry manager column', () => {
+    it('can de-select and select all down the entry manager column', async () => {
       const column = 'manager';
-      expect<any>(configPage.unifiedPane.entry.selectAll.manager.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.entry.selectAll.manager.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.entry.selectAll.manager, false);
-      expect<any>(configPage.unifiedPane.entry.selectAll.manager.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.entry.selectAll.manager, false);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.manager.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.entry.selectAll.manager, true);
-      expect<any>(configPage.unifiedPane.entry.selectAll.manager.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.entry.selectAll.manager, true);
+      expect<any>(await configPage.unifiedPane.entry.selectAll.manager.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can de-select and select all down the sense observer column', () => {
+    it('can de-select and select all down the sense observer column', async () => {
       const column = 'observer';
-      expect<any>(configPage.unifiedPane.sense.selectAll.observer.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.sense.selectAll.observer.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.sense.selectAll.observer, false);
-      expect<any>(configPage.unifiedPane.sense.selectAll.observer.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.sense.selectAll.observer, false);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.observer.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.sense.selectAll.observer, true);
-      expect<any>(configPage.unifiedPane.sense.selectAll.observer.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.sense.selectAll.observer, true);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.observer.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can de-select and select all down the sense commenter column', () => {
+    it('can de-select and select all down the sense commenter column', async () => {
       const column = 'commenter';
-      expect<any>(configPage.unifiedPane.sense.selectAll.commenter.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.sense.selectAll.commenter.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.sense.selectAll.commenter, false);
-      expect<any>(configPage.unifiedPane.sense.selectAll.commenter.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.sense.selectAll.commenter, false);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.commenter.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.sense.selectAll.commenter, true);
-      expect<any>(configPage.unifiedPane.sense.selectAll.commenter.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.sense.selectAll.commenter, true);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.commenter.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can fully function "Select All" down the sense contributor column', () => {
+    it('can fully function "Select All" down the sense contributor column', async () => {
       const column = 'contributor';
       const rowLabel = new RegExp('^Scientific Name$');
-      expect<any>(configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.sense.selectAll.contributor, false);
-      expect<any>(configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
+      expect<any>(await configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.sense.selectAll.contributor, false);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), true);
-      util.setCheckbox(configPage.unifiedPane.sense.selectAll.contributor, true);
-      expect<any>(configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), true);
+      await util.setCheckbox(configPage.unifiedPane.sense.selectAll.contributor, true);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), false);
-      expect<any>(configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
         .toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
         .toBe(false);
-      util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.contributor.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can de-select and select all down the sense manager column', () => {
+    it('can de-select and select all down the sense manager column', async () => {
       const column = 'manager';
-      expect<any>(configPage.unifiedPane.sense.selectAll.manager.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.sense.selectAll.manager.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.sense.selectAll.manager, false);
-      expect<any>(configPage.unifiedPane.sense.selectAll.manager.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.sense.selectAll.manager, false);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.manager.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.sense.selectAll.manager, true);
-      expect<any>(configPage.unifiedPane.sense.selectAll.manager.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.sense.selectAll.manager, true);
+      expect<any>(await configPage.unifiedPane.sense.selectAll.manager.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can de-select and select all down the example observer column', () => {
+    it('can de-select and select all down the example observer column', async () => {
       const column = 'observer';
-      expect<any>(configPage.unifiedPane.example.selectAll.observer.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.example.selectAll.observer.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.example.selectAll.observer, false);
-      expect<any>(configPage.unifiedPane.example.selectAll.observer.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.example.selectAll.observer, false);
+      expect<any>(await configPage.unifiedPane.example.selectAll.observer.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.example.selectAll.observer, true);
-      expect<any>(configPage.unifiedPane.example.selectAll.observer.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.example.selectAll.observer, true);
+      expect<any>(await configPage.unifiedPane.example.selectAll.observer.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can de-select and select all down the example commenter column', () => {
+    it('can de-select and select all down the example commenter column', async () => {
       const column = 'commenter';
-      expect<any>(configPage.unifiedPane.example.selectAll.commenter.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.example.selectAll.commenter.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.example.selectAll.commenter, false);
-      expect<any>(configPage.unifiedPane.example.selectAll.commenter.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.example.selectAll.commenter, false);
+      expect<any>(await configPage.unifiedPane.example.selectAll.commenter.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.example.selectAll.commenter, true);
-      expect<any>(configPage.unifiedPane.example.selectAll.commenter.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.example.selectAll.commenter, true);
+      expect<any>(await configPage.unifiedPane.example.selectAll.commenter.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can de-select and select all down the example contributor column', () => {
+    it('can de-select and select all down the example contributor column', async () => {
       const column = 'contributor';
-      expect<any>(configPage.unifiedPane.example.selectAll.contributor.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
+      expect<any>(await configPage.unifiedPane.example.selectAll.contributor.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.example.selectAll.contributor, false);
-      expect<any>(configPage.unifiedPane.example.selectAll.contributor.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
+      await util.setCheckbox(configPage.unifiedPane.example.selectAll.contributor, false);
+      expect<any>(await configPage.unifiedPane.example.selectAll.contributor.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.example.selectAll.contributor, true);
-      expect<any>(configPage.unifiedPane.example.selectAll.contributor.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.example.selectAll.contributor, true);
+      expect<any>(await configPage.unifiedPane.example.selectAll.contributor.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
         .toBe(true);
     });
 
-    it('can fully function "Select All" down the example manager column', () => {
+    it('can fully function "Select All" down the example manager column', async () => {
       const column = 'manager';
       const rowLabel = new RegExp('^Reference');
-      expect<any>(configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.example.selectAll.manager, false);
-      expect<any>(configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
+      expect<any>(await configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.example.selectAll.manager, false);
+      expect<any>(await configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), true);
-      util.setCheckbox(configPage.unifiedPane.example.selectAll.manager, true);
-      expect<any>(configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), true);
+      await util.setCheckbox(configPage.unifiedPane.example.selectAll.manager, true);
+      expect<any>(await configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), false);
-      expect<any>(configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
         .toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), false))
         .toBe(false);
-      util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
+      await util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.example.selectAll.manager.isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes(column), true))
         .toBe(true);
     });
 
@@ -473,83 +473,83 @@ describe('Lexicon E2E Configuration Fields', () => {
 
   describe('Select All for Rows', () => {
 
-    it('can fully function "Select All" along an Input System row', () => {
+    it('can fully function "Select All" along an Input System row', async () => {
       const rowLabel = new RegExp('^Thai$');
-      expect<any>(configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(5);
-      util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), false);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), false);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(true);
-      configPage.unifiedPane.resetInputSystemButton('observer').click();
-      configPage.unifiedPane.resetInputSystemButton('commenter').click();
-      configPage.unifiedPane.resetInputSystemButton('contributor').click();
-      configPage.unifiedPane.resetInputSystemButton('manager').click();
+      expect<any>(await configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(5);
+      await util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.commenterCheckbox(rowLabel), true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(true);
+      await configPage.unifiedPane.resetInputSystemButton('observer').click();
+      await configPage.unifiedPane.resetInputSystemButton('commenter').click();
+      await configPage.unifiedPane.resetInputSystemButton('contributor').click();
+      await configPage.unifiedPane.resetInputSystemButton('manager').click();
     });
 
-    it('can fully function "Select All" along an entry row', () => {
+    it('can fully function "Select All" along an entry row', async () => {
       const rowLabel = new RegExp('^Location$');
-      expect<any>(configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(5);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), false);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      expect<any>(await configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(5);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.contributorCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
     });
 
-    it('can fully function "Select All" along a sense row', () => {
+    it('can fully function "Select All" along a sense row', async () => {
       const rowLabel = new RegExp('^Scientific Name$');
-      expect<any>(configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(5);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), false);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      expect<any>(await configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(5);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.managerCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
     });
 
-    it('can fully function "Select All" along an example row', () => {
+    it('can fully function "Select All" along an example row', async () => {
       const rowLabel = new RegExp('^Reference');
-      expect<any>(configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(5);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), false);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      expect<any>(await configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(5);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.observerCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
     });
 
   });
@@ -557,137 +557,137 @@ describe('Lexicon E2E Configuration Fields', () => {
   describe('Member-Specific Settings', () => {
     let rowNumber = 0;
 
-    it('can count number of Input System rows', () => {
-      configPage.unifiedPane.inputSystem.rows().count().then(count => rowNumber = count);
+    it('can count number of Input System rows', async () => {
+      await configPage.unifiedPane.inputSystem.rows().count().then(count => rowNumber = count);
     });
 
-    it('can add a member-specific user settings', () => {
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(0);
-      configPage.unifiedPane.entry.addGroupButton.click();
-      browser.wait(configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed(), 500);
-      expect<any>(configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed()).toBe(true);
-      expect<any>(configPage.unifiedPane.addGroupModal.usernameTypeaheadResults.count()).toEqual(0);
-      expect<any>(configPage.unifiedPane.addGroupModal.addMemberSpecificSettingsButton.isDisplayed()).toBe(true);
-      configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.sendKeys('a');
-      expect<any>(configPage.unifiedPane.addGroupModal.usernameTypeaheadResults.count()).toEqual(6);
-      configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.clear();
-      configPage.unifiedPane.addGroupModal.usernameTypeaheadInput
+    it('can add a member-specific user settings', async () => {
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(0);
+      await configPage.unifiedPane.entry.addGroupButton.click();
+      await browser.wait(configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed(), 500);
+      expect<any>(await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed()).toBe(true);
+      expect<any>(await configPage.unifiedPane.addGroupModal.usernameTypeaheadResults.count()).toEqual(0);
+      expect<any>(await configPage.unifiedPane.addGroupModal.addMemberSpecificSettingsButton.isDisplayed()).toBe(true);
+      await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.sendKeys('a');
+      expect<any>(await configPage.unifiedPane.addGroupModal.usernameTypeaheadResults.count()).toEqual(6);
+      await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.clear();
+      await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput
         .sendKeys(constants.managerUsername + protractor.Key.ENTER);
-      configPage.unifiedPane.addGroupModal.addMemberSpecificSettingsButton.click();
-      expect<any>(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(0).count()).toEqual(rowNumber);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(0), false)).toBe(true);
+      await configPage.unifiedPane.addGroupModal.addMemberSpecificSettingsButton.click();
+      expect<any>(await configPage.unifiedPane.inputSystem.groupColumnCheckboxes(0).count()).toEqual(rowNumber);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(0), false)).toBe(true);
     });
 
-    it('cannot add the same member-specific user settings', () => {
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(1);
-      configPage.unifiedPane.entry.addGroupButton.click();
-      browser.wait(configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed(), 500);
-      expect<any>(configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed()).toBe(true);
-      configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.sendKeys('a');
-      expect<any>(configPage.unifiedPane.addGroupModal.usernameTypeaheadResults.count()).toEqual(5);
-      configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.clear();
-      configPage.unifiedPane.addGroupModal.usernameTypeaheadInput
+    it('cannot add the same member-specific user settings', async () => {
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(1);
+      await configPage.unifiedPane.entry.addGroupButton.click();
+      await browser.wait(configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed(), 500);
+      expect<any>(await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed()).toBe(true);
+      await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.sendKeys('a');
+      expect<any>(await configPage.unifiedPane.addGroupModal.usernameTypeaheadResults.count()).toEqual(5);
+      await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.clear();
+      await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput
         .sendKeys(constants.managerUsername + protractor.Key.ENTER);
-      expect<any>(configPage.unifiedPane.addGroupModal.usernameTypeaheadResults.count()).toEqual(0);
-      configPage.unifiedPane.addGroupModal.addMemberSpecificSettingsButton.click();
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(1);
+      expect<any>(await configPage.unifiedPane.addGroupModal.usernameTypeaheadResults.count()).toEqual(0);
+      await configPage.unifiedPane.addGroupModal.addMemberSpecificSettingsButton.click();
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(1);
     });
 
-    it('can add a second member-specific user settings', () => {
+    it('can add a second member-specific user settings', async () => {
       const rowLabel = 'English';
-      configPage.unifiedPane.entry.addGroupButton.click();
-      browser.wait(configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed(), 500);
-      expect<any>(configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed()).toBe(true);
-      configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.clear();
-      configPage.unifiedPane.addGroupModal.usernameTypeaheadInput
+      await configPage.unifiedPane.entry.addGroupButton.click();
+      await browser.wait(configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed(), 500);
+      expect<any>(await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.isDisplayed()).toBe(true);
+      await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput.clear();
+      await configPage.unifiedPane.addGroupModal.usernameTypeaheadInput
         .sendKeys(constants.memberUsername + protractor.Key.ENTER);
-      configPage.unifiedPane.addGroupModal.addMemberSpecificSettingsButton.click();
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(2);
-      expect<any>(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(1).count()).toEqual(rowNumber);
-      expect<any>(configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(7);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(1), false)).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes('select-row'), false))
+      await configPage.unifiedPane.addGroupModal.addMemberSpecificSettingsButton.click();
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(2);
+      expect<any>(await configPage.unifiedPane.inputSystem.groupColumnCheckboxes(1).count()).toEqual(rowNumber);
+      expect<any>(await configPage.unifiedPane.rowCheckboxes(rowLabel).count()).toEqual(7);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(1), false)).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes('select-row'), false))
         .toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.groupColumnCheckboxes(1), false)).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes('select-row'), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.groupColumnCheckboxes(1), false)).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes('select-row'), false))
         .toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.groupColumnCheckboxes(1), false)).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes('select-row'), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.groupColumnCheckboxes(1), false)).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes('select-row'), false))
         .toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.groupColumnCheckboxes(1), false)).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes('select-row'), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.groupColumnCheckboxes(1), false)).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes('select-row'), false))
         .toBe(true);
     });
 
-    it('can fully function "Select All" down a Input System member-specific column', () => {
+    it('can fully function "Select All" down a Input System member-specific column', async () => {
       const columnIndex = 0;
       const rowIndex = 0;
       const rowLabel = 'English';
-      expect<any>(configPage.unifiedPane.inputSystem.rowLabel(rowIndex).getText()).toEqual(rowLabel);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex).get(rowIndex), true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
+      expect<any>(await configPage.unifiedPane.inputSystem.rowLabel(rowIndex).getText()).toEqual(rowLabel);
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex).get(rowIndex), true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex).get(rowIndex), false);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex).get(rowIndex), false);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
         .toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), false))
         .toBe(false);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex).get(rowIndex), true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex).get(rowIndex), true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
         .toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), false);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), false))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), false);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), false))
         .toBe(true);
     });
 
-    it('check cross-over Select All row and column', () => {
+    it('check cross-over Select All row and column', async () => {
       const columnIndex = 0;
       const rowIndex = 0;
       const rowLabel = 'English';
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), true);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), true);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
         .toBe(true);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex).get(rowIndex), false);
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(true);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex).get(rowIndex), false);
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex).isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), true))
         .toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), false))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.groupColumnCheckboxes(columnIndex), false))
         .toBe(false);
-      expect<any>(configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), true);
-      util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), false);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
-      util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
+      expect<any>(await configPage.unifiedPane.selectRowCheckbox(rowLabel).isSelected()).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(false);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(false);
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), true);
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.groups().get(columnIndex), false);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), true);
+      await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
     });
 
-    it('can remove member-specific user settings', () => {
-      configPage.unifiedPane.resetInputSystemButton('observer').click();
-      configPage.unifiedPane.resetInputSystemButton('commenter').click();
-      configPage.unifiedPane.resetInputSystemButton('contributor').click();
-      configPage.unifiedPane.resetInputSystemButton('manager').click();
-      configPage.unifiedPane.entry.removeGroupButton(0).click();
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(1);
-      configPage.unifiedPane.entry.removeGroupButton(0).click();
-      expect<any>(configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(0);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes('select-row'), true))
+    it('can remove member-specific user settings', async () => {
+      await configPage.unifiedPane.resetInputSystemButton('observer').click();
+      await configPage.unifiedPane.resetInputSystemButton('commenter').click();
+      await configPage.unifiedPane.resetInputSystemButton('contributor').click();
+      await configPage.unifiedPane.resetInputSystemButton('manager').click();
+      await configPage.unifiedPane.entry.removeGroupButton(0).click();
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(1);
+      await configPage.unifiedPane.entry.removeGroupButton(0).click();
+      expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(0);
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes('select-row'), true))
         .toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes('select-row'), true))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.entry.columnCheckboxes('select-row'), true))
         .toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes('select-row'), true))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.sense.columnCheckboxes('select-row'), true))
         .toBe(true);
-      expect<any>(Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes('select-row'), true))
+      expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.example.columnCheckboxes('select-row'), true))
         .toBe(true);
     });
 
@@ -697,96 +697,96 @@ describe('Lexicon E2E Configuration Fields', () => {
     const customDisplayName = 'cust_name';
     let rowNumber = 0;
 
-    it('can discard Configuration changes', () => {
-      Utils.clickBreadcrumb(constants.testProjectName);
-      configPage.get();
-      configPage.tabs.unified.click();
-      expect<any>(configPage.applyButton.isEnabled()).toBe(false);
+    it('can discard Configuration changes', async () => {
+      await Utils.clickBreadcrumb(constants.testProjectName);
+      await configPage.get();
+      await configPage.tabs.unified.click();
+      expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
     });
 
-    it('can count number of entry rows', () => {
-      configPage.unifiedPane.entry.rows().count().then(count => rowNumber = count);
+    it('can count number of entry rows', async () => {
+      await configPage.unifiedPane.entry.rows().count().then(count => rowNumber = count);
     });
 
-    it('can open the custom field modal for an entry', () => {
-      expect<any>(configPage.unifiedPane.entry.addCustomEntryButton.isEnabled()).toBe(true);
-      configPage.unifiedPane.entry.addCustomEntryButton.click();
-      browser.wait(configPage.modal.customField.displayNameInput.isDisplayed(), 500);
-      expect<any>(configPage.modal.customField.displayNameInput.isDisplayed()).toBe(true);
-      expect<any>(configPage.modal.customField.typeDropdown.isDisplayed()).toBe(true);
-      expect<any>(configPage.modal.customField.listCodeDropdown.isPresent()).toBe(false);
-      expect<any>(configPage.modal.customField.addButton.isDisplayed()).toBe(true);
-      expect<any>(configPage.modal.customField.addButton.isEnabled()).toBe(false);
+    it('can open the custom field modal for an entry', async () => {
+      expect<any>(await configPage.unifiedPane.entry.addCustomEntryButton.isEnabled()).toBe(true);
+      await configPage.unifiedPane.entry.addCustomEntryButton.click();
+      await browser.wait(configPage.modal.customField.displayNameInput.isDisplayed(), 500);
+      expect<any>(await configPage.modal.customField.displayNameInput.isDisplayed()).toBe(true);
+      expect<any>(await configPage.modal.customField.typeDropdown.isDisplayed()).toBe(true);
+      expect<any>(await configPage.modal.customField.listCodeDropdown.isPresent()).toBe(false);
+      expect<any>(await configPage.modal.customField.addButton.isDisplayed()).toBe(true);
+      expect<any>(await configPage.modal.customField.addButton.isEnabled()).toBe(false);
     });
 
-    it('can enter a field name', () => {
-      expect<any>(configPage.modal.customField.fieldCodeExists.isPresent()).toBe(true);
-      expect<any>(configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
-      configPage.modal.customField.displayNameInput.sendKeys(customDisplayName + protractor.Key.ENTER);
-      expect<any>(configPage.modal.customField.addButton.getText()).toEqual('Add ' + customDisplayName);
-      expect<any>(configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
-      expect<any>(configPage.modal.customField.addButton.isEnabled()).toBe(false);
+    it('can enter a field name', async () => {
+      expect<any>(await configPage.modal.customField.fieldCodeExists.isPresent()).toBe(true);
+      expect<any>(await configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
+      await configPage.modal.customField.displayNameInput.sendKeys(customDisplayName + protractor.Key.ENTER);
+      expect<any>(await configPage.modal.customField.addButton.getText()).toEqual('Add ' + customDisplayName);
+      expect<any>(await configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
+      expect<any>(await configPage.modal.customField.addButton.isEnabled()).toBe(false);
     });
 
-    it('can enter a field type', () => {
-      Utils.clickDropdownByValue(configPage.modal.customField.typeDropdown, 'Multi-input-system Text');
-      expect<any>(configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
-      expect<any>(configPage.modal.customField.addButton.isEnabled()).toBe(true);
+    it('can enter a field type', async () => {
+      Utils.clickDropdownByValue(await configPage.modal.customField.typeDropdown, 'Multi-input-system Text');
+      expect<any>(await configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
+      expect<any>(await configPage.modal.customField.addButton.isEnabled()).toBe(true);
     });
 
-    it('can add custom field', () => {
-      configPage.modal.customField.addButton.click();
-      expect<any>(configPage.modal.customField.displayNameInput.isPresent()).toBe(false);
-      expect<any>(configPage.unifiedPane.entry.rows().count()).toEqual(rowNumber + 1);
-      expect<any>(configPage.unifiedPane.entry.rowLabelCustomInput(rowNumber).getAttribute('value'))
+    it('can add custom field', async () => {
+      await configPage.modal.customField.addButton.click();
+      expect<any>(await configPage.modal.customField.displayNameInput.isPresent()).toBe(false);
+      expect<any>(await configPage.unifiedPane.entry.rows().count()).toEqual(rowNumber + 1);
+      expect<any>(await configPage.unifiedPane.entry.rowLabelCustomInput(rowNumber).getAttribute('value'))
         .toEqual(customDisplayName);
-      expect<any>(configPage.applyButton.isEnabled()).toBe(true);
+      expect<any>(await configPage.applyButton.isEnabled()).toBe(true);
     });
 
-    it('cannot add a duplicate field name', () => {
-      configPage.unifiedPane.entry.addCustomEntryButton.click();
-      expect<any>(configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
-      configPage.modal.customField.displayNameInput.sendKeys(customDisplayName + protractor.Key.ENTER);
-      expect<any>(configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(true);
-      expect<any>(configPage.modal.customField.addButton.isEnabled()).toBe(false);
+    it('cannot add a duplicate field name', async () => {
+      await configPage.unifiedPane.entry.addCustomEntryButton.click();
+      expect<any>(await configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
+      await configPage.modal.customField.displayNameInput.sendKeys(customDisplayName + protractor.Key.ENTER);
+      expect<any>(await configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(true);
+      expect<any>(await configPage.modal.customField.addButton.isEnabled()).toBe(false);
     });
 
-    it('can cancel custom entry field modal', () => {
-      configPage.modal.customField.displayNameInput.sendKeys(protractor.Key.ESCAPE);
-      expect<any>(configPage.modal.customField.displayNameInput.isPresent()).toBe(false);
-      expect<any>(configPage.applyButton.isEnabled()).toBe(true);
+    it('can cancel custom entry field modal', async () => {
+      await configPage.modal.customField.displayNameInput.sendKeys(protractor.Key.ESCAPE);
+      expect<any>(await configPage.modal.customField.displayNameInput.isPresent()).toBe(false);
+      expect<any>(await configPage.applyButton.isEnabled()).toBe(true);
     });
 
-    it('can add a duplicate field name for a sense', () => {
-      configPage.unifiedPane.sense.addCustomSenseButton.click();
-      expect<any>(configPage.modal.customField.displayNameInput.getAttribute('value')).toEqual('');
-      configPage.modal.customField.displayNameInput.sendKeys(customDisplayName + protractor.Key.ENTER);
-      expect<any>(configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
-      expect<any>(configPage.modal.customField.addButton.isEnabled()).toBe(false);
+    it('can add a duplicate field name for a sense', async () => {
+      await configPage.unifiedPane.sense.addCustomSenseButton.click();
+      expect<any>(await configPage.modal.customField.displayNameInput.getAttribute('value')).toEqual('');
+      await configPage.modal.customField.displayNameInput.sendKeys(customDisplayName + protractor.Key.ENTER);
+      expect<any>(await configPage.modal.customField.fieldCodeExists.isDisplayed()).toBe(false);
+      expect<any>(await configPage.modal.customField.addButton.isEnabled()).toBe(false);
     });
 
-    it('list code only shows when a list type is selected', () => {
-      Utils.clickDropdownByValue(configPage.modal.customField.typeDropdown,
+    it('list code only shows when a list type is selected', async () => {
+      await Utils.clickDropdownByValue(configPage.modal.customField.typeDropdown,
         'Multi-input-system Text');
-      expect<any>(configPage.modal.customField.listCodeDropdown.isPresent()).toBe(false);
-      expect<any>(configPage.modal.customField.addButton.isEnabled()).toBe(true);
-      Utils.clickDropdownByValue(configPage.modal.customField.typeDropdown, 'Multi-option List');
-      expect<any>(configPage.modal.customField.listCodeDropdown.isDisplayed()).toBe(true);
-      expect<any>(configPage.modal.customField.addButton.isEnabled()).toBe(false);
-      Utils.clickDropdownByValue(configPage.modal.customField.typeDropdown, 'Option List');
-      expect<any>(configPage.modal.customField.listCodeDropdown.isDisplayed()).toBe(true);
-      expect<any>(configPage.modal.customField.addButton.isEnabled()).toBe(false);
+      expect<any>(await configPage.modal.customField.listCodeDropdown.isPresent()).toBe(false);
+      expect<any>(await configPage.modal.customField.addButton.isEnabled()).toBe(true);
+      await Utils.clickDropdownByValue(configPage.modal.customField.typeDropdown, 'Multi-option List');
+      expect<any>(await configPage.modal.customField.listCodeDropdown.isDisplayed()).toBe(true);
+      expect<any>(await configPage.modal.customField.addButton.isEnabled()).toBe(false);
+      await Utils.clickDropdownByValue(configPage.modal.customField.typeDropdown, 'Option List');
+      expect<any>(await configPage.modal.customField.listCodeDropdown.isDisplayed()).toBe(true);
+      expect<any>(await configPage.modal.customField.addButton.isEnabled()).toBe(false);
     });
 
-    it('can enter a list code', () => {
-      Utils.clickDropdownByValue(configPage.modal.customField.listCodeDropdown, 'Part of Speech');
-      expect<any>(configPage.modal.customField.addButton.isEnabled()).toBe(true);
+    it('can enter a list code', async () => {
+      await Utils.clickDropdownByValue(configPage.modal.customField.listCodeDropdown, 'Part of Speech');
+      expect<any>(await configPage.modal.customField.addButton.isEnabled()).toBe(true);
     });
 
-    it('can cancel custom sense field modal', () => {
-      configPage.modal.customField.displayNameInput.sendKeys(protractor.Key.ESCAPE);
-      expect<any>(configPage.modal.customField.displayNameInput.isPresent()).toBe(false);
-      expect<any>(configPage.applyButton.isEnabled()).toBe(true);
+    it('can cancel custom sense field modal', async () => {
+      await configPage.modal.customField.displayNameInput.sendKeys(protractor.Key.ESCAPE);
+      expect<any>(await configPage.modal.customField.displayNameInput.isPresent()).toBe(false);
+      expect<any>(await configPage.applyButton.isEnabled()).toBe(true);
     });
 
   });

--- a/test/app/languageforge/lexicon/settings/config-input-systems.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/config-input-systems.e2e-spec.ts
@@ -13,291 +13,291 @@ describe('Lexicon E2E Configuration Input Systems', () => {
   const firstLanguage = 'Maori';
   const lastLanguage  = 'Rarotongan';
 
-  it('setup: login as user, select test project, cannot configure', () => {
-    loginPage.loginAsUser();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
-    expect<any>(configPage.settingsMenuLink.getAttribute('class')).not.toContain('app-settings-available');
+  it('setup: login as user, select test project, cannot configure', async () => {
+    await loginPage.loginAsUser();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
+    expect<any>(await configPage.settingsMenuLink.getAttribute('class')).not.toContain('app-settings-available');
   });
 
-  it('setup: login as manager, select test project, goto configuration', () => {
-    loginPage.loginAsManager();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
-    expect<any>(configPage.settingsMenuLink.isDisplayed()).toBe(true);
-    configPage.get();
-    expect<any>(configPage.applyButton.isDisplayed()).toBe(true);
-    expect<any>(configPage.applyButton.isEnabled()).toBe(false);
+  it('setup: login as manager, select test project, goto configuration', async () => {
+    await loginPage.loginAsManager();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
+    expect<any>(await configPage.settingsMenuLink.isDisplayed()).toBe(true);
+    await configPage.get();
+    expect<any>(await configPage.applyButton.isDisplayed()).toBe(true);
+    expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
   });
 
-  it('can select Input Systems tab', () => {
-    configPage.tabs.inputSystems.click();
-    expect<any>(configPage.inputSystemsPane.newButton.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.moreButton.isDisplayed()).toBe(true);
+  it('can select Input Systems tab', async () => {
+    await configPage.tabs.inputSystems.click();
+    expect<any>(await configPage.inputSystemsPane.newButton.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.moreButton.isDisplayed()).toBe(true);
   });
 
-  it('can select an existing Input System', () => {
+  it('can select an existing Input System', async () => {
     const language = 'Thai (IPA)';
-    const inputSystem = configPage.inputSystemsPane.getLanguageByName(language);
+    const inputSystem = await configPage.inputSystemsPane.getLanguageByName(language);
     expect<any>(inputSystem.isDisplayed()).toBe(true);
     inputSystem.click();
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.displayName.getText()).toEqual(language);
-    expect<any>(configPage.applyButton.isEnabled()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.displayName.getText()).toEqual(language);
+    expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
   });
 
-  it('cannot change Special for an existing Input System', () => {
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('th-fonipa');
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isEnabled()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isEnabled()).toBe(false);
+  it('cannot change Special for an existing Input System', async () => {
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('th-fonipa');
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isEnabled()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isEnabled()).toBe(false);
   });
 
-  it('cannot add another IPA variation, but can add Voice and Variant', () => {
-    configPage.inputSystemsPane.moreButton.click();
-    expect(configPage.inputSystemsPane.moreButtonGroup.addIpa.getAttribute('class')).toContain('disabled');
-    expect(configPage.inputSystemsPane.moreButtonGroup.addVoice.getAttribute('class')).toContain('disabled');
-    expect(configPage.inputSystemsPane.moreButtonGroup.addVariant.getAttribute('class'))
+  it('cannot add another IPA variation, but can add Voice and Variant', async () => {
+    await configPage.inputSystemsPane.moreButton.click();
+    expect(await configPage.inputSystemsPane.moreButtonGroup.addIpa.getAttribute('class')).toContain('disabled');
+    expect(await configPage.inputSystemsPane.moreButtonGroup.addVoice.getAttribute('class')).toContain('disabled');
+    expect(await configPage.inputSystemsPane.moreButtonGroup.addVariant.getAttribute('class'))
       .not.toContain('disabled');
   });
 
-  it('cannot remove an existing Input System', () => {
-    expect<any>(configPage.inputSystemsPane.moreButtonGroup.remove.isDisplayed()).toBe(false);
+  it('cannot remove an existing Input System', async () => {
+    expect<any>(await configPage.inputSystemsPane.moreButtonGroup.remove.isDisplayed()).toBe(false);
   });
 
-  describe('Select a new Input System Language modal', () => {
+  describe('Select a new Input System Language modal', async () => {
 
-    it('can open the new language modal', () => {
-      expect<any>(configPage.inputSystemsPane.newButton.isEnabled()).toBe(true);
-      configPage.inputSystemsPane.newButton.click();
-      expect<any>(configPage.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(true);
+    it('can open the new language modal', async () => {
+      expect<any>(await configPage.inputSystemsPane.newButton.isEnabled()).toBe(true);
+      await configPage.inputSystemsPane.newButton.click();
+      expect<any>(await configPage.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(true);
     });
 
-    it('can search for a language', () => {
-      expect<any>(configPage.modal.selectLanguage.languageRows.count()).toBe(0);
-      configPage.modal.selectLanguage.searchLanguageInput.sendKeys(firstLanguage + protractor.Key.ENTER);
-      expect<any>(configPage.modal.selectLanguage.languageRows.first().isPresent()).toBe(true);
-      expect<any>(configPage.modal.selectLanguage.firstLanguageName.getText()).toEqual(firstLanguage);
-      expect<any>(configPage.modal.selectLanguage.languageRows.last().isPresent()).toBe(true);
-      expect<any>(configPage.modal.selectLanguage.lastLanguageName.getText()).toEqual(lastLanguage);
+    it('can search for a language', async () => {
+      expect<any>(await configPage.modal.selectLanguage.languageRows.count()).toBe(0);
+      await configPage.modal.selectLanguage.searchLanguageInput.sendKeys(firstLanguage + protractor.Key.ENTER);
+      expect<any>(await configPage.modal.selectLanguage.languageRows.first().isPresent()).toBe(true);
+      expect<any>(await configPage.modal.selectLanguage.firstLanguageName.getText()).toEqual(firstLanguage);
+      expect<any>(await configPage.modal.selectLanguage.languageRows.last().isPresent()).toBe(true);
+      expect<any>(await configPage.modal.selectLanguage.lastLanguageName.getText()).toEqual(lastLanguage);
     });
 
-    it('can clear language search', () => {
-      expect<any>(configPage.modal.selectLanguage.searchLanguageInput.getAttribute('value')).toEqual(firstLanguage);
-      configPage.modal.selectLanguage.clearSearchButton.click();
-      expect<any>(configPage.modal.selectLanguage.searchLanguageInput.getAttribute('value')).toEqual('');
-      expect<any>(configPage.modal.selectLanguage.languageRows.count()).toBe(0);
+    it('can clear language search', async () => {
+      expect<any>(await configPage.modal.selectLanguage.searchLanguageInput.getAttribute('value')).toEqual(firstLanguage);
+      await configPage.modal.selectLanguage.clearSearchButton.click();
+      expect<any>(await configPage.modal.selectLanguage.searchLanguageInput.getAttribute('value')).toEqual('');
+      expect<any>(await configPage.modal.selectLanguage.languageRows.count()).toBe(0);
     });
 
-    it('can select language', () => {
-      configPage.modal.selectLanguage.searchLanguageInput.sendKeys(firstLanguage + protractor.Key.ENTER);
-      expect<any>(configPage.modal.selectLanguage.addButton.isPresent()).toBe(true);
-      expect<any>(configPage.modal.selectLanguage.addButton.isEnabled()).toBe(false);
-      configPage.modal.selectLanguage.languageRows.last().click();
-      expect<any>(configPage.modal.selectLanguage.addButton.isEnabled()).toBe(true);
-      expect<any>(configPage.modal.selectLanguage.addButton.getText()).toEqual('Add ' + lastLanguage);
-      configPage.modal.selectLanguage.languageRows.first().click();
-      expect<any>(configPage.modal.selectLanguage.addButton.isEnabled()).toBe(true);
-      expect<any>(configPage.modal.selectLanguage.addButton.getText()).toEqual('Add ' + firstLanguage);
+    it('can select language', async () => {
+      await configPage.modal.selectLanguage.searchLanguageInput.sendKeys(firstLanguage + protractor.Key.ENTER);
+      expect<any>(await configPage.modal.selectLanguage.addButton.isPresent()).toBe(true);
+      expect<any>(await configPage.modal.selectLanguage.addButton.isEnabled()).toBe(false);
+      await configPage.modal.selectLanguage.languageRows.last().click();
+      expect<any>(await configPage.modal.selectLanguage.addButton.isEnabled()).toBe(true);
+      expect<any>(await configPage.modal.selectLanguage.addButton.getText()).toEqual('Add ' + lastLanguage);
+      await configPage.modal.selectLanguage.languageRows.first().click();
+      expect<any>(await configPage.modal.selectLanguage.addButton.isEnabled()).toBe(true);
+      expect<any>(await configPage.modal.selectLanguage.addButton.getText()).toEqual('Add ' + firstLanguage);
     });
 
-    it('can add language', () => {
-      configPage.modal.selectLanguage.addButton.click();
-      expect<any>(configPage.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(false);
-      expect<any>(configPage.applyButton.isEnabled()).toBe(true);
+    it('can add language', async () => {
+      await configPage.modal.selectLanguage.addButton.click();
+      expect<any>(await configPage.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(false);
+      expect<any>(await configPage.applyButton.isEnabled()).toBe(true);
     });
 
   });
 
-  it('new Input System is selected', () => {
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.displayName.getText()).toEqual(firstLanguage);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi');
+  it('new Input System is selected', async () => {
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.displayName.getText()).toEqual(firstLanguage);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi');
   });
 
-  it('can change Special to IPA', () => {
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.variantInput.isDisplayed()).toBe(false);
-    Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.specialDropdown, 'IPA transcription');
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa');
+  it('can change Special to IPA', async () => {
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.variantInput.isDisplayed()).toBe(false);
+    await Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.specialDropdown, 'IPA transcription');
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa');
   });
 
-  it('can change IPA Variant', () => {
-    configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.sendKeys('ngati' + protractor.Key.TAB);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-ngati');
-    configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.clear();
+  it('can change IPA Variant', async () => {
+    await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.sendKeys('ngati' + protractor.Key.TAB);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-ngati');
+    await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.clear();
   });
 
-  it('can change IPA Purpose to Etic', () => {
-    Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown, 'Etic');
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-etic');
+  it('can change IPA Purpose to Etic', async () => {
+    await Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown, 'Etic');
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-etic');
   });
 
-  it('can change IPA Variant', () => {
-    configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.sendKeys('ngati' + protractor.Key.TAB);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-etic-ngati');
-    configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.clear();
+  it('can change IPA Variant', async () => {
+    await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.sendKeys('ngati' + protractor.Key.TAB);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-etic-ngati');
+    await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.clear();
   });
 
-  it('can change IPA Purpose to Emic', () => {
-    Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown, 'Emic');
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-emic');
+  it('can change IPA Purpose to Emic', async () => {
+    await Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown, 'Emic');
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-emic');
   });
 
-  it('can change IPA Variant', () => {
-    configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.sendKeys('ngati' + protractor.Key.TAB);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-emic-ngati');
-    configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.clear();
+  it('can change IPA Variant', async () => {
+    await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.sendKeys('ngati' + protractor.Key.TAB);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa-x-emic-ngati');
+    await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.clear();
   });
 
-  it('can change IPA Purpose to unspecified', () => {
-    Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown, 'unspecified');
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa');
+  it('can change IPA Purpose to unspecified', async () => {
+    await Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown, 'unspecified');
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa');
   });
 
-  it('can change Special to Voice', () => {
-    Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.specialDropdown, 'Voice');
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Zxxx-x-audio');
+  it('can change Special to Voice', async () => {
+    await Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.specialDropdown, 'Voice');
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Zxxx-x-audio');
   });
 
-  it('can change Voice Variant', () => {
-    configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.sendKeys('ngati' + protractor.Key.TAB);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Zxxx-x-audio-ngati');
-    configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.clear();
+  it('can change Voice Variant', async () => {
+    await configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.sendKeys('ngati' + protractor.Key.TAB);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Zxxx-x-audio-ngati');
+    await configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.clear();
   });
 
-  it('can change Special to Script / Region / Variant', () => {
-    Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.specialDropdown,
+  it('can change Special to Script / Region / Variant', async () => {
+    await Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.specialDropdown,
       'Script / Region / Variant');
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.variantInput.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-unspecified');
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.variantInput.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-unspecified');
   });
 
-  it('can not add unspecified Variant', () => {
-    expect<any>(configPage.noticeList.count()).toBe(0);
-    Utils.scrollTop();
-    configPage.applyButton.click();
-    expect<any>(configPage.noticeList.count()).toBe(1);
-    expect(configPage.noticeList.get(0).getText()).toContain('Specify at least one Script, Region or Variant');
-    configPage.firstNoticeCloseButton.click();
+  it('can not add unspecified Variant', async () => {
+    expect<any>(await configPage.noticeList.count()).toBe(0);
+    await Utils.scrollTop();
+    await configPage.applyButton.click();
+    expect<any>(await configPage.noticeList.count()).toBe(1);
+    expect(await configPage.noticeList.get(0).getText()).toContain('Specify at least one Script, Region or Variant');
+    await configPage.firstNoticeCloseButton.click();
   });
 
-  it('can change Script', () => {
-    Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.scriptDropdown, new RegExp('Latin$'));
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Latn');
+  it('can change Script', async () => {
+    await Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.scriptDropdown, new RegExp('Latin$'));
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Latn');
   });
 
-  it('can change Region', () => {
-    Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.regionDropdown, 'Cook Islands');
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Latn-CK');
+  it('can change Region', async () => {
+    await Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.regionDropdown, 'Cook Islands');
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Latn-CK');
   });
 
-  it('can change Variant', () => {
-    configPage.inputSystemsPane.selectedInputSystem.variantInput.sendKeys('ngati' + protractor.Key.TAB);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Latn-CK-x-ngati');
+  it('can change Variant', async () => {
+    await configPage.inputSystemsPane.selectedInputSystem.variantInput.sendKeys('ngati' + protractor.Key.TAB);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Latn-CK-x-ngati');
   });
 
-  it('can change Special to none', () => {
-    Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.specialDropdown, 'none');
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.variantInput.isDisplayed()).toBe(false);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi');
+  it('can change Special to none', async () => {
+    await Utils.clickDropdownByValue(configPage.inputSystemsPane.selectedInputSystem.specialDropdown, 'none');
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.variantInput.isDisplayed()).toBe(false);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi');
   });
 
-  it('can add IPA variation', () => {
-    Utils.scrollTop();
-    configPage.inputSystemsPane.moreButton.click();
-    configPage.inputSystemsPane.moreButtonGroup.addIpa.click();
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isEnabled()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isEnabled()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa');
+  it('can add IPA variation', async () => {
+    await Utils.scrollTop();
+    await configPage.inputSystemsPane.moreButton.click();
+    await configPage.inputSystemsPane.moreButtonGroup.addIpa.click();
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isEnabled()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.purposeDropdown.isEnabled()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.ipaVariantInput.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-fonipa');
   });
 
-  it('cannot add another IPA variation', () => {
-    configPage.inputSystemsPane.moreButton.click();
-    expect(configPage.inputSystemsPane.moreButtonGroup.addIpa.getAttribute('class')).toContain('disabled');
+  it('cannot add another IPA variation', async () => {
+    await configPage.inputSystemsPane.moreButton.click();
+    expect(await configPage.inputSystemsPane.moreButtonGroup.addIpa.getAttribute('class')).toContain('disabled');
   });
 
-  it('can remove IPA variation', () => {
-    expect<any>(configPage.inputSystemsPane.moreButtonGroup.remove.isDisplayed()).toBe(true);
-    configPage.inputSystemsPane.moreButtonGroup.remove.click();
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('en');
+  it('can remove IPA variation', async () => {
+    expect<any>(await configPage.inputSystemsPane.moreButtonGroup.remove.isDisplayed()).toBe(true);
+    await configPage.inputSystemsPane.moreButtonGroup.remove.click();
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('en');
   });
 
-  it('can add Voice variation', () => {
-    configPage.inputSystemsPane.getLanguageByName(firstLanguage).click();
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi');
-    configPage.inputSystemsPane.moreButton.click();
-    configPage.inputSystemsPane.moreButtonGroup.addVoice.click();
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isEnabled()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Zxxx-x-audio');
+  it('can add Voice variation', async () => {
+    await configPage.inputSystemsPane.getLanguageByName(firstLanguage).click();
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi');
+    await configPage.inputSystemsPane.moreButton.click();
+    await configPage.inputSystemsPane.moreButtonGroup.addVoice.click();
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isEnabled()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.voiceVariantInput.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-Zxxx-x-audio');
   });
 
-  it('cannot add another Voice variation', () => {
-    configPage.inputSystemsPane.moreButton.click();
-    expect(configPage.inputSystemsPane.moreButtonGroup.addVoice.getAttribute('class')).toContain('disabled');
+  it('cannot add another Voice variation', async () => {
+    await configPage.inputSystemsPane.moreButton.click();
+    expect(await configPage.inputSystemsPane.moreButtonGroup.addVoice.getAttribute('class')).toContain('disabled');
   });
 
-  it('can remove Voice variation', () => {
-    expect<any>(configPage.inputSystemsPane.moreButtonGroup.remove.isDisplayed()).toBe(true);
-    configPage.inputSystemsPane.moreButtonGroup.remove.click();
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('en');
+  it('can remove Voice variation', async () => {
+    expect<any>(await configPage.inputSystemsPane.moreButtonGroup.remove.isDisplayed()).toBe(true);
+    await configPage.inputSystemsPane.moreButtonGroup.remove.click();
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('en');
   });
 
-  it('can add Variant variation', () => {
-    configPage.inputSystemsPane.getLanguageByName(firstLanguage).click();
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi');
-    configPage.inputSystemsPane.moreButton.click();
-    configPage.inputSystemsPane.moreButtonGroup.addVariant.click();
-    expect<any>(configPage.noticeList.count()).toBe(0);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isEnabled()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isEnabled()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isEnabled()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.variantInput.isDisplayed()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.variantInput.isEnabled()).toBe(true);
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-unspecified');
+  it('can add Variant variation', async () => {
+    await configPage.inputSystemsPane.getLanguageByName(firstLanguage).click();
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi');
+    await configPage.inputSystemsPane.moreButton.click();
+    await configPage.inputSystemsPane.moreButtonGroup.addVariant.click();
+    expect<any>(await configPage.noticeList.count()).toBe(0);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.specialDropdown.isEnabled()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.scriptDropdown.isEnabled()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.regionDropdown.isEnabled()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.variantInput.isDisplayed()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.variantInput.isEnabled()).toBe(true);
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi-unspecified');
   });
 
-  it('can always add another Variant variation', () => {
-    configPage.inputSystemsPane.moreButton.click();
-    expect(configPage.inputSystemsPane.moreButtonGroup.addVariant.getAttribute('class')).not.toContain('disabled');
+  it('can always add another Variant variation', async () => {
+    await configPage.inputSystemsPane.moreButton.click();
+    expect(await configPage.inputSystemsPane.moreButtonGroup.addVariant.getAttribute('class')).not.toContain('disabled');
   });
 
-  it('can remove Variant variation', () => {
-    expect<any>(configPage.inputSystemsPane.moreButtonGroup.remove.isDisplayed()).toBe(true);
-    configPage.inputSystemsPane.moreButtonGroup.remove.click();
-    expect<any>(configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('en');
+  it('can remove Variant variation', async () => {
+    expect<any>(await configPage.inputSystemsPane.moreButtonGroup.remove.isDisplayed()).toBe(true);
+    await configPage.inputSystemsPane.moreButtonGroup.remove.click();
+    expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('en');
   });
 
-  it('can save new Input System', () => {
-    expect<any>(configPage.noticeList.count()).toBe(0);
-    configPage.applyButton.click();
-    expect<any>(configPage.noticeList.count()).toBe(1);
-    expect(configPage.noticeList.get(0).getText()).toContain('Configuration updated successfully');
+  it('can save new Input System', async () => {
+    expect<any>(await configPage.noticeList.count()).toBe(0);
+    await configPage.applyButton.click();
+    expect<any>(await configPage.noticeList.count()).toBe(1);
+    expect(await configPage.noticeList.get(0).getText()).toContain('Configuration updated successfully');
   });
 
 });

--- a/test/app/languageforge/lexicon/settings/interface-language.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/interface-language.e2e-spec.ts
@@ -5,36 +5,36 @@ import {PageHeader} from '../../../bellows/shared/page-header.element';
 describe('Interface Language picker (LF only so far)', () => {
   const header = new PageHeader();
 
-  it('should be using English interface for user at Login', () => {
-    BellowsLoginPage.logout();
-    BellowsLoginPage.get();
-    expect<any>(header.language.button.getText()).toEqual('English');
+  it('should be using English interface for user at Login', async () => {
+    await BellowsLoginPage.logout();
+    await BellowsLoginPage.get();
+    expect<any>(await header.language.button.getText()).toEqual('English');
   });
 
-  it('can change user interface language to French', () => {
-    header.language.button.click();
-    header.language.findItem('Français').click();
-    expect<any>(header.language.button.getText()).toEqual('Français');
+  it('can change user interface language to French', async () => {
+    await header.language.button.click();
+    await header.language.findItem('Français').click();
+    expect<any>(await header.language.button.getText()).toEqual('Français');
   });
 
-  describe('local storage', () => {
+  describe('local storage', async () => {
 
-    it('should still be using French in another page', () => {
-      BellowsForgotPasswordPage.get();
-      expect<any>(header.language.button.getText()).toEqual('Français');
+    it('should still be using French in another page', async () => {
+      await BellowsForgotPasswordPage.get();
+      expect<any>(await header.language.button.getText()).toEqual('Français');
     });
 
-    it('should still be using French back in the login page', () => {
-      BellowsLoginPage.get();
-      expect<any>(header.language.button.getText()).toEqual('Français');
+    it('should still be using French back in the login page', async () => {
+      await BellowsLoginPage.get();
+      expect<any>(await header.language.button.getText()).toEqual('Français');
     });
 
   });
 
-  it('can change user interface language to back English', () => {
-    header.language.button.click();
-    header.language.findItem('English').click();
-    expect<any>(header.language.button.getText()).toEqual('English');
+  it('can change user interface language to back English', async () => {
+    await header.language.button.click();
+    await header.language.findItem('English').click();
+    expect<any>(await header.language.button.getText()).toEqual('English');
   });
 
 });

--- a/test/app/languageforge/lexicon/settings/lexicon-project-settings.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/lexicon-project-settings.e2e-spec.ts
@@ -6,10 +6,10 @@ describe('Lexicon E2E Project Settings', () => {
   const loginPage = new BellowsLoginPage();
   const projectSettingsPage = new ProjectSettingsPage();
 
-  it('should display project properties for manager', () => {
-    loginPage.loginAsManager();
-    projectSettingsPage.get(constants.testProjectName);
-    expect(projectSettingsPage.tabs.project.isDisplayed());
-    expect<any>(projectSettingsPage.projectTab.saveButton.isDisplayed()).toBe(true);
+  it('should display project properties for manager', async () => {
+    await loginPage.loginAsManager();
+    await projectSettingsPage.get(constants.testProjectName);
+    expect(await projectSettingsPage.tabs.project.isDisplayed());
+    expect<any>(await projectSettingsPage.projectTab.saveButton.isDisplayed()).toBe(true);
   });
 });

--- a/test/app/languageforge/lexicon/settings/semantic-domains.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/semantic-domains.e2e-spec.ts
@@ -18,120 +18,120 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
   const semanticDomain1dot1English = constants.testEntry1.senses[0].semanticDomain.values[0] + ' Sky';
   const semanticDomain1dot1Thai = constants.testEntry1.senses[0].semanticDomain.values[0] + ' ท้องฟ้า';
 
-  it('should be using English Semantic Domain for manager', () => {
-    loginPage.loginAsManager();
-    projectsPage.get();
-    projectsPage.clickOnProject(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    expect<any>(editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
-    expect<any>(editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
-    expect<any>(header.language.button.getText()).toEqual('English');
+  it('should be using English Semantic Domain for manager', async () => {
+    await loginPage.loginAsManager();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    expect<any>(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
+    expect<any>(await header.language.button.getText()).toEqual('English');
   });
 
-  it('can change Project default language to Thai', () => {
-    projectSettingsPage.getByLink();
-    expect<any>(projectSettingsPage.tabs.project.isDisplayed()).toBe(true);
-    expect<any>(projectSettingsPage.projectTab.saveButton.isDisplayed()).toBe(true);
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelect.isDisplayed()).toBe(true);
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
-    projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
-    projectSettingsPage.projectTab.saveButton.click();
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
-    expect<any>(header.language.button.getText()).toEqual('ภาษาไทย');
+  it('can change Project default language to Thai', async () => {
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.tabs.project.isDisplayed()).toBe(true);
+    expect<any>(await projectSettingsPage.projectTab.saveButton.isDisplayed()).toBe(true);
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelect.isDisplayed()).toBe(true);
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    expect<any>(await header.language.button.getText()).toEqual('ภาษาไทย');
   });
 
-  it('should be using Thai Semantic Domain', () => {
-    Utils.clickBreadcrumb(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    expect<any>(editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
+  it('should be using Thai Semantic Domain', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
   });
 
-  it('can change Project default language back to English', () => {
-    projectSettingsPage.getByLink();
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
-    projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('English');
-    projectSettingsPage.projectTab.saveButton.click();
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
-    expect<any>(header.language.button.getText()).toEqual('English');
+  it('can change Project default language back to English', async () => {
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('English');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    expect<any>(await header.language.button.getText()).toEqual('English');
   });
 
-  it('should be using English Semantic Domain', () => {
-    Utils.clickBreadcrumb(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    expect<any>(editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
+  it('should be using English Semantic Domain', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
   });
 
-  it('can change Project default language back to Thai', () => {
-    projectSettingsPage.getByLink();
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
-    projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
-    projectSettingsPage.projectTab.saveButton.click();
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+  it('can change Project default language back to Thai', async () => {
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
   });
 
-  it('should be using Thai Semantic Domain after refresh', () => {
-    Utils.clickBreadcrumb(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    expect<any>(editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
-    expect<any>(editorPage.edit.entryCountElem.isDisplayed()).toBe(true);
-    browser.refresh();
-    browser.wait(ExpectedConditions.visibilityOf(editorPage.edit.entryCountElem), Utils.conditionTimeout);
-    expect<any>(editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
+  it('should be using Thai Semantic Domain after refresh', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
+    expect<any>(await editorPage.edit.entryCountElem.isDisplayed()).toBe(true);
+    await browser.refresh();
+    await browser.wait(ExpectedConditions.visibilityOf(editorPage.edit.entryCountElem), Utils.conditionTimeout);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
   });
 
-  it('can change user interface language', () => {
-    expect<any>(header.language.button.getText()).toEqual('ภาษาไทย');
-    header.language.button.click();
-    header.language.findItem('English').click();
-    expect<any>(header.language.button.getText()).toEqual('English');
+  it('can change user interface language', async () => {
+    expect<any>(await header.language.button.getText()).toEqual('ภาษาไทย');
+    await header.language.button.click();
+    await header.language.findItem('English').click();
+    expect<any>(await header.language.button.getText()).toEqual('English');
   });
 
-  it('should still have Thai for Project default language', () => {
-    projectSettingsPage.getByLink();
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+  it('should still have Thai for Project default language', async () => {
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
   });
 
-  it('should be using English Semantic Domain', () => {
-    Utils.clickBreadcrumb(constants.testProjectName);
-    editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
-    expect<any>(editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
+  it('should be using English Semantic Domain', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
   });
 
-  it('should be using English Semantic Domain after refresh', () => {
-    expect<any>(editorPage.edit.entryCountElem.isDisplayed()).toBe(true);
-    browser.refresh();
-    browser.wait(ExpectedConditions.visibilityOf(editorPage.edit.entryCountElem), Utils.conditionTimeout);
-    expect<any>(editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
+  it('should be using English Semantic Domain after refresh', async () => {
+    expect<any>(await editorPage.edit.entryCountElem.isDisplayed()).toBe(true);
+    await browser.refresh();
+    await browser.wait(ExpectedConditions.visibilityOf(editorPage.edit.entryCountElem), Utils.conditionTimeout);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
   });
 
-  it('should still have Thai for Project default language', () => {
-    projectSettingsPage.getByLink();
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+  it('should still have Thai for Project default language', async () => {
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
   });
 
-  it('can change user interface language to English', () => {
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
-    header.language.button.click();
-    header.language.findItem('English').click();
-    expect<any>(header.language.button.getText()).toEqual('English');
+  it('can change user interface language to English', async () => {
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    await header.language.button.click();
+    await header.language.findItem('English').click();
+    expect<any>(await header.language.button.getText()).toEqual('English');
   });
 
-  it('can change Project default language to match interface language twice', () => {
-    projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('English');
-    projectSettingsPage.projectTab.saveButton.click();
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
-    expect<any>(header.language.button.getText()).toEqual('English');
+  it('can change Project default language to match interface language twice', async () => {
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('English');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    expect<any>(await header.language.button.getText()).toEqual('English');
 
-    projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
-    projectSettingsPage.projectTab.saveButton.click();
-    expect<any>(projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
-    expect<any>(header.language.button.getText()).toEqual('ภาษาไทย');
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    expect<any>(await header.language.button.getText()).toEqual('ภาษาไทย');
   });
 
-  it('can change user interface language to back English', () => {
-    header.language.button.click();
-    header.language.findItem('English').click();
-    expect<any>(header.language.button.getText()).toEqual('English');
+  it('can change user interface language to back English', async () => {
+    await header.language.button.click();
+    await header.language.findItem('English').click();
+    expect<any>(await header.language.button.getText()).toEqual('English');
   });
 
 });

--- a/test/app/languageforge/lexicon/shared/configuration.page.ts
+++ b/test/app/languageforge/lexicon/shared/configuration.page.ts
@@ -12,10 +12,10 @@ export class ConfigurationPage {
   settingsMenuLink = element(by.id('settings-dropdown-button'));
   configurationLink = element(by.id('dropdown-configuration'));
 
-  get() {
-    Utils.scrollTop();
-    this.settingsMenuLink.click();
-    this.configurationLink.click();
+  async get() {
+    await Utils.scrollTop();
+    await this.settingsMenuLink.click();
+    return this.configurationLink.click();
   }
 
   applyButton = element(by.id('configuration-apply-btn'));
@@ -225,9 +225,9 @@ export class ConfigurationPage {
       remove:     this.activePane.element(by.id('configuration-remove-btn')),
       // tslint:disable-next-line:max-line-length
       // see http://stackoverflow.com/questions/25553057/making-protractor-wait-until-a-ui-boostrap-modal-box-has-disappeared-with-cucum
-      newButtonClick: () => {
-        this.inputSystemsPane.newButton.click();
-        browser.executeScript('$(\'.modal\').removeClass(\'fade\');');
+      newButtonClick: async () => {
+        await this.inputSystemsPane.newButton.click();
+        return browser.executeScript('$(\'.modal\').removeClass(\'fade\');');
       }
     },
     getLanguageByName: (languageName: string) =>

--- a/test/app/languageforge/lexicon/shared/editor.page.ts
+++ b/test/app/languageforge/lexicon/shared/editor.page.ts
@@ -183,8 +183,8 @@ export class EditorPage {
       return this.editorUtil.dcMultitextToObject(lexeme);
     },
 
-    getFirstLexeme: () => {
-      browser.wait(ExpectedConditions.visibilityOf(this.edit.fields.get(0)), Utils.conditionTimeout);
+    getFirstLexeme: async () => {
+      await browser.wait(ExpectedConditions.visibilityOf(this.edit.fields.get(0)), Utils.conditionTimeout);
 
       // Returns the first (topmost) lexeme regardless of its wsid
       const lexeme = this.edit.fields.get(0);

--- a/test/app/languageforge/lexicon/shared/new-lex-project.page.ts
+++ b/test/app/languageforge/lexicon/shared/new-lex-project.page.ts
@@ -9,7 +9,7 @@ export class NewLexProjectPage {
   modal = new LexModals();
 
   static get() {
-    browser.get(browser.baseUrl + '/app/lexicon/new-project');
+    return browser.get(browser.baseUrl + '/app/lexicon/new-project');
   }
 
   // form controls
@@ -20,22 +20,22 @@ export class NewLexProjectPage {
   backButton = element(by.id('back-button'));
   nextButton = element(by.id('next-button'));
 
-  expectFormIsValid() {
-    expect(this.nextButton.getAttribute('class')).toMatch(/btn-primary(?:\s|$)/);
+  async expectFormIsValid() {
+    expect(await this.nextButton.getAttribute('class')).toMatch(/btn-primary(?:\s|$)/);
   }
 
-  expectFormIsNotValid() {
-    expect(this.nextButton.getAttribute('class')).not.toMatch(/btn-primary(?:\s|$)/);
+  async expectFormIsNotValid() {
+    expect(await this.nextButton.getAttribute('class')).not.toMatch(/btn-primary(?:\s|$)/);
   }
 
   formStatus = {
-    expectHasNoError() {
-      expect(element(by.id('form-status')).getAttribute('class')).not.toContain('alert');
+    async expectHasNoError() {
+      expect(await element(by.id('form-status')).getAttribute('class')).not.toContain('alert');
     },
-    expectContainsError(partialMsg: string) {
+    async expectContainsError(partialMsg: string) {
       if (!partialMsg) partialMsg = '';
-      expect(element(by.id('form-status')).getAttribute('class')).toContain('alert-danger');
-      expect(element(by.id('form-status')).getText()).toContain(partialMsg);
+      expect(await element(by.id('form-status')).getAttribute('class')).toContain('alert-danger');
+      expect(await element(by.id('form-status')).getText()).toContain(partialMsg);
     }
   };
 
@@ -86,9 +86,9 @@ export class NewLexProjectPage {
     selectButton: element(by.id('select-language-button')),
     // tslint:disable-next-line:max-line-length
     // see http://stackoverflow.com/questions/25553057/making-protractor-wait-until-a-ui-boostrap-modal-box-has-disappeared-with-cucum
-    selectButtonClick() {
-      element(by.id('select-language-button')).click();
-      browser.executeScript('$(\'.modal\').removeClass(\'fade\');');
+    async selectButtonClick() {
+      await element(by.id('select-language-button')).click();
+      return browser.executeScript('$(\'.modal\').removeClass(\'fade\');');
     }
   };
   // step 3 alternate: send receive clone

--- a/test/app/languageforge/lexicon/shared/project-settings.page.ts
+++ b/test/app/languageforge/lexicon/shared/project-settings.page.ts
@@ -10,17 +10,17 @@ export class ProjectSettingsPage {
   projectSettingsLink = element(by.id('dropdown-project-settings'));
 
   // Get the projectSettings for project projectName
-  get(projectName: string) {
-    this.projectsPage.get();
-    this.projectsPage.clickOnProject(projectName);
-    this.getByLink();
+  async get(projectName: string) {
+    await this.projectsPage.get();
+    await this.projectsPage.clickOnProject(projectName);
+    return this.getByLink();
   }
 
-  getByLink() {
-    browser.wait(ExpectedConditions.visibilityOf(this.settingsMenuLink), this.conditionTimeout);
-    this.settingsMenuLink.click();
-    browser.wait(ExpectedConditions.visibilityOf(this.projectSettingsLink), this.conditionTimeout);
-    this.projectSettingsLink.click();
+  async getByLink() {
+    await browser.wait(ExpectedConditions.visibilityOf(this.settingsMenuLink), this.conditionTimeout);
+    await this.settingsMenuLink.click();
+    await browser.wait(ExpectedConditions.visibilityOf(this.projectSettingsLink), this.conditionTimeout);
+    return this.projectSettingsLink.click();
   }
 
   tabDivs = element.all(by.className('tab-pane'));


### PR DESCRIPTION
This fixes many (hopefully, all) E2E test failures caused by race conditions, e.g. a FooPage.get() call at the end of one test that isn't being awaited, so the next test starts before the get() call has actually completed and then the next test fails because the browser isn't yet on that page.

There are still quite a few E2E test failures remaining, but I believe those are all, or mostly, real failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/847)
<!-- Reviewable:end -->
