### PR TITLE
parameterized the mail host as an ENV var

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       # - WEBSITE=qa.languageforge.org
       - DATABASE=scriptureforge
       - MONGODB_CONN=mongodb://db:27017
+      - MAIL_HOST=mail
       # only when ENVIRONMENT=production will BUGSNAG_API_KEY be utilized.
       # - BUGSNAG_API_KEY=some-key
       - GOOGLE_CLIENT_ID=bogus-development-token

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -202,6 +202,7 @@ services:
       - ENVIRONMENT=development
       - DATABASE=scriptureforge_test
       - MONGODB_CONN=mongodb://db:27017
+      - MAIL_HOST=mail
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
     command: sh -c "/wait && /run.sh"
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -183,6 +183,7 @@ services:
       - WEBSITE=localhost
       - DATABASE=scriptureforge_test
       - MONGODB_CONN=mongodb://db:27017
+      - MAIL_HOST=mail
       - REMEMBER_ME_SECRET=bogus-development-key
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
     command: sh -c "/wait && /run.sh"

--- a/src/Api/Library/Shared/Communicate/Email.php
+++ b/src/Api/Library/Shared/Communicate/Email.php
@@ -1,8 +1,8 @@
 <?php
 
-use Sil\PhpEnv\Env; // https://github.com/silinternational/php-env#class-env-summary-of-functions
-
 namespace Api\Library\Shared\Communicate;
+
+use Sil\PhpEnv\Env; // https://github.com/silinternational/php-env#class-env-summary-of-functions
 
 class Email
 {

--- a/src/Api/Library/Shared/Communicate/Email.php
+++ b/src/Api/Library/Shared/Communicate/Email.php
@@ -1,5 +1,7 @@
 <?php
 
+use Sil\PhpEnv\Env; // https://github.com/silinternational/php-env#class-env-summary-of-functions
+
 namespace Api\Library\Shared\Communicate;
 
 class Email
@@ -14,7 +16,7 @@ class Email
     public static function send($from, $to, $subject, $content, $htmlContent = '')
     {
         // Create the Transport
-        $transport = \Swift_SmtpTransport::newInstance('mail', 25);
+        $transport = \Swift_SmtpTransport::newInstance(Env::requireEnv('MAIL_HOST'));
 
         // Create the Mailer using your created Transport
         $mailer = \Swift_Mailer::newInstance($transport);


### PR DESCRIPTION
there may be times when the host name of the mailer is not "mail" so it's better to have this parameterized so there is more flexibility in deployments.