### PR TITLE
Fix job name for production workflows

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -7,7 +7,7 @@ on:
       - v*
 
 jobs:
-  staging:
+  production:
     if: github.event.base_ref == 'refs/heads/master'
 
     # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses


### PR DESCRIPTION
## Description
The job name for production workflows is wrong, see #1287 for details.

Fixes #1287 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Testing on your branch

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

N/A