### PR TITLE
change JsonDecoder to handle partial array updates

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexEntryDecoder.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexEntryDecoder.php
@@ -13,9 +13,10 @@ class LexEntryDecoder extends JsonDecoder
      * @param array $values A mixed array of JSON (like) data.
      * @param string $id
      */
-    public static function decode($model, $values, $id = '')
+    public static function decode($model, $values, $isDeltaUpdate = false, $id = '')
     {
         $decoder = new LexEntryDecoder();
+        $decoder->isDeltaUpdate = $isDeltaUpdate;
         $decoder->_decode($model, $values, $id);
     }
 

--- a/src/Api/Model/Shared/Mapper/MongoDecoder.php
+++ b/src/Api/Model/Shared/Mapper/MongoDecoder.php
@@ -22,9 +22,10 @@ class MongoDecoder extends JsonDecoder
      * @param string $id
      * @throws \Exception
      */
-    public static function decode($model, $values, $id = '')
+    public static function decode($model, $values, $isDeltaUpdate = false, $id = '')
     {
         $decoder = new MongoDecoder();
+        $decoder->isDeltaUpdate = $isDeltaUpdate;
         $decoder->_decode($model, $values, $id);
     }
 

--- a/src/Api/Model/Shared/Mapper/MongoMapper.php
+++ b/src/Api/Model/Shared/Mapper/MongoMapper.php
@@ -197,7 +197,7 @@ class MongoMapper
             return;
         }
         try {
-            MongoDecoder::decode($model, $data, (string) $data['_id']);
+            MongoDecoder::decode($model, $data, false, (string) $data['_id']);
         } catch (\Exception $ex) {
             throw new \Exception("Exception thrown while reading", $ex->getCode(), $ex);
         }
@@ -233,7 +233,7 @@ class MongoMapper
             throw new \Exception("Could not find id '$id' in '$collection'");
         }
         try {
-            MongoDecoder::decode($model, $data, $id);
+            MongoDecoder::decode($model, $data, false, $id);
         } catch (\Exception $ex) {
             CodeGuard::exception("Exception thrown while decoding " . get_class($model) . "('$id')", $ex->getCode(), $ex);
         }
@@ -253,7 +253,7 @@ class MongoMapper
         CodeGuard::checkTypeAndThrow($value, 'string');
         $data = $this->_collection->findOne(array($property => $value));
         if ($data != NULL) {
-            MongoDecoder::decode($model, $data, (string) $data['_id']);
+            MongoDecoder::decode($model, $data, false, (string) $data['_id']);
             return true;
         }
         return false;
@@ -269,7 +269,7 @@ class MongoMapper
         CodeGuard::checkTypeAndThrow($properties, 'array');
         $data = $this->_collection->findOne($properties);
         if ($data != NULL) {
-            MongoDecoder::decode($model, $data, (string) $data['_id']);
+            MongoDecoder::decode($model, $data, false, (string) $data['_id']);
             return true;
         }
         return false;
@@ -280,7 +280,7 @@ class MongoMapper
         CodeGuard::checkTypeAndThrow($value, 'string');
         $data = $this->_collection->findOne([$property => $value]);  // Yes, it's that simple
         if ($data != NULL) {
-            MongoDecoder::decode($model, $data, (string) $data['_id']);
+            MongoDecoder::decode($model, $data, false, (string) $data['_id']);
             return true;
         }
         return false;
@@ -296,7 +296,7 @@ class MongoMapper
         }
         // TODO Check this out on nested sub docs > 1
         $data = $data[$property][$id];
-        MongoDecoder::decode($model, $data, $id);
+        MongoDecoder::decode($model, $data, false, $id);
     }
 
     /**

--- a/test/php/model/shared/mapper/json/JsonEncoderDecoderTest.php
+++ b/test/php/model/shared/mapper/json/JsonEncoderDecoderTest.php
@@ -266,7 +266,7 @@ class JsonEncoderDecoderTest extends TestCase
         $this->assertEquals('Chinese', $object->language);
     }
 
-    public function testDecode_propertyArrayElementChanged_existingObjectIsUpdatedNotOverwritten()
+    public function testDecodeDeltaUpdate_propertyArrayElementChanged_existingObjectIsUpdatedNotOverwritten()
     {
         $person1 = new PropertyObject();
         $person1->name = 'John';
@@ -303,9 +303,7 @@ class JsonEncoderDecoderTest extends TestCase
         // person 3 - change name to empty string
         $paramsToUpdate['data'][] = ['name' => ''];
 
-        print_r($paramsToUpdate);
-        JsonDecoder::decode($team, $paramsToUpdate);
-        print_r($team);
+        JsonDecoder::decode($team, $paramsToUpdate, true);
 
         // person 1
         $this->assertEquals('John', $team->data[0]->name);


### PR DESCRIPTION

## Description

This is a change to JsonDecoder to be able to handle partial updates.  This is a work in progress.  The purpose of this PR work is to prove out an alternate strategy for handling delta updates as @rmunn implemented in #1204 

I also added some unit tests to demonstrate partial updates to arrays.

### Type of Change


- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
