### PR TITLE
Fix flaky E2E test

### DIFF
--- a/test/app/languageforge/lexicon/shared/new-lex-project.page.ts
+++ b/test/app/languageforge/lexicon/shared/new-lex-project.page.ts
@@ -30,7 +30,7 @@ export class NewLexProjectPage {
 
   formStatus = {
     async expectHasNoError() {
-      expect(await element(by.id('form-status')).getAttribute('class')).not.toContain('alert');
+      expect(await element(by.id('form-status')).getAttribute('class')).not.toContain('alert-danger');
     },
     async expectContainsError(partialMsg: string) {
       if (!partialMsg) partialMsg = '';


### PR DESCRIPTION
Another attempt to fix the flaky E2E test. I looked into it and noticed that the "no error" check only looks for the presence of the string "alert" in the element's class attribute... but if the form is valid then there's supposed to be a green checkmark with the class `alert-success`. So this PR is attempting to fix the flaky test by only considering the text `alert-danger` to represent an error, and not failing the test if `alert-success` is present in the element's class attribute.

I'll create this PR in draft mode, then set it as ready to review & merge if the E2E tests pass on TeamCity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languageforge/940)
<!-- Reviewable:end -->
