### PR TITLE
Feature/entry number for display and navigation

### DIFF
--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -269,6 +269,17 @@ export class EditorDataService {
     return index;
   }
 
+  // find entry id from index number, used to goto and display  editor record 
+  getIdInFilteredList = (index: number): string => {
+    let list = this.filteredEntries;
+    let id: string;
+    if(index > 0 && index <= list.length){
+      let entry = list[index-1];
+      id = entry.id;
+    }
+    return id;
+  }
+
   sortEntries = (shouldResetVisibleEntriesList: boolean): angular.IPromise<any> => {
     const startTime = performance.now();
     return this.configService.getEditorConfig().then(config => {

--- a/src/angular-app/languageforge/lexicon/core/lexicon-editor-data.service.ts
+++ b/src/angular-app/languageforge/lexicon/core/lexicon-editor-data.service.ts
@@ -17,6 +17,7 @@ export class LexiconEditorDataService {
   removeEntryFromLists = this.editorDataService.removeEntryFromLists;
   addEntryToEntryList = this.editorDataService.addEntryToEntryList;
   getIndexInList = this.editorDataService.getIndexInList;
+  getIdInFilteredList = this.editorDataService.getIdInFilteredList;
   showInitialEntries = this.editorDataService.showInitialEntries;
   showMoreEntries = this.editorDataService.showMoreEntries;
   sortEntries = this.editorDataService.sortEntries;

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -827,3 +827,20 @@ dc-entry .card {
 form.submitted .ng-invalid {
     border: 1px solid #f00;
 }
+
+// remove up/down arrows for goto Entry
+.gotoEntry {
+  width: 60px;
+  &::-webkit-inner-spin-button{ display: none; }
+  -moz-appearance:textfield;
+}
+
+.gotoEntry.ng-invalid {
+  border: 3px solid #f00;
+}
+
+.gotoEntry:focus.ng-invalid {
+  background-color: #fff;
+  outline: none;
+  border: 3px solid #f00;
+}

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -116,7 +116,7 @@
                             <dc-rendered config="$ctrl.lecConfig.entry" global-config="$ctrl.lecConfig"
                                         model="$ctrl.currentEntry" option-lists="$ctrl.lecOptionLists"></dc-rendered>
                         </div>
-                        <dc-entry config="$ctrl.lecConfig.entry" model="$ctrl.currentEntry" control="$ctrl.control"></dc-entry>
+                        <dc-entry config="$ctrl.lecConfig.entry" model="$ctrl.currentEntry" control="$ctrl.control" entry-index="$ctrl.entryIndex()"></dc-entry>
                     </div>
                 </div>
             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -16,7 +16,7 @@
                                 <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
                             </button>
                             <input type="number" id="goto" name="goto" class="gotoEntry" title="Enter a number and press Enter to go to that entry"
-                                data-ng-model="item.value" data-ng-value="$ctrl.currentIndex.index" data-ng-disabled="$ctrl.filterIsOn()" data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
+                            data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length" data-ng-model="item.value" data-ng-value="$ctrl.currentIndex.index" data-ng-disabled="$ctrl.filterIsOn()" data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
                             <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1) || $ctrl.filterIsOn()">
                                 <span class="d-none d-lg-inline-block">Next</span> <span class="fa fa-arrow-right"></span>
                             </button>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -11,10 +11,12 @@
                             <span class="d-none d-md-inline-block">List</span></a>
                     </div>
                     <div class="float-right" data-ng-show="$ctrl.isAtEditorEntry()">
-                        <div class="btn-group">
+                        <div class="btn-group" ng-form="validateGoto">
                             <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1)">
                                 <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
                             </button>
+                            <input type="number" name="goto" class="gotoEntry" title="Enter an entry number between 1 and {{$ctrl.filteredEntries.length}}, then press enter" data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length" data-ng-model="item.value"
+                                data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
                             <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1)">
                                 <span class="d-none d-lg-inline-block">Next</span> <span class="fa fa-arrow-right"></span>
                             </button>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -15,7 +15,7 @@
                             <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1)">
                                 <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
                             </button>
-                            <input type="number" name="goto" class="gotoEntry" title="Enter an entry number between 1 and {{$ctrl.filteredEntries.length}}, then press enter" data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length" data-ng-model="item.value"
+                            <input type="number" id="goto" name="goto" class="gotoEntry" title="Enter an entry number between 1 and {{$ctrl.filteredEntries.length}}, then press enter" data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length" data-ng-model="item.value"
                                 data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
                             <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1)">
                                 <span class="d-none d-lg-inline-block">Next</span> <span class="fa fa-arrow-right"></span>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -15,7 +15,7 @@
                             <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1) || $ctrl.filterIsOn()">
                                 <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
                             </button>
