### PR TITLE
chore: lfmerge-copy-state Makefile target

### DIFF
--- a/docker/deployment/.gitignore
+++ b/docker/deployment/.gitignore
@@ -1,1 +1,3 @@
 *-current.yaml
+all_projects
+on_hold

--- a/docker/deployment/Makefile
+++ b/docker/deployment/Makefile
@@ -56,3 +56,11 @@ delete-app-assets:
 	kubectl delete pvc lf-project-assets
 delete-app-sendreceive-data:
 	kubectl delete pvc lfmerge-sendreceive-data
+
+APPPOD = $(shell kubectl get pods --selector='app=app' -o name | sed -e s'/pod\///')
+lfmerge-copy-state:
+	rm -rf all_projects/*.state on_hold/*.state
+	kubectl cp $(APPPOD):/var/lib/languageforge/lexicon/sendreceive/state all_projects
+	grep -l HOLD all_projects/*.state | wc | awk '{printf $$1; }' && echo ' projects on HOLD'
+	mkdir -p on_hold
+	for f in `grep -l HOLD all_projects/*.state`; do mv $$f on_hold; done


### PR DESCRIPTION
## Description

Add a Makefile target that copies all Send/Receive state files to the developer's machine, and then copy projects ONHOLD into a separate folder for further inspection.

This PR is intended to commit utility code that I used to conveniently get state files onto my machine for local inspection.  It is not intended as a long-term fix or implementation.  We should instead [write an email handler for whenever a project goes on HOLD](https://github.com/sillsdev/web-languageforge/issues/1189).