### PR TITLE
Fix "undefined (reported to Bugsnag)" errors

### DIFF
--- a/src/angular-app/bellows/core/exception-handling.service.ts
+++ b/src/angular-app/bellows/core/exception-handling.service.ts
@@ -42,9 +42,9 @@ export class ExceptionHandlingService {
 
   reportUnhandledException(exception: Error, cause?: string) {
     if (cause == null) {
-      this.$log.error('Error: ' + exception.message + ' (reported to Bugsnag)');
+      this.$log.error('Error: ' + exception.message ? exception.message : exception + ' (reported to Bugsnag)');
     } else {
-      this.$log.error('Error: ' + exception.message + '; caused by: ' + cause + ' (reported to Bugsnag)');
+      this.$log.error('Error: ' + exception.message ? exception.message : exception + '; caused by: ' + cause + ' (reported to Bugsnag)');
     }
 
     this.notifyBugsnag(exception, cause);


### PR DESCRIPTION
Our exception handling service is getting many errors with no `.message` property while running unit tests, which results in the useless error message "undefined (reported to Bugsnag)" in E2E test logs. This should fix that and at least print *something* meaningful even if the exception received has no `.message` property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/856)
<!-- Reviewable:end -->
