### PR TITLE
Run lfmergeqm every 24 hours

### DIFF
--- a/docker/app-base/Dockerfile
+++ b/docker/app-base/Dockerfile
@@ -24,6 +24,7 @@ RUN adduser www-data fieldworks \
 && chown www-data:www-data /var/www/.local
 
 COPY entrypoint.sh /
+COPY lfmergeqm-background.sh /
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "apache2-foreground" ]

--- a/docker/app-base/entrypoint.sh
+++ b/docker/app-base/entrypoint.sh
@@ -4,7 +4,10 @@
 /etc/init.d/rsyslog start
 
 # run lfmergeqm on startup to clear out any failed send/receive sessions from previous container
-which lfmergeqm && su www-data -s /bin/bash -c lfmergeqm
+if [ which /lfmergeqm-background.sh ]; then
+    # MUST be run as a background process as it kicks off an infinite loop to run every 24 hours
+    /lfmergeqm-background.sh &
+fi
 
 # Now chain to Docker entrypoint from base php:apache image
 exec docker-php-entrypoint "$@"

--- a/docker/app-base/lfmergeqm-background.sh
+++ b/docker/app-base/lfmergeqm-background.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Run lfmergeqm every 24 hours to clean up any failed syncs that aren't in the queue
+# This script MUST be run as a background process ("script.sh &")!
+
+# First time we're run is before Apache starts up, so wait 60 seconds to allow Apache time to start up
+# (because LfMerge depends on Apache and PHP being up so that the RunClass.php code will work right)
+sleep 60
+
+# Now enter an infinite loop that will run eery 24*60*60 = 86400 seconds
+while :
+do
+  which lfmergeqm && su www-data -s /bin/bash -c lfmergeqm
+  sleep 86400
+done


### PR DESCRIPTION
This will allow lfmergeqm's Janitor class to find and clean up any failed syncs that aren't in the queue (state is SYNCING but there's no active lfmerge process handling that project). The main reason this can happen is if the app container was restarted in the middle of a Send/Receive, killing a previous lfmerge process.

This will have a minor merge conflict with #1030, which moves and rearranges some of the files touched here.