### PR TITLE
update to MongoDB 5.0.4

### DIFF
--- a/docker/deployment/db-deployment.yaml
+++ b/docker/deployment/db-deployment.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
       - name: db
-        image: mongo:4.0
+        image: mongo:5.0.4
         volumeMounts:
         - mountPath: /data/db
           name: data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -105,7 +105,7 @@ services:
     command: sh -c "postconf -e 'default_transport = retry:no outbound email allowed' && /run.sh"
 
   db:
-    image: mongo:4.0
+    image: mongo:5.0.4
     container_name: lf-db
     ports:
       # exposed this to host for admin tools


### PR DESCRIPTION
## Description

Our current version of MongoDB, version 4.0 was released Jule 2018 and is therefore over 3 years old.  This PR upgrades us to the latest MongoDB version 5.0.4 and pins the Docker image.  I read a bit about how an upgrade works, but I think the only way to be sure that the upgrade is successful to to test this with a full production copy on our staging server.

Note that in v5.0 the mongo shell has been renamed from `mongo` to `mongosh`

links:

https://en.wikipedia.org/wiki/MongoDB
https://docs.mongodb.com/manual/release-notes/5.0-compatibility/
### Type of Change

Only keep lines below that describe this change, then delete the rest.

- infrastructure change

## Screenshots

## How Has This Been Tested?

If the following prove successful, then we can have some confidence that it is safe to move to MongoDB v5

- [ ] E2E tests pass
- [ ] We do extensive testing in Staging with a full production dataset

