### PR TITLE
Long-term deployment strategy

### DIFF
--- a/.github/workflows/build-and-deploy-images.yml
+++ b/.github/workflows/build-and-deploy-images.yml
@@ -4,7 +4,7 @@ name: Deploy to Docker Hub
 on:
   push:
     branches:
-      - master
+      - staging
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -44,7 +44,7 @@ jobs:
         working-directory: ./docker/app-base
         run: |
           docker build . -t lf-app-base
-          docker tag lf-app-base sillsdev/web-languageforge:app-base-latest
+          docker tag lf-app-base sillsdev/web-languageforge:app-base-staging
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
@@ -54,7 +54,7 @@ jobs:
 
       - name: Publish base app image to Docker Hub
         run: |
-          docker push sillsdev/web-languageforge:app-base-latest
+          docker push sillsdev/web-languageforge:app-base-staging
 
       - name: Build app
         run: make --directory=docker deployable-app
@@ -63,11 +63,11 @@ jobs:
 
       - name: Tag app image with Docker Hub location
         run: |
-          docker tag lf-app sillsdev/web-languageforge:app-latest
+          docker tag lf-app sillsdev/web-languageforge:app-staging
 
       - name: Reveal images
         run: docker images
 
       - name: Publish images to Docker Hub
         run: |
