### PR TITLE
Disable Protractor Control Flow for Stability

### DIFF
--- a/test/app/protractorConf.js
+++ b/test/app/protractorConf.js
@@ -5,6 +5,7 @@ var specs = [
   "/data/test/app/languageforge/**/" + specString + ".e2e-spec.js",
 ];
 exports.config = {
+  SELENIUM_PROMISE_MANAGER: false,
   seleniumAddress: 'http://selenium:4444/wd/hub',
   baseUrl: 'http://app-for-e2e',
   allScriptsTimeout: 12000,


### PR DESCRIPTION
According to 
- https://www.protractortest.org/#/control-flow
- https://www.protractortest.org/#/async-await

We should not be using the control flow since it can cause stability with tests writting usingasync/await (that's us).  I thought we already had this disabled...hmm.

Maybe this will improve stability in the tests?

From the docs:
> Don’t forget to turn off control_flow, you cannot use a mix of async/await and the control flow: async/await causes the control flow to become unreliable (see [github issue](https://github.com/SeleniumHQ/selenium/issues/3037)). So if you async/await anywhere in a spec, you should use the SELENIUM_PROMISE_MANAGER: false