### PR TITLE
remove black border on dc-text textarea

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-text.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-text.scss
@@ -117,7 +117,7 @@
   display: grid;
 }
 .grow-wrap::after {
-  /* Note the weird space! Needed to preventy jumpy behavior */
+  /* Note the weird space! Needed to prevent jumpy behavior */
   content: attr(data-replicated-value) " ";
 
   /* This is how textarea text behaves */
@@ -136,7 +136,6 @@
 .grow-wrap > textarea,
 .grow-wrap::after {
   /* Identical styling required!! */
-  border: 1px solid black;
   padding: 0.5rem;
   font: inherit;
   width: 100%;


### PR DESCRIPTION


## Description

This changes the textarea border from black to grey to be consistent with all other inputs

See #1172 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Unwanted black borders before this change
![image](https://user-images.githubusercontent.com/3444521/135428632-017e39c9-0891-42de-9f13-7b311e0650bb.png)

Grey borders after this change
![image](https://user-images.githubusercontent.com/3444521/135428567-4ac72567-2cec-4c70-adc7-af699bf3ba5d.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
