### PR TITLE
Optimize app Dockerfile with npm cache

### DIFF
--- a/.github/workflows/build-and-publish-npm-cache.yml
+++ b/.github/workflows/build-and-publish-npm-cache.yml
@@ -1,0 +1,29 @@
+name: Build and publish an NPM cache image
+
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
+on:
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE: sillsdev/web-languageforge:npm-cache
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build and tag cache image
+        run: docker build -t ${{ env.IMAGE }} -f docker/npm-cache/Dockerfile .
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Publish image
+        run: |
+          docker push ${{ env.IMAGE }}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -57,3 +57,4 @@ clean-volumes:
 .PHONY: clean-powerwash
 clean-powerwash: clean-volumes
 	docker-compose down --rmi all
+	docker rmi -f lf-npm-cache:npm-cache

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p /data
 WORKDIR /data
 
 # copy npm cache directory; as optimization for npm install
-COPY --from=megahirt/web-languageforge:npm-cache /root/.npm /root/.npm
+COPY --from=sillsdev/web-languageforge:npm-cache /root/.npm /root/.npm
 
 # unsafe-perm true is required to work around an npm bug since we are running as root, have a git+HTTPS repo source and it has a `prepare` script (perfect storm).
 # see https://github.com/npm/npm/issues/17346

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -10,6 +10,9 @@ RUN npm config set unsafe-perm true && npm install -g npm@7.6.3
 RUN mkdir -p /data
 WORKDIR /data
 
+# copy npm cache directory; as optimization for npm install
+COPY --from=megahirt/web-languageforge:npm-cache /root/.npm /root/.npm
+
 # unsafe-perm true is required to work around an npm bug since we are running as root, have a git+HTTPS repo source and it has a `prepare` script (perfect storm).
 # see https://github.com/npm/npm/issues/17346
 COPY package.json package-lock.json ./
@@ -20,12 +23,11 @@ COPY typings ./typings/
 COPY webpack.config.js webpack-dev.config.js webpack-prd.config.js tsconfig.json tslint.json ./
 
 # copy in src local files
+# Note: *.html files in src/angular-app aren't necessary for webpack compilation, however changes to HTML files will invalidate this layer
 COPY src/angular-app ./src/angular-app
-COPY src/appManifest ./src/appManifest
-COPY src/js ./src/js
-COPY src/json ./src/json
 COPY src/sass ./src/sass
-COPY src/Site/views ./src/Site/views
+COPY src/Site/views/languageforge/theme/default/sass/ ./src/Site/views/languageforge/theme/default/sass
+COPY src/Site/views/shared/*.scss ./src/Site/views/shared/
 
 FROM ui-builder-base AS production-ui-builder
 ENV NPM_BUILD_SUFFIX=prd

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -13,14 +13,13 @@ WORKDIR /data
 # copy npm cache directory; as optimization for npm install
 COPY --from=sillsdev/web-languageforge:npm-cache /root/.npm /root/.npm
 
-# unsafe-perm true is required to work around an npm bug since we are running as root, have a git+HTTPS repo source and it has a `prepare` script (perfect storm).
-# see https://github.com/npm/npm/issues/17346
-COPY package.json package-lock.json ./
-RUN npm config set unsafe-perm true && npm install --legacy-peer-deps
-
 # Copy in files needed for compilation, located in the repo root
 COPY typings ./typings/
-COPY webpack.config.js webpack-dev.config.js webpack-prd.config.js tsconfig.json tslint.json ./
+COPY package.json package-lock.json webpack.config.js webpack-dev.config.js webpack-prd.config.js tsconfig.json tslint.json ./
+
+# unsafe-perm true is required to work around an npm bug since we are running as root, have a git+HTTPS repo source and it has a `prepare` script (perfect storm).
+# see https://github.com/npm/npm/issues/17346
+RUN npm config set unsafe-perm true && npm install --legacy-peer-deps
 
 # copy in src local files
 # Note: *.html files in src/angular-app aren't necessary for webpack compilation, however changes to HTML files will invalidate this layer

--- a/docker/npm-cache/Dockerfile
+++ b/docker/npm-cache/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:14.16.1-alpine3.11
+COPY package.json package-lock.json ./
+RUN npm config set unsafe-perm true && npm install -g npm@7.6.3
+RUN npm config set unsafe-perm true && npm install --legacy-peer-deps


### PR DESCRIPTION
## Description

This PR is intended to be merged after Billy's service-worker PR.  It probably won't pass tests until it is merged.

This PR optimizes the build time of `docker-compose build app` in the following ways:

1. It utilizes an npm cache image to reduce/eliminate having to download npm packages from the internet.  As we update our dependencies, this npm cache image will slowly provide less performance value.  For now, it provides about a 50% speed increase in `npm install` time.
2. It remove unnecessary COPY lines that aren't used by webpack
3. It targets the COPY src/Site/views to only copy sass files

## Performance Metrics on Chris's machine from Thailand
`docker-compose build app`

### Before This PR

package.json file change 2:47
sass file, html file, typescript file change 0:47
PHP file change 0:03
TWIG file change 0:47

### After This PR
package.json file change **1:53**
sass file, html file, typescript file change 0:47
PHP file change 0:03
TWIG file change **0:09**

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

TODO:
- publish the npm-cache image to sillsdev so it's not published under megahirt.  At this time I don't have access to push and I need help getting push access.