### PR TITLE
Add ability to reset E2E tests before debugging

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,15 +31,11 @@
 
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
-  "initializeCommand": "echo Initialize command",
-  "onCreateCommand": "echo On create command",
-  "updateContentCommand": "echo Update content command",
-  "postCreateCommand": "echo Post create command",
-  "postStartCommand": "echo Post start command",
-  "postAttachCommand": "echo Post attach command",
 
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+	"initializeCommand": "cd docker && make",
+
+	// Uncomment the next line to run commands after the container is created - for example installing docker.
+	"postCreateCommand": "apk add docker",
 
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,8 +24,11 @@ services:
       # To transfer custom launch.json and so on
       - ./test-e2e/.vscode:/data/.vscode:cached
 
+      # Forwards the local Docker socket to the container so we can do things like `docker-compose restart app-for-e2e`
+      - /var/run/docker.sock:/var/run/docker.sock
+
       # So that any changes you make in the E2E test files while debugging will also be changed in the Git repo
-      - ../test:/data/test
+      # - ../test:/data/test
 
     # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
     # cap_add:

--- a/README.md
+++ b/README.md
@@ -134,13 +134,7 @@ Once you're running VS Code inside the `test-e2e` container, you can do the foll
 
 If you interrupt the E2E tests halfway through their run (easy to do when debugging), you might find that the test database gets into a situation where running the tests a second time causes lots of spurious failures. For example, if you interrupt the "change password" test right in the middle, after it has changed the test user's password but before it has reset the test user's password back to the original value, then a subsequent run of E2E tests will completely fail to run. If that's the case, you'll want to reset the E2E test app container so that it will re-run the test initialization script and reset the test database.
 
-To reset the E2E test app container, do the following:
-
-1. Exit the E2E container (click the green container menu in the lower left corner of VS Code and choose "Reopen folder locally")
-1. Hit `F1` or `Ctrl+Shift+P` and choose **Tasks: Run Task** (you can type "Run" to find it quickly)
-1. Pick the **Rest E2E tests** task
-
-Now you should be able to run the E2E tests again.
+To reset the E2E test app container, simply choose the **Reset and debug E2E tests** option in the debugging dropdown instead of the **Debug E2E tests** option. Now you should be able to run the E2E tests again.
 
 If you edit files in the `src` or `data` folders of the test container, these changes will be applied to the files in your Git repository. But to make those changes "stick", you might have to exit the test container and rebuild it. To do that:
 

--- a/docker/test-e2e/.vscode/launch.json
+++ b/docker/test-e2e/.vscode/launch.json
@@ -23,6 +23,30 @@
         "${workspaceRoot}/node_modules/**"
       ],
       "type": "pwa-node"
+    },
+    {
+      "name": "Reset and debug E2E tests",
+      "request": "launch",
+      "presentation": {
+        "hidden": false,
+        "group": "test",
+        "order": 1
+      },
+      "preLaunchTask": "Reset E2E tests",
+      "runtimeArgs": [
+        "run-script",
+        "test-e2e",
+        // Uncomment the two lines below and edit the --specs value to run just one file (for more than one file, make it a comma-separated list)
+        // "--",
+        // "--specs=test/app/bellows/change-password.e2e-spec.js"
+      ],
+      "sourceMaps": true,
+      "runtimeExecutable": "npm",
+      "skipFiles": [
+        "<node_internals>/**",
+        "${workspaceRoot}/node_modules/**"
+      ],
+      "type": "pwa-node"
     }
   ]
 }

--- a/docker/test-e2e/.vscode/tasks.json
+++ b/docker/test-e2e/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Reset E2E tests",
+            "command": "docker",
+            "type": "process",
+            "args": [
+                "restart",
+                "app-for-e2e",
+            ],
+            "group": "test",
+            "presentation": {
+                "reveal": "silent"
+            },
+        }
+    ]
+}


### PR DESCRIPTION
Now you can use the launch config "Reset and debug E2E tests" to re-run the `setupTestEnvironment.php` script before launching your E2E debug session, all from within the E2E test container.