### PR TITLE
Add mongo dump and restore script for deployment

### DIFF
--- a/docker/deployment/scripts/kubeRsyncAssets.sh
+++ b/docker/deployment/scripts/kubeRsyncAssets.sh
@@ -5,4 +5,6 @@
 # -p 55555 this port is being forwarded to 22 on the container
 # -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" these are a hack to bypass security checks for "localhost".  localhost isn't a real host so I don't care about "host key verification failed" errors when doing localhost port forwarding
 
-ssh -A -p 55555 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "rsync -avzhP chirt@sysops.languageforge.org:/var/www/languageforge.org/htdocs/assets/lexicon/ /var/www/html/assets/lexicon/"
+USERANDHOSTNAME=user@hostname
+
+ssh -A -p 55555 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "rsync -avzhP $USERANDHOSTNAME:/var/www/languageforge.org/htdocs/assets/lexicon/ /var/www/html/assets/lexicon/"

--- a/docker/deployment/scripts/kubeRsyncMongo.sh
+++ b/docker/deployment/scripts/kubeRsyncMongo.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+echo Mongo Dump
+ssh mongo-xf mongodump
+
+echo Remove Scripture Forge data from dump
+ssh mongo-xf rm -r dump/xforge
+
+echo Create tar file of dump
+ssh mongo-xf tar -czvf mongodump.tgz dump
+
+echo Copy tar file to local filesystem
+scp mongo-xf:mongodump.tgz .
+
+echo Clean up on remote
+ssh mongo-xf rm -r dump
+ssh mongo-xf rm mongodump.tgz
+
+MONGOPOD=$(kubectl get pods --selector='app=db' -o name | sed -e s'/pod\///')
+
+echo Copying mongodump.tgz into $MONGOPOD/data/db
+kubectl cp -c db mongodump.tgz $MONGOPOD:/data/db
+
+echo Untarring mongodump.tgz
+kubectl exec -c db $MONGOPOD -- bash -c "cd /data/db \
+    && tar -xvzf mongodump.tgz"
+
+echo MongoRestore
+kubectl exec -c db $MONGOPOD -- bash -c "cd /data/db \
+    && mongorestore --drop dump"
+
+echo Clean Up
+kubectl exec -c db $MONGOPOD -- bash -c "rm -r /data/db/dump && rm /data/db/mongodump.tgz"
+rm mongodump.tgz
+
+echo Run Mongo migration
+kubectl exec -c db $MONGOPOD -- bash -c 'mongo scriptureforge --eval "db.projects.updateMany({}, {"\$unset": {userProperties: 1}});"'

--- a/docker/deployment/scripts/kubeSetup.sh
+++ b/docker/deployment/scripts/kubeSetup.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 MONGO=deploy/db
-POD=$(kubectl get pods --selector='app=app' -o name | sed -e s'/pod\///')
+APPPOD=$(kubectl get pods --selector='app=app' -o name | sed -e s'/pod\///')
+MONGOPOD=$(kubectl get pods --selector='app=db' -o name | sed -e s'/pod\///')
 
 # install SSH and rsync; also start the SSH service
-echo Installing SSH on pod $POD
-kubectl exec -c app $POD -- bash -c "apt-get update \
+echo Installing SSH on pod $APPPOD
+kubectl exec -c app $APPPOD -- bash -c "apt-get update \
 && apt-get install -y openssh-server openssh-client rsync \
 && mkdir -p -m 700 /root/.ssh \
 && service ssh start"
 
 # add my public key to the container so I can "ssh root@localhost"
 # --no-preserve=true keeps the permissions intact for root on the container side
-kubectl cp -c app ~/.ssh/authorized_keys $POD:/root/.ssh/authorized_keys --no-preserve=true
+kubectl cp -c app ~/.ssh/authorized_keys $APPPOD:/root/.ssh/authorized_keys --no-preserve=true
+
+echo Installing SSH on pod $MONGOPOD
+kubectl exec -c db $MONGOPOD -- bash -c "apt-get update \
+&& apt-get install -y openssh-server openssh-client rsync \
+&& mkdir -p -m 700 /root/.ssh \
+&& service ssh start"
+
+# add my public key to the container so I can "ssh root@localhost"
+# --no-preserve=true keeps the permissions intact for root on the container side
+kubectl cp -c db ~/.ssh/authorized_keys $MONGOPOD:/root/.ssh/authorized_keys --no-preserve=true


### PR DESCRIPTION
This PR adds a script to do a mongo dump and restore via `kubectl`.

This script is intended to be run from my (Chris's) machine, but can be adapted for other machines.  It documents as a script each step of dumping production mongo data and restoring it on the running db container.

Also the kubeSetup.sh has been modified to setup both app and db containers simultaneously.