-          docker push sillsdev/web-languageforge:app-latest
+          docker push sillsdev/web-languageforge:app-staging

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ To use **Language Forge** go to [languageforge.org](https://languageforge.org).
 To report an issue using the **Language Forge** service, email "languageforgeissues @ sil dot org".
 
 ## Special Thanks To ##
-
+- ![BrowserStack Logo](readme_images/browserstack-logo.png "BrowserStack") for mobile device testing.
+-
 [![Bugsnag logo](readme_images/bugsnag-logo.png "Bugsnag")](https://bugsnag.com/blog/bugsnag-loves-open-source) for error reporting.
 
 ## Developers ##

--- a/README.md
+++ b/README.md
@@ -12,30 +12,23 @@ To report an issue using the **Language Forge** service, email "languageforgeiss
 
 ## Special Thanks To ##
 
-![BrowserStack Logo](readme_images/browserstack-logo.png "BrowserStack") for end-to-end test automation.
-
 [![Bugsnag logo](readme_images/bugsnag-logo.png "Bugsnag")](https://bugsnag.com/blog/bugsnag-loves-open-source) for error reporting.
 
 ## Developers ##
 
-We use [Gitflow](http://nvie.com/posts/a-successful-git-branching-model/) with two modifications:
+We use [Gitflow](http://nvie.com/posts/a-successful-git-branching-model/) mostly, however we do not utilize a `develop` branch.  All work starts and returns to the `master` branch.  Deployment of software to a staging and/or a production environment occur through the use of the respective branches being fast-forwarded to the appropriate commit on `master` which will in turn kick off our automated deployment processes.
 
-- The Gitflow **master** branch is our **live** branch.
-- The Gitflow **develop** branch is our **master** branch. All pull requests go against **master**.
-
-We merge from **master** to testing (**qa** branch) then ship to **live**.
-
-| Master Branch | QA/Staging Branch | Live/Production Branch |
+| Master Branch | Staging Branch (for testing) | Production Branch |
 | ------------- | --------- | ----------- |
-| `master` | `lf-qa` | `lf-live` |
+| `master` | `staging` | `prod` |
 
 ### CI Builds ###
 
 Status of builds from our continuous integration (CI) [server](https://build.palaso.org):
 
-| PHP Unit Tests | E2E Tests | Staging | Production |
-| ----------- | ---------- | -- | ---- |
-| [![Build Status](https://build.palaso.org/app/rest/builds/buildType:LanguageForgeDocker_PhpTests/statusIcon.svg)](https://build.palaso.org/buildConfiguration/LanguageForgeDocker_PhpTests) | [![Build Status](https://build.palaso.org/app/rest/builds/buildType:LanguageForgeDocker_E2eTests/statusIcon.svg)](https://build.palaso.org/buildConfiguration/LanguageForgeDocker_E2eTests) | [![Build Status](https://build.palaso.org/app/rest/builds/buildType:LanguageForge_LanguageForgeQa/statusIcon.svg)](https://build.palaso.org/buildConfiguration/LanguageForge_LanguageForgeQa) | [![Build Status](https://build.palaso.org/app/rest/builds/buildType:xForgeDeploy_LanguageForgeLiveBionic/statusIcon.svg)](https://build.palaso.org/buildConfiguration/xForgeDeploy_LanguageForgeLiveBionic) |
+| PHP Unit Tests | E2E Tests |
+| ----------- | ---------- |
+| [![Build Status](https://build.palaso.org/app/rest/builds/buildType:LanguageForgeDocker_PhpTests/statusIcon.svg)](https://build.palaso.org/buildConfiguration/LanguageForgeDocker_PhpTests) | [![Build Status](https://build.palaso.org/app/rest/builds/buildType:LanguageForgeDocker_E2eTests/statusIcon.svg)](https://build.palaso.org/buildConfiguration/LanguageForgeDocker_E2eTests) |
 
 ### Deployed Sites ###
 
@@ -75,7 +68,7 @@ Other useful resources:
 
 ## Docker Development Environment ##
 
-1. Install [Docker](https://www.docker.com/get-started) (Linux users will need some additional steps, please visit https://docs.docker.com/compose/install for info on install the engine and compose)
+1. Install [Docker](https://www.docker.com/get-started) (Linux users will need some additional steps, please visit https://docs.docker.com/compose/install for info on installing the engine and compose)
 1. Install [Make](https://www.gnu.org/software/make/).  This is actually optional but simplifies things a bit.
 1. Clone the repo:  `git clone https://github.com/sillsdev/web-languageforge`
 1. `cd web-languageforge/docker`
@@ -115,12 +108,6 @@ Other useful resources:
 ### Building for production
 
 1. `make prod` will build a production version of the app.
-
-### LiveReload ###
-
-### LiveReload Chrome extension ####
-
-Install the [LiveReload](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en-US) extension.
 
 ### Visual Studio Code ###
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ To debug the tests:
 - Start the tests with `./rune2e.sh`. Wait for the tests to actually start running before moving to the next steps.
 - To debug in Chrome, go to `chrome://inspect/#devices`. Under "Remote Target" click to inspect the Node.js process.
 - To debug in VSCode, select the "Node debugger" debug configuration and run it.
+
+## Application deployment ##
+Language Forge is built to run in a containerized environment.  For now, Kubernetes is the chosen runtime platform.
+
+### Staging (QA) ###
+Deployments are not currently automated and must be manually run with the appropriate credentials or from within our CD platform, TeamCity at this time.
+
+Deployment scripts for k8s can be found in `docker/deployment` and staging deployments can be run via `make deploy-staging` from within the same directory.
+
+Current workflow:
+1. move the `staging` branch to the appropriate commit on `master`
+1. this will kick off the GHA (`.github/workflows/build-and-deploy-images.yml`) to build and publish the necessary images to Docker Hub (https://hub.docker.com/r/sillsdev/web-languageforge/tags)
+1. then the deployment scripts can be run either manually or via the TeamCity deploy job
+
+### Production ###
+TBD
+
 ## Libraries Used ##
 
 [lamejs](https://github.com/zhuker/lamejs) is used for encoding recorded audio and is based on [LAME](http://lame.sourceforge.net/), which is licensed under the terms of [the LGPL](https://www.gnu.org/licenses/old-licenses/lgpl-2.0.html).

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ Additional considerations:
 
 If you encounter errors such as VSCode cannot find a file in the path "vendor", these source files are not available to VSCode as they are running inside Docker.  If you want to debug vendor libraries (not required), you will have to use Composer to download dependencies and put them in your source tree.
 
-
 ### E2E Tests - TODO Needs Updating/Review ###
 To test a certain test spec, add a parameter `--specs [spec name]`.  For example,
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM sillsdev/web-languageforge:app-base-latest
+FROM sillsdev/web-languageforge:app-base-staging
 
 # php customizations
 RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini

--- a/docker/deployment/Makefile
+++ b/docker/deployment/Makefile
@@ -29,16 +29,16 @@ retrieve-current-deployments:
 create-new-deployment-mail:
 	kubectl create deployment mail --image=juanluisbaptiste/postfix:1.0.0 --dry-run=client -o yaml > mail-deployment-new.yaml
 
-.PHONY: deploy-qa
-deploy-qa: deploy-db deploy-mail-qa deploy-app-qa
-.PHONY: deploy-mail-qa
-deploy-mail-qa:
+.PHONY: deploy-staging
+deploy-staging: deploy-db deploy-mail-staging deploy-app-staging
+.PHONY: deploy-mail-staging
+deploy-mail-staging:
 	sed -e s/{{SERVER_HOSTNAME}}/qa.languageforge.org/ mail-deployment.yaml | kubectl apply -f -
 .PHONY: deploy-mail-prod
 deploy-mail-prod:
 	sed -e s/{{SERVER_HOSTNAME}}/languageforge.org/ mail-deployment.yaml | kubectl apply -f -
-.PHONY: deploy-app-qa
-deploy-app-qa:
+.PHONY: deploy-app-staging
+deploy-app-staging:
 	sed -e s/{{ENVIRONMENT}}/development/ app-deployment.yaml \
   | sed -e s/{{WEBSITE}}/qa.languageforge.org/ | kubectl apply -f -
 .PHONY: deploy-app-prod

--- a/docker/deployment/app-deployment.yaml
+++ b/docker/deployment/app-deployment.yaml
@@ -59,8 +59,8 @@ spec:
     spec:
       containers:
       - name: app
-        image: sillsdev/web-languageforge:app-latest
-        imagePullPolicy: Always # TODO: this can be removed (or changed to IfNotPresent) once the image is being tagged properly.
+        image: sillsdev/web-languageforge:app-staging
+        imagePullPolicy: Always
         env:
           - name: DATABASE
             value: scriptureforge

--- a/docker/mail/Dockerfile
+++ b/docker/mail/Dockerfile
@@ -1,4 +1,4 @@
-FROM juanluisbaptiste/postfix
+FROM juanluisbaptiste/postfix:1.0.0
 
 ENV SMTP_SERVER=nobody.localhost \
 SMTP_USERNAME=username \


### PR DESCRIPTION
The goal for `staging` will be the following:

Any push to `staging` or fast-forwarding the branch to a commit on `master` will trigger the build-n-publish workflow on GHA.  While that's happening, TC should be running unit and e2e tests.  Once those tests finish successfully, TC should deploy the infrastructure to QA.  It's important at this point to know that the build-n-publish workflow in GHA is in no way coupled/serialized to the unit/e2e tests that are running, these two platforms should be running at the same time and, if they do, the newly built images will be available by the time the QA deployment goes looking for the latest images.