### PR TITLE
Use WEBSITE env var to get base URL

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -28,7 +28,7 @@ ifeq ("$(TEAMCITY_VERSION)",$())
 	docker-compose run test-php
 else
 	# teamcity CI
-	docker-compose run --name unittests test-php
+	docker-compose run -e WEBSITE=languageforge.org --name unittests test-php
 	docker cp unittests:/var/www/PhpUnitTests.xml ..
 endif
 

--- a/src/Api/Library/Shared/Communicate/Communicate.php
+++ b/src/Api/Library/Shared/Communicate/Communicate.php
@@ -5,6 +5,7 @@ namespace Api\Library\Shared\Communicate;
 use Api\Library\Shared\Communicate\Sms\SmsModel;
 use Api\Library\Shared\Communicate\Sms\SmsQueue;
 use Api\Library\Shared\Website;
+use Api\Library\Shared\UrlHelper;
 use Api\Model\Shared\ProjectModel;
 use Api\Model\Shared\ProjectSettingsModel;
 use Api\Model\Shared\MessageModel;
@@ -110,7 +111,7 @@ class Communicate
         $subject = $website->name . ' account signup validation';
         $vars = [
                 'user' => $userModel,
-                'link' => $website->baseUrl() . '/validate/' . $userModel->validationKey,
+                'link' => UrlHelper::baseUrl() . '/validate/' . $userModel->validationKey,
                 'website' => $website,
         ];
 
@@ -128,7 +129,7 @@ class Communicate
         $subject = 'Welcome to ' . $website->name;
         $vars = [
             'user' => $userModel,
-            'link' => $website->baseUrl(),
+            'link' => UrlHelper::baseUrl(),
             'website' => $website,
         ];
 
@@ -218,7 +219,7 @@ class Communicate
         $subject = $website->name . ' Forgotten Password Verification';
         $vars = [
             'user' => $user,
-            'link' => $website->baseUrl() . '/auth/reset_password/' . $user->resetPasswordKey,
+            'link' => UrlHelper::baseUrl() . '/auth/reset_password/' . $user->resetPasswordKey,
             'website' => $website,
         ];
 
@@ -265,7 +266,7 @@ class Communicate
             'user' => $user,
             'admin' => $admin,
             'project' => $projectModel,
-            'link' => $website->baseUrl() . '/app/usermanagement/' . $projectModel->id->asString() . '#!/joinRequests',
+            'link' => UrlHelper::baseUrl() . '/app/usermanagement/' . $projectModel->id->asString() . '#!/joinRequests',
             'website' => $website
         ];
 
@@ -285,7 +286,7 @@ class Communicate
         $vars = [
             'user' => $user,
             'project' => $projectModel,
-            'link' => $website->baseUrl() . "/app/{$projectModel->appName}/" . $projectModel->id->asString(),
+            'link' => UrlHelper::baseUrl() . "/app/{$projectModel->appName}/" . $projectModel->id->asString(),
             'website' => $website
         ];
 
@@ -332,7 +333,7 @@ class Communicate
      */
     public static function calculateSignupUrl(Website $website, string $email, string $name = null, string $avatar = null): string
     {
-        $url = $website->baseUrl() . '/public/signup#!/?e=' . urlencode($email);
+        $url = UrlHelper::baseUrl() . '/public/signup#!/?e=' . urlencode($email);
         if ($name) {
             $url = $url . '&n=' . urlencode($name);
         }

--- a/src/Api/Library/Shared/UrlHelper.php
+++ b/src/Api/Library/Shared/UrlHelper.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Api\Library\Shared;
+
+use Sil\PhpEnv\Env; // https://github.com/silinternational/php-env#class-env-summary-of-functions
+
+class UrlHelper
+{
+    public static function getHostname()
+    {
+        return Env::requireEnv('WEBSITE');
+    }
+
+    public static function baseUrl()
+    {
+        return "https://" . self::getHostname();
+    }
+}

--- a/src/Api/Library/Shared/Website.php
+++ b/src/Api/Library/Shared/Website.php
@@ -90,7 +90,7 @@ class Website
     {
         $protocol = ($this->ssl) ? "https" : "http";
 
-        return $protocol . "://" . $this->domain;
+        return $protocol . "://" . self::getHostname();
     }
 
     /**

--- a/src/Site/OAuth/OAuthBase.php
+++ b/src/Site/OAuth/OAuthBase.php
@@ -3,6 +3,7 @@
 namespace Site\OAuth;
 
 use Api\Library\Shared\Website;
+use Api\Library\Shared\UrlHelper;
 use Api\Model\Shared\UserModel;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Token\AccessToken as OAuthAccessToken;
@@ -36,8 +37,7 @@ abstract class OAuthBase extends Base
 
     public function oauthCallback(Request $request, Application $app)
     {
-        $website = Website::get();
-        $redirectUri = $website->baseUrl() . '/oauthcallback/'. $this->getProviderName();
+        $redirectUri = UrlHelper::baseUrl() . '/oauthcallback/'. $this->getProviderName();
         $provider = $this->getOAuthProvider($redirectUri);
 
         $error = $request->query->get('error', null);


### PR DESCRIPTION
To fix the OAuth login issue introduced by #955, we need to actually use the `WEBSITE` environment variable that is being passed in. This allows qa.languageforge.org to create redirection URLs after OAuth login that return to the correct site instead of having the QA site redirect to the live site.