### PR TITLE
Restore refreshDeps.sh script (used by LfMerge build)

### DIFF
--- a/refreshDeps.sh
+++ b/refreshDeps.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Usage
+# ./refreshDeps.sh : refreshes PHP and NPM dependencies for LF
+
+(cd src && composer install)
+npm install
+echo -e "\n---------Finished refreshing npm and composer----------"


### PR DESCRIPTION
The LfMerge build on Jenkins expects the refreshDeps.sh script to exist in this repo. (The LfMerge build clones the web-languageforge repo to get access to some of its PHP files during unit testing). The simplest way to fix the Jenkins LfMerge build is to just make sure that there's a refreshDeps.sh script in the LF Git repo, for now. Eventually I'll update the Jenkins LfMerge build, but that's a more complicated process.

Thankfully, now that we're no longer using Gulp, it's much easier to see what refreshDeps.sh is doing, and we also no longer need to specify the applicationName in the script either. So it's just "composer install" and "npm install" in the appropriate directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/939)
<!-- Reviewable:end -->
