### PR TITLE
Better handling of field input systems overrides

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Config/LexRoleViewConfig.php
+++ b/src/Api/Model/Languageforge/Lexicon/Config/LexRoleViewConfig.php
@@ -9,6 +9,7 @@ class LexRoleViewConfig
 {
     public function __construct()
     {
+        $this->inputSystems = new ArrayOf();
         $this->fields = new MapOf(function ($data) {
             if (array_key_exists('overrideInputSystems', $data)) {
                 return new LexViewMultiTextFieldConfig();
@@ -18,6 +19,9 @@ class LexRoleViewConfig
         });
         $this->showTasks = new MapOf();
     }
+
+    /** @var ArrayOf<string> */
+    public $inputSystems;
 
     /**
      * key is LexConfig field const

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.html
@@ -112,12 +112,7 @@
                         <i class="fa fa-plus"></i>
                     </button>
                 </th>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td colspan="6"></td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td data-ng-repeat="group in $ctrl.unifiedViewModel.inputSystems.selectAllColumns.groups"></td>
                 <td></td>
@@ -125,12 +120,7 @@
             <tr style="background-color: initial; height: 2rem">
                 <td></td>
                 <th></th>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td colspan="6"></td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td data-ng-repeat="group in $ctrl.unifiedViewModel.inputSystems.selectAllColumns.groups"></td>
                 <td></td>
@@ -288,12 +278,7 @@
                         <i class="fa fa-plus"></i>
                     </button>
                 </th>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td colspan="6"></td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td data-ng-repeat="group in $ctrl.unifiedViewModel.entryFields.selectAllColumns.groups"></td>
                 <td></td>
@@ -303,12 +288,7 @@
                 <th class="text-left align-top">
                     <small>Custom Fields shown in <i>italics</i></small>
                 </th>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td colspan="6"></td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td data-ng-repeat="group in $ctrl.unifiedViewModel.entryFields.selectAllColumns.groups"></td>
                 <td></td>
@@ -475,12 +455,7 @@
                         <i class="fa fa-plus"></i>
                     </button>
                 </th>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td colspan="6"></td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td data-ng-repeat="group in $ctrl.unifiedViewModel.senseFields.selectAllColumns.groups"></td>
                 <td></td>
@@ -490,12 +465,7 @@
                 <th class="text-left align-top">
                     <small>Custom Fields shown in <i>italics</i></small>
                 </th>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td colspan="6"></td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td data-ng-repeat="group in $ctrl.unifiedViewModel.senseFields.selectAllColumns.groups"></td>
                 <td></td>
@@ -654,12 +624,7 @@
                         <i class="fa fa-plus"></i>
                     </button>
                 </th>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td colspan="6"></td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td data-ng-repeat="group in $ctrl.unifiedViewModel.exampleFields.selectAllColumns.groups"></td>
                 <td></td>
@@ -669,12 +634,7 @@
                 <th class="text-left align-top">
                     <small>Custom Fields shown in <i>italics</i></small>
                 </th>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td colspan="6"></td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td data-ng-repeat="group in $ctrl.unifiedViewModel.exampleFields.selectAllColumns.groups"></td>
                 <td></td>

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.html
@@ -31,37 +31,32 @@
                 <td class="text-center align-middle">
                     <input class="position-static" id="input-system-select-all-observer-checkbox"
                            data-ng-model="$ctrl.unifiedViewModel.inputSystems.selectAllColumns.observer"
-                           data-ng-change="$ctrl.selectAllRoleColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'observer');
-                                          $ctrl.overrideRoleColumn($ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, 'observer')"
+                           data-ng-change="$ctrl.selectAllRoleColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'observer')"
                            aria-label="..."  type="checkbox">
                 </td>
                 <td class="text-center align-middle">
                     <input class="position-static" id="input-system-select-all-commenter-checkbox"
                            data-ng-model="$ctrl.unifiedViewModel.inputSystems.selectAllColumns.commenter"
-                           data-ng-change="$ctrl.selectAllRoleColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'commenter');
-                                          $ctrl.overrideRoleColumn($ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, 'commenter')"
+                           data-ng-change="$ctrl.selectAllRoleColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'commenter')"
                            aria-label="..." type="checkbox">
                 </td>
                 <td class="text-center align-middle">
                     <input class="position-static" id="input-system-select-all-contributor-checkbox"
                            data-ng-model="$ctrl.unifiedViewModel.inputSystems.selectAllColumns.contributor"
-                           data-ng-change="$ctrl.selectAllRoleColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'contributor');
-                                          $ctrl.overrideRoleColumn($ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, 'contributor')"
+                           data-ng-change="$ctrl.selectAllRoleColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'contributor')"
                            aria-label="..." type="checkbox">
                 </td>
                 <td class="text-center align-middle">
                     <input class="position-static" id="input-system-select-all-manager-checkbox"
                            data-ng-model="$ctrl.unifiedViewModel.inputSystems.selectAllColumns.manager"
-                           data-ng-change="$ctrl.selectAllRoleColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'manager');
-                                          $ctrl.overrideRoleColumn($ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, 'manager')"
+                           data-ng-change="$ctrl.selectAllRoleColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'manager')"
                            aria-label="..." type="checkbox">
                 </td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td class="text-center align-middle" data-ng-repeat="group in $ctrl.unifiedViewModel.inputSystems.selectAllColumns.groups">
                     <input class="position-static input-system-select-all-group-checkbox"
                            data-ng-model="group.show"
-                           data-ng-change="$ctrl.selectAllGroupColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, $index);
-                                          $ctrl.overrideGroupColumn($ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $index)"
+                           data-ng-change="$ctrl.selectAllGroupColumn($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, $index)"
                            aria-label="..." type="checkbox">
                 </td>
                 <td></td>
@@ -73,39 +68,38 @@
                 <th class="table-secondary text-center align-middle">
                     <input class="position-static select-row-checkbox"
                            data-ng-model="inputSystem.isAllRowSelected"
-                           data-ng-change="$ctrl.selectAllRow(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns);
-                                          $ctrl.overrideAll(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns)"
+                           data-ng-change="$ctrl.selectAllRow(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns)"
                            aria-label="..." type="checkbox">
                 </th>
                 <td class="text-center align-middle">
                     <input class="position-static observer-checkbox"
                            data-ng-model="inputSystem.observer"
-                           data-ng-change="$ctrl.overrideRoleInputSystem(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'observer')"
+                           data-ng-change="$ctrl.checkIfAllRoleSelected(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'observer')"
                            aria-label="..." type="checkbox">
                 </td>
                 <td class="text-center align-middle">
                     <input class="position-static commenter-checkbox"
                            data-ng-model="inputSystem.commenter"
-                           data-ng-change="$ctrl.overrideRoleInputSystem(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'commenter')"
+                           data-ng-change="$ctrl.checkIfAllRoleSelected(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'commenter')"
                            aria-label="..." type="checkbox">
                 </td>
                 <td class="text-center align-middle">
                     <input class="position-static contributor-checkbox"
                            data-ng-model="inputSystem.contributor"
-                           data-ng-change="$ctrl.overrideRoleInputSystem(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'contributor')"
+                           data-ng-change="$ctrl.checkIfAllRoleSelected(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'contributor')"
                            aria-label="..." type="checkbox">
                 </td>
                 <td class="text-center align-middle">
                     <input class="position-static manager-checkbox"
                            data-ng-model="inputSystem.manager"
-                           data-ng-change="$ctrl.overrideRoleInputSystem(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'manager')"
+                           data-ng-change="$ctrl.checkIfAllRoleSelected(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, 'manager')"
                            aria-label="..." type="checkbox">
                 </td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td class="text-center align-middle" data-ng-repeat="group in inputSystem.groups">
                     <input class="position-static" data-ng-class="'checkbox-group-' + $index"
                            data-ng-model="group.show"
-                           data-ng-change="$ctrl.overrideGroupInputSystem(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, $index)"
+                           data-ng-change="$ctrl.checkIfAllGroupSelected(inputSystem, $ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, $index)"
                            aria-label="..." type="checkbox">
                 </td>
                 <td></td>
@@ -120,42 +114,12 @@
                 </th>
                 <td></td>
                 <td></td>
-                <td class="text-middle align-middle">
-                    <button type="button" class="btn btn-std text-middle" data-ng-click="$ctrl.resetInputSystemsForRole($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, $ctrl.fccConfigDirty, 'observer')"
-                            data-ng-show="$ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride.observer"
-                            id="reset-input-system-observer-btn" title="Reset input systems for observer">
-                        Reset
-                    </button>
-                </td>
-                <td>
-                    <button type="button" class="btn btn-std" data-ng-click="$ctrl.resetInputSystemsForRole($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, $ctrl.fccConfigDirty, 'commenter')"
-                            data-ng-show="$ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride.commenter"
-                            id="reset-input-system-commenter-btn" title="Reset input systems for commenter">
-                        Reset
-                    </button>
-                </td>
-                <td>
-                    <button type="button" class="btn btn-std" data-ng-click="$ctrl.resetInputSystemsForRole($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, $ctrl.fccConfigDirty, 'contributor')"
-                            data-ng-show="$ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride.contributor"
-                            id="reset-input-system-contributor-btn" title="Reset input systems for contributor">
-                        Reset
-                    </button>
-                </td>
-                <td>
-                    <button type="button" class="btn btn-std" data-ng-click="$ctrl.resetInputSystemsForRole($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, $ctrl.fccConfigDirty, 'manager')"
-                            data-ng-show="$ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride.manager"
-                            id="reset-input-system-manager-btn" title="Reset input systems for manager">
-                        Reset
-                    </button>
-                </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
                 <!--suppress JSUnusedLocalSymbols -->
-                <td data-ng-repeat="group in $ctrl.unifiedViewModel.inputSystems.selectAllColumns.groups">
-                    <button type="button" class="btn btn-std" data-ng-click="$ctrl.resetInputSystemsForGroup($ctrl.unifiedViewModel.inputSystems.settings, $ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride, $ctrl.unifiedViewModel.inputSystems.selectAllColumns, $ctrl.fccConfigDirty, $index)"
-                            data-ng-show="$ctrl.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride.groups[$index]"
-                            title="Reset input systems for user">
-                        Reset
-                    </button>
-                </td>
+                <td data-ng-repeat="group in $ctrl.unifiedViewModel.inputSystems.selectAllColumns.groups"></td>
                 <td></td>
             </tr>
             <tr style="background-color: initial; height: 2rem">

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.ts
@@ -65,13 +65,6 @@ export class FieldsConfigurationController implements angular.IController {
   selectAllGroupColumn = ConfigurationFieldUnifiedViewModel.selectAllGroupColumn;
   checkIfAllRoleSelected = ConfigurationFieldUnifiedViewModel.checkIfAllRoleSelected;
   checkIfAllGroupSelected = ConfigurationFieldUnifiedViewModel.checkIfAllGroupSelected;
-  overrideRoleInputSystem = ConfigurationFieldUnifiedViewModel.overrideRoleInputSystem;
-  overrideGroupInputSystem = ConfigurationFieldUnifiedViewModel.overrideGroupInputSystem;
-  overrideRoleColumn = ConfigurationFieldUnifiedViewModel.overrideRoleColumn;
-  overrideGroupColumn = ConfigurationFieldUnifiedViewModel.overrideGroupColumn;
-  overrideAll = ConfigurationFieldUnifiedViewModel.overrideAll;
-  resetInputSystemsForRole = ConfigurationFieldUnifiedViewModel.resetInputSystemsForRole;
-  resetInputSystemsForGroup = ConfigurationFieldUnifiedViewModel.resetInputSystemsForGroup;
 
   openNewCustomFieldModal(fieldLevel: string): void {
     interface NewCustomData {
@@ -229,7 +222,6 @@ export class FieldsConfigurationController implements angular.IController {
       typeahead.userName = '';
       this.removeFromUsersWithoutSettings(user.id);
       this.unifiedViewModel.groupLists.push({ label: user.username, userId: user.id } as GroupList);
-      this.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride.groups.push(new Group());
       this.unifiedViewModel.inputSystems.selectAllColumns.groups.push(new Group());
       this.unifiedViewModel.entryFields.selectAllColumns.groups.push(new Group());
       this.unifiedViewModel.senseFields.selectAllColumns.groups.push(new Group());
@@ -264,7 +256,6 @@ export class FieldsConfigurationController implements angular.IController {
     const userId = this.unifiedViewModel.groupLists[index].userId;
     this.typeahead.usersWithoutSettings.push(this.fccUsers[userId]);
     this.unifiedViewModel.groupLists.splice(index, 1);
-    this.unifiedViewModel.inputSystems.hasCustomInputSystemsOverride.groups.splice(index, 1);
     this.unifiedViewModel.inputSystems.selectAllColumns.groups.splice(index, 1);
     this.unifiedViewModel.entryFields.selectAllColumns.groups.splice(index, 1);
     this.unifiedViewModel.senseFields.selectAllColumns.groups.splice(index, 1);
@@ -367,7 +358,6 @@ export const FieldsConfigurationComponent: angular.IComponentOptions = {
     fccUsers: '<',
     fccOptionLists: '<',
     fccAddInputSystem: '&',
-    fccResetInputSystems: '&',
     fccOnUpdate: '&'
   },
   controller: FieldsConfigurationController,

--- a/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
@@ -394,7 +394,7 @@ export class ConfigurationFieldUnifiedViewModel {
       if (roleView.inputSystems && roleView.inputSystems.length) {
         inputSystemSettings[role] = roleView.inputSystems.includes(tag);
       } else {
-        inputSystemSettings[role] = ConfigurationFieldUnifiedViewModel.isInputSystemUsed(tag, config);
+        inputSystemSettings[role] = true;
       }
     }
   }
@@ -406,55 +406,9 @@ export class ConfigurationFieldUnifiedViewModel {
       if (userView.inputSystems && userView.inputSystems.length) {
         inputSystemSettings.groups[groupIndex].show = userView.inputSystems.includes(tag);
       } else {
-        inputSystemSettings.groups[groupIndex].show = ConfigurationFieldUnifiedViewModel.isInputSystemUsed(tag, config);
+        inputSystemSettings.groups[groupIndex].show = true;
       }
     }
-  }
-
-  private static isInputSystemUsed(tag: string, config: LexiconConfig): boolean {
-    if (!config) {
-      return false;
-    }
-    const entryConfig = config.entry;
-    if (!entryConfig || !entryConfig.fields) {
-      return false;
-    }
-    for (const fieldName in entryConfig.fields) {
-      if (ConfigurationFieldUnifiedViewModel.isInputSystemUsedInFieldList(tag, fieldName, entryConfig)) {
-        return true;
-      }
-    }
-    const sensesConfig = entryConfig.fields.senses as LexConfigFieldList;
-    if (!sensesConfig || !sensesConfig.fields) {
-      return false;
-    }
-    for (const fieldName in sensesConfig.fields) {
-      if (ConfigurationFieldUnifiedViewModel.isInputSystemUsedInFieldList(tag, fieldName, sensesConfig)) {
-        return true;
-      }
-    }
-    const examplesConfig = sensesConfig.fields.examples as LexConfigFieldList;
-    if (!examplesConfig || !examplesConfig.fields) {
-      return false;
-    }
-    for (const fieldName in examplesConfig.fields) {
-      if (ConfigurationFieldUnifiedViewModel.isInputSystemUsedInFieldList(tag, fieldName, examplesConfig)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static isInputSystemUsedInFieldList(tag: string, fieldName: string, fieldList: LexConfigFieldList): boolean {
-    if (fieldList.fields.hasOwnProperty(fieldName)) {
-      if (ConfigurationFieldUnifiedViewModel.isMultitextFieldType(fieldList.fields[fieldName].type)) {
-        const fieldConfig = fieldList.fields[fieldName] as LexConfigMultiText;
-        if (fieldConfig.inputSystems.includes(tag)) {
-          return true;
-        }
-      }
-    }
-    return false;
   }
 
   private static setLevelViewModel(levelConfig: LexConfigFieldList, config: LexiconConfig): FieldSettings[] {

--- a/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/field-unified-view.model.ts
@@ -19,9 +19,8 @@ export class ConfigurationFieldUnifiedViewModel {
     this.groupLists = ConfigurationFieldUnifiedViewModel.setGroupLists(config, users);
 
     this.inputSystems = new InputSystemSettingsList();
-    const [settings, overrides] = ConfigurationFieldUnifiedViewModel.setInputSystemsViewModel(config);
+    const settings = ConfigurationFieldUnifiedViewModel.setInputSystemsViewModel(config);
     this.inputSystems.settings = settings;
-    this.inputSystems.hasCustomInputSystemsOverride = overrides;
     this.inputSystemsPristine = angular.copy(this.inputSystems);
     const optionSelects = new OptionSelects();
     for (const tag in config.inputSystems) {
@@ -58,7 +57,6 @@ export class ConfigurationFieldUnifiedViewModel {
     }
 
     for (let i = 0; i < this.inputSystems.settings[0].groups.length; i++) {
-      this.inputSystems.hasCustomInputSystemsOverride.groups.push(new Group());
       this.inputSystems.selectAllColumns.groups.push(new Group());
       this.entryFields.selectAllColumns.groups.push(new Group());
       this.senseFields.selectAllColumns.groups.push(new Group());
@@ -76,22 +74,22 @@ export class ConfigurationFieldUnifiedViewModel {
 
   toConfig(config: LexiconConfig): void {
     // Config updates for Input Systems
-    ConfigurationFieldUnifiedViewModel.inputSystemsToConfig(this.inputSystems.settings,
-      this.inputSystems.hasCustomInputSystemsOverride, config, this.groupLists);
+    ConfigurationFieldUnifiedViewModel.inputSystemsToConfig(this.inputSystems, config, this.groupLists);
 
     // Config updates for fields
     const entryConfig = config.entry;
-    ConfigurationFieldUnifiedViewModel.fieldsToConfig(this.entryFields.settings, config, entryConfig, this.groupLists);
+    ConfigurationFieldUnifiedViewModel
+      .fieldsToConfig(this.entryFields.settings, this.inputSystems, config, entryConfig, this.groupLists);
     if ('senses' in entryConfig.fields) {
       entryConfig.fieldOrder.push('senses');
       const sensesConfig = entryConfig.fields.senses as LexConfigFieldList;
       ConfigurationFieldUnifiedViewModel
-        .fieldsToConfig(this.senseFields.settings, config, sensesConfig, this.groupLists);
+        .fieldsToConfig(this.senseFields.settings, this.inputSystems, config, sensesConfig, this.groupLists);
       if ('examples' in sensesConfig.fields) {
         sensesConfig.fieldOrder.push('examples');
         const examplesConfig = sensesConfig.fields.examples as LexConfigFieldList;
-        ConfigurationFieldUnifiedViewModel.fieldsToConfig(this.exampleFields.settings, config, examplesConfig,
-          this.groupLists);
+        ConfigurationFieldUnifiedViewModel
+          .fieldsToConfig(this.exampleFields.settings, this.inputSystems, config, examplesConfig, this.groupLists);
       }
     }
   }
@@ -175,98 +173,38 @@ export class ConfigurationFieldUnifiedViewModel {
     ConfigurationFieldUnifiedViewModel.checkIfAllGroupColumnSelected(settings, selectAll, groupIndex);
   }
 
-  static overrideRoleInputSystem(setting: SettingsBase, settings: SettingsBase[], overrides: InputSystemSettings,
-                                 selectAll: SettingsBase, role: string): void {
-    overrides[role] = true;
-    ConfigurationFieldUnifiedViewModel.checkIfAllRoleSelected(setting, settings, selectAll, role);
-  }
-
-  static overrideGroupInputSystem(setting: SettingsBase, settings: SettingsBase[], overrides: InputSystemSettings,
-                                  selectAll: SettingsBase, groupIndex: number): void {
-    overrides.groups[groupIndex].show = true;
-    ConfigurationFieldUnifiedViewModel.checkIfAllGroupSelected(setting, settings, selectAll, groupIndex);
-  }
-
-  static overrideRoleColumn(overrides: InputSystemSettings, role: string): void {
-    overrides[role] = true;
-  }
-
-  static overrideGroupColumn(overrides: InputSystemSettings, groupIndex: number): void {
-    overrides.groups[groupIndex].show = true;
-  }
-
-  static overrideAll(setting: SettingsBase, settings: SettingsBase[], overrides: InputSystemSettings,
-                     selectAll: SettingsBase): void {
-    const roles = RoleType.roles();
-    for (const role of roles) {
-      ConfigurationFieldUnifiedViewModel.overrideRoleInputSystem(
-        setting, settings, overrides, selectAll, role);
-    }
-    for (const group of setting.groups) {
-      ConfigurationFieldUnifiedViewModel.overrideGroupInputSystem(
-        setting, settings, overrides, selectAll, setting.groups.indexOf(group));
-    }
-  }
-
-  static resetInputSystemsForRole(settings: InputSystemSettings[], overrides: InputSystemSettings,
-                                  selectAll: SettingsBase, config: LexiconConfig, role: string): void {
-    for (const inputSystem of settings) {
-      const tag = inputSystem.tag;
-      ConfigurationFieldUnifiedViewModel.setInputSystemRoleSettingsFromFields(
-        tag, config, role, inputSystem);
-      ConfigurationFieldUnifiedViewModel.checkIfAllRoleSelected(
-        inputSystem, settings, selectAll, role);
-    }
-    overrides[role] = false;
-  }
-
-  static resetInputSystemsForGroup(settings: InputSystemSettings[], overrides: InputSystemSettings,
-                                   selectAll: SettingsBase, config: LexiconConfig, groupIndex: number): void {
-    for (const inputSystem of settings) {
-      const tag = inputSystem.tag;
-      ConfigurationFieldUnifiedViewModel.setInputSystemGroupSettingsFromFields(
-        tag, config, groupIndex, inputSystem);
-      ConfigurationFieldUnifiedViewModel.checkIfAllGroupSelected(
-        inputSystem, settings, selectAll, groupIndex);
-    }
-    overrides.groups[groupIndex].show = false;
-  }
-
   private static isMultitextFieldType(fieldType: string) {
     // Picture fields are also multitext fields and have lists of input systems
     return (fieldType === 'multitext' || fieldType === 'pictures');
   }
 
-  private static inputSystemsToConfig(inputSystems: InputSystemSettings[],
-                                      overrides: InputSystemSettings,
+  private static inputSystemsToConfig(inputSystemSettings: InputSystemSettingsList,
                                       config: LexiconConfig, groupLists: GroupList[]): void {
     // iterate over every role type
     const roleType = new RoleType();
     for (const role of RoleType.roles()) {
       const roleView: LexRoleViewConfig = config.roleViews[roleType[role]];
-      const overrideInputSystems: boolean = overrides[role];
-      if (roleView != null && roleView.fields != null) {
-        // add any Input Systems to the array for this role
+      // Was: if (roleView != null && roleView.fields != null) {
+      if (roleView != null) {
+        let allSelected = inputSystemSettings.selectAllColumns[role];
         const tags: string[] = [];
-        let tagsIndex = 0;
-        for (const inputSystem of inputSystems) {
-          if (inputSystem[role]) {
-            tags[tagsIndex++] = inputSystem.tag;
+        if (!allSelected) {
+          // add any Input Systems to the array for this role
+          let tagsIndex = 0;
+          for (const inputSystem of inputSystemSettings.settings) {
+            if (inputSystem[role]) {
+              tags[tagsIndex++] = inputSystem.tag;
+            }
+          }
+          if (tags.length === inputSystemSettings.settings.length) {
+            allSelected = true;
           }
         }
 
-        for (const fieldName in roleView.fields) {
-          if (roleView.fields.hasOwnProperty(fieldName) &&
-              ConfigurationFieldUnifiedViewModel.isMultitextFieldType(roleView.fields[fieldName].type)) {
-            const multiTextFieldConfig = roleView.fields[fieldName] as LexViewMultiTextFieldConfig;
-            if (overrideInputSystems) {
-              multiTextFieldConfig.overrideInputSystems = true;
-              multiTextFieldConfig.inputSystems = tags;
-            } else {
-              multiTextFieldConfig.overrideInputSystems = false;
-              multiTextFieldConfig.inputSystems = [];
-            }
-          }
+        if (allSelected) {
+          roleView.inputSystems = [];
+        } else {
+          roleView.inputSystems = tags;
         }
       }
     }
@@ -274,28 +212,26 @@ export class ConfigurationFieldUnifiedViewModel {
     // iterate over groups
     for (let i = 0; i < groupLists.length; i++) {
       const userView: LexUserViewConfig = config.userViews[groupLists[i].userId];
-      const overrideInputSystems: boolean = overrides.groups[i].show;
-      if (userView != null && userView.fields != null) {
-        // add any Input Systems to the array for this group
+      // Was: if (userView != null && userView.fields != null) {
+      if (userView != null) {
+        let allSelected = inputSystemSettings.selectAllColumns.groups[i].show;
         const tags: string[] = [];
-        let tagsIndex = 0;
-        for (const inputSystem of inputSystems) {
-          if (inputSystem.groups[i].show) {
-            tags[tagsIndex++] = inputSystem.tag;
-          }
-        }
-
-        for (const fieldName in userView.fields) {
-          if (userView.fields.hasOwnProperty(fieldName) &&
-              ConfigurationFieldUnifiedViewModel.isMultitextFieldType(userView.fields[fieldName].type)) {
-            const multiTextFieldConfig = userView.fields[fieldName] as LexViewMultiTextFieldConfig;
-            if (overrideInputSystems) {
-              multiTextFieldConfig.overrideInputSystems = true;
-              multiTextFieldConfig.inputSystems = tags;
-            } else {
-              multiTextFieldConfig.overrideInputSystems = false;
-              multiTextFieldConfig.inputSystems = [];
+        if (!allSelected) {
+          // add any Input Systems to the array for this role
+          let tagsIndex = 0;
+          for (const inputSystem of inputSystemSettings.settings) {
+            if (inputSystem.groups[i].show) {
+              tags[tagsIndex++] = inputSystem.tag;
             }
+          }
+          if (tags.length === inputSystemSettings.settings.length) {
+            allSelected = true;
+          }
+
+          if (allSelected) {
+            userView.inputSystems = [];
+          } else {
+            userView.inputSystems = tags;
           }
         }
       }
@@ -303,8 +239,18 @@ export class ConfigurationFieldUnifiedViewModel {
 
   }
 
-  private static fieldsToConfig(fields: FieldSettings[], config: LexiconConfig, levelConfig: LexConfigFieldList,
-                                groupLists: GroupList[]): void {
+  private static listIntersection(a: string[], b: string[]): string[] {
+    const result = [];
+    for (const item of a) {
+      if (b.indexOf(item) !== -1) {
+        result.push(item);
+      }
+    }
+    return result;
+  }
+
+  private static fieldsToConfig(fields: FieldSettings[], inputSystemSettings: InputSystemSettingsList,
+                                config: LexiconConfig, levelConfig: LexConfigFieldList, groupLists: GroupList[]): void {
     levelConfig.fieldOrder = [];
     for (const field of fields) {
       // from setLevelViewModel
@@ -314,14 +260,17 @@ export class ConfigurationFieldUnifiedViewModel {
       if (levelConfigField.type === 'pictures') {
         (levelConfigField as LexConfigPictures).captionHideIfEmpty = field.captionHiddenIfEmpty;
       }
+      // Create this array outside the if() because we'll use it in for loops lower down
+      const fieldInputSystems = [];
       if (ConfigurationFieldUnifiedViewModel.isMultitextFieldType(levelConfigField.type)) {
         const multiTextLevelConfigField = levelConfigField as LexConfigMultiText;
         multiTextLevelConfigField.inputSystems = [];
-        for (const inputSystemSettings of field.inputSystems) {
-          if (inputSystemSettings != null && inputSystemSettings.isAllRowSelected) {
-            multiTextLevelConfigField.inputSystems.push(inputSystemSettings.tag);
+        for (const fieldInputSystemSettings of field.inputSystems) {
+          if (fieldInputSystemSettings != null && fieldInputSystemSettings.isAllRowSelected) {
+            fieldInputSystems.push(fieldInputSystemSettings.tag);
           }
         }
+        multiTextLevelConfigField.inputSystems = fieldInputSystems;
       }
 
       // from setLevelRoleSettings
@@ -330,6 +279,19 @@ export class ConfigurationFieldUnifiedViewModel {
         const roleView: LexRoleViewConfig = config.roleViews[roleType[role]];
         if (roleView != null && roleView.fields != null) {
           roleView.fields[field.fieldName].show = field[role];
+          // Set overridden input systems if (and only if) this role doesn't see all input systems
+          if (roleView.fields.hasOwnProperty(field.fieldName) &&
+              ConfigurationFieldUnifiedViewModel.isMultitextFieldType(levelConfigField.type)) {
+            const roleFieldConfig = roleView.fields[field.fieldName] as LexViewMultiTextFieldConfig;
+            if (roleView.inputSystems && roleView.inputSystems.length) {
+              const combinedTags = this.listIntersection(fieldInputSystems, roleView.inputSystems);
+              roleFieldConfig.overrideInputSystems = true;
+              roleFieldConfig.inputSystems = combinedTags;
+            } else {
+              roleFieldConfig.overrideInputSystems = false;
+              roleFieldConfig.inputSystems = [];
+            }
+          }
         }
       }
 
@@ -337,40 +299,52 @@ export class ConfigurationFieldUnifiedViewModel {
       for (let i = 0; i < groupLists.length; i++) {
         const userView = config.userViews[groupLists[i].userId];
         userView.fields[field.fieldName].show = field.groups[i].show;
+        // Set overridden input systems if (and only if) this user doesn't see all input systems
+        if (userView.fields.hasOwnProperty(field.fieldName) &&
+            ConfigurationFieldUnifiedViewModel.isMultitextFieldType(levelConfigField.type)) {
+          const userFieldConfig = userView.fields[field.fieldName] as LexViewMultiTextFieldConfig;
+          if (userView.inputSystems && userView.inputSystems.length) {
+            const combinedTags = this.listIntersection(fieldInputSystems, userView.inputSystems);
+            userFieldConfig.overrideInputSystems = true;
+            userFieldConfig.inputSystems = combinedTags;
+          } else {
+            userFieldConfig.overrideInputSystems = false;
+            userFieldConfig.inputSystems = [];
+          }
+        }
       }
 
       levelConfig.fieldOrder.push(field.fieldName);
     }
   }
 
-  private static setInputSystemsViewModel(config: LexiconConfig): [InputSystemSettings[], InputSystemSettings] {
+  private static setInputSystemsViewModel(config: LexiconConfig): InputSystemSettings[] {
     const inputSystems: InputSystemSettings[] = [];
-    const overrides: InputSystemSettings = new InputSystemSettings();
     const selectedManagerTags = ConfigurationFieldUnifiedViewModel.getSelectedInputSystemsManagerTags(config);
     let i = 0;
     for (const tag of selectedManagerTags) {
-      ConfigurationFieldUnifiedViewModel.setInputSystemViewModel(config, inputSystems, overrides, tag, i);
+      ConfigurationFieldUnifiedViewModel.setInputSystemViewModel(config, inputSystems, tag, i);
       i++;
     }
     for (const tag in config.inputSystems) {
       if (config.inputSystems.hasOwnProperty(tag) && !selectedManagerTags.includes(tag)) {
-        ConfigurationFieldUnifiedViewModel.setInputSystemViewModel(config, inputSystems, overrides, tag, i);
+        ConfigurationFieldUnifiedViewModel.setInputSystemViewModel(config, inputSystems, tag, i);
         i++;
       }
     }
 
-    return [inputSystems, overrides];
+    return inputSystems;
   }
 
   private static setInputSystemViewModel(config: LexiconConfig, inputSystems: InputSystemSettings[],
-                                         overrides: InputSystemSettings, tag: string, index: number): void {
+                                         tag: string, index: number): void {
     const inputSystemSettings = new InputSystemSettings();
     inputSystemSettings.tag = tag;
     const roles = RoleType.roles();
     const roleType = new RoleType();
     for (const role of roles) {
       ConfigurationFieldUnifiedViewModel.setInputSystemRoleSettings(
-        tag, config, role, roleType[role], inputSystemSettings, overrides);
+        tag, config, role, roleType[role], inputSystemSettings);
     }
     let groupIndex = 0;
     for (const userId in config.userViews) {
@@ -378,7 +352,7 @@ export class ConfigurationFieldUnifiedViewModel {
         config.userViews[userId].fields != null
       ) {
         ConfigurationFieldUnifiedViewModel.setInputSystemGroupSettings(
-          tag, config, userId, groupIndex, inputSystemSettings, overrides);
+          tag, config, userId, groupIndex, inputSystemSettings);
         groupIndex++;
       }
     }
@@ -386,18 +360,25 @@ export class ConfigurationFieldUnifiedViewModel {
     ConfigurationFieldUnifiedViewModel.checkIfAllRowSelected(inputSystemSettings);
   }
 
+  private static addWithoutDuplicates(orig: string[], newItems: string[]): void {
+    for (const item of newItems) {
+      if (orig.indexOf(item) !== -1) {
+        orig.push(item);
+      }
+    }
+  }
+
   private static getSelectedInputSystemsManagerTags(config: LexiconConfig): string[] {
     const roleType = new RoleType();
     const roleView: LexRoleViewConfig = config.roleViews[roleType.manager];
-    let tags: string[] = [];
+    const tags: string[] = [];
     if (roleView != null && roleView.fields != null) {
       for (const fieldName in roleView.fields) {
         if (roleView.fields.hasOwnProperty(fieldName) &&
             ConfigurationFieldUnifiedViewModel.isMultitextFieldType(roleView.fields[fieldName].type)) {
           const multiTextField = roleView.fields[fieldName] as LexViewMultiTextFieldConfig;
           if (multiTextField.overrideInputSystems) {
-            tags = multiTextField.inputSystems;
-            break;
+            ConfigurationFieldUnifiedViewModel.addWithoutDuplicates(tags, multiTextField.inputSystems);
           }
         }
       }
@@ -407,68 +388,27 @@ export class ConfigurationFieldUnifiedViewModel {
   }
 
   private static setInputSystemRoleSettings(tag: string, config: LexiconConfig, role: string, roleType: string,
-                                            inputSystemSettings: InputSystemSettings,
-                                            overrides: InputSystemSettings): void {
-    let hasOverride = false;
+                                            inputSystemSettings: InputSystemSettings): void {
     const roleView: LexRoleViewConfig = config.roleViews[roleType];
-    if (roleView != null && roleView.fields != null) {
-      for (const fieldName in roleView.fields) {
-        if (roleView.fields.hasOwnProperty(fieldName) &&
-            ConfigurationFieldUnifiedViewModel.isMultitextFieldType(roleView.fields[fieldName].type)) {
-          const multiTextField = roleView.fields[fieldName] as LexViewMultiTextFieldConfig;
-          if (multiTextField.overrideInputSystems) {
-            hasOverride = true;
-            inputSystemSettings[role] = multiTextField.inputSystems.includes(tag);
-            break;
-          }
-        }
+    if (roleView != null) {
+      if (roleView.inputSystems && roleView.inputSystems.length) {
+        inputSystemSettings[role] = roleView.inputSystems.includes(tag);
+      } else {
+        inputSystemSettings[role] = ConfigurationFieldUnifiedViewModel.isInputSystemUsed(tag, config);
       }
     }
-    if (hasOverride) {
-      overrides[role] = true;
-    } else {
-      ConfigurationFieldUnifiedViewModel.setInputSystemRoleSettingsFromFields(
-        tag, config, role, inputSystemSettings);
-      overrides[role] = false;
-    }
-  }
-
-  static setInputSystemRoleSettingsFromFields(tag: string, config: LexiconConfig, role: string,
-                                              inputSystemSettings: InputSystemSettings): void {
-    inputSystemSettings[role] = ConfigurationFieldUnifiedViewModel.isInputSystemUsed(tag, config);
   }
 
   private static setInputSystemGroupSettings(tag: string, config: LexiconConfig, userId: string, groupIndex: number,
-                                             inputSystemSettings: InputSystemSettings,
-                                             overrides: InputSystemSettings): void {
-    let hasOverride = false;
-    for (const fieldName in config.userViews[userId].fields) {
-      if (config.userViews[userId].fields.hasOwnProperty(fieldName) &&
-          ConfigurationFieldUnifiedViewModel.isMultitextFieldType(config.userViews[userId].fields[fieldName].type)
-      ) {
-        const multiTextField = config.userViews[userId].fields[fieldName] as LexViewMultiTextFieldConfig;
-        inputSystemSettings.groups[groupIndex] = new Group();
-        if (multiTextField.overrideInputSystems) {
-          hasOverride = true;
-          inputSystemSettings.groups[groupIndex].show = multiTextField.inputSystems.includes(tag);
-          break;
-        }
+                                             inputSystemSettings: InputSystemSettings): void {
+    const userView: LexUserViewConfig = config.userViews[userId];
+    if (userView != null) {
+      if (userView.inputSystems && userView.inputSystems.length) {
+        inputSystemSettings.groups[groupIndex].show = userView.inputSystems.includes(tag);
+      } else {
+        inputSystemSettings.groups[groupIndex].show = ConfigurationFieldUnifiedViewModel.isInputSystemUsed(tag, config);
       }
     }
-    if (hasOverride) {
-      overrides.groups[groupIndex] = new Group();
-      overrides.groups[groupIndex].show = true;
-    } else {
-      ConfigurationFieldUnifiedViewModel.setInputSystemGroupSettingsFromFields(
-        tag, config, groupIndex, inputSystemSettings);
-      overrides.groups[groupIndex] = new Group();
-      overrides.groups[groupIndex].show = false;
-    }
-  }
-
-  static setInputSystemGroupSettingsFromFields(tag: string, config: LexiconConfig, groupIndex: number,
-                                               inputSystemSettings: InputSystemSettings): void {
-    inputSystemSettings.groups[groupIndex].show = ConfigurationFieldUnifiedViewModel.isInputSystemUsed(tag, config);
   }
 
   private static isInputSystemUsed(tag: string, config: LexiconConfig): boolean {
@@ -532,12 +472,8 @@ export class ConfigurationFieldUnifiedViewModel {
         ConfigurationFieldUnifiedViewModel.setLevelRoleSettings(fieldName, config, fieldSettings);
         ConfigurationFieldUnifiedViewModel.setLevelGroupSettings(fieldName, config, fieldSettings);
 
-        const roleType = new RoleType();
-        const managerRoleViewField = config.roleViews[roleType.manager].fields[fieldName];
         if (ConfigurationFieldUnifiedViewModel.isMultitextFieldType(levelConfig.fields[fieldName].type)) {
           const multiTextLevelConfigField = levelConfig.fields[fieldName] as LexConfigMultiText;
-          // const multiTextFieldConfig = managerRoleViewField as LexViewMultiTextFieldConfig;
-          // fieldSettings.hasCustomInputSystemsOverride = !multiTextFieldConfig.overrideInputSystems;
           for (const tag of multiTextLevelConfigField.inputSystems) {
             const inputSystemSettings = new InputSystemSettings();
             inputSystemSettings.tag = tag;
@@ -627,7 +563,6 @@ export class FieldSettings extends SettingsBase {
 
 export class InputSystemSettingsList {
   settings: InputSystemSettings[] = [];
-  hasCustomInputSystemsOverride: InputSystemSettings = new InputSystemSettings();
   selectAllColumns: InputSystemSettings = new InputSystemSettings();
   labels: { [tag: string]: string } = {};
 }

--- a/src/angular-app/languageforge/lexicon/shared/model/lexicon-config.model.ts
+++ b/src/angular-app/languageforge/lexicon/shared/model/lexicon-config.model.ts
@@ -48,6 +48,7 @@ export class LexViewMultiTextFieldConfig extends LexViewFieldConfig {
 }
 
 export class LexRoleViewConfig {
+  inputSystems: string[];
   fields: { [fieldType: string]: LexViewFieldConfig | LexViewMultiTextFieldConfig };
   showTasks: { [taskType: string]: boolean };
 }

--- a/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-entry.e2e-spec.ts
@@ -506,13 +506,16 @@ describe('Lexicon E2E Editor List and Entry', () => {
     });
 
   describe('Configuration check', async () => {
-    const englishISIndex = 3;
+    const ipaRowLabel = /^Thai \(IPA\)$/;
+    const thaiAudioRowLabel = 'Thai Voice (Voice)';
+    const englishRowLabel = 'English';
 
     it('Word has only "th", "tipa" and "taud" visible', async () => {
-      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(3);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toBeGreaterThanOrEqual(3);
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(3);
     });
 
     it('make "en" input system visible for "Word" field', async () => {
@@ -520,18 +523,19 @@ describe('Lexicon E2E Editor List and Entry', () => {
       await configPage.tabs.unified.click();
       await configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
       await util.setCheckbox(
-        configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, englishISIndex), true);
+        configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, englishRowLabel), true);
       await configPage.applyButton.click();
       await Utils.clickBreadcrumb(constants.testProjectName);
       await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     });
 
     it('Word has "th", "tipa", "taud" and "en" visible', async () => {
-      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(4);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toBeGreaterThanOrEqual(4);
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(3).getText()).toEqual('en');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(4);
     });
 
     it('make "en" input system invisible for "Word" field', async () => {
@@ -539,17 +543,85 @@ describe('Lexicon E2E Editor List and Entry', () => {
       await configPage.tabs.unified.click();
       await configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
       await util.setCheckbox(
-        configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, englishISIndex), false);
+        configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, englishRowLabel), false);
       await configPage.applyButton.click();
       await Utils.clickBreadcrumb(constants.testProjectName);
       await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
     });
 
-    it('Word has only "th", "tipa" and "taud" visible', async () => {
-      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(3);
+    it('Word has only "th", "tipa" and "taud" visible again', async () => {
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toBeGreaterThanOrEqual(3);
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
       expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(3);
+    });
+
+    it('make "taud" input system invisible for "Word" field and "tipa" invisible for manager role', async () => {
+      await configPage.get();
+      await configPage.tabs.unified.click();
+
+      // Ensure field-specific input systems for Word are visible
+      const wordChevron = await configPage.unifiedPane.fieldSpecificIcon(lexemeLabel).getAttribute('class');
+      if (wordChevron.includes('fa-chevron-down')) {
+        await configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
+      }
+
+      // Alternately, just do it regardless
+      // await configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
+      await util.setCheckbox(
+        configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, thaiAudioRowLabel), false);
+      await util.setCheckbox(configPage.unifiedPane.managerCheckbox(ipaRowLabel), false);
+
+      await configPage.applyButton.click();
+      await Utils.clickBreadcrumb(constants.testProjectName);
+      await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
+    });
+
+    it('Word has only "th" visible', async () => {
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toBeGreaterThanOrEqual(1);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(1);
+    });
+
+    it('restore visibility of "taud" for "Word" field', async () => {
+      await configPage.get();
+      await configPage.tabs.unified.click();
+      // Ensure field-specific input systems for Word are visible
+      const wordChevron = await configPage.unifiedPane.fieldSpecificIcon(lexemeLabel).getAttribute('class');
+      if (wordChevron.includes('fa-chevron-down')) {
+        await configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
+      }
+      // await configPage.unifiedPane.fieldSpecificButton(lexemeLabel).click();
+      await util.setCheckbox(
+        configPage.unifiedPane.entry.fieldSpecificInputSystemCheckbox(lexemeLabel, thaiAudioRowLabel), true);
+      await configPage.applyButton.click();
+      await Utils.clickBreadcrumb(constants.testProjectName);
+      await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
+    });
+
+    it('Word has only "th" and "taud" visible for manager role', async () => {
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toBeGreaterThanOrEqual(2);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('taud');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(2);
+    });
+
+    it('restore visibility of "tipa" input system for manager role', async () => {
+      await configPage.get();
+      await configPage.tabs.unified.click();
+      await util.setCheckbox(configPage.unifiedPane.managerCheckbox(ipaRowLabel), true);
+      await configPage.applyButton.click();
+      await Utils.clickBreadcrumb(constants.testProjectName);
+      await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
+    });
+
+    it('Word has "th", "tipa" and "taud" visible again for manager role', async () => {
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toBeGreaterThanOrEqual(3);
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(0).getText()).toEqual('th');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(1).getText()).toEqual('tipa');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).get(2).getText()).toEqual('taud');
+      expect<any>(await editorPage.edit.getMultiTextInputSystems(lexemeLabel).count()).toEqual(3);
     });
 
   });

--- a/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
@@ -665,6 +665,13 @@ describe('Lexicon E2E Configuration Fields', () => {
     });
 
     it('can remove member-specific user settings', async () => {
+      // Setup, resetting state changed by previous tests
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.observer, true);
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.commenter, true);
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.contributor, true);
+      await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.manager, true);
+
+      // Exercise
       await configPage.unifiedPane.entry.removeGroupButton(0).click();
       expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(1);
       await configPage.unifiedPane.entry.removeGroupButton(0).click();

--- a/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
@@ -54,7 +54,7 @@ describe('Lexicon E2E Configuration Fields', () => {
     expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
     await configPage.unifiedPane.observerCheckbox('English').click();
     expect<any>(await configPage.applyButton.isEnabled()).toBe(true);
-    await configPage.unifiedPane.resetInputSystemButton('observer').click();
+    await configPage.unifiedPane.observerCheckbox('English').click();
     expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
   });
 
@@ -208,7 +208,6 @@ describe('Lexicon E2E Configuration Fields', () => {
         .toBe(false);
       await util.setCheckbox(configPage.unifiedPane.inputSystem.selectAll.observer, true);
       expect<any>(await configPage.unifiedPane.inputSystem.selectAll.observer.isSelected()).toBe(true);
-      await configPage.unifiedPane.resetInputSystemButton('observer').click();
     });
 
     it('can select and de-select all down the Input System commenter column', async () => {
@@ -224,7 +223,6 @@ describe('Lexicon E2E Configuration Fields', () => {
       expect<any>(await configPage.unifiedPane.inputSystem.selectAll.commenter.isSelected()).toBe(true);
       expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      await configPage.unifiedPane.resetInputSystemButton('commenter').click();
     });
 
     it('can select and de-select all down the Input System contributor column', async () => {
@@ -240,7 +238,6 @@ describe('Lexicon E2E Configuration Fields', () => {
       expect<any>(await configPage.unifiedPane.inputSystem.selectAll.contributor.isSelected()).toBe(true);
       expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      await configPage.unifiedPane.resetInputSystemButton('contributor').click();
     });
 
     it('can select and de-select all down the Input System manager column', async () => {
@@ -256,7 +253,6 @@ describe('Lexicon E2E Configuration Fields', () => {
       expect<any>(await configPage.unifiedPane.inputSystem.selectAll.manager.isSelected()).toBe(true);
       expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.inputSystem.columnCheckboxes(column), true))
         .toBe(true);
-      await configPage.unifiedPane.resetInputSystemButton('manager').click();
     });
 
     it('can de-select and select all down the entry observer column', async () => {
@@ -489,10 +485,6 @@ describe('Lexicon E2E Configuration Fields', () => {
       expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), true)).toBe(true);
       await util.setCheckbox(configPage.unifiedPane.selectRowCheckbox(rowLabel), false);
       expect<any>(await Utils.isAllCheckboxes(configPage.unifiedPane.rowCheckboxes(rowLabel), false)).toBe(true);
-      await configPage.unifiedPane.resetInputSystemButton('observer').click();
-      await configPage.unifiedPane.resetInputSystemButton('commenter').click();
-      await configPage.unifiedPane.resetInputSystemButton('contributor').click();
-      await configPage.unifiedPane.resetInputSystemButton('manager').click();
     });
 
     it('can fully function "Select All" along an entry row', async () => {
@@ -673,10 +665,6 @@ describe('Lexicon E2E Configuration Fields', () => {
     });
 
     it('can remove member-specific user settings', async () => {
-      await configPage.unifiedPane.resetInputSystemButton('observer').click();
-      await configPage.unifiedPane.resetInputSystemButton('commenter').click();
-      await configPage.unifiedPane.resetInputSystemButton('contributor').click();
-      await configPage.unifiedPane.resetInputSystemButton('manager').click();
       await configPage.unifiedPane.entry.removeGroupButton(0).click();
       expect<any>(await configPage.unifiedPane.inputSystem.selectAll.groups().count()).toEqual(1);
       await configPage.unifiedPane.entry.removeGroupButton(0).click();

--- a/test/app/languageforge/lexicon/shared/configuration.page.ts
+++ b/test/app/languageforge/lexicon/shared/configuration.page.ts
@@ -91,10 +91,12 @@ export class ConfigurationPage {
         return this.activePane.element(by.id('entry-header'))
           .element(by.className('remove-button-group-' + groupIndex));
       },
-      fieldSpecificInputSystemCheckbox: (label: string|RegExp, inputSystemIndex: number) => {
-        return this.getRowByLabel(label).element(by.xpath('..')).element(by.className('field-specific-input-systems'))
-          .all(by.repeater('inputSystemSettings in entryField.inputSystems'))
-          .get(inputSystemIndex).element(by.className('checkbox'));
+      fieldSpecificInputSystemCheckbox: (label: string|RegExp, inputSystemSelector: string|number) => {
+        const candidates = this.getRowByLabel(label).element(by.xpath('..')).element(by.className('field-specific-input-systems'))
+          .all(by.repeater('inputSystemSettings in entryField.inputSystems'));
+        const filtered = typeof inputSystemSelector === 'number' ? candidates.get(inputSystemSelector) :
+          candidates.filter(elem => elem.getText().then(text => text.includes(inputSystemSelector))).first();
+        return filtered.element(by.className('checkbox'));
       },
       addCustomEntryButton: this.activePane.element(by.id('add-custom-entry-btn'))
     },
@@ -129,10 +131,12 @@ export class ConfigurationPage {
         return this.activePane.element(by.id('sense-header'))
           .element(by.className('remove-button-group-' + groupIndex));
       },
-      fieldSpecificInputSystemCheckbox: (label: string|RegExp, inputSystemIndex: number) => {
-        return this.getRowByLabel(label).element(by.xpath('..')).element(by.className('field-specific-input-systems'))
-          .all(by.repeater('inputSystemSettings in senseField.inputSystems'))
-          .get(inputSystemIndex).element(by.className('checkbox'));
+      fieldSpecificInputSystemCheckbox: (label: string|RegExp, inputSystemSelector: string|number) => {
+        const candidates = this.getRowByLabel(label).element(by.xpath('..')).element(by.className('field-specific-input-systems'))
+          .all(by.repeater('inputSystemSettings in senseField.inputSystems'));
+        const filtered = typeof inputSystemSelector === 'number' ? candidates.get(inputSystemSelector) :
+          candidates.filter(elem => elem.getText().then(text => text.includes(inputSystemSelector))).first();
+        return filtered.element(by.className('checkbox'));
       },
       addCustomSenseButton: this.activePane.element(by.id('add-custom-sense-btn'))
     },
@@ -167,10 +171,12 @@ export class ConfigurationPage {
         return this.activePane.element(by.id('example-header'))
           .element(by.className('remove-button-group-' + groupIndex));
       },
-      fieldSpecificInputSystemCheckbox: (label: string|RegExp, inputSystemIndex: number) => {
-        return this.getRowByLabel(label).element(by.xpath('..')).element(by.className('field-specific-input-systems'))
-          .all(by.repeater('inputSystemSettings in exampleField.inputSystems'))
-          .get(inputSystemIndex).element(by.className('checkbox'));
+      fieldSpecificInputSystemCheckbox: (label: string|RegExp, inputSystemSelector: string|number) => {
+        const candidates = this.getRowByLabel(label).element(by.xpath('..')).element(by.className('field-specific-input-systems'))
+          .all(by.repeater('inputSystemSettings in exampleField.inputSystems'));
+        const filtered = typeof inputSystemSelector === 'number' ? candidates.get(inputSystemSelector) :
+          candidates.filter(elem => elem.getText().then(text => text.includes(inputSystemSelector))).first();
+        return filtered.element(by.className('checkbox'));
       },
       addCustomExampleButton: this.activePane.element(by.id('add-custom-example-btn'))
     },

--- a/test/app/languageforge/lexicon/shared/configuration.page.ts
+++ b/test/app/languageforge/lexicon/shared/configuration.page.ts
@@ -205,9 +205,6 @@ export class ConfigurationPage {
       return this.getRowByLabel(label).all(by.xpath('following-sibling::tr')).get(0)
         .element(by.className('caption-hidden-if-empty-checkbox'));
     },
-    resetInputSystemButton: (label: string) => {
-      return this.activePane.element(by.id('reset-input-system-' + label + '-btn'));
-    },
     addGroupModal: {
       usernameTypeaheadInput: element(by.id('typeaheadInput')),
       usernameTypeaheadResults: element.all(by.repeater('user in $ctrl.typeahead.users')),


### PR DESCRIPTION
In project config, field input systems are supposed to override user input systems, not the other way around. Previously the logic was incorrectly having user input systems override field input systems.

This fix changes the logic for input systems so that the list of input systems for the field and the list of input systems for the user are ANDed together to get the override list. I.e., if the user has input systems A, B and D selected but C turned off, and the field is supposed to show input systems B, C and D, then the user will see just input systems B and D for that field.

We also get rid of the Reset buttons on the input systems settings. It was insufficiently obvious to users what they did, and with the new logic for calculating field overrides they're not needed any longer.

Demo:

![input systems 1](https://user-images.githubusercontent.com/90762/125043503-335f6100-e0c5-11eb-818f-e480f400922e.png) 
![field input systems 1](https://user-images.githubusercontent.com/90762/125043711-6f92c180-e0c5-11eb-80bf-0555b7a5e3a9.png)

Produces:

![result 1](https://user-images.githubusercontent.com/90762/125044229-f778cb80-e0c5-11eb-9865-4203daea14c1.png)

If manager turns off French:

![input systems 2](https://user-images.githubusercontent.com/90762/125043975-b680b700-e0c5-11eb-89cc-7fe6ff4e7c60.png)
![field input systems 2](https://user-images.githubusercontent.com/90762/125043711-6f92c180-e0c5-11eb-80bf-0555b7a5e3a9.png)

Result (when logged in as manager) is:

![result 2](https://user-images.githubusercontent.com/90762/125044343-10817c80-e0c6-11eb-81f5-388c62373768.png)

