### PR TITLE
remove unnecessary port mappings from app and db deployments

### DIFF
--- a/docker/deployment/app-deployment.yaml
+++ b/docker/deployment/app-deployment.yaml
@@ -61,10 +61,6 @@ spec:
       - name: app
         image: sillsdev/web-languageforge:app-latest
         imagePullPolicy: Always # TODO: this can be removed (or changed to IfNotPresent) once the image is being tagged properly.
-        ports:
-          - name: http
-            protocol: TCP
-            containerPort: 80
         env:
           - name: DATABASE
             value: scriptureforge

--- a/docker/deployment/db-deployment.yaml
+++ b/docker/deployment/db-deployment.yaml
@@ -46,10 +46,6 @@ spec:
       containers:
       - name: db
         image: mongo:4.0
-        ports:
-        - name: mongodb
-          protocol: TCP
-          containerPort: 27017
         volumeMounts:
         - mountPath: /data/db
           name: vol1


### PR DESCRIPTION
These port mappings are unnecessary based upon YAML file upload workload/service testing.

The goal of these PRs is to have a fully recreatable deployment from no existing workload/service configuration.