### PR TITLE
make languageforge.org the default for Website::get()

### DIFF
--- a/scripts/tools/csvInsights.php
+++ b/scripts/tools/csvInsights.php
@@ -9,4 +9,4 @@ use Api\Library\Shared\Website;
 
 (php_sapi_name() == 'cli') or die('this script must be run on the command-line');
 
-ProjectInsightsDto::csvInsightsToFile(Website::get('languageforge.org'), 'languageforge.csv');
+ProjectInsightsDto::csvInsightsToFile(Website::get(), 'languageforge.csv');

--- a/src/Api/Library/Shared/Website.php
+++ b/src/Api/Library/Shared/Website.php
@@ -69,7 +69,7 @@ class Website
      * @param string $hostname
      * @return Website
      */
-    public static function get($hostname = '')
+    public static function get($hostname = 'languageforge.org')
     {
         if (!$hostname) {
             $hostname = self::getHostname();

--- a/test/app/setupTestEnvironment.php
+++ b/test/app/setupTestEnvironment.php
@@ -21,16 +21,11 @@ use Api\Model\Shared\UserModel;
 $constants = json_decode(file_get_contents(TestPath . 'app/testConstants.json'), true);
 
 // Fake some $_SERVER variables like HTTP_HOST for the sake of the code that needs it
-$hostname = "localhost";
 if (count($argv) > 1) {
     // hostname is passed in on command line
     $hostname = $argv[1];
 }
-$_SERVER['HTTP_HOST'] = $hostname;
-$website = Website::get($hostname);
-if (is_null($website)) {
-    exit("Error: $hostname is not a registered website hostname!\n\n");
-}
+$website = Website::get();
 $site = $website->base;
 
 // start with a fresh database

--- a/test/php/library/shared/WebsiteTest.php
+++ b/test/php/library/shared/WebsiteTest.php
@@ -7,7 +7,7 @@ class WebsiteTest extends TestCase
 {
     public function testGet_Works()
     {
-        $website = Website::get('languageforge.org');
+        $website = Website::get();
         $this->assertEquals('languageforge.org', $website->domain);
         $this->assertEquals('languageforge', $website->base);
         $this->assertEquals('default', $website->theme);

--- a/test/php/library/shared/communicate/CommunicateTest.php
+++ b/test/php/library/shared/communicate/CommunicateTest.php
@@ -173,7 +173,7 @@ class CommunicateTest extends TestCase
         $userId = self::$environ->createUser('User', 'Name', 'name@example.com');
         $user = new UserModel($userId);
         $delivery = new MockCommunicateDelivery();
-        $website = Website::get('languageforge.org');
+        $website = Website::get();
 
         Communicate::sendVerifyEmail($user, $website, $delivery);
 
@@ -198,7 +198,7 @@ class CommunicateTest extends TestCase
         $project->projectCode = 'test_project';
         $project->write();
         $delivery = new MockCommunicateDelivery();
-        $website = Website::get('languageforge.org');
+        $website = Website::get();
         $website->defaultProjectCode = 'test_project';
 
         Communicate::sendVerifyEmail($user, $website, $delivery);


### PR DESCRIPTION
This is a small "hack" necessary for Language Forge to function with production data under any site e.g. localhost, qa.languageforge.org or languageforge.org.  There is no longer a business case to keep a separate site distinction in this code-base.  A future change may remove the Website class entirely.