### PR TITLE
Emulate x86 so local dev is possible on arm64 machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Other useful resources:
 
 ### Running E2E Tests
 
-1. `make e2e-tests`
+1. `make e2e-tests` (⚠️ these do not work on Apple Silicon at this time)
 1. Individual test results will appear in your terminal but if you'd like to watch them in real-time, simply VNC into the running tests via `localhost:5900`, e.g., Mac OSX users simply `open vnc://localhost:5900` and use `secret` as the password.  Other operating systems may require installing a separate VNC Viewer tool.
 
 To run a single E2E spec file, put its path (relative to the repo root) into the `TEST_SPECS` environment variable (don't forget to `export` it), or pass it as an option to `make e2e-tests` as follows:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -122,6 +122,7 @@ services:
   ld-db:
     image: mysql:5.7
     container_name: ld-db
+    platform: linux/amd64
     # To access the MySQL database via localhost:3306 on your dev machine (e.g., in VS Code), uncomment the "ports" config below
     # Note that if you're running MySQL on your dev machine already, change the first number to something else, like 3307 and access localhost:3307
     # ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,5 @@
 # https://docs.docker.com/compose/compose-file
+# https://github.com/compose-spec/compose-spec/blob/master/spec.md
 version: '3.5'
 services:
   ui-builder:
@@ -29,6 +30,7 @@ services:
         - ENVIRONMENT=development
     image: lf-app
     container_name: lf-app
+    platform: linux/amd64
     depends_on:
       - db
       - mail

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -210,6 +210,7 @@ services:
       dockerfile: docker/test-php/Dockerfile
     image: test-php
     container_name: test-php
+    platform: linux/amd64
     depends_on:
       - db
       - mail

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -189,6 +189,7 @@ services:
       dockerfile: docker/app-for-e2e/Dockerfile
     image: app-for-e2e
     container_name: app-for-e2e
+    platform: linux/amd64
     depends_on:
       - db
       - mail


### PR DESCRIPTION
## Description

I have a new M1 machine and was running into docker build failures for `app`.  This was the result of lfmerge not having an arm64 pkg.  Creating one would be too much effort so this PR is the effort to emulate an x86 during the image build where lfmerge is used.

### Type of Change

configuration

## Screenshots

N/A

## How Has This Been Tested?

- [x] `app` builds without error
- [x] `make` creates a running app locally (with basic functionality testing)
- [x] `make unit-tests` should run all tests successfully
- [ ] `make e2e-tests` should run all tests successfully
- [x] test latest changes on my old machine
- [x] test on a win machine

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added (manual) tests that prove my fix is effective or that my feature works