-                            <input type="number" id="goto" name="goto" class="gotoEntry" title="Enter an entry number between 1 and {{$ctrl.filteredEntries.length}}, then press enter" data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length"
+                            <input type="number" id="goto" name="goto" class="gotoEntry" title="Enter a number and press Enter to go to that entry"
                                 data-ng-model="item.value" data-ng-value="$ctrl.currentIndex.index" data-ng-disabled="$ctrl.filterIsOn()" data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
                             <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1) || $ctrl.filterIsOn()">
                                 <span class="d-none d-lg-inline-block">Next</span> <span class="fa fa-arrow-right"></span>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -12,12 +12,12 @@
                     </div>
                     <div class="float-right" data-ng-show="$ctrl.isAtEditorEntry()">
                         <div class="btn-group" ng-form="validateGoto">
-                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1)">
+                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1) || $ctrl.filterSortIsOn()">
                                 <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
                             </button>
                             <input type="number" id="goto" name="goto" class="gotoEntry" title="Enter an entry number between 1 and {{$ctrl.filteredEntries.length}}, then press enter" data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length" data-ng-model="item.value"
-                                data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
-                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1)">
+                                ng-disabled="$ctrl.filterSortIsOn()" data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
+                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1) || $ctrl.filterSortIsOn()">
                                 <span class="d-none d-lg-inline-block">Next</span> <span class="fa fa-arrow-right"></span>
                             </button>
                         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -12,12 +12,12 @@
                     </div>
                     <div class="float-right" data-ng-show="$ctrl.isAtEditorEntry()">
                         <div class="btn-group" ng-form="validateGoto">
-                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1) || $ctrl.filterSortIsOn()">
+                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1) || $ctrl.filterIsOn()">
                                 <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
                             </button>
-                            <input type="number" id="goto" name="goto" class="gotoEntry" title="Enter an entry number between 1 and {{$ctrl.filteredEntries.length}}, then press enter" data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length" data-ng-model="item.value"
-                                ng-disabled="$ctrl.filterSortIsOn()" data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
-                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1) || $ctrl.filterSortIsOn()">
+                            <input type="number" id="goto" name="goto" class="gotoEntry" title="Enter an entry number between 1 and {{$ctrl.filteredEntries.length}}, then press enter" data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length"
+                                data-ng-model="item.value" data-ng-value="$ctrl.currentIndex.index" data-ng-disabled="$ctrl.filterIsOn()" data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
+                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1) || $ctrl.filterIsOn()">
                                 <span class="d-none d-lg-inline-block">Next</span> <span class="fa fa-arrow-right"></span>
                             </button>
                         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -11,13 +11,13 @@
                             <span class="d-none d-md-inline-block">List</span></a>
                     </div>
                     <div class="float-right" data-ng-show="$ctrl.isAtEditorEntry()">
-                        <div class="btn-group" ng-form="validateGoto">
-                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1) || $ctrl.filterIsOn()">
+                        <div class="btn-group" ng-form="validateGoto" ng-hide="$ctrl.entryListModifiers.filterActive()">
+                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1)">
                                 <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
                             </button>
                             <input type="number" id="goto" name="goto" class="gotoEntry" title="Enter a number and press Enter to go to that entry"
