### PR TITLE
fix PgUp and PgDn behavior in editor

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -107,24 +107,23 @@ export class LexiconEditorController implements angular.IController {
   ) { }
 
   $onInit(): void {
-    this.$scope.$on('$viewContentLoaded', () => {
-      angular.element(window).bind('keyup', (e: Event) => {
-        if ((e as KeyboardEvent).key === 'PageUp') {
-          this.$scope.$apply(() => {
-            if (this.canSkipToEntry(-1)){
-              this.skipToEntry(-1);
-            }
-          });
-        }
 
-        if ((e as KeyboardEvent).key === 'PageDown') {
-          this.$scope.$apply(() => {
-            if (this.canSkipToEntry(1)){
-              this.skipToEntry(1);
-            }
-          });
-        }
-      });
+    // add PgUp and PgDn global window handlers to facilitate paging through entries
+    angular.element(window).bind('keydown', (e: Event) => {
+      var key = (e as KeyboardEvent).key;
+      if (key == 'PageUp' || key == 'PageDown') {
+        e.preventDefault();
+        this.$scope.$apply(() => {
+          if (key == 'PageUp' && this.canSkipToEntry(-1)) {
+            console.log("page up");
+            this.skipToEntry(-1);
+          }
+          if (key == 'PageDown' && this.canSkipToEntry(1)) {
+            console.log("page down");
+            this.skipToEntry(1);
+          }
+        });
+      }
     });
 
     this.show.more = this.editorService.showMoreEntries;
@@ -148,8 +147,6 @@ export class LexiconEditorController implements angular.IController {
       if (this.hasUnsavedChanges()) {
         this.saveCurrentEntry();
       }
-      // destroy listeners when leaving editor page
-      angular.element(window).unbind('keyup', (e: Event) => {});
     };
 
     this.show.entryListModifiers = !(this.$window.localStorage.getItem('viewFilter') == null ||
@@ -216,6 +213,7 @@ export class LexiconEditorController implements angular.IController {
   $onDestroy(): void {
     this.cancelAutoSaveTimer();
     this.saveCurrentEntry();
+    angular.element(window).unbind('keydown', (e: Event) => {});
   }
 
   navigateToLiftImport(): void {


### PR DESCRIPTION
## Description of Changes

- changed the event handler registration to just $onInit instead of $viewContentLoaded.  This fixes #1178 the skipping entries problem.
- moved the unregister handler to $onDestroy, complementary to $onInit.  This is called whenever the editor component is destroyed - good enough.
- register event handler for `keydown`.  `keyup` works fine for adding events, but it appears to late for the browser default behavior of PgUp/PgDown which appears to trigger on PgDn.
- add e.preventDefault() to prevent scrolling inside the entry list and editor pane when using these keys to page entries.

Fixes #1177 #1178 

Supersedes PR #1174 (can be closed)

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Hard to provide screenshots for a keyboard shortcut, so I decline.

## How Has This Been Tested?

- [x] I tested this locally on my developer machine and did not experience any adverse scrolling when <kbd>PgUp</kbd> or <kbd>PgDn</kbd> keys are pressed.  No double skipping, no scrolling.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
