### PR TITLE
Fix E2E tests not starting after clean-powerwash

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - MONGO_INITDB_DATABASE=scriptureforge
 
   selenium:
-    image: selenium/standalone-chrome-debug
+    image: selenium/standalone-chrome-debug:3.141.59-20210713
     volumes:
       - /dev/shm:/dev/shm
     ports:


### PR DESCRIPTION
The Selenium docker image tagged 3.141.59-20210729 contains a browser version that our current Protractor version doesn't know how to handle.

Temporarily pin our Selenium docker image to 3.141.59-20210713 so that our E2E tests will run; later when we upgrade Protractor we can unpin this and run the latest Selenium image again.