### PR TITLE
Add GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,5 +29,6 @@ Please describe the manual tests that you ran to verify your changes. Provide in
 ## Checklist:
 
 - [ ] I have performed a self-review of my own code
+- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have added tests that prove my fix is effective or that my feature works

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+### Type of Change
+
+Check all that apply:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] migration required (a model change requiring a mongodb script or migration script)
+- [ ] UI change
+
+## Screenshots
+
+Please provide screenshots / animations for any change that involves the UI.  Please provide animations to demonstrate user interaction / behavior changes
+
+## How Has This Been Tested?
+
+Please describe the manual tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+## Checklist:
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have added tests that prove my fix is effective or that my feature works


### PR DESCRIPTION
This PR template is based off of https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/
and customized for this project.

It's a philosophical exercise to open a PR containing template code for new PRs.

Followed the directions at https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository