### PR TITLE
Tweak workflows with respect to playwright tests

### DIFF
--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -48,18 +48,23 @@ jobs:
           node-version: '16.14.0'
           cache: 'npm'
       -
-        run: npm install
+        run: npm ci
       -
         name: Build app
         run: docker-compose build --build-arg ENVIRONMENT=production --build-arg BUILD_VERSION=${{ steps.image.outputs.TAG }} app
       -
         run:  docker-compose run --rm app cat /var/www/html/build-version.txt /var/www/html/version.php
       -
-        name: Check unit tests
+        name: Unit Tests
         run: make unit-tests-ci
-      # -
-      #   name: Check e2e tests
-      #   run: make e2e-tests-ci
+      -
+        name: Setup Playwright E2E test environment
+        run: docker-compose up -d app-for-playwright
+        working-directory: docker
+      -
+        run: npx playwright install
+      -
+        run: npx playwright test
       -
         name: Log in to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -58,13 +58,11 @@ jobs:
         name: Unit Tests
         run: make unit-tests-ci
       -
-        name: Setup Playwright E2E test environment
-        run: docker-compose up -d app-for-playwright
-        working-directory: docker
-      -
-        run: npx playwright install
-      -
-        run: npx playwright test
+        name: Playwright E2E Tests
+        run: |
+          docker-compose -f docker/docker-compose.yml up -d app-for-playwright
+          npx playwright install
+          npx playwright test
       -
         name: Log in to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
       -
         uses: actions/checkout@v2
       -
-        name: Run Unit Tests
+        name: Unit Tests
         run: make unit-tests-ci
       -
         name: Publish Test Results
@@ -43,19 +43,18 @@ jobs:
           node-version: '16.14.0'
           cache: 'npm'
       -
-        run: npm ci
+        name: Build app
+        run: |
+          npm ci
+          docker-compose build app
       -
-        run: docker-compose build app
-      -
-        run: docker-compose up -d app-for-playwright
-
+        name: Playwright E2E Tests
+        working-directory: .
         # see https://playwright.dev/docs/ci#github-actions
-      -
-        run: npx playwright install
-        working-directory: .
-      -
-        run: npx playwright test
-        working-directory: .
+        run: |
+          docker-compose -f docker/docker-compose.yml up -d app-for-playwright
+          npx playwright install
+          npx playwright test
 
   # protractor-tests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,10 +48,10 @@ jobs:
         run: docker-compose build app
       -
         run: docker-compose up -d app-for-playwright
-        
+
         # see https://playwright.dev/docs/ci#github-actions
       -
-        run: npx playwright install --with-deps
+        run: npx playwright install
         working-directory: .
       -
         run: npx playwright test

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,12 +2,11 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-    "JuanCasanova.awesometypescriptproblemmatcher",
-    "msjsdiag.debugger-for-chrome",
-    "ms-vscode-remote.remote-containers",
-    "EditorConfig.editorconfig",
-    "felixfbecker.php-pack",
-    "dbaeumer.vscode-eslint",
-    "emallin.phpunit"
-	]
+        "juancasanova.awesometypescriptproblemmatcher",
+        "msjsdiag.debugger-for-chrome",
+        "ms-vscode-remote.remote-containers",
+        "editorconfig.editorconfig",
+        "dbaeumer.vscode-eslint",
+        "xdebug.php-pack"
+    ]
 }


### PR DESCRIPTION
This PR tweaks the `pull-request` and `integrate-and-deploy` workflows.

Tweaks in this PR:
- update VS Code workspace recommendation to reflect a package name change
- remove `--with-deps` from `npx playwright install` because it's appears unnecessary and is slower
- move to use `npm ci` since we're on CI - it seems to be the recommended thing to do
- add playwright tests to integrate-and-deploy workflow

A future TODO could be to restructure the integrate and deploy such that it is generic enough to be used in the PR workflow.  These two workflows are increasingly performing the same function.

**Note**: The changes to integrate-and-deploy won't actually be tested until this PR is merged.  If there's a problem with my change I'll either follow up with another PR or make a change directly on develop.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
