### PR TITLE
Silence xdebug chattiness in lf-app logs

### DIFF
--- a/docker/app/customizations.php.ini
+++ b/docker/app/customizations.php.ini
@@ -1,3 +1,4 @@
 memory_limit = 256M
 post_max_size = 60M
 upload_max_filesize = 60M
+xdebug.log_level = 0


### PR DESCRIPTION
This will stop the lf-app logs from getting filled up with a constant stream of xdebug messages about not being able to connect.

Fixes #1207.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran this myself, and breathed a sigh of relief as I could actually read the lf-app log messages.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
