### PR TITLE
Add two tests for renaming custom fields

### DIFF
--- a/test/php/model/languageforge/lexicon/command/LexProjectCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexProjectCommandsTest.php
@@ -144,7 +144,7 @@ class LexProjectCommandsTest extends TestCase
                 'fieldType' => $viewFieldConfig->type
             ]
         ];
-        $mangerRoleViewFieldCount = $project->config->roleViews[LexRoles::MANAGER]->fields->count();
+        $managerRoleViewFieldCount = $project->config->roleViews[LexRoles::MANAGER]->fields->count();
         $customFieldNameToDelete = 'customField_senses_testOptionList';
         $viewFieldConfig = new LexViewFieldConfig();
         $viewFieldConfig->type = 'ReferenceAtom';
@@ -158,7 +158,7 @@ class LexProjectCommandsTest extends TestCase
         // verify
         $this->assertEquals($projectId, $result);
         $project2 = new LexProjectModel($projectId);
-        $this->assertEquals($mangerRoleViewFieldCount + 1,
+        $this->assertEquals($managerRoleViewFieldCount + 1,
             $project2->config->roleViews[LexRoles::MANAGER]->fields->count());
         $this->assertArrayNotHasKey($customFieldNameToDelete, $project2->config->roleViews[LexRoles::MANAGER]->fields);
         $customFieldCreated = $project2->config->roleViews[LexRoles::MANAGER]->fields[$customFieldNameToCreate];
@@ -238,7 +238,7 @@ class LexProjectCommandsTest extends TestCase
                 'fieldType' => 'MultiUnicode'
             ]
         ];
-        $mangerRoleViewFieldCount = $project->config->roleViews[LexRoles::MANAGER]->fields->count();
+        $managerRoleViewFieldCount = $project->config->roleViews[LexRoles::MANAGER]->fields->count();
         $projectId = $project->write();
         $this->assertFalse($project->config->roleViews[LexRoles::MANAGER]->fields[$customFieldNameExisting]->show);
 
@@ -261,7 +261,7 @@ class LexProjectCommandsTest extends TestCase
         // verify
         $this->assertEquals($projectId, $result);
         $project2 = new LexProjectModel($projectId);
-        $this->assertEquals($mangerRoleViewFieldCount,
+        $this->assertEquals($managerRoleViewFieldCount,
             $project2->config->roleViews[LexRoles::MANAGER]->fields->count());
         $this->assertArrayNotHasKey($customFieldNameExisting, $project2->config->roleViews[LexRoles::MANAGER]->fields);
         $customFieldRenamed = $project2->config->roleViews[LexRoles::MANAGER]->fields[$customFieldNameRenamed];

--- a/test/php/model/languageforge/lexicon/command/LexProjectCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexProjectCommandsTest.php
@@ -219,4 +219,63 @@ class LexProjectCommandsTest extends TestCase
         $customField1 = $project2->config->roleViews[LexRoles::MANAGER]->fields[$customFieldName];
         $this->assertTrue(is_a($customField1, 'Api\Model\Languageforge\Lexicon\Config\LexViewFieldConfig'));
     }
+
+    private function runCustomFieldRenameTest($newName) {
+        $environ = new LexiconMongoTestEnvironment();
+        $environ->clean();
+
+        // setup: 1 example custom field (existing), 1 in senses (to delete), 1 in entry (to create)
+        $project = $environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
+        $customFieldNameExisting = 'customField_examples_testOptionList';
+        $viewFieldConfig = new LexViewFieldConfig();
+        $viewFieldConfig->type = 'MultiUnicode';
+        $viewFieldConfig->show = false;
+        $project->config->roleViews[LexRoles::MANAGER]->fields[$customFieldNameExisting] = $viewFieldConfig;
+        $customFieldNameToCreate = 'customField_entry_testMultiText';
+        $customFieldSpecs = [
+            [
+                'fieldName' => $customFieldNameExisting,
+                'fieldType' => 'MultiUnicode'
+            ]
+        ];
+        $mangerRoleViewFieldCount = $project->config->roleViews[LexRoles::MANAGER]->fields->count();
+        $projectId = $project->write();
+        $this->assertFalse($project->config->roleViews[LexRoles::MANAGER]->fields[$customFieldNameExisting]->show);
+
+        $result1 = LexProjectCommands::updateCustomFieldViews($project->projectCode, $customFieldSpecs);
+        $project1 = new LexProjectModel($projectId);
+        $customFieldExisting = $project1->config->roleViews[LexRoles::MANAGER]->fields[$customFieldNameExisting];
+        $this->assertEquals('MultiUnicode', $customFieldExisting->type);
+
+        $customFieldNameRenamed = $newName;
+        $customFieldSpecs = [
+            [
+                'fieldName' => $customFieldNameRenamed,
+                'fieldType' => 'MultiUnicode'
+            ]
+        ];
+
+        // execute
+        $result = LexProjectCommands::updateCustomFieldViews($project->projectCode, $customFieldSpecs);
+
+        // verify
+        $this->assertEquals($projectId, $result);
+        $project2 = new LexProjectModel($projectId);
+        $this->assertEquals($mangerRoleViewFieldCount,
+            $project2->config->roleViews[LexRoles::MANAGER]->fields->count());
+        $this->assertArrayNotHasKey($customFieldNameExisting, $project2->config->roleViews[LexRoles::MANAGER]->fields);
+        $customFieldRenamed = $project2->config->roleViews[LexRoles::MANAGER]->fields[$customFieldNameRenamed];
+        $this->assertEquals('multitext', $customFieldRenamed->type);
+        $this->assertTrue($customFieldRenamed->show); // Managers see all custom fields
+    }
+
+    public function testCreateCustomFieldsViews_RenameCustomFieldView_RenamesInRoleViewAndUserView()
+    {
+        $this->runCustomFieldRenameTest('customField_entry_testMultiText_renamed');
+    }
+
+    public function testCreateCustomFieldsViews_RenameCustomFieldViewWithUnicodeCharacters_RenamesInRoleViewAndUserView()
+    {
+        $this->runCustomFieldRenameTest('customField_entry_🍿popcorn');  // Astral-plane character to try to break things
+    }
 }


### PR DESCRIPTION
## Description

This is a regression test for one project where a custom field was renamed and its roleViews did not get updated correctly.

Fixes #1236

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This PR adds two regression tests to try to prevent #1228 from happening again. It's been tested by, well, running the unit tests (`make unit-tests`). :grin: 

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
