### PR TITLE
Ignore diacritics by default when searching

### DIFF
--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -475,7 +475,7 @@ export class EditorDataService {
         if (isSemanticDomain && this.semanticDomainsMatch(val, rawQuery)) {
           found = true;
         } else {
-          const normalizedValue = this.entryListModifiers.matchDiacritic ? val : this.normalizeDiacritics(val)
+          const normalizedValue = this.entryListModifiers.matchDiacritic ? val : this.removeDiacritics(val)
 
           if (queryRegex.test(normalizedValue)) {
             found = true;

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -45,6 +45,7 @@ class EntryListModifiers {
   sortOptions: SortOption[] = [];
   sortReverse = false;
   wholeWord = false;
+  matchDiacritic = false;
   filterBy: {
     text: string;
     option: FilterOption;

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -456,9 +456,7 @@ export class EditorDataService {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes
     // https://unicode.org/reports/tr44/#Diacritic
-
     // https://stackoverflow.com/a/37511463/10818013
-
 
     return input.normalize('NFD').replace(/\p{Diacritic}/gu, '')
   }

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -466,7 +466,7 @@ export class EditorDataService {
   private entryMeetsFilterCriteria(config: any, entry: LexEntry): boolean {
     if (this.entryListModifiers.filterText() !== '') {
       const rawQuery = this.entryListModifiers.filterText()
-      const normalizedQuery = this.entryListModifiers.matchDiacritic ? rawQuery : this.normalizeDiacritics(rawQuery);
+      const normalizedQuery = this.entryListModifiers.matchDiacritic ? rawQuery : this.removeDiacritics(rawQuery);
       const regexSafeQuery = this.escapeRegex(normalizedQuery);
       const queryRegex = new RegExp(this.entryListModifiers.wholeWord ? `\\b${regexSafeQuery}\\b` : regexSafeQuery, 'i');
       let found = false;

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -451,7 +451,7 @@ export class EditorDataService {
     return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matche
   }
 
-  private normalizeDiacritics(input: string) {
+  private removeDiacritics(input: string) {
     // refs:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes

--- a/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-entry.view.html
@@ -70,15 +70,20 @@
                                 <div class="form-group sortfilter-form">
                                     <label class="font-weight-bold" for="sortEntriesBy">Advanced</label>
 
-                                    <section class="d-flex justify-content-around">
-                                        <label>
+                                    <section class="d-flex flex-wrap">
+                                        <label class="mr-3">
                                             <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse" class="align-middle">
                                             <span class="align-middle pl-1">Reverse</span>
                                         </label>
-    
-                                        <label>
+
+                                        <label class="mr-3">
                                             <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.wholeWord" class="align-middle">
                                             <span class="align-middle pl-1">Whole word</span>
+                                        </label>
+
+                                        <label class="mr-3">
+                                            <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.matchDiacritic" class="align-middle">
+                                            <span class="align-middle pl-1">Match diacritics</span>
                                         </label>
                                     </section>
                                 </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -71,15 +71,20 @@
                             <div class="sortfilter-form h-100">
                                 <label class="font-weight-bold">Advanced</label>
 
-                                <section class="d-flex justify-content-around">
-                                    <label>
+                                <section class="d-flex flex-wrap">
+                                    <label class="mr-3">
                                         <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.sortReverse" class="align-middle">
                                         <span class="align-middle pl-1">Reverse</span>
                                     </label>
 
-                                    <label>
+                                    <label class="mr-3">
                                         <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.wholeWord" class="align-middle">
                                         <span class="align-middle pl-1">Whole word</span>
+                                    </label>
+
+                                    <label>
+                                        <input type="checkbox" data-ng-change="$ctrl.filterAndSortEntries()" data-ng-model="$ctrl.entryListModifiers.matchDiacritic" class="align-middle">
+                                        <span class="align-middle pl-1">Match diacritics</span>
                                     </label>
                                 </section>
                             </div>

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -232,6 +232,7 @@ export class LexiconEditorController implements angular.IController {
       filterText: this.$state.params.filterText,
       sortReverse: this.$state.params.sortReverse,
       wholeWord: this.$state.params.wholeWord,
+      matchDiacritic: this.$state.params.matchDiacritic,
       filterType: this.$state.params.filterType,
       filterBy: this.$state.params.filterBy
     }, { notify: true });
@@ -270,6 +271,7 @@ export class LexiconEditorController implements angular.IController {
       }
       this.entryListModifiers.sortReverse = this.$state.params.sortReverse === 'true';
       this.entryListModifiers.wholeWord = this.$state.params.wholeWord === 'true';
+      this.entryListModifiers.matchDiacritic = this.$state.params.matchDiacritic === 'true';
 
       if (this.$state.params.filterType) {
         this.entryListModifiers.filterType = this.$state.params.filterType;
@@ -299,6 +301,7 @@ export class LexiconEditorController implements angular.IController {
       filterText: this.entryListModifiers.filterText(),
       sortReverse: this.entryListModifiers.sortReverse,
       wholeWord: this.entryListModifiers.wholeWord,
+      matchDiacritic: this.entryListModifiers.matchDiacritic,
       filterType: this.entryListModifiers.filterType,
       filterBy: this.entryListModifiers.filterByLabel()
     }, { notify: false });
@@ -307,7 +310,7 @@ export class LexiconEditorController implements angular.IController {
 
   filterOptionsActive() {
     const mod = this.entryListModifiers;
-    return (mod.filterBy && mod.filterBy.option) || mod.sortBy.value !== 'default' || mod.sortReverse || mod.wholeWord
+    return (mod.filterBy && mod.filterBy.option) || mod.sortBy.value !== 'default' || mod.sortReverse || mod.wholeWord || mod.matchDiacritic
   }
 
   shouldShowFilterReset() {
@@ -318,6 +321,7 @@ export class LexiconEditorController implements angular.IController {
   resetEntryListFilter(): void {
     this.entryListModifiers.filterBy = null;
     this.entryListModifiers.wholeWord = false;
+    this.entryListModifiers.matchDiacritic = false;
 
     this.filterAndSortEntries();
   }
@@ -921,6 +925,7 @@ export class LexiconEditorController implements angular.IController {
         filterText: this.entryListModifiers.filterText(),
         sortReverse: this.entryListModifiers.sortReverse,
         wholeWord: this.entryListModifiers.wholeWord,
+        matchDiacritic: this.entryListModifiers.matchDiacritic,
         filterType: this.entryListModifiers.filterType,
         filterBy: this.entryListModifiers.filterByLabel()
       }, { notify: false });
@@ -931,6 +936,7 @@ export class LexiconEditorController implements angular.IController {
         filterText: this.$state.params.filterText,
         sortReverse: this.$state.params.sortReverse,
         wholeWord: this.$state.params.wholeWord,
+        matchDiacritic: this.$state.params.matchDiacritic,
         filterType: this.$state.params.filterType,
         filterBy: this.$state.params.filterBy
       });
@@ -1245,7 +1251,7 @@ export class LexiconEditorController implements angular.IController {
   private static scrollDivToId(containerId: string, divId: string, posOffset: number = 0): void {
     const $containerDiv: any = $(containerId)
     const $div: any = $(divId)[0];
-    
+
     if ($div && $containerDiv.scrollTop) {
       let offsetTop: number = $div.offsetTop - posOffset;
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.module.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.module.ts
@@ -43,12 +43,12 @@ export const LexiconEditorModule = angular
                             lec-rights="$ctrl.rights"></lexicon-editor>`
       })
       .state('editor.list', {
-        url: '/list?sortBy&filterText&sortReverse&wholeWord&filterType&filterBy',
+        url: '/list?sortBy&filterText&sortReverse&wholeWord&matchDiacritic&filterType&filterBy',
         templateUrl: '/angular-app/languageforge/lexicon/editor/editor-list.view.html',
         controller: 'EditorListCtrl'
       })
       .state('editor.entry', {
-        url: '/entry/{entryId:[0-9a-z_]{6,24}}?sortBy&filterText&sortReverse&wholeWord&filterType&filterBy',
+        url: '/entry/{entryId:[0-9a-z_]{6,24}}?sortBy&filterText&sortReverse&wholeWord&matchDiacritic&filterType&filterBy',
         templateUrl: '/angular-app/languageforge/lexicon/editor/editor-entry.view.html',
         controller: 'EditorEntryCtrl'
       })

--- a/src/angular-app/languageforge/lexicon/lexicon-app.module.ts
+++ b/src/angular-app/languageforge/lexicon/lexicon-app.module.ts
@@ -37,7 +37,7 @@ export const LexiconAppModule = angular
       // this is needed to allow style="font-family" on ng-bind-html elements
       $sanitizeProvider.addValidAttrs(['style']);
 
-      $urlRouterProvider.otherwise('/editor/list?sortBy=Default&sortReverse=false&wholeWord=false&filterType=isNotEmpty&filterBy=null');
+      $urlRouterProvider.otherwise('/editor/list?sortBy=Default&sortReverse=false&wholeWord=false&matchDiacritic=false&filterType=isNotEmpty&filterBy=null');
 
       // State machine from ui.router
       $stateProvider


### PR DESCRIPTION
## Description

This feature will change the default search to include "diacritic-agnostic" results.  It will also add a new advanced option allowing users to narrow results based on diacritics.

Fixes #1114 

### Type of Change

- New feature (non-breaking change which adds functionality)
- UI change

## Screenshots

Provided with test cases below

## How Has This Been Tested?

Project used for testing (5491 entries):  [Alex's project.zip](https://github.com/sillsdev/web-languageforge/files/7412915/Alex.s.project.zip)

### Functional testing (should work the same in both list and entry view)

- [x] Searching for `chaca` or `CHACA` should result in 124 matches with no advanced options selected

![image](https://user-images.githubusercontent.com/4412848/140990945-3827e51e-86d4-4c27-9052-4b3864f1323a.png)

- [x] Searching for `chaca` or `CHACA` should result in 90 matches when "matching diacritics"

![image](https://user-images.githubusercontent.com/4412848/140991058-8b902c31-e895-48d7-8720-81cf44176eba.png)

- [x] Searching for `chacä` or `CHACÄ` should result in 124 matches with no advanced options selected

![image](https://user-images.githubusercontent.com/4412848/140991411-aa31c04c-2392-4636-a234-7e4c349ba3e6.png)

- [x] Searching for `chacä` or `CHACÄ` should result in 9 matches when "matching diacritics"

![image](https://user-images.githubusercontent.com/4412848/140991508-7f323d8f-c209-451e-a0cb-f1122f3facc0.png)

- [x] Searching for `chacå` or `CHACÅ` should result in 124 matches with no advanced options selected

![image](https://user-images.githubusercontent.com/4412848/140991689-e0a932f8-b28f-4d04-a67b-a7c2f8981629.png)

- [x] Searching for `chacå` or `CHACÅ` should result in 0 matches when "matching diacritics"

![image](https://user-images.githubusercontent.com/4412848/140991801-2ef3b5bb-4b3f-431d-88fd-7b657fd37f0b.png)

- [x] Checking the "Match diacritics" option should cause the "Options" changed indicator to appear

![image](https://user-images.githubusercontent.com/4412848/140992057-0f552f29-98c9-4f72-80ea-54345ca24ee7.png)

- [x] see #1229 for more regression tests

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
