### PR TITLE
Send lfmerge logs to stdout in lf-app container

### DIFF
--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -3,6 +3,11 @@
 # rsyslog needs to run so that lfmerge can log to /var/log/syslog
 /etc/init.d/rsyslog start
 
+# Ensure /var/log/syslog exists so tail -f /var/log/syslog will run
+logger "Starting container..."
+# echo /var/log/syslog to container stdout so it shows up in `kubectl logs`
+tail -f /var/log/syslog &
+
 # run lfmergeqm on startup to clear out any failed send/receive sessions from previous container
 /lfmergeqm-background.sh & # MUST be run as a background process as it kicks off an infinite loop to run every 24 hours
 

--- a/docker/deployment/app-deployment.yaml
+++ b/docker/deployment/app-deployment.yaml
@@ -131,6 +131,8 @@ spec:
             value: {{WEBSITE}}
           - name: MAIL_HOST
             value: mail
+          - name: LFMERGE_LOGGING_DEST
+            value: syslog
           - name: MONGODB_CONN
             valueFrom:
               secretKeyRef:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - FACEBOOK_CLIENT_SECRET=bogus-development-token
       - REMEMBER_ME_SECRET=bogus-development-key
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
+      - LFMERGE_LOGGING_DEST=syslog
     command: sh -c "/wait && apache2-foreground"
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
This will ensure that lfmerge logs get sent to stdout whether or not https://github.com/sillsdev/LfMerge/pull/134 is merged. Currently lfmerge runs in the lf-app container so its log messages end up mixed together with the PHP logs in `kubectl logs` output, but it's pretty easy to sort them out. If that mixing is not desired, then the entrypoint.sh changes can be reverted and `kubectl exec` can be used to run `tail -f /var/log/syslog` on the container instead.