### PR TITLE
disable initial capital for some fields

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-multitext.component.html
@@ -13,7 +13,8 @@
                     fte-disabled-reason="$ctrl.modelContainsSpan(tag) ? 'would-lose-metadata' : $ctrl.control.rights.sendReceive.isInProgress() ? 'sr-in-progress' : 'editing-not-permitted'"
                     fte-toolbar="[[]]"
                     fte-model="$ctrl.model[tag].value"
-                    fte-dir="$ctrl.inputSystemDirection(tag)"></dc-text>
+                    fte-dir="$ctrl.inputSystemDirection(tag)"
+                    fte-field-name="$ctrl.fieldName"></dc-text>
                 <dc-audio data-ng-if="$ctrl.isAudio(tag)" dc-filename="$ctrl.model[tag].value" dc-rights="$ctrl.control.rights"
                           dc-interface-config="$ctrl.control.interfaceConfig" dc-project-slug="$ctrl.control.project.slug">
                 </dc-audio>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.html
@@ -5,6 +5,7 @@
         data-ng-model="$ctrl.textFieldValue" 
         data-ng-change="$ctrl.inputChanged()"
         data-ng-disabled="$ctrl.fteDisabled" 
-        title="{{$ctrl.fteDisabled ? $ctrl.disabledMsg() : ''}}">
+        title="{{$ctrl.fteDisabled ? $ctrl.disabledMsg() : ''}}"
+        autocapitalize="{{$ctrl.autocapitalize}}">
     </textarea>
 </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.ts
@@ -1,6 +1,7 @@
 import * as angular from 'angular';
 
 // cross-ref src/Api/Model/Languageforge/Lexicon/Config/LexConfig.php for expected field names
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize
 const autocapitalizeHints = {
   anthropologyNote: 'sentences',
   cvPattern: 'characters',

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.ts
@@ -1,5 +1,25 @@
 import * as angular from 'angular';
 
+// cross-ref src/Api/Model/Languageforge/Lexicon/Config/LexConfig.php for expected field names
+const autocapitalizeHints = {
+  anthropologyNote: 'sentences',
+  cvPattern: 'characters',
+  discourseNote: 'sentences',
+  encyclopedicNote: 'sentences',
+  entryBibliography: 'sentences',
+  etymologyComment: 'sentences',
+  generalNote: 'sentences',
+  grammarNote: 'sentences',
+  note: 'sentences',
+  phonologyNote: 'sentences',
+  scientificName: 'sentences',
+  semanticsNote: 'sentences',
+  senseBibliography: 'sentences',
+  sociolinguisticsNote: 'sentences',
+  sentence: 'sentences',
+  reference: 'sentences',
+}
+
 export class FieldTextController implements angular.IController {
   fteModel: string;
   fteToolbar: string;
@@ -7,9 +27,11 @@ export class FieldTextController implements angular.IController {
   fteDisabledReason: string;
   fteMultiline: boolean;
   fteDir: string;
-
+  fteFieldName: string;
+  
   fte: any = {};
   textFieldValue: string = '';
+  autocapitalize: string
 
   static $inject = ['$scope'];
   constructor(private $scope: angular.IScope) { }
@@ -26,6 +48,8 @@ export class FieldTextController implements angular.IController {
     } else {
       this.fte.toolbar = '[[]]';
     }
+
+    this.autocapitalize = autocapitalizeHints[this.fteFieldName] || 'none'
   }
 
   disabledMsg(): string {
@@ -73,7 +97,8 @@ export const FieldTextComponent: angular.IComponentOptions = {
     fteDisabled: '<',
     fteDisabledReason: '<',
     fteMultiline: '<',
-    fteDir: '<'
+    fteDir: '<',
+    fteFieldName: '<',
   },
   controller: FieldTextController,
   templateUrl: '/angular-app/languageforge/lexicon/editor/field/dc-text.component.html'


### PR DESCRIPTION
## Description
When mobile users were trying to add data in the app, the device keyboard, e.g., Android keyboard, would pop up and already be in a "title-case" mode where the first letter would be capitalized but this is a bit cumbersome for users because he/she would have to go back to the word and lowercase the first letter.  So this request is made to help us give the user's browser some hints that the user's keyboard should not "autocapitalize" for given fields or perhaps the keyboard should "all caps" for other fields.  It's worth noting that this is not something the application can necessarily force upon the user's keyboard but hopefully these "hints" will be respected in many, if not all, cases.

Fixes #1113 

### Type of Change

- New feature (non-breaking change which adds functionality)
- UI change

## Screenshots

Provided below in the context of the appropriate test.

## How Has This Been Tested?

I tested the following three fields from my phone accessing a locally running app:
- [x] Clicked on the "Note" field expecting sentence style, i.e., keyboard capitalizes first letter and then automatically switches to lowercase.
![Screenshot_20210921-125546.png](https://user-images.githubusercontent.com/4412848/134215248-9bb340ae-0e03-48c8-a0a9-934f1268c523.png)

- [x] Clicked on the "CV Pattern" field expecting all caps style, i.e., keyboard stays in capitalize mode for all letters typed.
![Screenshot_20210921-125516.png](https://user-images.githubusercontent.com/4412848/134215268-661bc355-8f93-4c5f-8ba6-a1415f75ca60.png)

- [x] Clicked on the "Definition" field expecting all lowercase style, i.e., keyboard starts in lowercase mode.
![Screenshot_20210921-125434.png](https://user-images.githubusercontent.com/4412848/134215292-436e56f6-43a8-4c6f-a0bd-ed56afb7a227.png)

- [x] Confirmed the number of the applied settings (below)
```javascript
$$('textarea').map(ta => console.log(ta.autocapitalize))
3 none
1 characters
3 none
1 sentences
1 none
1 sentences
1 none
1 sentences
5 none
8 sentences
1 none
2 sentences
2 none
1 sentences
1 none
1 sentences
```

## Checklist:

- [x] I have rebased off `develop` after #1159 and #1160 have been merged
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
> In agreement with the team on the value of adding E2E tests for this, we opted against them.