### PR TITLE
Fix one flaky E2E test

### DIFF
--- a/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
@@ -592,8 +592,10 @@ describe('Lexicon E2E Editor List and Entry', () => {
     await editorPage.browse.clickEntryByLexeme(constants.testEntry3.lexeme.th.value);
     await editorPage.edit.actionMenu.click();
     await editorPage.edit.deleteMenuItem.click();
+    await browser.waitForAngular();
     expect<any>(await editorPage.modal.modalBodyText.getText()).toContain(constants.testEntry3.lexeme.th.value);
     await Utils.clickModalButton('Delete Entry');
+    await browser.waitForAngular();
     expect<any>(await editorPage.edit.getEntryCount()).toBe(3);
   });
 


### PR DESCRIPTION
Race condition between dismissing modal and checking that the item was deleted; solved with `waitForAngular()` which will ensure that the item deletion completes before the next line of the E2E test proceeds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/866)
<!-- Reviewable:end -->
