### PR TITLE
Fix wording on E2E tests involving relative time

### DIFF
--- a/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/editor/editor-comments.e2e-spec.ts
@@ -43,7 +43,7 @@ describe('Lexicon E2E Editor Comments', () => {
     expect<any>(await comment.score.getText()).toEqual('0 Likes');
     expect<any>(await comment.plusOne.isPresent()).toBe(true);
     expect<any>(await comment.content.getText()).toEqual('First comment on this word.');
-    expect<any>(await comment.date.getText()).toMatch(/ago|in a few seconds/);
+    expect<any>(await comment.date.getText()).toMatch(/ago|in a few seconds|in less than a minute/);
   });
 
   it('comments panel: add comment to another part of the entry', async () => {
@@ -66,7 +66,7 @@ describe('Lexicon E2E Editor Comments', () => {
     expect<any>(await comment.score.getText()).toEqual('0 Likes');
     expect<any>(await comment.plusOne.isPresent()).toBe(true);
     expect<any>(await comment.content.getText()).toEqual('Second comment.');
-    expect<any>(await comment.date.getText()).toMatch(/ago|in a few seconds/);
+    expect<any>(await comment.date.getText()).toMatch(/ago|in a few seconds|in less than a minute/);
   });
 
   it('comments panel: check regarding value is hidden when the field value matches', async () => {


### PR DESCRIPTION
## Description

Two tests rely on wording from moment.js which has changed slightly in date-fns. Specifically, a comment whose date shows up as being "in the future" (which can happen if the E2E tests are running on a fast machine) used to show up as having a date "in a few seconds", but now it shows up with the text "in less than a minute" instead. (Or that might not have anything to do with the date-fns change, and just be because my computer ran the E2E tests exceptionally fast twice in a row).

This commit allows the new date-fns wording to be matched.

I didn't create a tracking issue for this PR as it's a trivial fix.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Ran E2E tests

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] (N/A) I have commented my code, particularly in hard-to-understand areas
- [ ] (N/A) I have added tests that prove my fix is effective or that my feature works
