### PR TITLE
Allow dev to test locally running app from any device on same network

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Other useful resources:
 > ```
 > 
 > then hit `http://192.168.161.99` from your phone or other device on the same network.
+>
+> NOTE: disabling cache on your device may not be trivial, you'll either need to wipe the site settings on your device's browser or you'll need some do it via USB debugging.
 
 ### Running E2E Tests
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Other useful resources:
 > 
 > then hit `http://192.168.161.99` from your phone or other device on the same network.
 >
-> NOTE: disabling cache on your device may not be trivial, you'll either need to wipe the site settings on your device's browser or you'll need some do it via USB debugging.
+> NOTE: disabling cache on your device may not be trivial, you'll either need to wipe the site settings on your device's browser or you'll need to do it via USB debugging.
 
 ### Running E2E Tests
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Other useful resources:
 1. You should see a landing page, click "Login"
 1. Use `admin` and `password` to get in
 
+> Sometimes there may be a need to hit the locally running app from a device other than the machine the app is running on.  In order to do that, you'll need to do the following:
+> 1. Figure out your local ip address
+> 1. Access the app via http at that address
+> 
+> On a Mac for example:
+> ```
+> ifconfig | grep broadcast
+> 	inet 192.168.161.99 netmask 0xfffffc00 broadcast 192.168.163.255
+> ```
+> 
+> then hit `http://192.168.161.99` from your phone or other device on the same network.
+
 ### Running E2E Tests
 
 1. `make e2e-tests` (⚠️ these do not work on Apple Silicon at this time)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -82,14 +82,15 @@ services:
     ports:
       - 80:80
       - 443:443
+    restart: unless-stopped
     depends_on:
       - app
     volumes:
       - lf-caddy-data:/data
       - lf-caddy-config:/config
-    # https://caddyserver.com/docs/command-line
-    command: caddy reverse-proxy --from localhost --to app
-    restart: unless-stopped
+
+      # for developer convenience
+      - ./ssl/Caddyfile:/etc/caddy/Caddyfile
 
   mail:
     image: juanluisbaptiste/postfix:1.0.0

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -85,6 +85,8 @@ services:
     restart: unless-stopped
     depends_on:
       - app
+    environment:
+      - APP_ADDRESS=app:80
     volumes:
       - lf-caddy-data:/data
       - lf-caddy-config:/config

--- a/docker/ssl/Caddyfile
+++ b/docker/ssl/Caddyfile
@@ -1,0 +1,14 @@
+# https://caddyserver.com/docs/caddyfile
+{
+	#debug
+}
+
+localhost {
+	# NOTE: "app" here is the name of the service found in the docker-compose.yml
+	reverse_proxy app:80
+}
+
+:80 {
+	# NOTE: "app" here is the name of the service found in the docker-compose.yml
+	reverse_proxy app:80
+}

--- a/docker/ssl/Caddyfile
+++ b/docker/ssl/Caddyfile
@@ -4,11 +4,9 @@
 }
 
 localhost {
-	# NOTE: "app" here is the name of the service found in the docker-compose.yml
-	reverse_proxy app:80
+	reverse_proxy {$APP_ADDRESS}
 }
 
 :80 {
-	# NOTE: "app" here is the name of the service found in the docker-compose.yml
-	reverse_proxy app:80
+	reverse_proxy {$APP_ADDRESS}
 }


### PR DESCRIPTION
## Description

There are times when a dev needs to access his/her locally running app from another device on the same network.  Before these changes, this was not really feasibly with our reverse-proxy configuration.

Fixes an untracked issue

### Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Screenshots

N/A

## How Has This Been Tested?

- [x] I ran the app locally and accessed it from my phone via WiFi

## Checklist:

- [x] I have rebased off `develop` after #1159 has been merged
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
