### PR TITLE
Run lfmerge queue manager on container startup

### DIFF
--- a/docker/app-base/entrypoint.sh
+++ b/docker/app-base/entrypoint.sh
@@ -3,5 +3,8 @@
 # rsyslog needs to run so that lfmerge can log to /var/log/syslog
 /etc/init.d/rsyslog start
 
+# run lfmergeqm on startup to clear out any failed send/receive sessions from previous container
+which lfmergeqm && su www-data -s /bin/bash -c lfmergeqm
+
 # Now chain to Docker entrypoint from base php:apache image
 exec docker-php-entrypoint "$@"


### PR DESCRIPTION
This will allow us to fix any send/receive sessions that were partway through being run when the previous container was killed (e.g. if the pod was moved to a different Kubernetes node during a S/R process). We use `which lfmergeqm && ...` to ensure that this doesn't cause the container to fail if the entrypoint script ends up run on a container without lfmerge (which might happen once we separate lfmerge into its own container in the future).