### PR TITLE
Fix white space on mobile

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -295,7 +295,7 @@ dc-entry .card {
     .lexiconItemListContainer {
       margin-bottom: 15px;
       @include media-breakpoint-up(sm) {
-        height: calc(100vh - 600px);
+        height: calc(100vh - 568px);
         overflow: auto;
         }
     }
@@ -318,7 +318,7 @@ dc-entry .card {
 
 #lexAppEditView {
   .lexiconItemListContainer {
-    max-height: calc(100vh - 600px);
+    height: calc(100vh - 568px);
     overflow: auto;
   }
   .word-definition-title {

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -295,7 +295,7 @@ dc-entry .card {
     .lexiconItemListContainer {
       margin-bottom: 15px;
       @include media-breakpoint-up(sm) {
-        height: calc(100vh - 420px);
+        height: calc(100vh - 600px);
         overflow: auto;
         }
     }
@@ -318,7 +318,7 @@ dc-entry .card {
 
 #lexAppEditView {
   .lexiconItemListContainer {
-    max-height: calc(100vh - 420px);
+    max-height: calc(100vh - 600px);
     overflow: auto;
   }
   .word-definition-title {

--- a/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.scss
+++ b/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.scss
@@ -17,7 +17,8 @@
 
 .container-scroll {
   overflow-y: scroll;
-  height: calc(100vh - 360px);
+  overflow-x: hidden;
+  height: calc(100vh - 330px);
   }
 
 .comments-right-panel {

--- a/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.scss
+++ b/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.scss
@@ -18,7 +18,7 @@
 .container-scroll {
   overflow-y: scroll;
   overflow-x: hidden;
-  height: calc(100vh - 330px);
+  height: calc(100vh - 296px);
   }
 
 .comments-right-panel {

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-md-5 col-lg-4 entries-list-container d-none d-md-block">
                 <div class="entry-words-minimized"><button class="btn btn-primary" data-ng-click="$ctrl.hideRightPanel()">Show words in dictionary</button></div>
-                <div class="entry-words-container">
+                <div id="scrolling-entry-words-container" class="entry-words-container">
                     <div class="row">
                         <div class="col">
                             <div class="words-container-title list-group-item list-group-item-action active">
@@ -92,7 +92,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-md-7 col-lg-8 entry-primary-container container-scroll">
+            <div id="scrolling-editor-container" class="col-md-7 col-lg-8 entry-primary-container container-scroll">
                 <div>
                     <div class="entryItemView" data-ng-if="$ctrl.entryLoaded()">
                         <dc-entry config="$ctrl.lecConfig.entry" model="$ctrl.currentEntry" control="$ctrl.control"></dc-entry>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -43,7 +43,7 @@
         </div>
         <div class="row">
             <div class="col">
-                <div class="word-definition-title">
+                <div id="editor-title-text" class="word-definition-title">
                     <dc-rendered config="$ctrl.lecConfig.entry" global-config="$ctrl.lecConfig"
                                  model="$ctrl.currentEntry" option-lists="$ctrl.lecOptionLists"></dc-rendered>
                 </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
@@ -25,3 +25,11 @@
     font-style: normal;
   }
 }
+.dc-rendered-overflow{
+  @include media-breakpoint-down(sm) {
+   display: -webkit-box;
+   -webkit-line-clamp: 3;
+   -webkit-box-orient: vertical; 
+   overflow: hidden; 
+  }
+}

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-rendered.component.html
@@ -1,4 +1,4 @@
-<div class="dc-rendered-entryContainer" data-ng-hide="$ctrl.hideIfEmpty && !$ctrl.entry.word">
+<div class="dc-rendered-entryContainer dc-rendered-overflow" data-ng-hide="$ctrl.hideIfEmpty && !$ctrl.entry.word">
     <span class="dc-rendered-word" data-ng-bind-html="$ctrl.entry.word"></span>
     <span class="dc-rendered-senseContainer" data-ng-repeat="sense in $ctrl.entry.senses track by $index">
         <span dir="ltr" data-ng-if="$ctrl.entry.senses.length !== 1" class="notranslate dc-rendered-senseNumber">{{$index + 1}}</span>

--- a/src/angular-app/languageforge/lexicon/shared/fit-text.directive.ts
+++ b/src/angular-app/languageforge/lexicon/shared/fit-text.directive.ts
@@ -4,17 +4,44 @@ export class FitTextDirective implements angular.IDirective {
 
   link(scope: angular.IScope, element: angular.IAugmentedJQuery, attr: angular.IAttributes) {
     let kInput: boolean = false;
+    var defaultHeight = 24;
+    element.height(40);
+    element.css({ 'max-height': '40px' });
+    element.css({ height: '40px' });
+
     function updateHeight(): any {
       let height = element.prop('scrollHeight');
       element.height = height;
       element.css({ 'max-height': height + 'px' });
       element.css({ height: height + 'px' });
+      updateContainersHeight();
     }
+
+    function updateContainersHeight(): any {
+      var wHeight = angular.element(window).height();
+      var editorTitleTextElement = angular.element(document).find('#editor-title-text');
+      var tHeight = editorTitleTextElement.height();
+      var primaryNavigationElement = angular.element(document).find('#primary-navigation');
+      var primaryNavigationHeight = primaryNavigationElement.height();
+      var scrollingEditorContainerElement = angular.element(document).find('#scrolling-editor-container');
+      var compactEntryListContainerElement = angular.element(document).find('#compactEntryListContainer');
+
+      var adjHeight = wHeight - (tHeight - defaultHeight);
+      var sHeight = adjHeight - (177 + primaryNavigationHeight);
+      var lHeight = adjHeight - (447 + primaryNavigationHeight);
+      scrollingEditorContainerElement.css({ height: sHeight + 'px' });
+      compactEntryListContainerElement.css({ height: lHeight + 'px' });
+    }
+
     element.on('keyup', () => {
       kInput = true;
       scope.$apply(() => {
         updateHeight();
       });
+    });
+
+    angular.element(window).on('resize',() => { 
+      updateHeight();
     });
 
     scope.$watch(() => {
@@ -31,3 +58,4 @@ export class FitTextDirective implements angular.IDirective {
   }
 
 }
+


### PR DESCRIPTION
## Description

Added css styles and FitTextDirective directive class to enable textarea auto sizing on the editor page. 

Fixes #1151, #1144, #1111

### Type of Change

Check all that apply:

- Bug fix (non-breaking change which fixes an issue)


## Screenshots

![Screenshot from 2021-09-08 20-15-38](https://user-images.githubusercontent.com/7799495/132616618-dd16fc9d-132e-4f9e-927e-fe81f68e93fb.png)

Please describe the manual tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A Load editor page, no white space
- [ ] Test B Reduce page size, no white space

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works

