### PR TITLE
Make Playwright start E2E server if needed

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -99,8 +99,9 @@ const config: PlaywrightTestConfig = {
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'sleep 1',
+    command: 'docker-compose -f docker/docker-compose.yml up app-for-playwright',
     port: 3238,
+    timeout: 15 * 1000,
     reuseExistingServer: true,
   },
 };


### PR DESCRIPTION
## Description

This allows `npx playwright test` to be run even when the E2E server is not running yet.
