### PR TITLE
Simplify fit-text directive

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -6,7 +6,7 @@
 
 .lexAppToolbar {
     border: 1px solid $line-color;
-    margin: 10px 0 20px;
+    margin: 0 0 5px;
     padding: 4px;
     width: 100%;
     float: left;

--- a/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.scss
+++ b/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.scss
@@ -18,8 +18,14 @@
 .container-scroll {
   overflow-y: scroll;
   overflow-x: hidden;
-  height: calc(100vh - 296px);
+
+  @include media-breakpoint-up(sm) {
+    height: calc(100vh - 296px);
   }
+  @include media-breakpoint-down(sm) {
+    height: calc(100vh - 270px);
+  }
+}
 
 .comments-right-panel {
   color: $Eden;

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
@@ -26,10 +26,8 @@
   }
 }
 .dc-rendered-overflow{
-  @include media-breakpoint-down(sm) {
-   display: -webkit-box;
-   -webkit-line-clamp: 3;
-   -webkit-box-orient: vertical; 
-   overflow: hidden; 
-  }
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }

--- a/src/angular-app/languageforge/lexicon/shared/fit-text.directive.ts
+++ b/src/angular-app/languageforge/lexicon/shared/fit-text.directive.ts
@@ -4,8 +4,16 @@ export class FitTextDirective implements angular.IDirective {
 
   link(scope: angular.IScope, element: angular.IAugmentedJQuery, attr: angular.IAttributes) {
     function updateHeight(): void {
+
+        // element is a JQuery object, and element[0] is the textarea DOM object
+        // the DOM object is the only way we can access the calculated "scrollHeight",
+        // since the JQuery object doesn't have that property
         let el = element[0] as HTMLTextAreaElement;
+
+        // start with a small minimum height
       	el.style.height = "10px";
+
+        // grow to the height necessary to fit all the text
         el.style.height = el.scrollHeight+"px";
     }
 
@@ -19,6 +27,7 @@ export class FitTextDirective implements angular.IDirective {
       updateHeight();
     });
 
+    // this is required in order to resize the text area when switching between entries
     scope.$watch(() => {
       updateHeight();
     });

--- a/src/angular-app/languageforge/lexicon/shared/fit-text.directive.ts
+++ b/src/angular-app/languageforge/lexicon/shared/fit-text.directive.ts
@@ -3,52 +3,25 @@ import * as angular from 'angular';
 export class FitTextDirective implements angular.IDirective {
 
   link(scope: angular.IScope, element: angular.IAugmentedJQuery, attr: angular.IAttributes) {
-    let kInput: boolean = false;
-    var defaultHeight = 24;
-    element.height(40);
-    element.css({ 'max-height': '40px' });
-    element.css({ height: '40px' });
-
-    function updateHeight(): any {
-      let height = element.prop('scrollHeight');
-      element.height = height;
-      element.css({ 'max-height': height + 'px' });
-      element.css({ height: height + 'px' });
-      updateContainersHeight();
-    }
-
-    function updateContainersHeight(): any {
-      var wHeight = angular.element(window).height();
-      var editorTitleTextElement = angular.element(document).find('#editor-title-text');
-      var tHeight = editorTitleTextElement.height();
-      var primaryNavigationElement = angular.element(document).find('#primary-navigation');
-      var primaryNavigationHeight = primaryNavigationElement.height();
-      var scrollingEditorContainerElement = angular.element(document).find('#scrolling-editor-container');
-
-      var adjHeight = wHeight - (tHeight - defaultHeight);
-      var sHeight = adjHeight - (177 + primaryNavigationHeight);
-      var lHeight = adjHeight - (447 + primaryNavigationHeight);
-      scrollingEditorContainerElement.css({ height: sHeight + 'px' });
+    function updateHeight(): void {
+        let el = element[0] as HTMLTextAreaElement;
+      	el.style.height = "10px";
+        el.style.height = el.scrollHeight+"px";
     }
 
     element.on('keyup', () => {
-      kInput = true;
       scope.$apply(() => {
         updateHeight();
       });
     });
 
-    angular.element(window).on('resize',() => { 
+    angular.element(window).on('resize',() => {
       updateHeight();
     });
 
     scope.$watch(() => {
-      if (!kInput){
-        kInput = false;
-        updateHeight();
-      }
+      updateHeight();
     });
-
   }
 
   static factory(): angular.IDirectiveFactory {


### PR DESCRIPTION
## Description

This removes some unnecessary complexity in the fit-text directive while completing required features of the text area resize issue #1190

This PR also optimizes a few different container height and margin values to provide a more consistent app height across viewports.  This complements the fit-text directive changes, which previously were making changes to parent containers via JS/CSS.

The change to dc-rendered now puts a maximum of two lines on the div across all viewports.

Fixes #1190 and #1172

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Video demo

You can watch the old behavior in #1190 here:
https://user-images.githubusercontent.com/3444521/135624012-8c70a2bc-44da-4b0d-8630-9f6136079915.mp4

See below for the new behavior:
https://user-images.githubusercontent.com/3444521/135638562-e92470aa-4c74-450a-a6be-d29deaf44977.mp4

## How Has This Been Tested?

- [ ] The text area defaults to a single line width when there is either no content or a single line of content
- [ ] Switching between entries should appropriately size the text area to it's content
- [ ] Resizing the window / switching viewports should trigger a text area resize
- [ ] Enter text that results in additional lines should grow the text area appropriately
- [ ] Deleting text that results in fewer lines should shrink the text area appropriately

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
