### PR TITLE
Use GH for release notes

### DIFF
--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -24,7 +24,7 @@
                             <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge/how-to">Tutorials and How-Tos</a>
                             <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge">Community Support</a>
                             <a class="dropdown-item" target="_blank" href="mailto:issues@languageforge.org">Report a Problem<br />(email issues@languageforge.org)</a>
-                            <a class="dropdown-item" href="/releasenotes">Release Notes</a>
+                            <a class="dropdown-item" target="_blank" href="https://github.com/sillsdev/web-languageforge/releases">What's new in the app?</a>
                         </div>
                     </li>
                     <li class="nav-item dropdown" uib-dropdown>


### PR DESCRIPTION
## Description

Release notes were being maintained in a separate file which added overhead to our deployment processes.

### Type of Change

- UI change

## Screenshots

![image](https://user-images.githubusercontent.com/4412848/137375433-7d2af143-5448-4239-806a-66eebd150787.png)

## How Has This Been Tested?

- [x] Opened Help menu and confirmed wording had changed.
- [x] Clicked on link and verified the GH release page was pulled up in a new tab

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
