### PR TITLE
Fix LfMerge config in base Docker image

### DIFF
--- a/docker-static/base-app/Dockerfile
+++ b/docker-static/base-app/Dockerfile
@@ -13,6 +13,8 @@ RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add -
 && apt-get update \
 && apt-get install --yes --no-install-recommends lfmerge rsyslog logrotate cron
 
+COPY lfmerge.conf /etc/languageforge/conf/sendreceive.conf
+
 # setup LFMerge permissions
 # TODO: we may not actually need to add www-data to the fieldworks group.  Needs testing
 RUN adduser www-data fieldworks \

--- a/docker-static/base-app/lfmerge.conf
+++ b/docker-static/base-app/lfmerge.conf
@@ -1,0 +1,10 @@
+# Configuration file for LfMerge
+BaseDir = /var/lib/languageforge/lexicon/sendreceive
+WebworkDir = webwork
+TemplatesDir = Templates
+MongoHostname = db
+MongoPort = 27017
+MongoMainDatabaseName = scriptureforge
+MongoDatabaseNamePrefix = sf_
+VerboseProgress = true
+PhpSourcePath = /var/www/html


### PR DESCRIPTION
This will allow LfMerge to find the Mongo database container. Future improvements might include looking for environment variables in LfMerge, but this is enough to get LfMerge working in the Docker environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/925)
<!-- Reviewable:end -->
