### PR TITLE
Make unit tests build faster by basing the image off base-php instead of the full app image

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: satackey/action-docker-layer-caching@v0.0.11
 
       - name: Run unit tests
         working-directory: ./docker/

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -22,7 +22,7 @@ else
 endif
 
 .PHONY: unit-tests
-unit-tests: build
+unit-tests:
 	docker-compose build test-php
 	docker-compose run test-php
 

--- a/docker/test-php/Dockerfile
+++ b/docker/test-php/Dockerfile
@@ -1,5 +1,36 @@
-FROM lf-app:latest
+FROM sillsdev/web-languageforge:base-php
 
+
+# ----- LINES BELOW COPIED FROM APP DOCKERFILE ----------
+WORKDIR /var/www/html
+COPY src/composer.json src/composer.lock /var/www/html/
+ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
+    && install-php-extensions @composer && composer install
+
+# uncomment if you want xdebug in your local image
+#RUN install-php-extensions xdebug
+#COPY docker/app/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d
+
+RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
+COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait
+
+# copy src files into image
+COPY src /var/www/html/
+RUN ln -s /var/www/html /var/www/src
+
+# ensure correct write permissions for assets folders,
+RUN    chown -R www-data:www-data /var/www/html/assets /var/www/html/cache \
+    && chmod -R g+ws /var/www/html/assets /var/www/html/cache
+
+# patch exception handling from Symfony to actually show exceptions instead of swallowing them
+COPY docker/app/symfony-exceptions.patch /
+RUN patch -p4 -i /symfony-exceptions.patch
+
+# -------- END COPY FROM APP DOCKERFILE --------------
+
+
+# PHP test specific lines
 COPY test /var/www/test/
 COPY docker/test-php/run.sh /run.sh
 

--- a/docker/test-php/run.sh
+++ b/docker/test-php/run.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 cd /var/www/
-echo "##teamcity[importData type='junit' path='PhpUnitTests.xml']"
 src/vendor/bin/phpunit --configuration test/php/phpunit.xml --log-junit PhpUnitTests.xml


### PR DESCRIPTION
## Description

Re-architect the test-php image to be built off the base-php image for faster building and execution of unit tests.  This should get unit tests running in under 2 minutes without all the UI building happening in the full app image (not necessary for PHP unit tests)

Also, use a docker layer cache action.

Informal testing:
- before this PR: unit tests complete in 4 minutes
- this PR, without layer caching: unit tests complete in 2 minutes
- this PR, layer caching first run (create cache): 2.5 minutes
- this PR, with existing cache: 1.5 minutes 🥇 
- 
## Testing on your branch

- [x] Unit tests run correctly on my local machine
- [x] Unit tests run correctly on CI

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
