### PR TITLE
Fixed `make dev` for local CSS development

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,8 +19,10 @@ services:
       - ../package.json:/data/package.json
       - ../package-lock.json:/data/package-lock.json
 
-      # needed this volume mapping so changes to typescript would be reflected in running app, actually rebundled and output to dist which is then shared to the app container.
+      # needed these volume maps so changes to typescript/scss would be reflected in running app, actually rebundled and output to dist which is then shared to the app container.
       - ../src/angular-app:/data/src/angular-app
+      - ../src/sass:/data/src/sass
+      - ../src/Site/views/languageforge/theme/default/sass:/data/src/Site/views/languageforge/theme/default/sass
 
   app:
     build:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ../package.json:/data/package.json
       - ../package-lock.json:/data/package-lock.json
 
-      # needed this volume mapping so changes to typescript would be reflected in running app, actually rebundled and outpt to dist which is then shared to the app container.
+      # needed this volume mapping so changes to typescript would be reflected in running app, actually rebundled and output to dist which is then shared to the app container.
       - ../src/angular-app:/data/src/angular-app
 
   app:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:dev:watch": "npm-run-all -p -l sass:watch webpack:dev:watch",
     "build:prd": "npm-run-all -p -l sass webpack:prd",
     "sass": "sass src/sass:src/dist/css",
-    "sass:watch": "npm run sass && sass src/sass:src/dist/css --watch --recursive",
+    "sass:watch": "sass --watch src/sass:src/dist/css src/Site/views/languageforge/theme/default/sass:src/dist/css src/angular-app:src/dist/css",
     "webpack:dev": "webpack --config webpack-dev.config.js",
     "webpack:dev:watch": "webpack -w --config webpack-dev.config.js",
     "webpack:prd": "webpack --config webpack-prd.config.js",


### PR DESCRIPTION
## Description

`make dev` was always meant to allow developers to make changes locally and see those changes reflected in his/her running app.  However, CSS development was overlooked in the initial creation of the infrastructure, i.e., local CSS changes would not show up in the locally running app unless the dev cleaned volumes and rebuilt the ui image from scratch.

Fixes an untracked issue

### Type of Change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Screenshots

N/A

## How Has This Been Tested?

- [x] change an `.scss` file under `src/sass/`
- [x] change an `.scss` file under `src/Site/views/languageforge/theme/default/sass/`
- [x] change an `.scss` file under `src/angular-app/`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
