### PR TITLE
time to change the GHA trigger from staging to master

### DIFF
--- a/.github/workflows/build-and-deploy-images.yml
+++ b/.github/workflows/build-and-deploy-images.yml
@@ -4,7 +4,7 @@ name: Deploy to Docker Hub
 on:
   push:
     branches:
-      - staging
+      - master
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Now that the QA infrastructure deployment is in place, this will ensure the images are ready when the CI/CD processes kick off.