### PR TITLE
Roll back angular-ui-router version to 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "angular-route": "1.8.2",
         "angular-sanitize": "1.8.2",
         "angular-ui-bootstrap-4": "git+https://github.com/sillsdev/bootstrap.git",
-        "angular-ui-router": "1.0.29",
+        "angular-ui-router": "0.4.3",
         "angular-ui-validate": "^1.2.3",
         "angular-zxcvbn": "^3.2.2",
         "angularjs-slider": "^6.2.3",
@@ -409,14 +409,6 @@
       "integrity": "sha512-Fx+NpfOO0CpeYX2g9bkvX8O5qh9wrU1sOF4g8sft4Mu7z+qfe387YlyY8w8daDyDsKY5vUxM0yxkAYnbkRbZEw==",
       "dev": true
     },
-    "node_modules/@uirouter/core": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-6.0.7.tgz",
-      "integrity": "sha512-KUTJxL+6q0PiBnFx4/Z+Hsyg0pSGiaW5yZQeJmUxknecjpTbnXkLU8H2EqRn9N2B+qDRa7Jg8RcgeNDPY72O1w==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
@@ -748,17 +740,12 @@
       "license": "MIT"
     },
     "node_modules/angular-ui-router": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-1.0.29.tgz",
-      "integrity": "sha512-VurVxwueqEFD0JJBHkATOvLinhebc8/052jyhYrFVbHtWEc//IX4Wr55WvmJoTZJ6lnQ3nBlpX9VBKS5wiRsOg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.3.tgz",
+      "integrity": "sha512-EGBG7G7ArFVkJPM+ZIgPKuMYuT16UQrr3zj3BEiXHKwxss867bGt3u7QD9g4BxR+K2qQOSWok6JGvgTWXAko3A==",
+      "deprecated": "This npm package 'angular-ui-router' has been renamed to '@uirouter/angularjs'. Please update your package.json. See https://ui-router.github.io/blog/uirouter-scoped-packages/",
       "dependencies": {
-        "@uirouter/core": "6.0.7"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      },
-      "peerDependencies": {
-        "angular": ">=1.2.0"
+        "angular": "^1.0.8"
       }
     },
     "node_modules/angular-ui-validate": {
@@ -13943,11 +13930,6 @@
       "integrity": "sha512-Fx+NpfOO0CpeYX2g9bkvX8O5qh9wrU1sOF4g8sft4Mu7z+qfe387YlyY8w8daDyDsKY5vUxM0yxkAYnbkRbZEw==",
       "dev": true
     },
-    "@uirouter/core": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-6.0.7.tgz",
-      "integrity": "sha512-KUTJxL+6q0PiBnFx4/Z+Hsyg0pSGiaW5yZQeJmUxknecjpTbnXkLU8H2EqRn9N2B+qDRa7Jg8RcgeNDPY72O1w=="
-    },
     "@webassemblyjs/ast": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
@@ -14238,11 +14220,11 @@
       "from": "angular-ui-bootstrap-4@git+https://github.com/sillsdev/bootstrap.git"
     },
     "angular-ui-router": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-1.0.29.tgz",
-      "integrity": "sha512-VurVxwueqEFD0JJBHkATOvLinhebc8/052jyhYrFVbHtWEc//IX4Wr55WvmJoTZJ6lnQ3nBlpX9VBKS5wiRsOg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.3.tgz",
+      "integrity": "sha512-EGBG7G7ArFVkJPM+ZIgPKuMYuT16UQrr3zj3BEiXHKwxss867bGt3u7QD9g4BxR+K2qQOSWok6JGvgTWXAko3A==",
       "requires": {
-        "@uirouter/core": "6.0.7"
+        "angular": "^1.0.8"
       }
     },
     "angular-ui-validate": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "angular-route": "1.8.2",
     "angular-sanitize": "1.8.2",
     "angular-ui-bootstrap-4": "git+https://github.com/sillsdev/bootstrap.git",
-    "angular-ui-router": "1.0.29",
+    "angular-ui-router": "0.4.3",
     "angular-ui-validate": "^1.2.3",
     "angular-zxcvbn": "^3.2.2",
     "angularjs-slider": "^6.2.3",


### PR DESCRIPTION
Version 1.0.0 of `angular-ui-router` introduces unwanted behavior: when calling `$state.go()`, the page components get refreshed, which causes the input field to lose cursor focus. Since we're calling `$state.go()` every time the user stops typing for a moment, that causes very bad UX on the list-filter field.

Fixes #1002.