### PR TITLE
Fix multiple keyup event handlers

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -108,23 +108,22 @@ export class LexiconEditorController implements angular.IController {
 
   $onInit(): void {
     this.$scope.$on('$viewContentLoaded', () => {
-      angular.element(window).bind('keyup', (e: Event) => {
-        if ((e as KeyboardEvent).key === 'PageUp') {
-          this.$scope.$apply(() => {
-            if (this.canSkipToEntry(-1)){
-              this.skipToEntry(-1);
-            }
-          });
+        this.$window.onkeyup = (e: KeyboardEvent) => {
+          if ((e as KeyboardEvent).key === 'PageUp') {
+            this.$scope.$apply(() => {
+              if (this.canSkipToEntry(-1)) {
+                this.skipToEntry(-1);
+              }
+            });
+          }
+          if ((e as KeyboardEvent).key === 'PageDown') {
+            this.$scope.$apply(() => {
+              if (this.canSkipToEntry(1)) {
+                this.skipToEntry(1);
+              }
+            });
+          }
         }
-
-        if ((e as KeyboardEvent).key === 'PageDown') {
-          this.$scope.$apply(() => {
-            if (this.canSkipToEntry(1)){
-              this.skipToEntry(1);
-            }
-          });
-        }
-      });
     });
 
     this.show.more = this.editorService.showMoreEntries;
@@ -149,7 +148,7 @@ export class LexiconEditorController implements angular.IController {
         this.saveCurrentEntry();
       }
       // destroy listeners when leaving editor page
-      angular.element(window).unbind('keyup', (e: Event) => {});
+      this.$window.onkeyup = null;
     };
 
     this.show.entryListModifiers = !(this.$window.localStorage.getItem('viewFilter') == null ||


### PR DESCRIPTION
## Description

Multiple keyup event handlers are injected for the page up/down editor feature.
Binding event handlers outside of angularjs $scope  "angular.element(window).bind" seems to produce duplicate events. Using local scope $window will discard duplicate instances if encountered. 

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

## Screenshots
![Peek 2021-09-28 06-58](https://user-images.githubusercontent.com/7799495/135101820-b6db1b8f-0251-4a86-b943-2ec15a780f52.gif)

## How Has This Been Tested?

Please describe the manual tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Navigate to the editor page, press page up/down and the record focus will only move once per key stroke. 

## Checklist:

- [X] I have performed a self-review of my own code
