### PR TITLE
remove site footer across application

### DIFF
--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -11,7 +11,7 @@
         <div id="primary-navigation" class="fixed-nav-bar" data-ng-cloak data-ng-controller="navbarController as $ctrl">
             <nav class="navbar navbar-expand navbar-dark align-items-stretch">
                 <span class="navbar-brand d-md-inline-block mr-auto">
-                    <img class="navbar-logo" src="/Site/views/languageforge/theme/default/image/lf_logo_medium.png">
+                    <img class="navbar-logo" title="v{{ version }}" src="/Site/views/languageforge/theme/default/image/lf_logo_medium.png">
                     <a class="website-title" href="/">{{ app.website.name }}</a>
                 </span>
                 <ul class="nav navbar-nav">
@@ -127,7 +127,7 @@
         <div id="primary-navigation" class="logged-out" data-ng-cloak data-ng-controller="navbarController as $ctrl">
             <nav class="fixed-nav-bar navbar navbar-expand navbar-dark align-items-stretch logged-out">
                 <span class="navbar-brand d-md-inline-block mr-auto">
-                    <img class="navbar-logo" src="/Site/views/languageforge/theme/default/image/lf_logo_medium.png">
+                    <img class="navbar-logo" title="v{{ version }}" src="/Site/views/languageforge/theme/default/image/lf_logo_medium.png">
                     <a class="" href="/">{{ app.website.name }}</a>
                 </span>
                 <ul class="nav navbar-nav">
@@ -149,28 +149,6 @@
             </nav>
         </div>
     {% endif %}
-{% endblock %}
-
-{% block footer %}
-    <footer class="footer">
-        <div class="d-flex">
-            <div class="d-none d-sm-flex align-items-end">
-                <div>
-                    <a href="https://inter.payap.ac.th/"><img src="/Site/views/shared/image/payap_logo.png"
-                                                          alt="Payap University Logo" width="85" height="25" /></a>
-                    <a href="http://www.sil.org"><img src="/Site/views/shared/image/sil_logo_small.png"
-                                                      alt="SIL International Logo" width="25" height="30" /></a>
-                </div>
-            </div>
-            <div class="d-flex flex-grow justify-content-end align-items-end">
-                <small>
-                    v {{ version }}.
-                    Copyright <span class="notranslate">{{ "now"|date("Y") }}</span> <a href="http://www.sil.org" class="links">SIL International</a>.
-                    <a href="/terms_and_conditions" class="links">Terms and conditions</a>.
-                </small>
-            </div>
-        </div>
-    </footer>
 {% endblock %}
 
 {% block analytics %}

--- a/src/Site/views/shared/_global.scss
+++ b/src/Site/views/shared/_global.scss
@@ -173,27 +173,6 @@ nav {
   @include button-variant(white, #ADADAD, #E6E6E6);
 }
 
-.footer{
-  background-color: $theme-primary;
-  color: white;
-  padding: 0.5em;
-  margin-top: 0.5em;
-
-  .links{
-    color: white;
-    border-bottom: 1px dotted white;
-    text-decoration: none;
-  }
-
-  .footerimages {
-    padding-bottom: 10px;
-  }
-
-  img {
-   margin-right: 5px;
-  }
-}
-
 // TODO: Remove hack for modal box issue as a result of ui.bootstrap
 .modal-select-language {
 

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -293,12 +293,12 @@ dc-entry .card {
         }
     }
     .lexiconItemListContainer {
-      @include media-breakpoint-up(sm) {
+      @include media-breakpoint-up(md) {
         margin-bottom: 5px;
-        height: calc(100vh - 310px);
+        height: calc(100vh - 260px);
       }
       @include media-breakpoint-down(sm) {
-        height: calc(100vh - 260px);
+        height: calc(100vh - 220px);
       }
       overflow: auto;
     }
@@ -321,7 +321,7 @@ dc-entry .card {
 
 #lexAppEditView {
   #compactEntryListContainer {
-    height: calc(100vh - 400px);
+    height: calc(100vh - 325px);
     overflow: auto;
   }
   .word-definition-title {

--- a/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.scss
+++ b/src/angular-app/languageforge/lexicon/editor/comment/lex-comments-view.scss
@@ -1,4 +1,7 @@
 @import '../../../../../Site/views/languageforge/theme/default/sass/variables';
+@import '../../../../../../node_modules/bootstrap/scss/functions';
+@import '../../../../../../node_modules/bootstrap/scss/variables';
+@import '../../../../../../node_modules/bootstrap/scss/mixins';
 
 #lexAppEditView {
   display: flex;
@@ -19,11 +22,12 @@
   overflow-y: scroll;
   overflow-x: hidden;
 
-  @include media-breakpoint-up(sm) {
-    height: calc(100vh - 296px);
+  @include media-breakpoint-up(md) {
+    height: calc(100vh - 230px);
   }
+
   @include media-breakpoint-down(sm) {
-    height: calc(100vh - 270px);
+    height: calc(100vh - 215px);
   }
 }
 

--- a/src/releasenotes/languageforge.md
+++ b/src/releasenotes/languageforge.md
@@ -14,6 +14,7 @@
 - Test developer builds on their local network; useful for device testing
 - Use dart-sass instead of node-sass for CSS compilation
 - Use date-fn instead of moment.js dependency
+
 ### 1.8 Release (31-August-2021)
 #### User Improvements/Fixes ####
 - More projects can now do Send/Receive with FLEx


### PR DESCRIPTION
## Description

- This removes the footer across all views in the app.  We leave the footer in place for the brochure home page.
- Move the version string to be an image title on the logo.
- I adjusted the container height magic numbers to fill the space now available at the bottom of the view.

Fixes #1163 

### Type of Change

- UI change

## Screenshots

Desktop:
![image](https://user-images.githubusercontent.com/3444521/135746413-9875e634-7aff-442b-bc83-8f9ef33b4b28.png)

Mobile:
![image](https://user-images.githubusercontent.com/3444521/135746390-ae9bc11d-55b0-4215-99ad-c3e06b3f56dd.png)


## How Has This Been Tested?

- [x] Mobile: footer gone and space is maximized
- [x] Tablet / desktop: footer gone and space is maximized

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message