### PR TITLE
Added ability to run security scans of our images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ src/cache/*
 test/php/\.phpunit\.result\.cache
 node_modules
 .DS_Store
+docker-scan-results.txt

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: start
 start: build
-  # starts the entire runtime infrastructure
+    # starts the entire runtime infrastructure
 	docker-compose up -d ssl
 
 .PHONY: dev
@@ -36,6 +36,13 @@ endif
 .PHONY: build
 build:
 	docker-compose build mail app ld-api
+
+.PHONY: scan
+# https://docs.docker.com/engine/scan
+scan:
+	docker build -t lf-app:prod -f app/Dockerfile --platform linux/amd64 ..
+	docker login
+	docker scan --accept-license lf-app:prod > docker-scan-results.txt
 
 .PHONY: clean
 clean:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -42,7 +42,7 @@ build:
 scan:
 	docker build -t lf-app:prod -f app/Dockerfile --platform linux/amd64 ..
 	docker login
-	docker scan --accept-license lf-app:prod > docker-scan-results.txt
+	-docker scan --accept-license lf-app:prod > docker-scan-results.txt
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
## Description

We needed to run `docker scan` against our images to understand current vulnerabilities.  These commits will both added some convenience scripts for future use as well as begin to triage the results and plans for mitigation.

Fixes #1117 

### Type of Change

Check all that apply:

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

N/A

## How Has This Been Tested?

- [x] Tested the convenience scripts multiple times on my own machine while developing them

## Checklist:

- [x] I have rebased off `develop` after #1142 gets merged into `develop`
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
