### PR TITLE
Automatically add new issues to project board

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,0 +1,19 @@
+name: Add Issues To Project Board
+
+on: issues
+  types: opened
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Add new issues to project board
+        uses: dhruvkb/issue-projector@0.0.7
+        with:
+          ACCESS_TOKEN: ${{ github.token }}
+          ORG_NAME: sillsdev
+          PROJECT_NUMBER: 1
+          COLUMN_NAME: Backlog
+          ISSUE_TYPE: issue
+


### PR DESCRIPTION
Use dhruvkb/issue-projector@0.0.7 GA to add new issues to the project board.

This is a GA experiment - I don't know if it will work, and it can't be tested until it is merged.