### PR TITLE
Better setup for E2E test container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,10 +32,10 @@
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
 
-	"initializeCommand": "cd docker && make",
+	"initializeCommand": "cd docker && docker-compose build --build-arg BUGSNAG_API_KEY=${BUGSNAG_API_KEY} ui-builder && docker-compose build app && docker-compose build app-for-e2e test-e2e && docker-compose up -d app-for-e2e",
 
 	// Uncomment the next line to run commands after the container is created - for example installing docker.
-	"postCreateCommand": "apk add docker",
+	"onCreateCommand": "apk add docker",
 
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"


### PR DESCRIPTION
This ensures that the E2E test container will be ready for debugging as soon as it starts up. (Previously, VS Code could attach to the container before it was actually ready, and it wasn't always clear why you had to wait a minute before pressing the "Launch Debug Session" button).