### PR TITLE
standardize naming of volumes for easy cleanup on CI (TeamCity)

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -30,5 +30,9 @@ clean:
 	docker-compose kill
 	docker-compose rm -f
 	docker system prune -f
+
+    # remove lf-specific volumes
+	docker volume ls -q |grep _lf_ | xargs docker volume rm
+
   # by default volumes are not pruned.  To prune volumes as well, do:
   # docker system prune -f --volumes

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -32,7 +32,7 @@ clean:
 	docker system prune -f
 
     # remove lf-specific volumes
-	docker volume ls -q |grep _lf_ | xargs --no-run-if-empty docker volume rm
+	docker volume ls -q |grep ^docker_lf_ | xargs --no-run-if-empty docker volume rm
 
   # by default volumes are not pruned.  To prune volumes as well, do:
   # docker system prune -f --volumes

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -32,7 +32,7 @@ clean:
 	docker system prune -f
 
     # remove lf-specific volumes
-	docker volume ls -q |grep _lf_ | xargs docker volume rm
+	docker volume ls -q |grep _lf_ | xargs --no-run-if-empty docker volume rm
 
   # by default volumes are not pruned.  To prune volumes as well, do:
   # docker system prune -f --volumes

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - api
     volumes:
       # share dist folder between ui and api containers
-      - webpack-dist-folder:/data/src/dist
+      - lf_webpack_dist_folder:/data/src/dist
 
       # for developer convenience
       - ../src:/data/src
@@ -33,10 +33,10 @@ services:
     command: sh -c "/wait && apache2-foreground"
     volumes:
       # share dist folder between ui and api containers
-      - webpack-dist-folder:/var/www/src/dist
+      - lf_webpack_dist_folder:/var/www/src/dist
 
       # persist user data uploads and assets
-      - user-data-assets:/var/www/src/assets
+      - lf_user_data_assets:/var/www/src/assets
 
       # for developer convenience
       - ../src/Api:/var/www/src/Api
@@ -51,8 +51,8 @@ services:
     depends_on:
       - ui
     volumes:
-      - caddy_data:/data
-      - caddy_config:/config
+      - lf_caddy_data:/data
+      - lf_caddy_config:/config
     # https://caddyserver.com/docs/command-line
     command: caddy reverse-proxy --from localhost --to api
     restart: unless-stopped
@@ -71,7 +71,7 @@ services:
       # exposed this to host for admin tools
       - 27017:27017
     volumes:
-      - mongo-data:/data/db
+      - lf_mongo_data:/data/db
     restart: always
 
   # TODO: still needs to be built/run/tested, etc.
@@ -107,7 +107,7 @@ services:
     command: sh -c "/wait && /run.sh"
     volumes:
       # share dist folder between ui and api containers
-      - webpack-dist-folder:/data/src/dist
+      - lf_webpack_dist_folder:/data/src/dist
 
   e2e-api:
     build:
@@ -123,7 +123,7 @@ services:
     command: sh -c "/wait && /run.sh"
     volumes:
       # share dist folder between ui and api containers
-      - webpack-dist-folder:/var/www/src/dist
+      - lf_webpack_dist_folder:/var/www/src/dist
 
   test-api:
     # TODO: get XDebug working with VSCode
@@ -154,8 +154,8 @@ services:
       - db
 
 volumes:
-  caddy_config:
-  caddy_data:
-  mongo-data:
-  user-data-assets:
-  webpack-dist-folder:
+  lf_caddy_config:
+  lf_caddy_data:
+  lf_mongo_data:
+  lf_user_data_assets:
+  lf_webpack_dist_folder:


### PR DESCRIPTION
Use snake_case for names, as that's what Docker seems to prefer.  Add lf_ to the beginning of all volume names so that we can programmatically remove all lf_ volumes locally and on the build server without bothering other volumes needed for other projects

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/851)
<!-- Reviewable:end -->
