### PR TITLE
Make rendered entry scrollable on mobile

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -95,7 +95,7 @@
             <div id="scrolling-editor-container" class="col-md-7 col-lg-8 entry-primary-container container-scroll">
                 <div>
                     <div class="entryItemView" data-ng-if="$ctrl.entryLoaded()">
-                        <div id="editor-title-text" class="word-definition-title dc-rendered-on-mobile">
+                        <div class="word-definition-title dc-rendered-on-mobile">
                             <dc-rendered config="$ctrl.lecConfig.entry" global-config="$ctrl.lecConfig"
                                         model="$ctrl.currentEntry" option-lists="$ctrl.lecOptionLists"></dc-rendered>
                         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -95,6 +95,10 @@
             <div id="scrolling-editor-container" class="col-md-7 col-lg-8 entry-primary-container container-scroll">
                 <div>
                     <div class="entryItemView" data-ng-if="$ctrl.entryLoaded()">
+                        <div id="editor-title-text" class="word-definition-title dc-rendered-on-mobile">
+                            <dc-rendered config="$ctrl.lecConfig.entry" global-config="$ctrl.lecConfig"
+                                        model="$ctrl.currentEntry" option-lists="$ctrl.lecOptionLists"></dc-rendered>
+                        </div>
                         <dc-entry config="$ctrl.lecConfig.entry" model="$ctrl.currentEntry" control="$ctrl.control"></dc-entry>
                     </div>
                 </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -41,7 +41,7 @@
                 </div>
             </div>
         </div>
-        <div class="row" data-ng-show="$ctrl.isAtEditorEntry()">
+        <div class="row dc-rendered-container" data-ng-if="$ctrl.isAtEditorEntry()">
             <div class="col">
                 <div id="editor-title-text" class="word-definition-title">
                     <dc-rendered config="$ctrl.lecConfig.entry" global-config="$ctrl.lecConfig"

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -41,7 +41,7 @@
                 </div>
             </div>
         </div>
-        <div class="row dc-rendered-container" data-ng-if="$ctrl.isAtEditorEntry()">
+        <div class="row dc-rendered-on-desktop" data-ng-if="$ctrl.isAtEditorEntry()">
             <div class="col">
                 <div id="editor-title-text" class="word-definition-title">
                     <dc-rendered config="$ctrl.lecConfig.entry" global-config="$ctrl.lecConfig"

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -43,7 +43,7 @@
         </div>
         <div class="row dc-rendered-on-desktop" data-ng-if="$ctrl.isAtEditorEntry()">
             <div class="col">
-                <div id="editor-title-text" class="word-definition-title">
+                <div class="word-definition-title">
                     <dc-rendered config="$ctrl.lecConfig.entry" global-config="$ctrl.lecConfig"
                                  model="$ctrl.currentEntry" option-lists="$ctrl.lecOptionLists"></dc-rendered>
                 </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
@@ -26,7 +26,12 @@
   }
 }
 @include media-breakpoint-down(sm) {
-  .dc-rendered-container {
+  .dc-rendered-on-desktop {
+    display: none;
+  }
+}
+@include media-breakpoint-up(md) {
+  .dc-rendered-on-mobile {
     display: none;
   }
 }

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
@@ -25,6 +25,11 @@
     font-style: normal;
   }
 }
+@include media-breakpoint-down(sm) {
+  .dc-rendered-container {
+    display: none;
+  }
+}
 .dc-rendered-overflow{
   display: -webkit-box;
   -webkit-line-clamp: 2;


### PR DESCRIPTION
## Description

Per discussion below, make the "rendered entry" on mobile scrollable with the entry editor.  The rendered-entry on desktop remains sticky at the top of the surface.

Fixes #1112 

### Type of Change

- UI change

## Video Demo

https://user-images.githubusercontent.com/3444521/137492485-5ec18636-be8c-4fcc-9418-2772f4e874ae.mp4



See how the desktop version keeps the rendered entry sticky with the toolbar on top.
See how the mobile version scrolls the rendered entry with the editor fields

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
