### PR TITLE
fix CSS magic height numbers for list containers

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -293,11 +293,14 @@ dc-entry .card {
         }
     }
     .lexiconItemListContainer {
-      margin-bottom: 15px;
       @include media-breakpoint-up(sm) {
-        height: calc(100vh - 568px);
-        overflow: auto;
-        }
+        margin-bottom: 5px;
+        height: calc(100vh - 310px);
+      }
+      @include media-breakpoint-down(sm) {
+        height: calc(100vh - 260px);
+      }
+      overflow: auto;
     }
     .lexiconListItem.active {
         cursor: default;
@@ -317,8 +320,8 @@ dc-entry .card {
 }
 
 #lexAppEditView {
-  .lexiconItemListContainer {
-    height: calc(100vh - 568px);
+  #compactEntryListContainer {
+    height: calc(100vh - 400px);
     overflow: auto;
   }
   .word-definition-title {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -41,14 +41,14 @@
                 </div>
             </div>
         </div>
-        <div class="row">
+        <div class="row" data-ng-show="$ctrl.isAtEditorEntry()">
             <div class="col">
                 <div id="editor-title-text" class="word-definition-title">
                     <dc-rendered config="$ctrl.lecConfig.entry" global-config="$ctrl.lecConfig"
                                  model="$ctrl.currentEntry" option-lists="$ctrl.lecOptionLists"></dc-rendered>
                 </div>
             </div>
-        </div>        
+        </div>
     </div>
 
     <div data-ui-view></div>

--- a/src/angular-app/languageforge/lexicon/shared/fit-text.directive.ts
+++ b/src/angular-app/languageforge/lexicon/shared/fit-text.directive.ts
@@ -24,13 +24,11 @@ export class FitTextDirective implements angular.IDirective {
       var primaryNavigationElement = angular.element(document).find('#primary-navigation');
       var primaryNavigationHeight = primaryNavigationElement.height();
       var scrollingEditorContainerElement = angular.element(document).find('#scrolling-editor-container');
-      var compactEntryListContainerElement = angular.element(document).find('#compactEntryListContainer');
 
       var adjHeight = wHeight - (tHeight - defaultHeight);
       var sHeight = adjHeight - (177 + primaryNavigationHeight);
       var lHeight = adjHeight - (447 + primaryNavigationHeight);
       scrollingEditorContainerElement.css({ height: sHeight + 'px' });
-      compactEntryListContainerElement.css({ height: lHeight + 'px' });
     }
 
     element.on('keyup', () => {


### PR DESCRIPTION
## Description

The lexiconItemListContainer and compactEntryListContainer both contained non-optimal magic height numbers.

The new numbers provide a more consistent maximum height as well as no app surface scrollbar.

The only case where a scrollbar appears is when the search options dialog is exercised, and this is too complicated to fix without a more major CSS/HTML reshuffle.

Also remove line in FitTextDirective that fiddles with the compactListItemContainer height.  It should not.

Fixes #1179 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

The current non-optimal / broken behavior on staging can be seen here:
https://user-images.githubusercontent.com/3444521/135425203-fabf0b31-7b89-4946-9871-22f7f27c7544.mp4


This PR creates a more consistent container height using magic numbers and works on all viewports.
https://user-images.githubusercontent.com/3444521/135425260-3f764220-401f-4657-b224-bfc1d9573c99.mp4


## How Has This Been Tested?

- [x] Scrolling list containers (both compact and main list) take up as much vertical height as possible without creating a app scrollbar (except is when search options are showing)
- [x] Testing on Chrome using mobile viewport
- [ ] Tested on Android device

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
