### PR TITLE
Allow uploading images in .gif format

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -153,11 +153,16 @@ class LexUploadCommands
         $allowedTypes = array(
             "image/jpeg",
             "image/jpg",
+            // SVG disabled until we can ensure no embedded Javascript; see https://github.com/w3c/svgwg/issues/266
+            // "image/svg+xml",
+            "image/gif",
             "image/png"
         );
         $allowedExtensions = array(
             ".jpg",
             ".jpeg",
+            // ".svg",
+            ".gif",
             ".png"
         );
 


### PR DESCRIPTION
Fixes #1005.

I decided to not allow .svg images yet, since to be totally safe we need to write code that would strip out any embedded Javascript. Embedded Javascript in an .svg image can be useful for totally legitimate reasons such as tecnical images that can hide or reveal sections on click, but they can also be a vector (heh) for remote code execution. So before we allow SVGs, I want to add code that will examine the uploaded .svg file and strip out any embedded Javascript, because I cannot think of any reason why .svg images in Language Forge (and FieldWorks) would need embedded Javascript.