### PR TITLE
Fix mistake in entrypoint.sh script

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -73,6 +73,9 @@ RUN adduser www-data fieldworks \
 && mkdir -m 02775 -p /var/www/.local \
 && chown www-data:www-data /var/www/.local
 
+# rsyslog customizations (imklog reads kernel messages, which isn't allowed or desired in Docker containers)
+RUN sed -i '/load="imklog"/s/^/#/' /etc/rsyslog.conf
+
 # php customizations
 COPY docker/app/customizations.php.ini $PHP_INI_DIR/conf.d/
 

--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -12,7 +12,8 @@ fi
 /etc/init.d/rsyslog start
 
 # run lfmergeqm on startup to clear out any failed send/receive sessions from previous container
-if [ which /lfmergeqm-background.sh ]; then
+if (which /lfmergeqm-background.sh > /dev/null)
+then
     # MUST be run as a background process as it kicks off an infinite loop to run every 24 hours
     /lfmergeqm-background.sh &
 fi

--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 /etc/init.d/rsyslog start
 
 # run lfmergeqm on startup to clear out any failed send/receive sessions from previous container
-if (which /lfmergeqm-background.sh > /dev/null)
+if which /lfmergeqm-background.sh > /dev/null
 then
     # MUST be run as a background process as it kicks off an infinite loop to run every 24 hours
     /lfmergeqm-background.sh &


### PR DESCRIPTION
It's not `if [ which some-cmd ]`, it's `if which some-cmd`. It can also be a good idea to redirect the output of `which` to `/dev/null` so that you don't end up printing the full path of the command in your server logs (which is almost never necessary).