### PR TITLE
normalize search string to NFC before comparison

### DIFF
--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -457,7 +457,7 @@ export class EditorDataService {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes
     // https://unicode.org/reports/tr44/#Diacritic
     // https://stackoverflow.com/a/37511463/10818013
-
+// Convert to NFD in order to remove any code points with the property 'Diacritic', then convert back to NFC for comparison
     return input.normalize('NFD').replace(/\p{Diacritic}/gu, '').normalize('NFC');
   }
 

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -458,12 +458,12 @@ export class EditorDataService {
     // https://unicode.org/reports/tr44/#Diacritic
     // https://stackoverflow.com/a/37511463/10818013
 
-    return input.normalize('NFD').replace(/\p{Diacritic}/gu, '')
+    return input.normalize('NFD').replace(/\p{Diacritic}/gu, '').normalize('NFC');
   }
 
   private entryMeetsFilterCriteria(config: any, entry: LexEntry): boolean {
     if (this.entryListModifiers.filterText() !== '') {
-      const rawQuery = this.entryListModifiers.filterText()
+      const rawQuery = this.entryListModifiers.filterText().normalize('NFC');
       const normalizedQuery = this.entryListModifiers.matchDiacritic ? rawQuery : this.removeDiacritics(rawQuery);
       const regexSafeQuery = this.escapeRegex(normalizedQuery);
       const queryRegex = new RegExp(this.entryListModifiers.wholeWord ? `\\b${regexSafeQuery}\\b` : regexSafeQuery, 'i');


### PR DESCRIPTION
## Description

Normalize the search string to NFC since all data in LF is normalized to NFC on disk.  This allows for exact match or ignore diacritic queries to work regardless of form or language, e.g. Korean.

A note about this fix:
- All data is normalized to NFC in the database on write.  It's been this way for years.
- @longrunningprocess 's addition in #1243 normalized the query to NFD for the purposes of removing diacritics from the data and query.  This a fine approach.
- This PR could have chosen to normalize all data to NFD for comparison under all circumstances given the second point above, however I chose to stick with NFC since that is what the data is underneath.  Either way works.

Fixes #1244

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Tests and Test Data

Consider the single Korean character below:

**감=감**

To the left of the equals sign is the NFC single composed character.  To the right is the NFD decomposed form (3 code points).  They are canonically equivalent and should display identically where Korean is properly supported.  Interestingly, my Windows machine isn't rendering the NFD portion correctly, as seen in the character identifier screenshot below.  My web browser displays it just fine, as you see it in this PR description.
![image](https://user-images.githubusercontent.com/3444521/148718294-e59dc0fa-b4ce-43f6-9191-c5b67ea6ee02.png)

### Test 1 - Query match with "match diacritics"
Steps:
1. Paste the NFC character 감 (left side) into a LF entry data field
2. Do a search using the NFC character 감 to verify a match
3. Do a search using the NFD characters 감 to verify a match  (**currently this fails on production**)

### Test 2 - Query match with "ignore diacritics" (default behavior)
Steps:
1. Paste the NFC character 감 (left side) into a LF entry data field
2. Do a search using the NFC character 감 to verify a match
3. Do a search using the NFD characters 감 to verify a match

### Screencast demo from this branch
![Animation2](https://user-images.githubusercontent.com/3444521/148749119-e8c459bb-1a4f-4d8a-8875-d8c88ea0acb9.gif)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The tests above demonstrate my fix is effective or that my feature works
