### PR TITLE
Build ld-api container with pnpm 6

### DIFF
--- a/docker/ld-api/Dockerfile
+++ b/docker/ld-api/Dockerfile
@@ -8,15 +8,13 @@
 
 # Step 1: Build app
 FROM node:14.15.4-alpine AS builder
-RUN npm i -g pnpm
+RUN npm i -g pnpm@6
 WORKDIR /git
 ADD https://github.com/sillsdev/web-languagedepot-api/tarball/nodejs ./
 # Github tarball has top-level directory USER-REPO-HASH, and HASH is unpredictable ahead of time, so we rename it
 RUN tar xvzf nodejs && rm nodejs && mv sillsdev-web-languagedepot-api-* ldapi
 WORKDIR /git/ldapi
 RUN pnpm i --frozen-lockfile
-# Temporary workaround for module resolution failure during svelte-kit build
-RUN npm i
 RUN pnpm run build
 
 # Step 2: Create minimal container with running app


### PR DESCRIPTION
Now that pnpm 6.0.1 is out, we can safely build the ld-api container with pnpm version 6, which includes a handy "pnpm fetch" command that's optimized for Dockerfile builds. I'll add that to the build soon.

This PR replaces #907.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/908)
<!-- Reviewable:end -->
