### PR TITLE
Attempting to speed up app builds

### DIFF
--- a/.github/workflows/build-and-publish-base-php.yml
+++ b/.github/workflows/build-and-publish-base-php.yml
@@ -1,0 +1,29 @@
+name: Build and publish a base PHP image for LF
+
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
+on:
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE: sillsdev/web-languageforge:base-php
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build and tag base image
+        run: docker build -t ${{ env.IMAGE }} -f docker/base-php/Dockerfile .
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Publish image
+        run: |
+          docker push ${{ env.IMAGE }}

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -38,43 +38,10 @@ FROM ${ENVIRONMENT}-ui-builder AS ui-builder
 # artifacts built to /data/src/dist
 RUN npm run build:${NPM_BUILD_SUFFIX}
 
-# APP-BASE
-FROM sillsdev/web-languageforge:base-php AS base-app
-
-# install and configure LFMerge
-# LFMerge required apt packages
-# python - required by Mercurial (written in Python), which is bundled in the LFMerge apt package
-# lfmerge - main package, from SIL sources
-# rsyslog - lfmerge logs to rsyslog and expects this to exist
-# logrotate - TODO: is this required?
-# iputils-ping - Chorus (part of LFMerge) requires the "ping" command to be available on the command line
-RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add - \
-&& echo "deb http://linux.lsdev.sil.org/ubuntu bionic main" > /etc/apt/sources.list.d/linux-lsdev-sil-org.list \
-&& apt-get update \
-&& apt-get install --yes --no-install-recommends python lfmerge rsyslog logrotate iputils-ping \
-&& rm -rf /var/lib/apt/lists/*
-COPY docker/app/lfmerge.conf /etc/languageforge/conf/sendreceive.conf
-COPY docker/app/lfmergeqm-background.sh /
-RUN adduser www-data fieldworks \
-&& chown -R www-data:www-data /var/lib/languageforge \
-&& chmod 0755 /var/lib/languageforge \
-&& mkdir -m 02775 -p /var/www/.local \
-&& chown www-data:www-data /var/www/.local
-
-# rsyslog customizations (imklog reads kernel messages, which isn't allowed or desired in Docker containers)
-RUN sed -i '/load="imklog"/s/^/#/' /etc/rsyslog.conf
-
-# php customizations
-COPY docker/app/customizations.php.ini $PHP_INI_DIR/conf.d/
-
-# apache2 customizations
-RUN a2enmod headers rewrite
-COPY docker/app/000-default.conf /etc/apache2/sites-enabled
-
 # COMPOSER-BUILDER
 # download composer app dependencies
 # git - needed for composer install
-FROM base-app AS composer-builder
+FROM sillsdev/web-languageforge:base-php AS composer-builder
 WORKDIR /composer
 COPY src/composer.json src/composer.lock /composer/
 ENV COMPOSER_ALLOW_SUPERUSER=1
@@ -82,13 +49,13 @@ RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
     && install-php-extensions @composer && composer install
 
 # PRODUCTION IMAGE
-FROM base-app AS production-app
+FROM sillsdev/web-languageforge:base-php AS production-app
 RUN rm /usr/local/bin/install-php-extensions
 RUN apt-get remove -y gnupg2
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 
 # DEVELOPMENT IMAGE
-FROM base-app AS development-app
+FROM sillsdev/web-languageforge:base-php AS development-app
 RUN install-php-extensions xdebug
 COPY docker/app/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d
 RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -39,19 +39,7 @@ FROM ${ENVIRONMENT}-ui-builder AS ui-builder
 RUN npm run build:${NPM_BUILD_SUFFIX}
 
 # APP-BASE
-FROM php:7.3.28-apache AS base-app
-
-# install apt packages
-# p7zip-full - used by LF application for unzipping lexicon uploads
-# unzip - used by LF application for unzipping lexicon uploads
-# gnupg2 - necessary for LFMerge package installation via SIL sources (will be uninstalled in production)
-# curl - used by LF application
-RUN apt-get update && apt-get -y install p7zip-full unzip gnupg2 curl && rm -rf /var/lib/apt/lists/*
-
-# see https://github.com/mlocati/docker-php-extension-installer
-# PHP extensions required by the LF application
-COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-RUN install-php-extensions gd mongodb intl
+FROM sillsdev/web-languageforge:base-php AS base-app
 
 # install and configure LFMerge
 # LFMerge required apt packages

--- a/docker/base-php/Dockerfile
+++ b/docker/base-php/Dockerfile
@@ -1,0 +1,13 @@
+FROM php:7.3.28-apache
+
+# install apt packages
+# p7zip-full - used by LF application for unzipping lexicon uploads
+# unzip - used by LF application for unzipping lexicon uploads
+# gnupg2 - necessary for LFMerge package installation via SIL sources (will be uninstalled in production)
+# curl - used by LF application
+RUN apt-get update && apt-get -y install p7zip-full unzip gnupg2 curl && rm -rf /var/lib/apt/lists/*
+
+# see https://github.com/mlocati/docker-php-extension-installer
+# PHP extensions required by the LF application
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions gd mongodb intl

--- a/docker/base-php/Dockerfile
+++ b/docker/base-php/Dockerfile
@@ -11,3 +11,33 @@ RUN apt-get update && apt-get -y install p7zip-full unzip gnupg2 curl && rm -rf 
 # PHP extensions required by the LF application
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions gd mongodb intl
+
+# install and configure LFMerge
+# LFMerge required apt packages
+# python - required by Mercurial (written in Python), which is bundled in the LFMerge apt package
+# lfmerge - main package, from SIL sources
+# rsyslog - lfmerge logs to rsyslog and expects this to exist
+# logrotate - TODO: is this required?
+# iputils-ping - Chorus (part of LFMerge) requires the "ping" command to be available on the command line
+RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add - \
+&& echo "deb http://linux.lsdev.sil.org/ubuntu bionic main" > /etc/apt/sources.list.d/linux-lsdev-sil-org.list \
+&& apt-get update \
+&& apt-get install --yes --no-install-recommends python lfmerge rsyslog logrotate iputils-ping \
+&& rm -rf /var/lib/apt/lists/*
+COPY docker/app/lfmerge.conf /etc/languageforge/conf/sendreceive.conf
+COPY docker/app/lfmergeqm-background.sh /
+RUN adduser www-data fieldworks \
+&& chown -R www-data:www-data /var/lib/languageforge \
+&& chmod 0755 /var/lib/languageforge \
+&& mkdir -m 02775 -p /var/www/.local \
+&& chown www-data:www-data /var/www/.local
+
+# rsyslog customizations (imklog reads kernel messages, which isn't allowed or desired in Docker containers)
+RUN sed -i '/load="imklog"/s/^/#/' /etc/rsyslog.conf
+
+# php customizations
+COPY docker/app/customizations.php.ini $PHP_INI_DIR/conf.d/
+
+# apache2 customizations
+RUN a2enmod headers rewrite
+COPY docker/app/000-default.conf /etc/apache2/sites-enabled


### PR DESCRIPTION
## Description

I had been noticing `gd` and `mongodb` were compiling from source code every build (~12 minutes) but these things don't need to necessarily be built like that every time so I set out to create a "base" PHP image for LF with this PR.

### Type of Change

- Engineering change to speed up development cycles

## How Has This Been Tested?

- [x] I tested `make` and `make unit-tests` locally after ensuring an image-free environment.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
