### PR TITLE
Fix more async problems in E2E tests

### DIFF
--- a/src/Api/Model/Shared/Command/LdapiCommands.php
+++ b/src/Api/Model/Shared/Command/LdapiCommands.php
@@ -68,8 +68,8 @@ class LdapiCommands
         return ($result === 'Manager');
     }
 
-    public static function getAllRoles($languageDepotUsername) {
-        return Ldapi::call($languageDepotUsername, 'get', self::ROLES_BASE_URL . self::URL_PART_GET_ALL);
+    public static function getAllRoles() {
+        return Ldapi::call(null, 'get', self::ROLES_BASE_URL . self::URL_PART_GET_ALL);
     }
 }
 

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -91,7 +91,7 @@ class RightsHelper
      */
     public function userHasProjectRight($right)
     {
-        return $this->_projectModel->hasRight($this->_userId, $right);
+        return isset($this->_projectModel) ? $this->_projectModel->hasRight($this->_userId, $right) : false;
     }
 
     /**

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -947,7 +947,7 @@ class Sf
         }
         if ($user->email) {
             $ldUsers = LdapiCommands::searchUsers('', $user->email);
-            if (count($ldUsers) == 1) {
+            if ($ldUsers && count($ldUsers) == 1) {
                 $username = $ldUsers[0]['username'];
                 if ($username) {
                     $user->languageDepotUsername = $username;
@@ -1004,7 +1004,7 @@ class Sf
     }
 
     public function ldapi_get_all_roles() {
-        return LdapiCommands::getAllRoles($this->get_ldapi_username());
+        return LdapiCommands::getAllRoles();
     }
 
     // ---------------------------------------------------------------

--- a/src/angular-app/bellows/core/api/roles.service.ts
+++ b/src/angular-app/bellows/core/api/roles.service.ts
@@ -13,6 +13,7 @@ export class RolesService {
   techSupport: IPromise<string>;
   static defaultContributorRole = 'Contributor';
   static defaultManagerRole = 'Manager';
+  static defaultTechSupportRole = 'LanguageDepotProgrammer';
   // get contributor(): IPromise<string {
   //   return this._contributor || RolesService.defaultContributorRole;
   // }
@@ -100,13 +101,13 @@ export class RolesService {
           }
         });
         if (!contributorFound) {
-          contributorD.reject('No contributor role found!');
+          contributorD.resolve(RolesService.defaultContributorRole);
         }
         if (!managerFound) {
-          managerD.reject('No manager role found!');
+          contributorD.resolve(RolesService.defaultManagerRole);
         }
         if (!techSupportFound) {
-          techSupportD.reject('No tech support role found!');
+          contributorD.resolve(RolesService.defaultTechSupportRole);
         }
         return result.data;
       } else {

--- a/test/app/bellows/shared/utils.ts
+++ b/test/app/bellows/shared/utils.ts
@@ -12,7 +12,7 @@ export class Utils {
     // what its current value is
     return checkboxElement.isSelected().then((checked: boolean) => {
       if (checked !== value) {
-        checkboxElement.click();
+        return checkboxElement.click();
       }
     });
   }
@@ -69,7 +69,7 @@ export class Utils {
   waitForAlert(timeout: number) {
     if (!timeout) { timeout = 8000; }
 
-    browser.wait(() => {
+    return browser.wait(() => {
       let alertPresent = true;
       try {
         browser.switchTo().alert();
@@ -86,12 +86,12 @@ export class Utils {
   notice: any = {
     list: this.noticeList,
     firstCloseButton: this.noticeList.first().element(by.partialButtonText('×')),
-    waitToInclude: (includedText: any): void => {
-      browser.wait(() =>
+    waitToInclude: async (includedText: any) => {
+      await browser.wait(() =>
         this.noticeList.count().then((count: any) =>
           count >= 1),
         Utils.conditionTimeout);
-      browser.wait(() =>
+      return browser.wait(() =>
         this.noticeList.first().getText().then((text: any) => text.includes(includedText)),
         Utils.conditionTimeout);
     }
@@ -144,7 +144,7 @@ export class Utils {
 
   static isAllCheckboxes(elementArray: ElementArrayFinder, state: boolean = true) {
     const all: boolean[] = [];
-    return elementArray.map((checkboxElement: ElementFinder) => {
+    return elementArray.each((checkboxElement: ElementFinder) => {
       checkboxElement.isSelected().then((isSelected: boolean) => {
         all.push(isSelected);
       });

--- a/test/app/languageforge/lexicon-traversal.e2e-spec.ts
+++ b/test/app/languageforge/lexicon-traversal.e2e-spec.ts
@@ -85,7 +85,7 @@ describe('Lexicon E2E Page Traversal', () => {
     it('Edit view', async () => {
       await projectsPage.get();
       await projectsPage.clickOnProject(constants.testProjectName);
-      await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+      await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
       await editorPage.noticeList.count();
       await editorPage.edit.entriesList.count();
       await editorPage.edit.senses.count();

--- a/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
@@ -24,7 +24,7 @@ describe('Lexicon E2E Editor Comments', () => {
   });
 
   it('click on first word', async () => {
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
   });
 
   it('click first comment bubble, type in a comment, add text to another part of the entry, ' +

--- a/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
   });
 
   it('click on first word', async () => {
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
   });
 
   it('refresh returns to entry view', async () => {
@@ -81,7 +81,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
     await util.setCheckbox(configPage.unifiedPane.hiddenIfEmptyCheckbox('Citation Form'), false);
     await configPage.applyButton.click();
     await Utils.clickBreadcrumb(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
   });
 
   it('citation form field overrides lexeme form in dictionary citation view', async () => {
@@ -137,7 +137,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
 
   it('caption is hidden when empty if "Hidden if empty" is set in config', async () => {
     await Utils.clickBreadcrumb(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     await editorPage.edit.hideHiddenFields();
     expect<any>(await editorPage.edit.pictures.captions.first().isDisplayed()).toBe(true);
     await editorPage.edit.selectElement.clear(editorPage.edit.pictures.captions.first());
@@ -155,7 +155,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
 
   it('when caption is empty, it is visible if "Hidden if empty" is cleared in config', async () => {
     await Utils.clickBreadcrumb(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     expect<any>(await editorPage.edit.pictures.captions.first().isDisplayed()).toBe(true);
   });
 
@@ -178,7 +178,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
 
   it('while Show Hidden Fields has not been clicked, Pictures field is hidden', async () => {
     await Utils.clickBreadcrumb(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     expect<any>(await editorPage.edit.getFields('Pictures').count()).toBe(0);
     await editorPage.edit.showHiddenFields();
     expect<any>(await editorPage.edit.pictures.list.isPresent()).toBe(true);
@@ -233,7 +233,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
     await loginPage.loginAsMember();
     await projectsPage.get();
     await projectsPage.clickOnProject(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
   });
 
   it('audio Input System is present, playable and has "more" control (member)', async () => {
@@ -266,7 +266,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
     await loginPage.loginAsObserver();
     await projectsPage.get();
     await projectsPage.clickOnProject(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
   });
 
   it('audio Input System is playable but does not have "more" control (observer)', async () => {
@@ -297,7 +297,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
     await loginPage.loginAsManager();
     await projectsPage.get();
     await projectsPage.clickOnProject(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
   });
 
   it('can delete audio Input System', async () => {
@@ -523,7 +523,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
         configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, englishISIndex), true);
       await configPage.applyButton.click();
       await Utils.clickBreadcrumb(constants.testProjectName);
-      await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+      await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     });
 
     it('Word has "th", "tipa", "taud" and "en" visible', async () => {
@@ -542,7 +542,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
         configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, englishISIndex), false);
       await configPage.applyButton.click();
       await Utils.clickBreadcrumb(constants.testProjectName);
-      await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+      await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     });
 
     it('Word has only "th", "tipa" and "taud" visible', async () => {
@@ -589,7 +589,7 @@ describe('Lexicon E2E Editor List and Entry', () => {
   });
 
   it('remove new word to restore original word count', async () => {
-    await editorPage.browse.findEntryByLexeme(constants.testEntry3.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry3.lexeme.th.value);
     await editorPage.edit.actionMenu.click();
     await editorPage.edit.deleteMenuItem.click();
     expect<any>(await editorPage.modal.modalBodyText.getText()).toContain(constants.testEntry3.lexeme.th.value);

--- a/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Lexicon E2E Configuration Fields', () => {
     await loginPage.loginAsManager();
     await projectsPage.get();
     await projectsPage.clickOnProject(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     expect(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
   });
 
@@ -126,7 +126,7 @@ describe('Lexicon E2E Configuration Fields', () => {
       await configPage.applyButton.click();
       expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
       await Utils.clickBreadcrumb(constants.testProjectName);
-      await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+      await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
       await editorPage.edit.showHiddenFields();
       expect<any>(await editorPage.edit.getFieldLabel(0).getText()).toEqual('Word');
       expect<any>(await editorPage.edit.getFieldLabel(1).getText()).toEqual('Pronunciation');

--- a/test/app/languageforge/lexicon/settings/semantic-domains.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/semantic-domains.e2e-spec.ts
@@ -22,7 +22,7 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
     await loginPage.loginAsManager();
     await projectsPage.get();
     await projectsPage.clickOnProject(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     expect<any>(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
     expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
     expect<any>(await header.language.button.getText()).toEqual('English');
@@ -42,7 +42,7 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
 
   it('should be using Thai Semantic Domain', async () => {
     await Utils.clickBreadcrumb(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
   });
 
@@ -57,7 +57,7 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
 
   it('should be using English Semantic Domain', async () => {
     await Utils.clickBreadcrumb(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
   });
 
@@ -71,7 +71,7 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
 
   it('should be using Thai Semantic Domain after refresh', async () => {
     await Utils.clickBreadcrumb(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
     expect<any>(await editorPage.edit.entryCountElem.isDisplayed()).toBe(true);
     await browser.refresh();
@@ -93,7 +93,7 @@ describe('Lexicon E2E Semantic Domains Lazy Load', () => {
 
   it('should be using English Semantic Domain', async () => {
     await Utils.clickBreadcrumb(constants.testProjectName);
-    await editorPage.browse.findEntryByLexeme(constants.testEntry1.lexeme.th.value).click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
   });
 


### PR DESCRIPTION
Three fixes included:

- Fix LD API call that was causing "Oh. Error." messages during most tests, and several test failures
- Fix unsightly RPC errors in Chrome if it hangs around after you cancel E2E test execution (caused by the offline check trying to look up rights in the current project when the current project was a test project that had been deleted at the end of the test)
- Fix a few utility helper functions that weren't actually async even though they looked async (e.g., findEntryByLexeme, which I renamed to clickEntryByLexeme because then it can be called as `await editorPage.browse.clickEntryByLexeme('foo')` instead of `await (await editorPage.browse.findEntryByLexeme('foo')).click()`).

This PR supersedes #846 as it includes all of #846's fixes. I decided it was less confusing to put all the fixes into a single PR rather than have multiple PRs that need to be merged in before you can start working on real E2E errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/849)
<!-- Reviewable:end -->
