### PR TITLE
move protractor e2e test command to package.json

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 # https://docs.docker.com/compose/reference/overview
 
 .PHONY: start
-start: wait
+start:
   # starts the entire runtime infrastructure
 	docker-compose up -d ssl
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,9 +121,12 @@ services:
     volumes:
       # for developer convenience
       - ../src:/data/src
+      - ../test:/data/test
       - ../typings:/data/typings
       - ../webpack.config.js:/data/webpack.config.js
       - ../gulpfile.js:/data/gulpfile.js
+      - ../package.json:/data/package.json
+      - ../package-lock.json:/data/package-lock.json
 
   app-for-e2e:
     build:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,12 +121,14 @@ services:
     volumes:
       # for developer convenience
       - ../src:/data/src
-      - ../test:/data/test
       - ../typings:/data/typings
       - ../webpack.config.js:/data/webpack.config.js
       - ../gulpfile.js:/data/gulpfile.js
       - ../package.json:/data/package.json
       - ../package-lock.json:/data/package-lock.json
+# uncomment on dev machine for convenience but don't commit - it messes up the e2e test run by
+# clobbering the JS files produced by tsc in the built image.
+#      - ../test:/data/test
 
   app-for-e2e:
     build:

--- a/docker/test-e2e/Dockerfile
+++ b/docker/test-e2e/Dockerfile
@@ -8,6 +8,6 @@ COPY docker/test-e2e/run.sh /run.sh
 # copy in test folder
 COPY test/ /data/test/
 
-RUN gulp test-e2e-clean-compile
+RUN npm run compile-test-e2e
 
 CMD ["/run.sh"]

--- a/docker/test-e2e/run.sh
+++ b/docker/test-e2e/run.sh
@@ -17,7 +17,7 @@ attach_debugger () {
 
 attach_debugger &
 cd /data
-gulp test-e2e-doTest --webserverHost app-for-e2e "$@"
+npm run test-e2e
 STATUS=$?
 
 exit $STATUS

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "sass:watch": "npm run sass && node-sass src/sass -o src/dist/css --watch --recursive",
     "webpack": "webpack",
     "webpack:watch": "webpack -w",
-    "webpack:production": "webpack -p"
+    "webpack:production": "webpack -p",
+    "compile-test-e2e": "tsc -p test/app",
+    "test-e2e": "protractor test/app/protractorConf.js"
   },
   "author": "",
   "license": "MIT",
@@ -83,7 +85,6 @@
     "gulp-clean-css": "^4.2.0",
     "gulp-concat": "^2.6.0",
     "gulp-exec": "~2.1.0",
-    "gulp-protractor": "^4.1.1",
     "gulp-replace": "^0.5.4",
     "gulp-uglify": "^2.0.0",
     "gulp-util": "~3.0.6",

--- a/test/app/protractorConf.js
+++ b/test/app/protractorConf.js
@@ -1,48 +1,27 @@
-
+var specString = '*';
+var specs = [
+  "/data/test/app/allspecs/**/*.e2e-spec.js",
+  "/data/test/app/bellows/**/" + specString + ".e2e-spec.js",
+  "/data/test/app/languageforge/**/" + specString + ".e2e-spec.js",
+];
 exports.config = {
-  // The address of a running selenium server.
   seleniumAddress: 'http://selenium:4444/wd/hub',
   baseUrl: 'http://app-for-e2e',
-
-  // The timeout in milliseconds for each script run on the browser. This should
-  // be longer than the maximum time your application needs to stabilize between
-  // tasks.
   allScriptsTimeout: 12000,
-
-  // To run tests in a single browser, uncomment the following
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {
       args: ['--start-maximized']
     }
   },
-
+  specs: specs,
   framework: 'jasmine2',
-
-  // To run tests in multiple browsers, uncomment the following
-  // multiCapabilities: [{
-  //   'browserName': 'chrome'
-  // }, {
-  //   'browserName': 'firefox'
-  // }],
-
-  // Selector for the element housing the angular app - this defaults to
-  // body, but is necessary if ng-app is on a descendant of <body>
   rootElement: '[id="app-container"]',
-
-  // Spec patterns are relative to the current working directly when
-  // protractor is called.
-  //specs: specs,
-
-  // Options to be passed to Jasmine-node.
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 120000,
     print: function () {}
-
-    //isVerbose: true,
   },
-
   onPrepare: function () {
     /* global angular: false, browser: false, jasmine: false */
 


### PR DESCRIPTION
This removes the protractor command (and related tsc compile command) from the gulpfile.  

This adds two new npm scripts:
- `compile-test-e2e`
- `test-e2e`

`compile-test-e2e` runs during image build and `test-e2e` runs as the container command.

I also took the opportunity to remove comments in the protractorConf.js file.

TODO: make custom specs  work by passing in arguments to npm run test-e2e (still figuring that out)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/891)
<!-- Reviewable:end -->
