### PR TITLE
enable xDebug for PHP unit-tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,8 @@
       "request": "launch",
       "port": 9003,
       "pathMappings": {
-        "/var/www/html/": "${workspaceRoot}/src/"
+        "/var/www/html/": "${workspaceRoot}/src/",
+        "/var/www/test/": "${workspaceRoot}/test/"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -138,12 +138,37 @@ To debug the Language Forge application locally, follow these steps:
 - run `make` or `make dev`
 - In VS Code, set a breakpoint on a line of code that should be executed
 - Click on the `Run and Debug` area of VS Code, then click the green play icon next to `XDebug` in the configuration dropdown.
+
 ![XDebug](readme_images/xdebug1.png "Debugging with XDebug")] 
+
 - The VSCode status bar will turn orange when XDebug is active
+- open the application in your web browser (`https://localhost`) and use the application such that you execute the code where you have a breakpoint set
+
+A [tutorial on YouTube is available showing how to use XDebug and VSCode](https://www.youtube.com/watch?v=nKh5DHViKlA) to debug the LF back-end application.
+
+### PHP Tests Debugging ###
+
+To debug the PHP tests, follow these steps:
+- uncomment the 3 lines in the docker-compose.yml file related to XDebug under the service section `test-php`:
+```
+       - XDEBUG_MODE=develop,debug
+     extra_hosts:
+       - "host.docker.internal:host-gateway
+```
+- In VS Code, set a breakpoint on a line of code in one of the PHP tests (in the `test/php` folder)
+- Click on the `Run and Debug` area of VS Code, then click the green play icon next to `XDebug` in the configuration dropdown.
+
+![XDebug](readme_images/xdebug1.png "Debugging with XDebug")] 
+
+- The VSCode status bar will turn orange when XDebug is active
+- run `make unit-tests` in the terminal
+- VSCode will stop the unit test execution when the breakpoint is hit
+
+A [tutorial on YouTube is available showing how to use XDebug and VSCode](https://www.youtube.com/watch?v=SxIORImpxrQ) to debug the PHP Tests.
 
 Additional considerations:
 
-If you encounter errors such as VSCode cannot find a file in the path "vendor", these source files are not available to VSCode as they are running inside Docker.  If you want to debug vendor libraries (not required), you will have to use Composer to download them put them in your source tree.
+If you encounter errors such as VSCode cannot find a file in the path "vendor", these source files are not available to VSCode as they are running inside Docker.  If you want to debug vendor libraries (not required), you will have to use Composer to download dependencies and put them in your source tree.
 
 
 ### E2E Tests - TODO Needs Updating/Review ###

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -187,7 +187,6 @@ services:
     command: sh -c "/wait && /run.sh"
 
   test-php:
-    # TODO: get XDebug working with VSCode
     build:
       context: ..
       dockerfile: docker/test-php/Dockerfile
@@ -202,6 +201,12 @@ services:
       - DATABASE=scriptureforge_test
       - MONGODB_CONN=mongodb://db:27017
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
+      # Note: Uncomment to enable XDebug in Unit Tests.  The default mode is "off".
+      # These lines are commented out as this XDebug setup causes CI failures.
+      # XDebug is intended for local development only.  Uncomment the following 3 lines:
+      # - XDEBUG_MODE=develop,debug
+    # extra_hosts:
+      # - "host.docker.internal:host-gateway"
     command: sh -c "/wait && /run.sh"
     volumes:
       # for developer convenience


### PR DESCRIPTION
This is a follow up PR to the initial enabling of XDebug PHP debugging.  With this change, you can now set a breakpoint in a PHP test and debug it in VSCode using XDebug.

In order to use XDebug for Unit Tests, 3 lines in the docker-compose file must be uncommented.  They are left commented because the XDebug settings do not play well with our CI environment.

Specifically the 
```
   # extra_hosts:
      # - "host.docker.internal:host-gateway"
```
fails on TeamCity for reasons I don't understand right now.