### PR TITLE
Remove entrypoint changes that aren't working

### DIFF
--- a/docker-static/base-app/Dockerfile
+++ b/docker-static/base-app/Dockerfile
@@ -25,7 +25,3 @@ RUN adduser www-data fieldworks \
 
 # make wait available for container ochestration
 COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait
-
-COPY entrypoint.sh /
-
-ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
#928 made two changes, adding the Python deb package and tweaking the entrypoint so that `/etc/init.d/rsyslog start` would be called on startup. The latter change didn't work properly, so this PR reverts that change while leaving the Python change in place. This will allow Send/Receive to work, although it won't log to `/var/log/syslog` until someone logs into the QA container and runs `/etc/init.d/rsyslog start` by hand. I'll submit a new PR with entrypoint changes once I've gotten them working, but this PR will at least get Send/Receive working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/929)
<!-- Reviewable:end -->
