### PR TITLE
WIP: Add an hgweb service for viewing sample LD projects

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - db
       - mail
       - ld-api
+      - ld-hgweb
       - ui-builder
     environment:
       - WAIT_HOSTS=db:27017, mail:25
@@ -102,6 +103,14 @@ services:
     env_file: ld-api/ld.env
     environment:
       - PORT=3000
+
+  ld-hgweb:
+    build:
+      context: hgweb
+    image: ld-hgweb
+    container_name: ld-hgweb
+    expose:
+      - 80
 
   test-e2e:
     build:

--- a/docker/hgweb/Dockerfile
+++ b/docker/hgweb/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:bullseye
+
+# Most of this is copied from https://github.com/tiangolo/meinheld-gunicorn-docker (which is MIT licensed)
+# I changed it to pull from Debian Bullseye instead of the Docker Python image, since Bullseye has a more up-to-date
+# version of Mercurial as of now (2021-03-12)
+
+# See README.md in same directory for more details about technology choices for this Docker image
+
+RUN apt-get update && \
+    apt-get install --yes apt-utils && \
+    apt-get install --yes python3 python3-pip python3-venv
+
+RUN apt-get install --yes mercurial
+
+RUN pip3 install meinheld gunicorn
+
+COPY entrypoint.sh /entrypoint.sh
+COPY start.sh /start.sh
+COPY gunicorn_conf.py /gunicorn_conf.py
+
+COPY main.py /app/
+WORKDIR /app/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 80
+
+COPY mkrepo.sh /mkrepo.sh
+ENV SAMPLE_REPO=/srv/hg/project
+RUN /mkrepo.sh
+
+COPY hgweb.config /hgweb.config
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Run the start script, it will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Gunicorn with Meinheld
+CMD ["/start.sh"]

--- a/docker/hgweb/README.md
+++ b/docker/hgweb/README.md
@@ -1,0 +1,10 @@
+# hgweb Docker image
+
+## What's Gunicorn? What's Meinheld? Why not use nginx?
+
+Mercurial's built-in hgweb app can run as either a CGI app or a [WSGI](https://docs.python.org/3/library/wsgiref.html) app.
+I (Robin Munn) decided that WSGI would be significantly faster since that way the Web server could keep a long-running Python
+process going, whereas the CGI approach would require starting up Python for every request. I originally planned to use an nginx
+container, and a bit of DuckDuckGo searching led me to https://github.com/tiangolo/uwsgi-nginx-docker/. But the README for that
+project recommended https://github.com/tiangolo/meinheld-gunicorn-docker instead, saying that the Meinheld+Gunicorn solution
+would provide four times the performance of WSGI under Nginx.

--- a/docker/hgweb/entrypoint.sh
+++ b/docker/hgweb/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+if [ -f /app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/gunicorn_conf.py
+elif [ -f /app/app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/app/gunicorn_conf.py
+else
+    DEFAULT_GUNICORN_CONF=/gunicorn_conf.py
+fi
+export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
+
+exec "$@"

--- a/docker/hgweb/gunicorn_conf.py
+++ b/docker/hgweb/gunicorn_conf.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+
+import json
+import multiprocessing
+import os
+
+workers_per_core_str = os.getenv("WORKERS_PER_CORE", "2")
+web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
+host = os.getenv("HOST", "0.0.0.0")
+port = os.getenv("PORT", "80")
+bind_env = os.getenv("BIND", None)
+use_loglevel = os.getenv("LOG_LEVEL", "info")
+if bind_env:
+    use_bind = bind_env
+else:
+    use_bind = "{host}:{port}".format(host=host, port=port)
+
+cores = multiprocessing.cpu_count()
+workers_per_core = float(workers_per_core_str)
+default_web_concurrency = workers_per_core * cores
+if web_concurrency_str:
+    web_concurrency = int(web_concurrency_str)
+    assert web_concurrency > 0
+else:
+    web_concurrency = int(default_web_concurrency)
+
+# Gunicorn config variables
+loglevel = use_loglevel
+workers = web_concurrency
+bind = use_bind
+keepalive = 120
+errorlog = "-"
+
+# For debugging and testing
+log_data = {
+    "loglevel": loglevel,
+    "workers": workers,
+    "bind": bind,
+    # Additional, non-gunicorn variables
+    "workers_per_core": workers_per_core,
+    "host": host,
+    "port": port,
+}
+print(json.dumps(log_data))

--- a/docker/hgweb/hgweb.config
+++ b/docker/hgweb/hgweb.config
@@ -1,0 +1,2 @@
+[paths]
+/ = /srv/hg/*

--- a/docker/hgweb/main.py
+++ b/docker/hgweb/main.py
@@ -1,0 +1,7 @@
+hgweb_config = b"/hgweb.config"
+
+# enable demandloading to reduce startup time
+from mercurial import demandimport; demandimport.enable()
+
+from mercurial.hgweb import hgweb
+app = hgweb(hgweb_config)

--- a/docker/hgweb/mkrepo.sh
+++ b/docker/hgweb/mkrepo.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/env sh
+set -e
+
+# Create a sample repo for testing whether hgweb is running
+SAMPLE_REPO=${SAMPLE_REPO:-foo}
+mkdir -p $SAMPLE_REPO
+cd $SAMPLE_REPO
+hg init
+echo Hello World > hello.txt
+hg add hello.txt
+hg commit -m 'Created a hello world file'

--- a/docker/hgweb/start.sh
+++ b/docker/hgweb/start.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env sh
+set -e
+
+# If there's a prestart.sh script in the /app directory, run it before starting
+PRE_START_PATH=/app/prestart.sh
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Gunicorn
+exec gunicorn -k egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"


### PR DESCRIPTION
This will eventually be part of the Language Depot deployment, not Language Forge, because the hgweb service will need filesystem access to the Mercurial repositories which live on the Language Depot server. But at the moment, the Language Depot containerization is a work-in-progress, so having this container as part of the Language Forge set will allow me to work on the Language Forge UI for viewing repositories on Language Depot, without being blocked on the Language Depot containerization.

Note: I've left this as a draft PR because it's not really necessary for anyone else to merge it yet: for anyone not working on the LF UI for managing LD projects, this PR would just add extra build steps to "docker-compose up" without providing any extra benefit in terms of working on Language Forge. Once I add the ability to view Language Depot project repositories in the Language Forge interface, though, it will probably be necessary to merge this PR so that the LF code continues to work (and E2E tests continue to pass) for other developers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/878)
<!-- Reviewable:end -->
