### PR TITLE
Dockerfile improvements

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -11,7 +11,7 @@ dev: start
 
 .PHONY: e2e-tests
 e2e-tests: build
-	docker-compose build ui-builder app-for-e2e test-e2e
+	docker-compose build app-for-e2e test-e2e
 ifeq ($(TEAMCITY_VERSION),$())
 	# developer machine
 	docker-compose restart app-for-e2e || docker-compose up -d app-for-e2e

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -83,19 +83,6 @@ COPY docker/app/customizations.php.ini $PHP_INI_DIR/conf.d/
 RUN a2enmod headers rewrite
 COPY docker/app/000-default.conf /etc/apache2/sites-enabled
 
-# copy app into image
-COPY src /var/www/html/
-RUN ln -s /var/www/html /var/www/src
-
-# grab the built assets from the ui image
-COPY --from=ui-builder /data/src/dist /var/www/html/dist
-
-# ensure correct write permissions for assets folders,
-RUN    chown -R www-data:www-data /var/www/html/assets /var/www/html/cache \
-    && chmod -R g+ws /var/www/html/assets /var/www/html/cache
-
-COPY docker/app/entrypoint.sh /
-
 # COMPOSER-BUILDER
 # download composer app dependencies
 # git - needed for composer install
@@ -122,6 +109,19 @@ COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait
 FROM ${ENVIRONMENT}-app AS languageforge-app
 ARG BUILD_VERSION=9.9.9
 ENV BUILD_VERSION=${BUILD_VERSION}
+
+# copy app into image
+COPY src /var/www/html/
+RUN ln -s /var/www/html /var/www/src
+
+# grab the built assets from the ui image
+COPY --from=ui-builder /data/src/dist /var/www/html/dist
+
+# ensure correct write permissions for assets folders,
+RUN    chown -R www-data:www-data /var/www/html/assets /var/www/html/cache \
+    && chmod -R g+ws /var/www/html/assets /var/www/html/cache
+
+COPY docker/app/entrypoint.sh /
 
 COPY --from=composer-builder /composer/vendor /var/www/html/vendor
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -150,6 +150,8 @@ services:
     build:
       context: ..
       dockerfile: docker/test-e2e/Dockerfile
+      args:
+        - ENVIRONMENT=development
     image: test-e2e
     container_name: test-e2e
     depends_on:

--- a/docker/test-e2e/Dockerfile
+++ b/docker/test-e2e/Dockerfile
@@ -1,4 +1,42 @@
-FROM lf-ui-builder:latest
+# ENVIRONMENT value can be either "production" or "development"
+ARG ENVIRONMENT=development
+
+# UI-BUILDER
+FROM node:14.16.1-alpine3.11 AS ui-builder-base
+
+# install npm globally
+RUN npm config set unsafe-perm true && npm install -g npm@7.6.3
+
+RUN mkdir -p /data
+WORKDIR /data
+
+# unsafe-perm true is required to work around an npm bug since we are running as root, have a git+HTTPS repo source and it has a `prepare` script (perfect storm).
+# see https://github.com/npm/npm/issues/17346
+COPY package.json package-lock.json ./
+RUN npm config set unsafe-perm true && npm install --legacy-peer-deps
+
+# Copy in files needed for compilation, located in the repo root
+COPY typings ./typings/
+COPY webpack.config.js webpack-dev.config.js webpack-prd.config.js tsconfig.json tslint.json ./
+
+# copy in src local files
+COPY src/angular-app ./src/angular-app
+COPY src/appManifest ./src/appManifest
+COPY src/js ./src/js
+COPY src/json ./src/json
+COPY src/sass ./src/sass
+COPY src/service-worker ./src/service-worker
+COPY src/Site/views ./src/Site/views
+
+FROM ui-builder-base AS production-ui-builder
+ENV NPM_BUILD_SUFFIX=prd
+
+FROM ui-builder-base AS development-ui-builder
+ENV NPM_BUILD_SUFFIX=dev
+
+FROM ${ENVIRONMENT}-ui-builder AS ui-builder
+# artifacts built to /data/src/dist
+RUN npm run build:${NPM_BUILD_SUFFIX}
 
 # make wait available for container ochestration
 COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait


### PR DESCRIPTION
Two changes here:

- Move ui-builder Docker into test-e2e. This lets us get rid of the `ui-builder` entirely from the Makefile.
- More efficient Dockerfile for the `lf-app` image. Specifically, there's no need to reinstall Composer dependencies every time we make any change to the source code anywhere. This change saves a couple minutes per build, and a LOT of time when iterating over code, building and running E2E tests repeatedly.

These could be split into separate PRs, but it's a little easier to keep them together in a single PR. I'll split them if requested during code review.