### PR TITLE
Fix lfmerge logging

### DIFF
--- a/docker-static/base-app/Dockerfile
+++ b/docker-static/base-app/Dockerfile
@@ -11,7 +11,7 @@ RUN install-php-extensions gd xdebug mongodb intl @composer
 RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add - \
 && echo "deb http://linux.lsdev.sil.org/ubuntu bionic main" > /etc/apt/sources.list.d/linux-lsdev-sil-org.list \
 && apt-get update \
-&& apt-get install --yes --no-install-recommends lfmerge
+&& apt-get install --yes --no-install-recommends lfmerge rsyslog logrotate cron
 
 # setup LFMerge permissions
 # TODO: we may not actually need to add www-data to the fieldworks group.  Needs testing


### PR DESCRIPTION
With this change, lfmerge logs will be sent to `/var/log/messages` and we'll be better able to debug lfmerge issues. (Without this change, lfmerge logs to syslog are being quietly swallowed in the Docker container and we can't see what it's doing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/924)
<!-- Reviewable:end -->
