### PR TITLE
Don't show 502's to end users

### DIFF
--- a/src/angular-app/bellows/core/api/json-rpc.service.ts
+++ b/src/angular-app/bellows/core/api/json-rpc.service.ts
@@ -126,7 +126,8 @@ export class JsonRpcService {
       // only report error if the browser/network is not OFFLINE and not timeout (status -1)
       // otherwise fail silently (the browser will console log a failed connection anyway)
       if (response.status > 0 && response.status !== '0') {
-        this.error.notify('RPC Error', 'Server Status Code ' + response.status);
+        // just absorb 502's, nothing the user can do about it.
+        response.status !== 502 && this.error.notify('RPC Error', 'Server Status Code ' + response.status);
         result.ok = false;
         result.data = response.data;
         result.status = response.status;


### PR DESCRIPTION
## Description

good description from #1162 already:
> Is your feature request related to a problem? Please describe.
> Currently our infrastructure is throwing a lot of HTTP 502 errors, which get reported to users in a yellow "Oh. RPC Error" box. But there's no action the user can take in response to a 502, and most of the time it doesn't mean there's anything wrong with their project.
> 
> Describe the solution you'd like
> We should filter out HTTP 502 errors from the pop-up notifications, and only log them in the Javascript console (which most users will never look at).
> 
> Describe alternatives you've considered
> We could also not log 502s in the JS console at all, but I think there's benefit to logging them in the console without showing a notification pop-up.

Fixes #1162 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots
First captured in #1106, screenshot here: https://user-images.githubusercontent.com/3444521/131461329-bef5a84a-b107-4d22-8847-13696a4db3a2.png

## How Has This Been Tested?

- [x] I wasn't immediately sure how to simulate the `502` in `app/sf` so I just replaced https://user-images.githubusercontent.com/3444521/131461329-bef5a84a-b107-4d22-8847-13696a4db3a2.png with a call to `https://httpbin.org/status/502`
![image](https://user-images.githubusercontent.com/4412848/134374337-18158e31-5467-461b-96a2-b6cf9079a79f.png)

- [x] I also wanted to ensure anything other than a `502` still behaved the same so I changed the call to `https://httpbin.org/status/400`
![image](https://user-images.githubusercontent.com/4412848/134374730-ab33f504-d2a0-485d-a2fd-2b7064ec5319.png)

- [x] Of course, I tested a little basic functionality to ensure basic features were unaffected.  I did see the "Downloading dictionary..." alert briefly when going into a dictionary.  I also bounced through a few pages and saw no problems.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
