### PR TITLE
reduce vertical padding/margin on form controls in edit view

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -323,6 +323,10 @@ dc-entry .card {
   #compactEntryListContainer {
     height: calc(100vh - 400px);
     overflow: auto;
+
+    .list-group-item {
+      padding: .25rem 1.25rem;
+    }
   }
   .word-definition-title {
     margin-bottom: 5px;
@@ -721,7 +725,7 @@ dc-entry .card {
     position: relative;
     overflow-y: hidden;
     min-height: 40px;
-    height: 55px;
+    height: 50px;
     border-bottom: solid 1px darkgrey;
     width: 100%;
     line-height: 1.2em;
@@ -736,10 +740,8 @@ dc-entry .card {
 }
 
 .entryItemView {
-    /*  TODO: review this in light of animation and the footer staying at the bottom. IJH 2014-09
-        The view is used in edit and comment view */
+  min-height: 580px;
 
-    min-height: 580px;
   .field-container {
     position: relative;
     .comment-bubble-group {
@@ -782,13 +784,16 @@ dc-entry .card {
 }
 
 .entryItemView {
-    i.fa-times {
-        cursor: pointer;
-        color: #888;
-    }
-    button i.fa-times {
-        color: inherit;
-    }
+  .form-group {
+    margin-bottom: 5px;
+  }
+  i.fa-times {
+    cursor: pointer;
+    color: #888;
+  }
+  button i.fa-times {
+    color: inherit;
+  }
 }
 
 #lexAppCommentView .commentCount {


### PR DESCRIPTION
## Description

The intent of reducing vertical padding/margin on edit controls is to increase the usable space in the editor which increases information density for the user.

With this change, the user can see more fields in the entry, as well as see more entries in the compact list on the left side.

I consider this to be an improvement over the existing margins, etc. but one could also argue against this change because it could also be harder for users with a touch screen to click on the right item/field.  To make these adjustments, I had to override the sensible default Bootstrap margins on form controls.

In the side list, this change increases the visible items from 11 to 13 (on my desktop).
In this example entry, this change increases the visible fields in the editor from 10 to 12 (on my desktop).

This PR is not about "redesigning the UI" but rather making small, incremental improvements that stakeholders agree is a move in the right direction.

### Type of Change
- UI change

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/3444521/135747577-12e64b52-7503-466a-b156-4e140cb4da78.png)

After:
![image](https://user-images.githubusercontent.com/3444521/135747516-ecc7bdef-8eba-4bf9-8e26-2da2b683d27e.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
