### PR TITLE
Better fix for ld api docker build

### DIFF
--- a/docker/ld-api/Dockerfile
+++ b/docker/ld-api/Dockerfile
@@ -15,15 +15,13 @@ ADD https://github.com/sillsdev/web-languagedepot-api/tarball/nodejs ./
 RUN tar xvzf nodejs && rm nodejs && mv sillsdev-web-languagedepot-api-* ldapi
 WORKDIR /git/ldapi
 RUN pnpm i --frozen-lockfile
-# Temporary workaround for module resolution failure during svelte-kit build
-RUN npm i
 RUN pnpm run build
 
 # Step 2: Create minimal container with running app
 FROM node:14.15.4-alpine
 COPY --from=builder /usr/local/lib/node_modules/pnpm /usr/local/lib/node_modules/pnpm
-RUN ln -s ../lib/node_modules/pnpm/bin/pnpm.cjs /usr/local/bin/pnpm && \
-    ln -s ../lib/node_modules/pnpm/bin/pnpx.cjs /usr/local/bin/pnpx
+RUN ln -s ../lib/node_modules/pnpm/bin/pnpm.js /usr/local/bin/pnpm && \
+    ln -s ../lib/node_modules/pnpm/bin/pnpx.js /usr/local/bin/pnpx
 WORKDIR /app
 COPY --from=builder /git/ldapi/static assets
 COPY --from=builder /git/ldapi/package.json /git/ldapi/pnpm-lock.yaml ./

--- a/docker/ld-api/Dockerfile
+++ b/docker/ld-api/Dockerfile
@@ -8,7 +8,7 @@
 
 # Step 1: Build app
 FROM node:14.15.4-alpine AS builder
-RUN npm i -g pnpm
+RUN npm i -g pnpm@5
 WORKDIR /git
 ADD https://github.com/sillsdev/web-languagedepot-api/tarball/nodejs ./
 # Github tarball has top-level directory USER-REPO-HASH, and HASH is unpredictable ahead of time, so we rename it


### PR DESCRIPTION
This is a better fix than the one in #905 (which this PR reverts). The root cause was that pnpm just released version 6, which has some breaking changes that, surprise surprise, broke something. :-) So we'll use pnpm 5 until Vite adapts to the breaking change in pnpm 6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/907)
<!-- Reviewable:end -->
