### PR TITLE
Fix PHP exception handling in Symfony

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -125,6 +125,10 @@ COPY docker/app/entrypoint.sh /
 
 COPY --from=composer-builder /composer/vendor /var/www/html/vendor
 
+# patch exception handling from Symfony to actually show exceptions instead of swallowing them
+COPY docker/app/symfony-exceptions.patch /
+RUN patch -p4 -i /symfony-exceptions.patch
+
 RUN echo "${BUILD_VERSION}" > /var/www/html/build-version.txt \
  && sed -i /var/www/html/version.php -e "s/^\\(define('VERSION', '\\).*;\$/\\1${BUILD_VERSION}'\\);/"
 

--- a/docker/app/symfony-exceptions.patch
+++ b/docker/app/symfony-exceptions.patch
@@ -1,0 +1,85 @@
+--- a/var/www/html/vendor/symfony/debug/ExceptionHandler.php	2019-07-23 15:39:19.000000000 +0700
++++ b/var/www/html/vendor/symfony/debug/ExceptionHandler.php	2021-09-27 15:08:37.000000000 +0700
+@@ -103,7 +103,7 @@
+      * The latter takes precedence and any output from the former is cancelled,
+      * if and only if nothing bad happens in this handling path.
+      */
+-    public function handle(\Exception $exception)
++    public function handle(\Error $exception)
+     {
+         if (null === $this->handler || $exception instanceof OutOfMemoryException) {
+             $this->sendPhpResponse($exception);
+@@ -144,7 +144,7 @@
+         try {
+             \call_user_func($this->handler, $exception);
+             $this->caughtLength = $caughtLength;
+-        } catch (\Exception $e) {
++        } catch (\Error $e) {
+             if (!$caughtLength) {
+                 // All handlers failed. Let PHP handle that now.
+                 throw $exception;
+@@ -158,7 +158,7 @@
+      * This method uses plain PHP functions like header() and echo to output
+      * the response.
+      *
+-     * @param \Exception|FlattenException $exception An \Exception or FlattenException instance
++     * @param \Error|FlattenException $exception An \Error or FlattenException instance
+      */
+     public function sendPhpResponse($exception)
+     {
+@@ -180,7 +180,7 @@
+     /**
+      * Gets the full HTML content associated with the given exception.
+      *
+-     * @param \Exception|FlattenException $exception An \Exception or FlattenException instance
++     * @param \Error|FlattenException $exception An \Error or FlattenException instance
+      *
+      * @return string The HTML content as a string
+      */
+@@ -250,7 +250,7 @@
+
+                 $content .= "</tbody>\n</table>\n</div>\n";
+             }
+-        } catch (\Exception $e) {
++        } catch (\Error $e) {
+             // something nasty happened and we cannot throw an exception anymore
+             if ($this->debug) {
+                 $title = sprintf('Exception thrown when handling an exception (%s: %s)', \get_class($e), $this->escapeHtml($e->getMessage()));
+@@ -390,7 +390,7 @@
+         } else {
+             try {
+                 $link = $fmt->format($path, $line);
+-            } catch (\Exception $e) {
++            } catch (\Error $e) {
+                 return sprintf('<span class="block trace-file-path">in <span title="%s%3$s"><strong>%s</strong>%s</span></span>', $this->escapeHtml($path), $file, 0 < $line ? ' line '.$line : '');
+             }
+         }
+--- a/var/www/html/vendor/symfony/debug/Exception/FlattenException.php	2019-07-23 15:39:19.000000000 +0700
++++ b/var/www/html/vendor/symfony/debug/Exception/FlattenException.php	2021-09-27 15:09:06.000000000 +0700
+@@ -33,7 +33,7 @@
+     private $file;
+     private $line;
+
+-    public static function create(\Exception $exception, $statusCode = null, array $headers = [])
++    public static function create(\Error $exception, $statusCode = null, array $headers = [])
+     {
+         $e = new static();
+         $e->setMessage($exception->getMessage());
+@@ -59,7 +59,7 @@
+
+         $previous = $exception->getPrevious();
+
+-        if ($previous instanceof \Exception) {
++        if ($previous instanceof \Error) {
+             $e->setPrevious(static::create($previous));
+         } elseif ($previous instanceof \Throwable) {
+             $e->setPrevious(static::create(new FatalThrowableError($previous)));
+@@ -178,7 +178,7 @@
+         return $this->trace;
+     }
+
+-    public function setTraceFromException(\Exception $exception)
++    public function setTraceFromException(\Error $exception)
+     {
+         $this->setTrace($exception->getTrace(), $exception->getFile(), $exception->getLine());
+     }


### PR DESCRIPTION
## Description

Fixes #1205 by patching the Symfony code to handle PHP 7 exceptions (Error instances instead of Exception instances), so that the original exception will be handled instead of a new "Expected Exception, got Error instead" exception being thrown, which was hiding the original exception.

This PR works by patching the Symfony code in our `vendor` folder after Composer has installed it. That's because upgrading our Symfony version to one that is actually based on PHP 7 would involve a LOT of updates, and this is a much lower-risk change. If we do end up upgrading Symfony at some point, this PR can be easily backed out by simply removing the patch from the Dockerfile.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Once I installed this patch in my Dockerfile, I could actually see the exceptions being thrown by my syntax errors as I worked in the guts of the server's PHP code.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
