### PR TITLE
Use published base-app to optimize docker build time

### DIFF
--- a/.github/workflows/build-and-deploy-images.yml
+++ b/.github/workflows/build-and-deploy-images.yml
@@ -1,0 +1,63 @@
+name: Deploy to Docker Hub
+
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
+on:
+  push:
+    branches:
+      - 'chore/publishBaseApp'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  environment:
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: What version of Make is installed
+        run: make --version
+
+      - name: What version of Docker is installed
+        run: docker --version
+
+      - name: What version of Docker-Compose is installed
+        run: docker-compose --version
+
+      - name: CPU info
+        run: cat /proc/cpuinfo
+
+      - name: RAM info
+        run: free
+
+      - name: Disk info
+        run: df -h
+
+  build-n-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build base-app image
+        working-directory: ./docker-static/base-app
+        run: docker build . -t lf-base-app
+
+      - name: Tag images with Docker Hub location
+        run: |
+          docker tag lf-base-app sillsdev/web-languageforge:base-app-latest
+
+      - name: Reveal images
+        run: docker images
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Publish images to Docker Hub
+        run: |
+          docker push sillsdev/web-languageforge:base-app-latest
+

--- a/.github/workflows/publish-base-app.yml.disabled
+++ b/.github/workflows/publish-base-app.yml.disabled
@@ -1,4 +1,4 @@
-name: Deploy to Docker Hub
+name: Publish Base App
 
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
 on:

--- a/docker-static/base-app/Dockerfile
+++ b/docker-static/base-app/Dockerfile
@@ -1,0 +1,25 @@
+FROM php:7.3-apache
+
+# install Language Forge APT dependencies
+RUN apt-get update && apt-get -y install p7zip-full unzip git gnupg2 curl
+
+# see https://github.com/mlocati/docker-php-extension-installer
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions gd xdebug mongodb intl @composer
+
+# install LFMerge
+RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add - \
+&& echo "deb http://linux.lsdev.sil.org/ubuntu bionic main" > /etc/apt/sources.list.d/linux-lsdev-sil-org.list \
+&& apt-get update \
+&& apt-get install --yes --no-install-recommends lfmerge
+
+# setup LFMerge permissions
+# TODO: we may not actually need to add www-data to the fieldworks group.  Needs testing
+RUN adduser www-data fieldworks \
+&& chown -R www-data:www-data /var/lib/languageforge \
+&& chmod 0755 /var/lib/languageforge \
+&& mkdir -m 02775 -p /var/www/.local \
+&& chown www-data:www-data /var/www/.local
+
+# make wait available for container ochestration
+COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,11 +1,4 @@
-FROM php:7.3-apache
-
-# install Language Forge APT dependencies
-RUN apt-get update && apt-get -y install p7zip-full unzip git gnupg2 curl
-
-# see https://github.com/mlocati/docker-php-extension-installer
-COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-RUN install-php-extensions gd xdebug mongodb intl @composer
+FROM sillsdev/web-languageforge:base-app-latest
 
 # php.ini customizations
 COPY docker/app/php.ini /usr/local/etc/php
@@ -14,27 +7,10 @@ COPY docker/app/php.ini /usr/local/etc/php
 RUN a2enmod headers rewrite
 COPY docker/app/000-default.conf /etc/apache2/sites-enabled
 
-# install LFMerge
-RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add - \
-&& echo "deb http://linux.lsdev.sil.org/ubuntu bionic main" > /etc/apt/sources.list.d/linux-lsdev-sil-org.list \
-&& apt-get update \
-&& apt-get install --yes --no-install-recommends lfmerge
-
-# setup LFMerge permissions
-# TODO: we may not actually need to add www-data to the fieldworks group.  Needs testing
-RUN adduser www-data fieldworks \
-&& chown -R www-data:www-data /var/lib/languageforge \
-&& chmod 0755 /var/lib/languageforge \
-&& mkdir -m 02775 -p /var/www/.local \
-&& chown www-data:www-data /var/www/.local
-
 # run composer install
 COPY src/composer.json src/composer.lock /var/www/html/
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN composer install
-
-# make wait available for container ochestration
-COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait
 
 # copy src files into our image
 COPY src /var/www/html/


### PR DESCRIPTION
This shifts about half of the lines in the app/Dockerfile into a separate Dockerfile which we publish under the name `sillsdev/web-languageforge:base-app-latest`  A previous run of this branch used a Github Action to publish the image which contains PHP7.3:apache, plus PHP extensions and LFMerge.  These things will rarely change and are a good starting place for further customizations.

This PR creates a docker-static folder which contains the base-app Dockerfile.  Publishing changes to this image is manual.  One can use the disabled github action which is checked into this PR as well for those manual updates if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/898)
<!-- Reviewable:end -->
