### PR TITLE
Add default issue templates for bug, feature and s/r issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,13 +26,11 @@ If applicable, add screenshots to help explain your problem.
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
 
 **Mobile (please complete the following information):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
 
 **Android App in Google Play**
 For Mobile, are you using the Language Forge Android app in the Google Play store?  [Yes/No]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'bug: '
+labels: triage
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Mobile (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Android App in Google Play**
+For Mobile, are you using the Language Forge Android app in the Google Play store?  [Yes/No]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'feat: '
+labels: triage
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/send-receive-with-flex.md
+++ b/.github/ISSUE_TEMPLATE/send-receive-with-flex.md
@@ -1,0 +1,21 @@
+---
+name: Send/Receive with FLEx
+about: Report a problem syncing your project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+If your project has been put on hold and you want to keep the details of your project private, please email languageforgeissues@sil.org with the following information.
+
+The Language Forge project is run as an open-source and open-issue-tracker project, meaning that all our code and issues are publicly available on the internet.  Information you submit below should not container private or personal information.
+
+
+Project name:
+
+Project code:
+
+Error message:
+
+Observed problem / description of the problem:


### PR DESCRIPTION
I used the GitHub Issue template wizard to generate and customize these issue templates.  Most all of the lingo in these templates are stock GitHub, and they seem pretty good to me.