### PR TITLE
Fix `make dev`

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -11,7 +11,7 @@ dev: start
 
 .PHONY: e2e-tests
 e2e-tests: build
-	docker-compose build app-for-e2e test-e2e
+	docker-compose build ui-builder app-for-e2e test-e2e
 ifeq ($(TEAMCITY_VERSION),$())
 	# developer machine
 	docker-compose restart app-for-e2e || docker-compose up -d app-for-e2e

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -35,7 +35,7 @@ endif
 
 .PHONY: build
 build:
-	docker-compose build mail ui-builder app ld-api
+	docker-compose build mail app ld-api
 
 .PHONY: deployable-app
 deployable-app:

--- a/docker/ui-builder/Dockerfile
+++ b/docker/ui-builder/Dockerfile
@@ -24,5 +24,4 @@ COPY src/sass ./src/sass
 COPY src/service-worker ./src/service-worker
 COPY src/Site/views ./src/Site/views
 
-# artifacts built to /data/src/dist
-RUN npm run build:dev
+CMD npm run build:dev:watch


### PR DESCRIPTION
The ui-builder changes from #1038 accidentally got reverted in #1040, probably due to a rebase onto a master branch that hadn't yet had the merge of #1038 applied yet. This should fix the issue.