### PR TITLE
Deployment migration script tweaks

### DIFF
--- a/docker/deployment/scripts/kubeRsyncAssets.sh
+++ b/docker/deployment/scripts/kubeRsyncAssets.sh
@@ -5,6 +5,7 @@
 # -p 55555 this port is being forwarded to 22 on the container
 # -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" these are a hack to bypass security checks for "localhost".  localhost isn't a real host so I don't care about "host key verification failed" errors when doing localhost port forwarding
 
-USERANDHOSTNAME=user@hostname
-
-ssh -A -p 55555 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "rsync -avzhP $USERANDHOSTNAME:/var/www/languageforge.org/htdocs/assets/lexicon/ /var/www/html/assets/lexicon/"
+USER=user
+HOSTNAME=hostname
+ssh -A -p 55555 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "[ -f ~/.ssh/known_hosts ] || ssh-keyscan $HOSTNAME >> ~/.ssh/known_hosts"
+ssh -A -p 55555 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "rsync -avzhP $USER@$HOSTNAME:/var/www/languageforge.org/htdocs/assets/lexicon/ /var/www/html/assets/lexicon/"

--- a/docker/deployment/scripts/kubeRsyncSendReceive.sh
+++ b/docker/deployment/scripts/kubeRsyncSendReceive.sh
@@ -5,6 +5,7 @@
 # -p 55555 this port is being forwarded to 22 on the container
 # -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" these are a hack to bypass security checks for "localhost".  localhost isn't a real host so I don't care about "host key verification failed" errors when doing localhost port forwarding
 
-USERANDHOSTNAME=user@hostname
-
-ssh -A -p 55555 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "rsync -avzhP ${USERANDHOSTNAME}:/var/lib/languageforge/lexicon/ /var/lib/languageforge/lexicon/"
+USER=user
+HOSTNAME=hostname
+ssh -A -p 55555 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "[ -f ~/.ssh/known_hosts ] || ssh-keyscan $HOSTNAME >> ~/.ssh/known_hosts"
+ssh -A -p 55555 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "rsync -avzhP $USER@$HOSTNAME:/var/lib/languageforge/lexicon/ /var/lib/languageforge/lexicon/"

--- a/docker/deployment/scripts/kubeSetup.sh
+++ b/docker/deployment/scripts/kubeSetup.sh
@@ -13,13 +13,3 @@ kubectl exec -c app $APPPOD -- bash -c "apt-get update \
 # add my public key to the container so I can "ssh root@localhost"
 # --no-preserve=true keeps the permissions intact for root on the container side
 kubectl cp -c app ~/.ssh/authorized_keys $APPPOD:/root/.ssh/authorized_keys --no-preserve=true
-
-echo Installing SSH on pod $MONGOPOD
-kubectl exec -c db $MONGOPOD -- bash -c "apt-get update \
-&& apt-get install -y openssh-server openssh-client rsync \
-&& mkdir -p -m 700 /root/.ssh \
-&& service ssh start"
-
-# add my public key to the container so I can "ssh root@localhost"
-# --no-preserve=true keeps the permissions intact for root on the container side
-kubectl cp -c db ~/.ssh/authorized_keys $MONGOPOD:/root/.ssh/authorized_keys --no-preserve=true


### PR DESCRIPTION
These are just a few adjustments to my migration scripts after giving them more exercise.

- removed unnecessary installing SSH on mongo container in kubeSetup.sh
- added step in the 2 rsync scripts to add the the host key to the known hosts ahead of the rsync, so that rsync succeeds on new hosts