### PR TITLE
Update search endpoints in LD API

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -34,7 +34,7 @@ endif
 
 .PHONY: build
 build:
-	docker-compose build mail ui-builder app
+	docker-compose build mail ui-builder app ld-api
 
 .PHONY: db-reset
 db-reset:

--- a/docker/ld-api/Dockerfile
+++ b/docker/ld-api/Dockerfile
@@ -8,20 +8,24 @@
 
 # Step 1: Build app
 FROM node:14.15.4-alpine AS builder
+RUN npm i -g pnpm
 WORKDIR /git
 ADD https://github.com/sillsdev/web-languagedepot-api/tarball/nodejs ./
 # Github tarball has top-level directory USER-REPO-HASH, and HASH is unpredictable ahead of time, so we rename it
 RUN tar xvzf nodejs && rm nodejs && mv sillsdev-web-languagedepot-api-* ldapi
 WORKDIR /git/ldapi
-RUN npm ci
-RUN npm run build && npm run adapt
+RUN pnpm i --frozen-lockfile
+RUN pnpm run build
 
 # Step 2: Create minimal container with running app
 FROM node:14.15.4-alpine
+COPY --from=builder /usr/local/lib/node_modules/pnpm /usr/local/lib/node_modules/pnpm
+RUN ln -s ../lib/node_modules/pnpm/bin/pnpm.js /usr/local/bin/pnpm && \
+    ln -s ../lib/node_modules/pnpm/bin/pnpx.js /usr/local/bin/pnpx
 WORKDIR /app
 COPY --from=builder /git/ldapi/static assets
-COPY --from=builder /git/ldapi/package*.json ./
-RUN npm ci
+COPY --from=builder /git/ldapi/package.json /git/ldapi/pnpm-lock.yaml ./
+RUN pnpm i --prod --frozen-lockfile
 COPY --from=builder /git/ldapi/build ./
 EXPOSE 3000
 USER node

--- a/src/Api/Model/Shared/Command/LdapiCommands.php
+++ b/src/Api/Model/Shared/Command/LdapiCommands.php
@@ -6,10 +6,11 @@ use Api\Service\Ldapi;
 
 class LdapiCommands
 {
+    const SEARCH_BASE_URL = 'search';
     const USERS_BASE_URL = 'users';
-    const SEARCHUSERS_BASE_URL = 'searchUsers';
+    const SEARCHUSERS_BASE_URL = self::SEARCH_BASE_URL . '/' . self::USERS_BASE_URL;
     const PROJECTS_BASE_URL = 'projects';
-    const SEARCHPROJECTS_BASE_URL = 'searchProjects';
+    const SEARCHPROJECTS_BASE_URL = self::SEARCH_BASE_URL . '/' . self::PROJECTS_BASE_URL;
     const ROLES_BASE_URL = 'roles';
 
     const URL_PART_GET_ALL = '';


### PR DESCRIPTION
Commit 607e5d51 in the LD API has changed the search endpoints from`/api/v2/searchUsers` to `/api/v2/search/users` (and similar for projects). This commit updates the API endpoints that Language Forge calls to match these new locations.

Since the ld-api container isn't part of the default "make build" list, you'll need to run `docker-compose build ld-api` after this PR is merged into master, or you'll see some error messages in the Language Forge UI as LF tries to access the new endpoints while your local ld-api container hasn't yet been rebuilt and is thus still serving up the old endpoints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/901)
<!-- Reviewable:end -->
