### PR TITLE
Fix "data.slice is not a function" exception

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -145,6 +145,7 @@ services:
       - MYSQL_USER=redmine
       - MYSQL_PASSWORD=not-a-secret
       - MYSQL_ROOT_PASSWORD=also-not-a-secret
+      - JWT_SIGNING_KEY=bogus-development-token
 
   test-e2e:
     build:

--- a/src/Api/Model/Shared/UserModel.php
+++ b/src/Api/Model/Shared/UserModel.php
@@ -32,7 +32,7 @@ class UserModel extends MapperModel
     const ADMIN_ACCESSIBLE =
         ['username', 'name', 'email', 'role', 'active', 'isInvited',
          'avatar_color', 'avatar_shape', 'avatar_ref', 'mobile_phone', 'communicate_via',
-         'name', 'age', 'gender', 'interfaceLanguageCode'];
+         'name', 'age', 'gender', 'interfaceLanguageCode', 'languageDepotUsername'];
 
     public function __construct($id = '')
     {

--- a/test/app/setupTestEnvironment.php
+++ b/test/app/setupTestEnvironment.php
@@ -64,6 +64,7 @@ $adminUserId = UserCommands::updateUser([
     'username' => $constants['adminUsername'],
     'password' => $constants['adminPassword'],
     'active' => true,
+    'languageDepotUsername' => 'admin',
     'role' => SystemRoles::SYSTEM_ADMIN
 ],
     $website


### PR DESCRIPTION
The exception was caused by the Language Depot API returning HTTP 403 Forbidden instead of HTTP 200 OK, because the JWT token keys weren't actually set up correctly in development mode. Also, our Ldapi.php code doesn't handle HTTP 403 Forbidden correctly, which is something else I'll need to work on. (Somehow it ends up throwing an unhandled exception in Javascript land, in a way I haven't quite traced yet). But this PR will at least stop that error being thrown during E2E testing in development.