### PR TITLE
Extract common Webpack config from dev and prd

### DIFF
--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -1,17 +1,6 @@
 const path = require("path");
 const webpackMerge = require("webpack-merge");
 const commonConfig = require("./webpack.config.js");
-const workboxPlugin = require('workbox-webpack-plugin');
-const DESTINATION = path.resolve(__dirname, 'src', 'dist');
-const LiveReloadPlugin = require('webpack-livereload-plugin');
-const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
-
-/**
- * Webpack Plugins
- */
-
-//UglifyJsPlugin has been depreciated using TerserPlugin
-const TerserPlugin = require("terser-webpack-plugin");
 
 module.exports = webpackMerge(commonConfig, {
   mode: "development",
@@ -20,47 +9,4 @@ module.exports = webpackMerge(commonConfig, {
     extensions: ['.ts', '.js'],
     modules: [path.resolve(__dirname, 'node_modules')]
   },
-  output: {
-    path: DESTINATION,
-    filename: "[name].bundle.js",
-  },
-  optimization: {
-    chunkIds: "named",
-    splitChunks: {
-      cacheGroups: {
-        vendor: {
-          test: /node_modules/,
-          chunks: "initial",
-          name: "vendor",
-          priority: 10,
-          enforce: true,
-        },
-      },
-    },
-    runtimeChunk: {
-      name: "manifest",
-    },
-    minimize: true,
-    minimizer: [new TerserPlugin()],
-  },
-  plugins: [
-    new LoaderOptionsPlugin({
-      debug: true,
-      options: {
-        tslint: {
-          configuration: require('./tslint.json'),
-          typeCheck: true
-        }
-      }
-    }),
-    new workboxPlugin.GenerateSW({
-      clientsClaim: true,
-      skipWaiting: true,
-      importScripts: [
-        '/service-worker/languageforge/service-worker.js'
-      ],
-      include: [] // To be changed once ready to start caching the whole app
-    }),
-    new LiveReloadPlugin()
-  ],
 });

--- a/webpack-prd.config.js
+++ b/webpack-prd.config.js
@@ -1,61 +1,6 @@
-const path = require("path");
 const webpackMerge = require("webpack-merge");
 const commonConfig = require("./webpack.config.js");
-const workboxPlugin = require('workbox-webpack-plugin');
-const DESTINATION = path.resolve(__dirname, 'src', 'dist');
-const LiveReloadPlugin = require('webpack-livereload-plugin');
-const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
-
-/**
- * Webpack Plugins
- */
-
-//UglifyJsPlugin has been depreciated using TerserPlugin
-const TerserPlugin = require("terser-webpack-plugin");
 
 module.exports = webpackMerge(commonConfig, {
-  mode: "production",
-  output: {
-    path: DESTINATION,
-    filename: "[name].bundle.js",
-  },
-  optimization: {
-    chunkIds: "named",
-    splitChunks: {
-      cacheGroups: {
-        vendor: {
-          test: /node_modules/,
-          chunks: "initial",
-          name: "vendor",
-          priority: 10,
-          enforce: true,
-        },
-      },
-    },
-    runtimeChunk: {
-      name: "manifest",
-    },
-    minimize: true,
-    minimizer: [new TerserPlugin()],
-  },
-  plugins: [
-    new LoaderOptionsPlugin({
-      debug: true,
-      options: {
-        tslint: {
-          configuration: require('./tslint.json'),
-          typeCheck: true
-        }
-      }
-    }),
-    new workboxPlugin.GenerateSW({
-      clientsClaim: true,
-      skipWaiting: true,
-      importScripts: [
-        '/service-worker/languageforge/service-worker.js'
-      ],
-      include: [] // To be changed once ready to start caching the whole app
-    }),
-    new LiveReloadPlugin()
-  ],
+  mode: "production"
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,9 @@
 const path = require('path');
 const ROOT = path.resolve(__dirname, './src/angular-app');
+const DESTINATION = path.resolve(__dirname, 'src', 'dist');
+const workboxPlugin = require('workbox-webpack-plugin');
+const LiveReloadPlugin = require('webpack-livereload-plugin');
+const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 
 /**
  * Webpack Plugins
@@ -7,11 +11,36 @@ const ROOT = path.resolve(__dirname, './src/angular-app');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyPlugin = require("copy-webpack-plugin");
 const webpack = require('webpack')
+//UglifyJsPlugin has been depreciated using TerserPlugin
+const TerserPlugin = require("terser-webpack-plugin");
 
 module.exports = {
     context: ROOT,
     resolve: {
       extensions: ['.ts', '.js']
+    },
+    output: {
+      path: DESTINATION,
+      filename: "[name].bundle.js",
+    },
+    optimization: {
+      chunkIds: "named",
+      splitChunks: {
+        cacheGroups: {
+          vendor: {
+            test: /node_modules/,
+            chunks: "initial",
+            name: "vendor",
+            priority: 10,
+            enforce: true,
+          },
+        },
+      },
+      runtimeChunk: {
+        name: "manifest",
+      },
+      minimize: true,
+      minimizer: [new TerserPlugin()],
     },
 
     devServer: {
@@ -76,7 +105,24 @@ module.exports = {
           new webpack.DefinePlugin({
             'process.env.BUGSNAG_API_KEY': JSON.stringify(process.env.BUGSNAG_API_KEY),
           }),
-
+          new LoaderOptionsPlugin({
+            debug: true,
+            options: {
+              tslint: {
+                configuration: require('./tslint.json'),
+                typeCheck: true
+              }
+            }
+          }),
+          new workboxPlugin.GenerateSW({
+            clientsClaim: true,
+            skipWaiting: true,
+            importScripts: [
+              '/service-worker/languageforge/service-worker.js'
+            ],
+            include: [] // To be changed once ready to start caching the whole app
+          }),
+          new LiveReloadPlugin()
     ],
 
     entry: './main.ts'


### PR DESCRIPTION
The dev and prd configs shared almost all of their values, so we can extract those parts of the config to the common config file.

Verified locally by re-running build and running E2E tests; Webpack config still works as it should.