### PR TITLE
improve efficiency of site-traversal tests by implementing new design pattern

### DIFF
--- a/test/e2e/site-traversal.spec.ts
+++ b/test/e2e/site-traversal.spec.ts
@@ -13,19 +13,19 @@ import { UserProfilePage } from './pages/user-profile.page';
  * page traversal without testing functionality
  */
 test.describe('E2E Page Traversal', () => {
-  // let signupPage: SignupPage;
-  // let forgotPasswordPage: ForgotPasswordPage;
-  // let loginPage: LoginPage;
+  let signupPage: SignupPage;
+  let forgotPasswordPage: ForgotPasswordPage;
+  let loginPage: LoginPage;
   let changePasswordPage: ChangePasswordPage;
   let activityPage: ActivityPage;
   let projectsPage: ProjectsPage;
   let siteAdminPage: SiteAdminPage;
   let userProfilePage: UserProfilePage;
 
-  test.beforeAll(async ({ adminTab }) => {
-    // signupPage = new SignupPage(adminTab);
-    // forgotPasswordPage = new ForgotPasswordPage(adminTab);
-    // loginPage = new LoginPage(adminTab);
+  test.beforeAll(async ({ anonTab, adminTab }) => {
+    signupPage = new SignupPage(anonTab);
+    forgotPasswordPage = new ForgotPasswordPage(anonTab);
+    loginPage = new LoginPage(anonTab);
     changePasswordPage = new ChangePasswordPage(adminTab);
     activityPage = new ActivityPage(adminTab);
     projectsPage = new ProjectsPage(adminTab);
@@ -33,8 +33,7 @@ test.describe('E2E Page Traversal', () => {
     userProfilePage = new UserProfilePage(adminTab);
   })
 
-  test('Explore signup page', async ({ page }) => {
-    const signupPage = new SignupPage(page);
+  test('Explore signup page', async () => {
     await signupPage.goto();
 
     await signupPage.emailInput.fill('');
@@ -45,16 +44,14 @@ test.describe('E2E Page Traversal', () => {
     await signupPage.captcha.redTriangleButton.click();
   });
 
-  test('Explore forgot password page', async ({ page }) => {
-    const forgotPasswordPage = new ForgotPasswordPage(page);
+  test('Explore forgot password page', async () => {
     await forgotPasswordPage.goto();
 
     await forgotPasswordPage.usernameInput.fill('');
     await forgotPasswordPage.submitButton.click();
   });
 
-  test('Explore login page', async ({ page }) => {
-    const loginPage = new LoginPage(page);
+  test('Explore login page', async () => {
     await loginPage.goto();
 
     await loginPage.usernameInput.type('');

--- a/test/e2e/site-traversal.spec.ts
+++ b/test/e2e/site-traversal.spec.ts
@@ -13,6 +13,25 @@ import { UserProfilePage } from './pages/user-profile.page';
  * page traversal without testing functionality
  */
 test.describe('E2E Page Traversal', () => {
+  // let signupPage: SignupPage;
+  // let forgotPasswordPage: ForgotPasswordPage;
+  // let loginPage: LoginPage;
+  let changePasswordPage: ChangePasswordPage;
+  let activityPage: ActivityPage;
+  let projectsPage: ProjectsPage;
+  let siteAdminPage: SiteAdminPage;
+  let userProfilePage: UserProfilePage;
+
+  test.beforeAll(async ({ adminTab }) => {
+    // signupPage = new SignupPage(adminTab);
+    // forgotPasswordPage = new ForgotPasswordPage(adminTab);
+    // loginPage = new LoginPage(adminTab);
+    changePasswordPage = new ChangePasswordPage(adminTab);
+    activityPage = new ActivityPage(adminTab);
+    projectsPage = new ProjectsPage(adminTab);
+    siteAdminPage = new SiteAdminPage(adminTab);
+    userProfilePage = new UserProfilePage(adminTab);
+  })
 
   test('Explore signup page', async ({ page }) => {
     const signupPage = new SignupPage(page);
@@ -43,8 +62,7 @@ test.describe('E2E Page Traversal', () => {
     await loginPage.submitButton.click();
   });
 
-  test('Explore change passsword page (admin)', async ({ adminTab }) => {
-    const changePasswordPage = new ChangePasswordPage(adminTab);
+  test('Explore change passsword page (admin)', async () => {
     await changePasswordPage.goto();
 
     await changePasswordPage.passwordInput.type('');
@@ -52,15 +70,13 @@ test.describe('E2E Page Traversal', () => {
     await expect(changePasswordPage.submitButton).toBeDisabled();
   });
 
-  test('Explore activity page (admin)', async ({ adminTab }) => {
-    const activityPage = new ActivityPage(adminTab);
+  test('Explore activity page (admin)', async () => {
     await activityPage.goto();
 
     await activityPage.activitiesList.count();
   });
 
-  test('Explore project page (admin)', async ({ adminTab }) => {
-    const projectsPage = new ProjectsPage(adminTab);
+  test('Explore project page (admin)', async () => {
     await projectsPage.goto();
 
     await projectsPage.projectsList.count();
@@ -68,8 +84,7 @@ test.describe('E2E Page Traversal', () => {
     await projectsPage.createButton.click();
   });
 
-  test('Explore site admin page', async ({ adminTab }) => {
-    const siteAdminPage = new SiteAdminPage(adminTab);
+  test('Explore site admin page', async () => {
     await siteAdminPage.goto();
 
     await siteAdminPage.tabs.archivedProjects.click();
@@ -78,8 +93,7 @@ test.describe('E2E Page Traversal', () => {
     await siteAdminPage.archivedProjectsTab.projectsList.count();
   });
 
-  test('Explore user profile page (admin)', async ({ adminTab }) => {
-    const userProfilePage = new UserProfilePage(adminTab);
+  test('Explore user profile page (admin)', async () => {
     await userProfilePage.goto();
 
     await userProfilePage.activitiesList.count();

--- a/test/e2e/utils/fixtures.ts
+++ b/test/e2e/utils/fixtures.ts
@@ -12,6 +12,7 @@ export type UserDetails = {
 }
 
 export type UserTab = Page & UserDetails;
+export type AnonTab = Page;
 
 function setupUserDetails(obj: any, username: usernamesForFixture) {
   obj.username = constants[`${username}Username`] ?? username;
@@ -29,6 +30,13 @@ const userTab = (username: usernamesForFixture) => async ({ browser, browserName
   await use(tab);
 }
 
+const anonTab = () => async ({ browser }: { browser: Browser }, use: (r: AnonTab) => Promise<void>) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const tab = page as AnonTab;
+  await use(tab);
+}
+
 // Add user fixtures to test function
 // Two kinds of fixtures: userTab and user, where "user" is one of "admin", "manager", "member", "member2", or "observer"
 // The userTab fixture represents a browser tab (a "page" in Playwright terms) that's already logged in as that user
@@ -41,6 +49,7 @@ export const test = (base
     memberTab: UserTab,
     member2Tab: UserTab,
     observerTab: UserTab,
+    anonTab: AnonTab,
     admin: UserDetails,
     manager: UserDetails,
     member: UserDetails,
@@ -52,6 +61,7 @@ export const test = (base
     memberTab: userTab('member'),
     member2Tab: userTab('member2'),
     observerTab: userTab('observer'),
+    anonTab: anonTab(),
     admin: async ({}, use) => {
       let admin = {} as UserDetails;
       setupUserDetails(admin, 'admin');

--- a/test/e2e/utils/fixtures.ts
+++ b/test/e2e/utils/fixtures.ts
@@ -32,6 +32,7 @@ const userTab = (username: usernamesForFixture) => async ({ browser, browserName
 // Add user fixtures to test function
 // Two kinds of fixtures: userTab and user, where "user" is one of "admin", "manager", "member", "member2", or "observer"
 // The userTab fixture represents a browser tab (a "page" in Playwright terms) that's already logged in as that user
+// The anonTab fixture represents a browser tab (a "page" in Playwright terms) where nobody is logged in; this tab can be used across different tests (like userTab)
 // The user fixture just carries that user's details (username, password, name and email)
 // Note: "Tab" was chosen instead of "Page" to avoid confusion with Page Object Model classes like SiteAdminPage
 export const test = (base

--- a/test/e2e/utils/fixtures.ts
+++ b/test/e2e/utils/fixtures.ts
@@ -12,7 +12,6 @@ export type UserDetails = {
 }
 
 export type UserTab = Page & UserDetails;
-export type AnonTab = Page;
 
 function setupUserDetails(obj: any, username: usernamesForFixture) {
   obj.username = constants[`${username}Username`] ?? username;
@@ -30,13 +29,6 @@ const userTab = (username: usernamesForFixture) => async ({ browser, browserName
   await use(tab);
 }
 
-const anonTab = () => async ({ browser }: { browser: Browser }, use: (r: AnonTab) => Promise<void>) => {
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  const tab = page as AnonTab;
-  await use(tab);
-}
-
 // Add user fixtures to test function
 // Two kinds of fixtures: userTab and user, where "user" is one of "admin", "manager", "member", "member2", or "observer"
 // The userTab fixture represents a browser tab (a "page" in Playwright terms) that's already logged in as that user
@@ -49,7 +41,7 @@ export const test = (base
     memberTab: UserTab,
     member2Tab: UserTab,
     observerTab: UserTab,
-    anonTab: AnonTab,
+    anonTab: Page,
     admin: UserDetails,
     manager: UserDetails,
     member: UserDetails,
@@ -61,7 +53,12 @@ export const test = (base
     memberTab: userTab('member'),
     member2Tab: userTab('member2'),
     observerTab: userTab('observer'),
-    anonTab: anonTab(),
+    anonTab: async ({ browser }: { browser: Browser }, use: (r: Page) => Promise<void>) => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      const tab = page;
+      await use(tab);
+    },
     admin: async ({}, use) => {
       let admin = {} as UserDetails;
       setupUserDetails(admin, 'admin');


### PR DESCRIPTION
## Description
Implementing a modified design pattern: For simple tests, the same page is reused instead of requesting a new page for every single test. Thereby, the tests run much faster.

### Details
The new design pattern is implemented by a fixture. It makes a page reusable and prevents Playwright from closing the page after a test. This fixtures is a page where no user is logged in and is called `anonTab`.

Fixes # (issue) no issue created 

### Type of Change
E2E test

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

