### PR TITLE
Tech Support user can manage project members

### DIFF
--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.ts
@@ -42,7 +42,9 @@ export class InviteMemberFormController implements angular.IController {
     this.sessionService.getSession().then(session => {
       this.session = session;
       this.project = session.data.project;
-      this.currentUserIsManager = this.session.data.userProjectRole === LexRoles.MANAGER.key;
+      this.currentUserIsManager =
+        this.session.data.userProjectRole === LexRoles.MANAGER.key ||
+        this.session.data.userProjectRole === LexRoles.TECH_SUPPORT.key;
 
       if (this.currentUserIsManager) {
         this.emailInviteRole = LexRoles.CONTRIBUTOR;

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/share-with-others.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/share-with-others.component.ts
@@ -20,7 +20,9 @@ export class ShareWithOthersModalInstanceController implements angular.IControll
     this.sessionService.getSession().then(session => {
       this.session = session;
       this.project = session.data.project;
-      this.currentUserIsManager = this.session.data.userProjectRole === LexRoles.MANAGER.key;
+      this.currentUserIsManager =
+        this.session.data.userProjectRole === LexRoles.MANAGER.key ||
+        this.session.data.userProjectRole === LexRoles.TECH_SUPPORT.key;
     });
   }
 


### PR DESCRIPTION
The intent of the Tech Support user role is that it has the same rights as a project manager, i.e. it can manage all aspects of the project. The "Share With Others" component was not giving Tech Support users the same rights as the manager: Tech Support was unable to list project members, manage their roles, and invite new users. This fixes that omission.

Fixes #1078.