-                            data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length" data-ng-model="item.value" data-ng-value="$ctrl.currentIndex.index" data-ng-disabled="$ctrl.filterIsOn()" data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
-                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1) || $ctrl.filterIsOn()">
+                            data-ng-min="1" data-ng-max="$ctrl.filteredEntries.length === 0 ? 1 : $ctrl.filteredEntries.length" data-ng-model="item.value" data-ng-value="$ctrl.currentIndex.index" data-ng-blur="item.value = $ctrl.currentIndex.index" data-on-enter="$ctrl.gotoToEntry(item.value, validateGoto.goto.$valid)"></input>
+                            <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(1)" ng-disabled="!$ctrl.canSkipToEntry(1)">
                                 <span class="d-none d-lg-inline-block">Next</span> <span class="fa fa-arrow-right"></span>
                             </button>
                         </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -316,6 +316,12 @@ export class LexiconEditorController implements angular.IController {
     return (mod.filterBy && mod.filterBy.option) || mod.sortBy.value !== 'default' || mod.sortReverse || mod.wholeWord || mod.matchDiacritic
   }
 
+  filterSortIsOn() {
+    const mod = this.entryListModifiers;
+    let on = mod.filterBy != null && mod.filterBy.option !=null || mod.sortBy.value !== 'default' || mod.sortReverse;
+    return on;
+  }
+
   shouldShowFilterReset() {
     const modifiers = this.entryListModifiers;
     return modifiers.filterActive() || modifiers.sortBy.value !== 'default' || modifiers.sortReverse

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -469,6 +469,13 @@ export class LexiconEditorController implements angular.IController {
     this.goToEntry(id);
   }
 
+  gotoToEntry(index: number, isValid: boolean) {
+    if (isValid) {
+      let id = this.editorService.getIdInFilteredList(Number(index));
+      this.editEntryAndScroll(id);
+    }
+  }
+
   canSkipToEntry(distance: number): boolean {
     const i = this.editorService.getIndexInList(this.currentEntry.id, this.visibleEntries) + distance;
     return i >= 0 && i < this.visibleEntries.length;

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -476,6 +476,12 @@ export class LexiconEditorController implements angular.IController {
     }
   }
 
+  entryIndex(): number {
+    let id = this.currentEntry.id;
+    let index = this.editorService.getIndexInList(id, this.entries)
+    return index + 1;
+  }
+
   canSkipToEntry(distance: number): boolean {
     const i = this.editorService.getIndexInList(this.currentEntry.id, this.visibleEntries) + distance;
     return i >= 0 && i < this.visibleEntries.length;

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -473,6 +473,8 @@ export class LexiconEditorController implements angular.IController {
     if (isValid) {
       let id = this.editorService.getIdInFilteredList(Number(index));
       this.editEntryAndScroll(id);
+      let gotoElement = (<HTMLInputElement>document.getElementById('goto'));
+      gotoElement.value = '';
     }
   }
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -321,12 +321,6 @@ export class LexiconEditorController implements angular.IController {
     return (mod.filterBy && mod.filterBy.option) || mod.sortBy.value !== 'default' || mod.sortReverse || mod.wholeWord || mod.matchDiacritic
   }
 
-  filterIsOn() {
-    const mod = this.entryListModifiers;
-    let on = mod.filterBy != null && mod.filterBy.option !=null;
-    return on;
-  }
-
   shouldShowFilterReset() {
     const modifiers = this.entryListModifiers;
     return modifiers.filterActive() || modifiers.sortBy.value !== 'default' || modifiers.sortReverse

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -49,6 +49,11 @@ export class LexiconEditorController implements angular.IController {
 
   lastSavedDate = new Date();
   currentEntry: LexEntry = new LexEntry();
+
+  currentIndex = {
+    index: -1
+  }
+
   commentContext = {
     contextGuid: ''
   };
@@ -316,9 +321,9 @@ export class LexiconEditorController implements angular.IController {
     return (mod.filterBy && mod.filterBy.option) || mod.sortBy.value !== 'default' || mod.sortReverse || mod.wholeWord || mod.matchDiacritic
   }
 
-  filterSortIsOn() {
+  filterIsOn() {
     const mod = this.entryListModifiers;
-    let on = mod.filterBy != null && mod.filterBy.option !=null || mod.sortBy.value !== 'default' || mod.sortReverse;
+    let on = mod.filterBy != null && mod.filterBy.option !=null;
     return on;
   }
 
@@ -479,15 +484,14 @@ export class LexiconEditorController implements angular.IController {
     if (isValid) {
       let id = this.editorService.getIdInFilteredList(Number(index));
       this.editEntryAndScroll(id);
-      let gotoElement = (<HTMLInputElement>document.getElementById('goto'));
-      gotoElement.value = '';
     }
   }
 
   entryIndex(): number {
     let id = this.currentEntry.id;
     let index = this.editorService.getIndexInList(id, this.entries)
-    return index + 1;
+    this.currentIndex.index = index + 1;
+    return this.currentIndex.index;
   }
 
   canSkipToEntry(distance: number): boolean {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
@@ -13,7 +13,7 @@
             <div class="comment-bubble-entry">
                 <comment-bubble control="$ctrl.control" field="$ctrl.fieldName" model="$ctrl.model" parent-context-guid="$ctrl.contextGuid"></comment-bubble>
             </div>
-            &nbsp;Entry
+            &nbsp;Entry, Number: {{$ctrl.entryIndex}}
         </div>
         <div class="card-body">
             <dc-fieldrepeat config="$ctrl.config" model="$ctrl.model" control="$ctrl.control" parent-context-guid="$ctrl.contextGuid"></dc-fieldrepeat>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
@@ -13,7 +13,7 @@
             <div class="comment-bubble-entry">
                 <comment-bubble control="$ctrl.control" field="$ctrl.fieldName" model="$ctrl.model" parent-context-guid="$ctrl.contextGuid"></comment-bubble>
             </div>
-            &nbsp;Entry, Number: {{$ctrl.entryIndex}}
+            &nbsp;Entry
         </div>
         <div class="card-body">
             <dc-fieldrepeat config="$ctrl.config" model="$ctrl.model" control="$ctrl.control" parent-context-guid="$ctrl.contextGuid"></dc-fieldrepeat>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
@@ -7,10 +7,15 @@ import {LexSense} from '../../shared/model/lex-sense.model';
 import {LexConfigFieldList} from '../../shared/model/lexicon-config.model';
 import {FieldControl} from './field-control.model';
 
+import {
+  EditorDataService
+} from '../../../../bellows/core/offline/editor-data.service';
+
 export class FieldEntryController implements angular.IController {
   model: LexEntry;
   config: LexConfigFieldList;
   control: FieldControl;
+  entryIndex: number;
 
   contextGuid: string = '';
   fieldName: string = 'entry';
@@ -83,7 +88,8 @@ export const FieldEntryComponent: angular.IComponentOptions = {
   bindings: {
     model: '=',
     config: '<',
-    control: '<'
+    control: '<',
+    entryIndex: '<'
   },
   controller: FieldEntryController,
   templateUrl: '/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html'

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
@@ -6,11 +6,6 @@ import {LexEntry} from '../../shared/model/lex-entry.model';
 import {LexSense} from '../../shared/model/lex-sense.model';
 import {LexConfigFieldList} from '../../shared/model/lexicon-config.model';
 import {FieldControl} from './field-control.model';
-
-import {
-  EditorDataService
-} from '../../../../bellows/core/offline/editor-data.service';
-
 export class FieldEntryController implements angular.IController {
   model: LexEntry;
   config: LexConfigFieldList;


### PR DESCRIPTION
## Description
This PR will allow users to enter an index number to move focus to an entry. With the below features.
 Should display the current entry's index number (1-based)
 Should be editable
 Should protect against invalid input, including numbers out of range (revert to current entry number)
 Upon user typing valid entry number, should navigate to that entry
 For desktop and mobile.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- New feature (non-breaking change which adds functionality)
- UI change

## Screenshots

![Peek 2021-10-09 08-12](https://user-images.githubusercontent.com/7799495/136663995-0486c5d7-74ea-423b-bb0c-4ef81da2b2a2.gif)

## How Has This Been Tested?
- [ ] Enter an entry index
- [ ] Change filter
- [ ] Change focus in list

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
