### PR TITLE
Remove duplicate unit test runs on develop

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,7 +6,6 @@ on:
 
   push:
     branches:
-      - develop
       - staging
 
 jobs:


### PR DESCRIPTION
## Description

This fixes a remnant from #1268 that was overlooked and resulting in unit tests running twice when changes were pushed to `develop`


### Type of Change

- Engineering

## Screenshots

N/A

## How Has This Been Tested?

This will be tested once the PR is merged into `develop` and the GHA does not get triggered.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
