### PR TITLE
Chore/simplify docker cleanup and get some more helpful docs in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Other useful resources:
 
 ### Docker ###
 
-1. Install [Docker](https://www.docker.com/get-started)
+1. Install [Docker](https://www.docker.com/get-started) (Linux users will need some additional steps, please visit https://docs.docker.com/compose/install for info on install the engine and compose)
 1. Install [Make](https://www.gnu.org/software/make/).  This is actually optional but simplifies things a bit.
 1. Clone the repo:  `git clone https://github.com/sillsdev/web-languageforge`
 1. `cd web-languageforge/docker`

--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ Other useful resources:
 1. You should see a landing page, click "Login"
 1. Use `admin` and `password` to get in
 
+#### If you would like to run the E2E tests
+
+1. `make e2e`
+1. Individual test results will appear in your terminal but if you'd like to watch them in real-time, simply VNC into the running tests via `localhost:5900`, e.g., Mac OSX users simply `open vnc://localhost:5900` and use `secret` as the password.  Other operating systems may require installing a separate VNC Viewer tool.
+
+#### If you would like to run the unit tests
+
+1. `make tests`
+1. Test results will appear in your terminal
+
+#### Viewing logs
+
+1. `make logs` will show logs from any runnign contianers, results can be filtered by simply grepping, e.g., `make logs | grep lf-ui`
+
+#### Cleanup
+
+1. `make clean` is the most common, it shuts down and cleans up running containers
+1. less commonly, if you need to blow away shared artifacts from previous runs, simply `make clean-volumes`
+1. rarely needed but for a "start from scratch" environment, `make clean-powerwash`.
+
 #### Language Forge Configuration File ####
 
 If you are working with FLEx Send and Receive feature, manually edit the Language Forge config file

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Other useful resources:
 
 #### If you would like to run the E2E tests
 
-1. `make e2e`
+1. `make build e2e`
 1. Individual test results will appear in your terminal but if you'd like to watch them in real-time, simply VNC into the running tests via `localhost:5900`, e.g., Mac OSX users simply `open vnc://localhost:5900` and use `secret` as the password.  Other operating systems may require installing a separate VNC Viewer tool.
 
 #### If you would like to run the unit tests

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -31,10 +31,10 @@ logs:
 
 .PHONY: clean
 clean:
-	docker-compose down
+	docker-compose down -t 1
 	docker system prune -f
 
 .PHONY: clean-volumes
 clean-volumes:
-	docker-compose down -v
+	docker-compose down -t 1 -v
 	docker system prune -f --volumes

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -31,8 +31,10 @@ logs:
 
 .PHONY: clean
 clean:
-	docker-compose down -v
+	docker-compose down
 	docker system prune -f
 
-  # by default volumes are not pruned.  To prune volumes as well, do:
-  # docker system prune -f --volumes
+.PHONY: clean-volumes
+clean-volumes:
+	docker-compose down -v
+	docker system prune -f --volumes

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,7 +7,7 @@ start: wait
 
 .PHONY: e2e
 e2e:
-  docker-compose build ui api
+	docker-compose build ui api
 	docker-compose run e2e-ui
 
 .PHONY: tests

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,7 +3,7 @@
 .PHONY: start
 start: wait
   # starts the entire runtime infrastructure
-	docker-compose up -d ssl && docker-compose logs -f ui
+	docker-compose up -d ssl
 
 .PHONY: e2e
 e2e:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,7 +6,7 @@ start: wait
 	docker-compose up -d ssl
 
 .PHONY: e2e
-e2e: build
+e2e:
 	docker-compose run e2e-ui
 
 .PHONY: tests

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,7 +6,7 @@ start: wait
 	docker-compose up -d ssl
 
 .PHONY: e2e
-e2e:
+e2e: build
 	docker-compose run e2e-ui
 
 .PHONY: tests
@@ -38,3 +38,7 @@ clean:
 clean-volumes:
 	docker-compose down -t 1 -v
 	docker system prune -f --volumes
+
+.PHONY: clean-powerwash
+clean-powerwash: clean-volumes
+	docker-compose down -t 1 --rmi all

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -27,12 +27,8 @@ db-reset:
 
 .PHONY: clean
 clean:
-	docker-compose kill
-	docker-compose rm -f
+	docker-compose down -v
 	docker system prune -f
-
-    # remove lf-specific volumes
-	docker volume ls -q |grep ^docker_lf_ | xargs --no-run-if-empty docker volume rm
 
   # by default volumes are not pruned.  To prune volumes as well, do:
   # docker system prune -f --volumes

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -25,6 +25,10 @@ wait:
 db-reset:
 	docker-compose run db-reset
 
+.PHONY: logs
+logs:
+	docker-compose logs
+
 .PHONY: clean
 clean:
 	docker-compose down -v

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,6 +7,7 @@ start: wait
 
 .PHONY: e2e
 e2e:
+  docker-compose build ui api
 	docker-compose run e2e-ui
 
 .PHONY: tests

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -102,7 +102,6 @@ services:
       - e2e-api
       - mail
       - selenium
-      - ui
     environment:
       - WAIT_HOSTS=db:27017, mail:25, selenium:4444
     command: sh -c "/wait && /run.sh"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,7 +84,9 @@ services:
   selenium:
     # image: selenium/standalone-chrome
     image: selenium/standalone-chrome-debug
+    # TODO: seems would should have a depends_on for the e2e-api
     links:
+      # TODO:  I wonder why this was necessary, I would've thought e2e-api was already available, maybe not?
       - "e2e-api:e2e"
     volumes:
       - /dev/shm:/dev/shm

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - api
     volumes:
       # share dist folder between ui and api containers
-      - lf_webpack_dist_folder:/data/src/dist
+      - lf-webpack-dist-folder:/data/src/dist
 
       # for developer convenience
       - ../src:/data/src
@@ -33,10 +33,10 @@ services:
     command: sh -c "/wait && apache2-foreground"
     volumes:
       # share dist folder between ui and api containers
-      - lf_webpack_dist_folder:/var/www/src/dist
+      - lf-webpack-dist-folder:/var/www/src/dist
 
       # persist user data uploads and assets
-      - lf_user_data_assets:/var/www/src/assets
+      - lf-user-data-assets:/var/www/src/assets
 
       # for developer convenience
       - ../src/Api:/var/www/src/Api
@@ -51,8 +51,8 @@ services:
     depends_on:
       - ui
     volumes:
-      - lf_caddy_data:/data
-      - lf_caddy_config:/config
+      - lf-caddy-data:/data
+      - lf-caddy-config:/config
     # https://caddyserver.com/docs/command-line
     command: caddy reverse-proxy --from localhost --to api
     restart: unless-stopped
@@ -71,7 +71,7 @@ services:
       # exposed this to host for admin tools
       - 27017:27017
     volumes:
-      - lf_mongo_data:/data/db
+      - lf-mongo-data:/data/db
     restart: always
 
   # TODO: still needs to be built/run/tested, etc.
@@ -107,7 +107,7 @@ services:
     command: sh -c "/wait && /run.sh"
     volumes:
       # share dist folder between ui and api containers
-      - lf_webpack_dist_folder:/data/src/dist
+      - lf-webpack-dist-folder:/data/src/dist
 
   e2e-api:
     build:
@@ -123,7 +123,7 @@ services:
     command: sh -c "/wait && /run.sh"
     volumes:
       # share dist folder between ui and api containers
-      - lf_webpack_dist_folder:/var/www/src/dist
+      - lf-webpack-dist-folder:/var/www/src/dist
 
   test-api:
     # TODO: get XDebug working with VSCode
@@ -154,8 +154,8 @@ services:
       - db
 
 volumes:
-  lf_caddy_config:
-  lf_caddy_data:
-  lf_mongo_data:
-  lf_user_data_assets:
-  lf_webpack_dist_folder:
+  lf-caddy-config:
+  lf-caddy-data:
+  lf-mongo-data:
+  lf-user-data-assets:
+  lf-webpack-dist-folder:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       - e2e-api
       - mail
       - selenium
+      - ui
     environment:
       - WAIT_HOSTS=db:27017, mail:25, selenium:4444
     command: sh -c "/wait && /run.sh"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -111,6 +111,12 @@ services:
       # share dist folder between ui and api containers
       - lf-webpack-dist-folder:/data/src/dist
 
+      # for developer convenience
+      - ../src:/data/src
+      - ../typings:/data/typings
+      - ../webpack.config.js:/data/webpack.config.js
+      - ../gulpfile.js:/data/gulpfile.js
+
   e2e-api:
     build:
       context: ..


### PR DESCRIPTION
php tests are all still passing
⚠️  e2e tests are pretty flaky:
46 failures on TC `master` , 48 on `master` locally
50 failures on TC `chore/simplify-docker-cleanup`, 52 on `chore/simplify-docker-cleanup` locally

so it seems there are 2 extra failures locally than out on TC and it seems I've increased the failures with this PR, I'll keep looking to see if I can determine which failures are new and which 2 fail locally only.  Please let me know if things jump out to you in this PR that could be having some effect on the tests.

I tried figuring out where exactly the specs are being loaded but was getting a little lost in whether they were getting loaded in the webpack config or the gulpfile or somewhere else.  It would be really nice to have a way to limit the tests that are being run for troubleshooting purposes.

I'll just wait on this one until I can either pair or get some more experienced eyes on it because the number of failures changes each run for me locally, no need to keep burning cycles on it when I can be productive elsewhere.  Thanks for any help you can offer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/852)
<!-- Reviewable:end -->
