### PR TITLE
use megahirt/wait instead of locally built wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ Other useful resources:
 
 ### Running E2E Tests
 
-1. `make build test-e2e`
+1. `make e2e-tests`
 1. Individual test results will appear in your terminal but if you'd like to watch them in real-time, simply VNC into the running tests via `localhost:5900`, e.g., Mac OSX users simply `open vnc://localhost:5900` and use `secret` as the password.  Other operating systems may require installing a separate VNC Viewer tool.
 
-### Running PHP Unit Tests
+### Running Unit Tests
 
-1. `make test-php`
+1. `make unit-tests`
 1. Test results will appear in your terminal
 
 ### Viewing logs

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,25 +1,17 @@
 # https://docs.docker.com/compose/reference/overview
 
 .PHONY: start
-start:
+start: build
   # starts the entire runtime infrastructure
 	docker-compose up -d ssl
 
-.PHONY: test-e2e
-test-e2e: build-test-e2e
+.PHONY: e2e-tests
+e2e-tests: build
 	docker-compose run test-e2e
 
-.PHONY: build-test-e2e
-build-test-e2e:
-	docker-compose build mail ui-builder app app-for-e2e test-e2e
-
-.PHONY: test-php
-test-php: build-test-php
+.PHONY: unit-tests
+unit-tests: build
 	docker-compose run test-php
-
-.PHONY: build-test-php
-build-test-php:
-	docker-compose build mail ui-builder app test-php
 
 .PHONY: build
 build:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ test-e2e: build-test-e2e
 	docker-compose run test-e2e
 
 .PHONY: build-test-e2e
-build-test-e2e: wait
+build-test-e2e:
 	docker-compose build mail ui-builder app app-for-e2e test-e2e
 
 .PHONY: test-php
@@ -18,19 +18,15 @@ test-php: build-test-php
 	docker-compose run test-php
 
 .PHONY: build-test-php
-build-test-php: wait
+build-test-php:
 	docker-compose build mail ui-builder app test-php
 
 .PHONY: build
-build: wait
+build:
 	docker-compose build mail ui-builder app
 
-.PHONY: wait
-wait:
-	docker build -t wait wait/.
-
 .PHONY: db-reset
-db-reset: wait
+db-reset:
 	docker-compose build app
 	docker-compose run db-reset
 
@@ -51,4 +47,3 @@ clean-volumes:
 .PHONY: clean-powerwash
 clean-powerwash: clean-volumes
 	docker-compose down --rmi all
-	docker rmi wait

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,11 +7,24 @@ start: build
 
 .PHONY: e2e-tests
 e2e-tests: build
+ifeq ($(TEAMCITY_VERSION),$())
+	# developer machine
 	docker-compose run test-e2e
+else
+	# teamcity CI
+	docker-compose run -e TEAMCITY_VERSION=TEAMCITY_VERSION test-e2e
+endif
 
 .PHONY: unit-tests
 unit-tests: build
+ifeq ("$(TEAMCITY_VERSION)",$())
+	# developer machine
 	docker-compose run test-php
+else
+	# teamcity CI
+	docker-compose run --name unittests test-php
+	docker cp unittests:/var/www/PhpUnitTests.xml ..
+endif
 
 .PHONY: build
 build:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,6 +7,7 @@ start: build
 
 .PHONY: e2e-tests
 e2e-tests: build
+	docker-compose build app-for-e2e test-e2e
 ifeq ($(TEAMCITY_VERSION),$())
 	# developer machine
 	docker-compose run test-e2e
@@ -17,6 +18,7 @@ endif
 
 .PHONY: unit-tests
 unit-tests: build
+	docker-compose build test-php
 ifeq ("$(TEAMCITY_VERSION)",$())
 	# developer machine
 	docker-compose run test-php

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -34,7 +34,7 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN composer install
 
 # make wait available for container ochestration
-COPY --from=wait /wait /wait
+COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait
 
 # copy src files into our image
 COPY src /var/www/html/

--- a/docker/test-e2e/Dockerfile
+++ b/docker/test-e2e/Dockerfile
@@ -1,7 +1,7 @@
 FROM lf-ui-builder:latest
 
 # make wait available for container ochestration
-COPY --from=wait /wait /wait
+COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait
 
 COPY docker/test-e2e/run.sh /run.sh
 

--- a/docker/wait/Dockerfile
+++ b/docker/wait/Dockerfile
@@ -1,9 +1,0 @@
-FROM busybox
-
-# https://github.com/ufoscout/docker-compose-wait#additional-configuration-options
-ENV WAIT_HOSTS_TIMEOUT=300 \
-    WAIT_SLEEP_INTERVAL=2 \
-    WAIT_HOST_CONNECT_TIMEOUT=30
-
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait wait
-RUN chmod +x wait


### PR DESCRIPTION
I built the wait image and pushed it to docker hub under my personal repository.  The wait image just includes docker-compose-wait, is simple and hasn't changed since @longrunningprocess created it, so I decided we could just build once and then reference it in our code as a simplification step.

This should hopefully simplify our building of the wait image, as well as resolve the conversation about where to build wait, as discussed in #891

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/893)
<!-- Reviewable:end -->
