### PR TITLE
build-and-deploy-images GA now tracks 'staging' branch

### DIFF
--- a/.github/workflows/build-and-deploy-images.yml
+++ b/.github/workflows/build-and-deploy-images.yml
@@ -3,8 +3,8 @@ name: Deploy to Docker Hub
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
 on:
   push:
-    tags:
-      - build-n-publish-images
+    branches:
+      - staging
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
We switch to using a branch as a trigger for GA after realizing that git tags are meant to be permanent and never be moved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/927)
<!-- Reviewable:end -->
