### PR TITLE
Correct scroll sync issues

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -451,7 +451,7 @@ export class LexiconEditorController implements angular.IController {
 
   editEntryAndScroll(id: string): void {
     this.editEntry(id);
-    this.scrollListToEntry(id, 'middle');
+    this.scrollListToEntry(id);
   }
 
   editEntry(id: string): void {
@@ -477,7 +477,7 @@ export class LexiconEditorController implements angular.IController {
   skipToEntry(distance: number): void {
     const i = this.editorService.getIndexInList(this.currentEntry.id, this.visibleEntries) + distance;
     this.editEntry(this.visibleEntries[i].id);
-    this.scrollListToEntry(this.visibleEntries[i].id, 'middle');
+    this.scrollListToEntry(this.visibleEntries[i].id);
   }
 
   newEntry(): void {
@@ -1218,9 +1218,7 @@ export class LexiconEditorController implements angular.IController {
     });
   }
 
-  private scrollListToEntry(id: string, position: string): void {
-    // const posOffset = (position === 'top') ? 274 : 487;
-
+  private scrollListToEntry(id: string, alignment: string = 'center'): void {
     const entryDivId = '#entryId_' + id;
     const listDivId = '#compactEntryListContainer';
     let index = this.editorService.getIndexInList(id, this.filteredEntries);
@@ -1246,37 +1244,25 @@ export class LexiconEditorController implements angular.IController {
     // It may actually not be visible at the moment because it may down inside a
     // scrolling div or scrolled off the view of the page
     if ($(listDivId).is(':visible') && $(entryDivId).is(':visible')) {
-      // LexiconEditorController.scrollDivToId(listDivId, entryDivId, posOffset);
-      LexiconEditorController.syncListEntryWithCurrentEntry(entryDivId)
+      LexiconEditorController.syncListEntryWithCurrentEntry(entryDivId, alignment)
     } else {
       // wait then try to scroll
       this.$interval(() => {
-        // LexiconEditorController.scrollDivToId(listDivId, entryDivId, posOffset);
-        LexiconEditorController.syncListEntryWithCurrentEntry(entryDivId)
+        LexiconEditorController.syncListEntryWithCurrentEntry(entryDivId, alignment)
       }, 200, 1);
     }
   }
 
-  private static syncListEntryWithCurrentEntry(elementId: string): void {
+  private static syncListEntryWithCurrentEntry(elementId: string, alignment: string = 'center'): void {
     const element = $(elementId)[0];
+    const block = alignment !== 'top' ? 'center' : 'start';
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
     element.scrollIntoView({
       behavior: 'smooth',
-      block: 'center',
+      block,
     });
   }
-
-  // private static scrollDivToId(containerId: string, divId: string, posOffset: number = 0): void {
-  //   const $containerDiv: any = $(containerId)
-  //   const $div: any = $(divId)[0];
-
-  //   if ($div && $containerDiv.scrollTop) {
-  //     let offsetTop: number = $div.offsetTop - posOffset;
-
-  //     $containerDiv.scrollTop(offsetTop > -1 ? offsetTop : 0);
-  //   }
-  // }
 
   private static entryIsNew(entry: LexEntry): boolean {
     return (entry.id && entry.id.includes('_new_'));

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -321,12 +321,14 @@ export class LexiconEditorController implements angular.IController {
     return modifiers.filterActive() || modifiers.sortBy.value !== 'default' || modifiers.sortReverse
   }
 
-  resetEntryListFilter(): void {
+  async resetEntryListFilter(): Promise<void> {
     this.entryListModifiers.filterBy = null;
     this.entryListModifiers.wholeWord = false;
     this.entryListModifiers.matchDiacritic = false;
 
-    this.filterAndSortEntries();
+    await this.filterAndSortEntries();
+
+    this.$state.reload();
   }
 
   hasUnsavedChanges(): boolean {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -477,6 +477,7 @@ export class LexiconEditorController implements angular.IController {
   skipToEntry(distance: number): void {
     const i = this.editorService.getIndexInList(this.currentEntry.id, this.visibleEntries) + distance;
     this.editEntry(this.visibleEntries[i].id);
+    this.scrollListToEntry(this.visibleEntries[i].id, 'middle');
   }
 
   newEntry(): void {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -288,15 +288,17 @@ export class LexiconEditorController implements angular.IController {
     });
   }
 
-  clearSearchText = () => {
+  clearSearchText = async () => {
     if (this.entryListModifiers.filterBy) {
       this.entryListModifiers.filterBy.text = '';
-      this.filterAndSortEntries();
+      await this.filterAndSortEntries();
+
+      this.$state.reload()
     }
   }
 
-  filterAndSortEntries(): void {
-    this.$state.go('.', {
+  async filterAndSortEntries(): Promise<void> {
+    await this.$state.go('.', {
       sortBy: this.entryListModifiers.sortBy.label,
       filterText: this.entryListModifiers.filterText(),
       sortReverse: this.entryListModifiers.sortReverse,
@@ -305,7 +307,8 @@ export class LexiconEditorController implements angular.IController {
       filterType: this.entryListModifiers.filterType,
       filterBy: this.entryListModifiers.filterByLabel()
     }, { notify: false });
-    this.editorService.filterAndSortEntries.apply(this, arguments);
+
+    return this.editorService.filterAndSortEntries(true);
   }
 
   filterOptionsActive() {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -1213,7 +1213,8 @@ export class LexiconEditorController implements angular.IController {
   }
 
   private scrollListToEntry(id: string, position: string): void {
-    const posOffset = (position === 'top') ? 274 : 487;
+    // const posOffset = (position === 'top') ? 274 : 487;
+
     const entryDivId = '#entryId_' + id;
     const listDivId = '#compactEntryListContainer';
     let index = this.editorService.getIndexInList(id, this.filteredEntries);
@@ -1239,25 +1240,37 @@ export class LexiconEditorController implements angular.IController {
     // It may actually not be visible at the moment because it may down inside a
     // scrolling div or scrolled off the view of the page
     if ($(listDivId).is(':visible') && $(entryDivId).is(':visible')) {
-      LexiconEditorController.scrollDivToId(listDivId, entryDivId, posOffset);
+      // LexiconEditorController.scrollDivToId(listDivId, entryDivId, posOffset);
+      LexiconEditorController.syncListEntryWithCurrentEntry(entryDivId)
     } else {
       // wait then try to scroll
       this.$interval(() => {
-        LexiconEditorController.scrollDivToId(listDivId, entryDivId, posOffset);
+        // LexiconEditorController.scrollDivToId(listDivId, entryDivId, posOffset);
+        LexiconEditorController.syncListEntryWithCurrentEntry(entryDivId)
       }, 200, 1);
     }
   }
 
-  private static scrollDivToId(containerId: string, divId: string, posOffset: number = 0): void {
-    const $containerDiv: any = $(containerId)
-    const $div: any = $(divId)[0];
+  private static syncListEntryWithCurrentEntry(elementId: string): void {
+    const element = $(elementId)[0];
 
-    if ($div && $containerDiv.scrollTop) {
-      let offsetTop: number = $div.offsetTop - posOffset;
-
-      $containerDiv.scrollTop(offsetTop > -1 ? offsetTop : 0);
-    }
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+    element.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
   }
+
+  // private static scrollDivToId(containerId: string, divId: string, posOffset: number = 0): void {
+  //   const $containerDiv: any = $(containerId)
+  //   const $div: any = $(divId)[0];
+
+  //   if ($div && $containerDiv.scrollTop) {
+  //     let offsetTop: number = $div.offsetTop - posOffset;
+
+  //     $containerDiv.scrollTop(offsetTop > -1 ? offsetTop : 0);
+  //   }
+  // }
 
   private static entryIsNew(entry: LexEntry): boolean {
     return (entry.id && entry.id.includes('_new_'));


### PR DESCRIPTION
## Description

There are a number of scenarios where the user can be left disoriented by the fact that the entry that is selected is not visible in the full list of entries on the left.  Some of the use cases are outlined in the comments of https://github.com/sillsdev/web-languageforge/issues/1133

Fixes #1133 Fixes #1130 Fixes #1014 

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Video's demoing the fixes are already captured in the issue comments.

## How Has This Been Tested?

- [ ] list scrolls to entry when PgUp / PgDn keyboard shortcuts are used
- [ ] list scrolls to entry when Prev / Next buttons are used
- [ ] list scrolls to entry when refreshing page on an entry that is down the list (keeping editor state)
- [ ] When clearing the filter via "show all" button, list scrolls to selected entry
- [ ] When clearing text in the search box, list scrolls to selected entry

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
