### PR TITLE
Optimize creation of login storage state files

### DIFF
--- a/test/e2e/utils/globalSetup.ts
+++ b/test/e2e/utils/globalSetup.ts
@@ -5,6 +5,7 @@ import { testControl } from './jsonrpc';
 import constants from '../../app/testConstants.json';
 import { loginAs } from './login';
 import { usersToCreate } from './userFixtures';
+import * as fs from 'fs';
 
 function createUser(request: APIRequestContext, baseName: string) {
   const username = constants[`${baseName}Username`] ?? baseName;
@@ -34,9 +35,15 @@ export default async function globalSetup(config: FullConfig) {
       createUser(context.request, user);
     }
     // Now log in as each user and ensure there's a storage state saved
-    // TODO: Optimize by skipping if storage state exists and is less than N days old,
-    // where N is based on the lifetime of our login cookies in the Language Forge source
+    const sessionLifetime = 365 * 24 * 60 * 60 * 1000;  // 1 year, in milliseconds
+    const now = new Date();
+    const sessionCutoff = now.getTime() - sessionLifetime;
     for (const user of usersToCreate) {
+      const path = `${browserName}-${user}-storageState.json`;
+      if (fs.existsSync(path) && fs.statSync(path)?.ctimeMs >= sessionCutoff) {
+        // Storage state file is recent, no need to re-create it
+        continue;
+      }
       const context = await browser.newContext({ baseURL });
       const page = await context.newPage();
       await loginAs(page, user);

--- a/test/e2e/utils/globalSetup.ts
+++ b/test/e2e/utils/globalSetup.ts
@@ -47,7 +47,7 @@ export default async function globalSetup(config: FullConfig) {
       const context = await browser.newContext({ baseURL });
       const page = await context.newPage();
       await loginAs(page, user);
-      await context.storageState({ path: `${browserName}-${user}-storageState.json` });
+      await context.storageState({ path });
     }
   }
 }


### PR DESCRIPTION
We now skip creating the file if it already exists and has a creation date less than 1 year old (since that's the default lifetime of the "Remember Me" cookies that Silex creates). This means that the slowness of logging in five times through the UI (which takes about 20 seconds on a relatively fast developer machine) will only happen once per machine.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
