### PR TITLE
remove "clusterIP: None" from db-deployment

### DIFF
--- a/docker/deployment/db-deployment.yaml
+++ b/docker/deployment/db-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   name: db
 spec:
   type: ClusterIP
-  clusterIP: None
   selector:
     app: db
 


### PR DESCRIPTION
The value "None" for the clusterIP property is invalid and so we remove the property entirely in hopes that it is not needed for deployment.

The following error occurred during deployment:

```
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
The Service "db" is invalid: spec.clusterIPs[0]: Invalid value: []string{"None"}: may not change once set
```