### PR TITLE
Another E2E async fix

### DIFF
--- a/test/app/bellows/shared/utils.ts
+++ b/test/app/bellows/shared/utils.ts
@@ -10,7 +10,7 @@ export class Utils {
   setCheckbox(checkboxElement: ElementFinder, value: boolean) {
     // Ensure a checkbox element will be either checked (true) or unchecked (false), regardless of
     // what its current value is
-    return checkboxElement.isSelected().then((checked: boolean) => {
+    return checkboxElement.isSelected().then(async (checked: boolean) => {
       if (checked !== value) {
         return checkboxElement.click();
       }

--- a/test/app/languageforge/lexicon/shared/editor.util.ts
+++ b/test/app/languageforge/lexicon/shared/editor.util.ts
@@ -157,23 +157,23 @@ export class EditorUtil {
 
   // designed for use with Text-Angular controls (i.e. that don't have ordinary input or textarea)
   selectElement = {
-    sendKeys(elem: any, keys: string) {
-      elem.click();
-      elem.sendKeys(keys);
+    async sendKeys(elem: any, keys: string) {
+      await elem.click();
+      return elem.sendKeys(keys);
     },
 
-    clear(elem: any) {
+    async clear(elem: any) {
       // fix problem with protractor not scrolling to element before click
-      elem.getLocation().then((navDivLocation: any) => {
+      await elem.getLocation().then((navDivLocation: any) => {
         const initTop = (navDivLocation.y - 150) > 0 ? navDivLocation.y - 150 : 1;
         const initLeft = navDivLocation.x;
         browser.executeScript('window.scrollTo(' + initLeft + ',' + initTop + ');');
       });
 
-      elem.click();
+      await elem.click();
       const ctrlA = Key.chord(Key.CONTROL, 'a');
-      elem.sendKeys(ctrlA);
-      elem.sendKeys(Key.DELETE);
+      await elem.sendKeys(ctrlA);
+      return elem.sendKeys(Key.DELETE);
     }
   };
 }


### PR DESCRIPTION
The `sendKeys` helper function in editor.util.ts wasn't properly async, so any tests relying on that were running their checks before the keystrokes had actually been sent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/860)
<!-- Reviewable:end -->
