### PR TITLE
Move ui-builder into app Dockerfile

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -33,22 +33,12 @@ else
 endif
 
 .PHONY: build
-build: build-ui
+build:
 	docker-compose build mail app ld-api
 
-.PHONY: build-ui
-build-ui:
-	docker-compose build --build-arg BUGSNAG_API_KEY=${BUGSNAG_API_KEY} ui-builder
-
 .PHONY: deployable-app
-deployable-app: build-ui
+deployable-app:
 	docker-compose build --build-arg BUILD_VERSION=${BUILD_VERSION} app
-
-.PHONY: prod
-prod: build-ui
-	docker build -f ui-builder/Dockerfile.prod . -t lf-ui-builder:prod
-	docker-compose build app
-	docker build -f app/Dockerfile.prod .. -t lf-app:prod
 
 .PHONY: logs
 logs:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,6 +14,7 @@ e2e-tests: build
 	docker-compose build app-for-e2e test-e2e
 ifeq ($(TEAMCITY_VERSION),$())
 	# developer machine
+	docker-compose restart app-for-e2e || docker-compose up -d app-for-e2e
 	docker-compose run -e TEST_SPECS=$(TEST_SPECS) test-e2e
 else
 	# teamcity CI

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,6 +1,47 @@
 # ENVIRONMENT value can be either "production" or "development"
 ARG ENVIRONMENT=production
 
+# UI-BUILDER
+FROM node:14.16.1-alpine3.11 AS ui-builder-base
+
+# install npm globally
+RUN npm config set unsafe-perm true && npm install -g npm@7.6.3
+
+RUN mkdir -p /data
+WORKDIR /data
+
+# unsafe-perm true is required to work around an npm bug since we are running as root, have a git+HTTPS repo source and it has a `prepare` script (perfect storm).
+# see https://github.com/npm/npm/issues/17346
+COPY package.json package-lock.json ./
+RUN npm config set unsafe-perm true && npm install --legacy-peer-deps
+
+# Copy in files needed for compilation, located in the repo root
+COPY typings ./typings/
+COPY webpack.config.js webpack-dev.config.js webpack-prd.config.js tsconfig.json tslint.json ./
+
+# copy in src local files
+COPY src/angular-app ./src/angular-app
+COPY src/appManifest ./src/appManifest
+COPY src/js ./src/js
+COPY src/json ./src/json
+COPY src/sass ./src/sass
+COPY src/service-worker ./src/service-worker
+COPY src/Site/views ./src/Site/views
+
+ARG BUGSNAG_API_KEY
+ENV BUGSNAG_API_KEY=${BUGSNAG_API_KEY:-'missing-bugsnag-api-key'}
+
+FROM ui-builder-base AS production-ui-builder
+# artifacts built to /data/src/dist
+RUN npm run build:prd
+
+FROM ui-builder-base AS development-ui-builder
+# artifacts built to /data/src/dist
+RUN npm run build:dev
+
+FROM ${ENVIRONMENT}-ui-builder AS ui-builder
+# empty, this just allows doing `COPY --from=ui-builder` later since `COPY --from=${ENVIRONMENT}-ui-builder` seems to be an error
+
 # APP-BASE
 FROM php:7.3.28-apache AS base-app
 
@@ -48,8 +89,7 @@ COPY src /var/www/html/
 RUN ln -s /var/www/html /var/www/src
 
 # grab the built assets from the ui image
-# TODO distinguish between production and dev builds here
-COPY --from=lf-ui-builder /data/src/dist /var/www/html/dist
+COPY --from=ui-builder /data/src/dist /var/www/html/dist
 
 # ensure correct write permissions for assets folders,
 RUN    chown -R www-data:www-data /var/www/html/assets /var/www/html/cache \

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -32,15 +32,14 @@ ARG BUGSNAG_API_KEY
 ENV BUGSNAG_API_KEY=${BUGSNAG_API_KEY:-'missing-bugsnag-api-key'}
 
 FROM ui-builder-base AS production-ui-builder
-# artifacts built to /data/src/dist
-RUN npm run build:prd
+ENV NPM_BUILD_SUFFIX=prd
 
 FROM ui-builder-base AS development-ui-builder
-# artifacts built to /data/src/dist
-RUN npm run build:dev
+ENV NPM_BUILD_SUFFIX=dev
 
 FROM ${ENVIRONMENT}-ui-builder AS ui-builder
-# empty, this just allows doing `COPY --from=ui-builder` later since `COPY --from=${ENVIRONMENT}-ui-builder` seems to be an error
+# artifacts built to /data/src/dist
+RUN npm run build:${NPM_BUILD_SUFFIX}
 
 # APP-BASE
 FROM php:7.3.28-apache AS base-app

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       dockerfile: docker/ui-builder/Dockerfile
     image: lf-ui-builder
     container_name: lf-ui-builder
-    command: npm run build:dev:watch
     volumes:
       # share dist folder between ui and api containers
       - lf-ui-dist:/data/src/dist

--- a/docker/ui-builder/Dockerfile
+++ b/docker/ui-builder/Dockerfile
@@ -27,5 +27,4 @@ COPY src/Site/views ./src/Site/views
 ARG BUGSNAG_API_KEY
 ENV BUGSNAG_API_KEY=${BUGSNAG_API_KEY:-'missing-bugsnag-api-key'}
 
-# artifacts built to /data/src/dist
-RUN npm run build:dev
+CMD npm run build:dev:watch

--- a/docker/ui-builder/Dockerfile.prod
+++ b/docker/ui-builder/Dockerfile.prod
@@ -1,3 +1,0 @@
-FROM lf-ui-builder:latest
-
-RUN npm run build:prd


### PR DESCRIPTION
This will allow us to simplify the Makefile and the build process; now building the `app` container will just require building one single Dockerfile.

Resolves #1028.