### PR TITLE
Mercurial needs python

### DIFF
--- a/docker-static/base-app/Dockerfile
+++ b/docker-static/base-app/Dockerfile
@@ -11,7 +11,7 @@ RUN install-php-extensions gd xdebug mongodb intl @composer
 RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add - \
 && echo "deb http://linux.lsdev.sil.org/ubuntu bionic main" > /etc/apt/sources.list.d/linux-lsdev-sil-org.list \
 && apt-get update \
-&& apt-get install --yes --no-install-recommends lfmerge rsyslog logrotate cron
+&& apt-get install --yes --no-install-recommends python lfmerge rsyslog logrotate cron
 
 COPY lfmerge.conf /etc/languageforge/conf/sendreceive.conf
 
@@ -25,3 +25,7 @@ RUN adduser www-data fieldworks \
 
 # make wait available for container ochestration
 COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait
+
+COPY entrypoint.sh /
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker-static/base-app/entrypoint.sh
+++ b/docker-static/base-app/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# rsyslog needs to run so that lfmerge can log to /var/log/syslog
+/etc/init.d/rsyslog start
+
+# Now chain to Docker entrypoint from base php:apache image
+exec docker-php-entrypoint "$@"


### PR DESCRIPTION
The Send/Receive feature uses Mercurial, which is a Python app. So our base image needs a working Python 2 installation.

This PR also adds an entrypoint script which will run `/etc/init.d/rsyslog start` so that lfmerge logs will go to /var/log/syslog rather than being silently swallowed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/928)
<!-- Reviewable:end -->
