### PR TITLE
Fixed broken scroll during poor connections

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -1219,13 +1219,7 @@ export class LexiconEditorController implements angular.IController {
   }
 
   private scrollListToEntry(id: string, alignment: string = 'center'): void {
-    const entryDivId = '#entryId_' + id;
-    const listDivId = '#compactEntryListContainer';
     let index = this.editorService.getIndexInList(id, this.filteredEntries);
-
-    // make sure the item is visible in the list
-    // todo implement lazy "up" scrolling to make this more efficient
-
     // only expand the "show window" if we know that the entry is actually in
     // the entry list - a safe guard
     if (index != null) {
@@ -1239,18 +1233,16 @@ export class LexiconEditorController implements angular.IController {
       }
     }
 
-    // note: ':visible' is a JQuery invention that means 'it takes up space on
-    // the page'.
-    // It may actually not be visible at the moment because it may down inside a
-    // scrolling div or scrolled off the view of the page
-    if ($(listDivId).is(':visible') && $(entryDivId).is(':visible')) {
-      LexiconEditorController.syncListEntryWithCurrentEntry(entryDivId, alignment)
-    } else {
-      // wait then try to scroll
-      this.$interval(() => {
+    // there's a fundamental problem in this code related to synchronization and the interval is a hack to deal with it until the correct solution is found.
+    // Ideally, we would only want to try and find this entry once the list is rendered, possibly on a lifecycle hook like mounted or something, or possibly
+    // asynchronously upon data retrieval...I'm not exactly sure what's needed here, but this is a poor-man's start.
+    const entryDivId = '#entryId_' + id;
+    const interval = this.$interval(() => {
+      if ($(entryDivId)[0]) {
         LexiconEditorController.syncListEntryWithCurrentEntry(entryDivId, alignment)
-      }, 200, 1);
-    }
+        console.log(this.$interval.cancel(interval))
+      }
+    }, 200, 30); // 200ms delay, 30 tries max
   }
 
   private static syncListEntryWithCurrentEntry(elementId: string, alignment: string = 'center'): void {

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -1240,7 +1240,7 @@ export class LexiconEditorController implements angular.IController {
     const interval = this.$interval(() => {
       if ($(entryDivId)[0]) {
         LexiconEditorController.syncListEntryWithCurrentEntry(entryDivId, alignment)
-        console.log(this.$interval.cancel(interval))
+        this.$interval.cancel(interval)
       }
     }, 200, 30); // 200ms delay, 30 tries max
   }


### PR DESCRIPTION
## Description

While testing #1253 , an additional use case was found to be broken when a user has a poor connection.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Demo's included with tests below

## How Has This Been Tested?

- [x] User chooses a term deep in scroll list from the list page, then clicks on it.  The list should scroll to the selected word

https://user-images.githubusercontent.com/4412848/144872443-28284593-6f3c-4f7d-b7ab-1adf246d8126.mov

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
