### PR TITLE
Fix race condition in E2E test startup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -144,7 +144,7 @@ services:
       - mail
       - selenium
     environment:
-      - WAIT_HOSTS=db:27017, mail:25, selenium:4444
+      - WAIT_HOSTS=db:27017, mail:25, selenium:4444, app-for-e2e:80
       - ENVIRONMENT=development
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
     command: sh -c "/wait && /run.sh"


### PR DESCRIPTION
Sometimes the E2E tests were starting before the app-for-e2e container was fully available. This PR fixes that race condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/931)
<!-- Reviewable:end -->
