### PR TITLE
added k8s config allowing large file uploads

### DIFF
--- a/docker/deployment/app-deployment.yaml
+++ b/docker/deployment/app-deployment.yaml
@@ -22,6 +22,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: languageforge-app
+  annotations:
+    # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size
+    # Added this to allow large file uploads, this setting should match the php custom config, i.e., upload_max_filesize, found in the app's customizations.php.ini
+    nginx.ingress.kubernetes.io/proxy-body-size: 60M
 spec:
   rules:
   - host: {{WEBSITE}}


### PR DESCRIPTION
I could not easily figure out how to isolate this configuration to just the `/upload` (or `upload/lf-lexicon/import-zip`) path so this will apply to any requests coming into LF.

I did try the following to no avail:

```yaml
    # nginx.ingress.kubernetes.io/client_max_body_size: 60M
    # nginx.ingress.kubernetes.io/configuration-snippet: |

    #   location /upload {

    #        proxy-body-size 60M;  
    #   }
    # nginx.ingress.kubernetes.io/configuration-snippet: |

    #   location /upload {

    #        client_max_body_size 60M;  
    #   }
```