### PR TITLE
Fixed S/R bug in staging (#981)

### DIFF
--- a/docker/deployment/app-deployment.yaml
+++ b/docker/deployment/app-deployment.yaml
@@ -110,7 +110,12 @@ spec:
       initContainers:
       - name: initialize-volume-ownership
         image: busybox:1.33
-        command: ['sh', '-c', 'chown www-data:www-data /var/www/html/assets /var/lib/languageforge/lexicon/sendreceive']
+        command:
+          - 'sh'
+          - '-c'
+          - |-
+            mkdir /var/lib/languageforge/lexicon/sendreceive/state
+            chown www-data:www-data /var/www/html/assets /var/lib/languageforge/lexicon/sendreceive /var/lib/languageforge/lexicon/sendreceive/state
         volumeMounts:
           - mountPath: /var/www/html/assets
             name: assets


### PR DESCRIPTION
due to diff's in k8s/docker volumes, S/R was not working in staging ultimately because LFMerge's directory setup (https://github.com/sillsdev/LfMerge/blob/master/debian/postinst#L24) was being blown away during a volume mount in staging, see discussion in #981 