### PR TITLE
Fix most-recently-used-entry delete bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/send-receive-with-flex.md
+++ b/.github/ISSUE_TEMPLATE/send-receive-with-flex.md
@@ -9,7 +9,7 @@ assignees: ''
 
 If your project has been put on hold and you want to keep the details of your project private, please email languageforgeissues@sil.org with the following information.
 
-The Language Forge project is run as an open-source and open-issue-tracker project, meaning that all our code and issues are publicly available on the internet.  Information you submit below should not container private or personal information.
+The Language Forge project is run as an open-source and open-issue-tracker project, meaning that all our code and issues are publicly available on the internet.  Please do not include any sensitive information (passwords, names, locations, etc.) in this issue report.
 
 
 Project name:

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -982,7 +982,7 @@ export class LexiconEditorController implements angular.IController {
 
             // see if there is a most-recently viewed entry in the cache
             await this.offlineCacheUtils.getProjectMruEntryData().then(data => {
-              if(data && data.mruEntryId){
+              if(data && data.mruEntryId && this.editorService.getIndexInList(data.mruEntryId, this.entries) != null){
                 entryId = data.mruEntryId;
               }
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -528,7 +528,7 @@ export class LexiconEditorController implements angular.IController {
         if (iShowList !== 0) {
           iShowList--;
         }
-        this.setCurrentEntry(this.visibleEntries[iShowList]);
+        this.editEntryAndScroll(this.visibleEntries[iShowList].id);
       } else {
         this.returnToList();
       }


### PR DESCRIPTION
## Description

This is a follow up PR to #1252 where during QA testing @longrunningprocess discovered a bug whereby deleting an entry caused the MRU cache and URL to not be updated, thereby creating a situation where the app could go to an invalid state.

Addresses testing and comments called out in #1252 

Also contains an unrelated tweak to a GH issue template 😁 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Testing on your branch

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce.  Please also provide relevant test data as necessary.  These instructions will be used for QA testing below.

- [x] Given a dictionary with many entries, click on an entry.  Notice the URL and entry ID.  Delete an entry, notice the URL changes to reflect where the currently selected entry (the one above it I believe).
- [x] Given a dictionary with many entries, click on an entry.  Copy the URL of the entry.  Delete the entry.  Paste in the URL you copied into the browser.  The dictionary will load the next available entry and not show an error state of a blank screen.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
