### PR TITLE
Run rsyslog on startup of base app

### DIFF
--- a/docker-static/base-app/Dockerfile
+++ b/docker-static/base-app/Dockerfile
@@ -23,5 +23,10 @@ RUN adduser www-data fieldworks \
 && mkdir -m 02775 -p /var/www/.local \
 && chown www-data:www-data /var/www/.local
 
+COPY entrypoint.sh /
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "apache2-foreground" ]
+
 # make wait available for container ochestration
 COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait


### PR DESCRIPTION
This fixes https://github.com/sillsdev/web-languageforge/pull/928 by restoring the CMD line to the Dockerfile, which was the cause of Apache not starting after #928 was merged. I had assumed that giving an ENTRYPOINT line without a CMD line would keep the CMD line of the parent Dockerfile, but it turns out that's not the case. Setting ENTRYPOINT resets CMD, so if you want to keep the same CMD you have to re-issue the CMD line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/930)
<!-- Reviewable:end -->
