### PR TITLE
Fix bug where simultaneous edits could lose data

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -377,7 +377,7 @@ export class LexiconEditorController implements angular.IController {
       const pristineEntryForDiffing = this.removeCustomFieldsForDeltaUpdate(this.prepEntryForUpdate(this.pristineEntry));
       const diffForUpdate = isNewEntry ? undefined : {
         id: entryForUpdate.id,
-        _update_deep_diff: diff(pristineEntryForDiffing, entryForDiffing)
+        _update_deep_diff: diff(LexiconEditorController.normalizeStrings(pristineEntryForDiffing), entryForDiffing)
       };
       let entryOrDiff = isNewEntry ? entryForUpdate : diffForUpdate;
       if (!isNewEntry && this.hasArrayChange(diffForUpdate._update_deep_diff)) {


### PR DESCRIPTION
## Description

Fixes #1248.

The cause of the issue was normalization: U+0061 LATIN SMALL LETTER A followed by U+0301 COMBINING ACUTE ACCENT was in the Mongo database (for example), but what got saved into Mongo was U+00E1 LATIN SMALL LETTER A WITH ACUTE. The diff algorithm naturally compared those two as different (since it's doing a basic byte comparison on strings), and therefore a delta update was being submitted which changed á to á. Mongo was therefore writing that field's value in the database, accidentally overwriting any previous edits to that field from a different user.

The answer is to normalize the `pristineEntry` value (the value that came out of the database) before passing it to the diffing algorithm, so that it's comparing NFC to NFC. With this change, I can no longer reproduce the test case for #1248, which I was consistently reproducing before the change. So although there might be other situations that can also cause edits to be lost, I'm confident that the most mysterious one is fixed.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Testing on your branch

Wrote a Playwright test (which I've preserved in draft PR #1307) to help me reproduce the bug reliably. Once the test went from failing every time to passing every time, I knew I'd gotten the fix correct.

I haven't included the Playwright test in this PR, because the test is still quite messy. Once I get the test pared down to something neat and tidy, I'll turn #1307 into a real PR and ask for a review. But I wanted to get the bugfix merged in right away, without waiting for the E2E test to be neat and tidy, so that we can get the fix deployed to users as soon as possible.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works (tests are in PR #1307)

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
