### PR TITLE
Fix build and push action

### DIFF
--- a/.github/workflows/build-and-deploy-images.yml
+++ b/.github/workflows/build-and-deploy-images.yml
@@ -44,15 +44,16 @@ jobs:
 
       - name: Set BUILD_VERSION for Staging
         if: github.ref == 'refs/heads/staging'
-        run: echo "BUILD_VERSION=staging-$GITHUB_SHA" >> "$GITHUB_ENV"
-        run: echo "BUILD_VERSION_LATEST=staging" >> "$GITHUB_ENV"
+        run: |-
+          echo "BUILD_VERSION=staging-$GITHUB_SHA" >> "$GITHUB_ENV"
+          echo "BUILD_VERSION_LATEST=staging" >> "$GITHUB_ENV"
 
       - name: Set BUILD_VERSION for Production from git tag
         if: startsWith(github.ref, 'refs/tags/v')
-        # define GIT_TAG as stripping off initial 11 characters, i.e. "refs/tags/v"
-        run: echo "GIT_TAG=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
-        run: echo "BUILD_VERSION=$GIT_TAG" >> "$GITHUB_ENV"
-        run: echo "BUILD_VERSION_LATEST=latest" >> "$GITHUB_ENV"
+        # define BUILD_VERSION as stripping off initial 11 characters, i.e. "refs/tags/v"
+        run: |-
+          echo "BUILD_VERSION=$(echo ${GITHUB_REF:11})" >> "$GITHUB_ENV"
+          echo "BUILD_VERSION_LATEST=latest" >> "$GITHUB_ENV"
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v1


### PR DESCRIPTION
Multiple "run:" lines in a single step are not allowed, but you can use YAML's `|-` syntax to have the same effect. No `&&` needed at the end of each line, as the entire block is treated like a bash script.

Note that I had to make one semantic change: I eliminated the `GIT_TAG` variable and replaced it with just using `BUILD_VERSION` instead. That's because the only purpose of the `GIT_TAG` variable was to be used in setting `BUILD_VERSION`, but that wasn't working. The `$GITHUB_ENV` file is only read *between* steps. You can't write `echo FOO=bar >> $GITHUB_ENV` and then in the *same* build step, write `echo OTHER_VAR=staging-$FOO`. It won't work. If you need to define a variable and then use it, the part where you use it must be in a separate step. Here, `GIT_TAG` wasn't used elsewhere (and couldn't be used elsewhere since we weren't setting it in the process for the `staging` branch, meaning we couldn't count on it being available in later steps), so I just got rid of it. The other way would have been to write:

```yaml
      - name: Set GIT_TAG from git tag
        if: startsWith(github.ref, 'refs/tags/v')
        # define GIT_TAG as stripping off initial 11 characters, i.e. "refs/tags/v"
        run: echo "GIT_TAG=$(echo ${GITHUB_REF:11})" >> "$GITHUB_ENV"

      - name: Set BUILD_VERSION for Production from git tag
        if: startsWith(github.ref, 'refs/tags/v')
        run: |-
          echo "BUILD_VERSION=$GIT_TAG" >> "$GITHUB_ENV"
          echo "BUILD_VERSION_LATEST=latest" >> "$GITHUB_ENV"
```

But I decided to do it in a single step, so that there's no chance of the `if` conditions later drifting apart when someone changes one but forgets to change the other one.