### PR TITLE
Fix two new E2E failures in user-profile tests

### DIFF
--- a/src/angular-app/bellows/apps/userprofile/user-profile-app.component.ts
+++ b/src/angular-app/bellows/apps/userprofile/user-profile-app.component.ts
@@ -229,8 +229,6 @@ export class UserProfileAppController implements angular.IController {
         }
       }
     });
-
-    this.userService.updateLdapiUser(this.originalUsername, this.user);
   }
 
   static getAvatarUrl(avatarRef: string): string {


### PR DESCRIPTION
The cause of the failure was an LD API call that I added to the updateUser method of UserProfileAppController. When the user updates their profile in Language Forge, I had an LD API call to update that user's account in Language Depot. And for some reason, by the time that LD API call is being made, LF no longer counts the user as being logged in. So the `checkPermissions` method in Sf.php says "Oh, you're not logged in? Well, this isn't an anonymous method, so go log in first." Except the actual error message printed in that code path is "Your session has timed out.  Please login again." And that's not the message the E2E test is expecting to see, so it fails.

Thing is, we're not yet at the stage of merging user accounts in Language Depot with Language Forge, so that LD API call is early. At the moment, where the Language Depot user pool and the Language Forge user pool are completely separate concepts, there's no reason to update the Language Depot user profile when you update your LF profile. So I've just removed the LD API call from the LF user profile app, and now when LF user profiles are updated, it won't touch the LD user profiles.

This PR reduces the number of E2E test failures by 2, consistently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/858)
<!-- Reviewable:end -->
