### PR TITLE
update YouTube video on home page (remove beta label)

### DIFF
--- a/src/Site/views/languageforge/theme/default/page/home/index.html.twig
+++ b/src/Site/views/languageforge/theme/default/page/home/index.html.twig
@@ -120,7 +120,7 @@
         <h2>See For Yourself</h2>
         <div class="outerVideoWrapper">
             <div class="videoWrapper">
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/wzQMsxOYauM?rel=0&showinfo=0" frameborder="0" allowfullscreen></iframe>
+                <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/jWWZadUNi5g?controls=0&rel=0&showinfo=0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
         </div>
         <ul class="actions">


### PR DESCRIPTION
## Description

This updates the YouTube video on the home page with a modified version of the 2016 LF video that does not have the beta label.

I also updated the YouTube embed code to the latest that YouTube recommends via their "share" dialog.

The new video is public on YouTube at https://www.youtube.com/watch?v=jWWZadUNi5g

Fixes #1234  (love the magic issue number on this one!)

### Type of Change

- static content change (youtube link)


![image](https://user-images.githubusercontent.com/3444521/139789275-8792660d-cc97-496f-a7ed-941ef0a43be4.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
