### PR TITLE
convert signup tests from Protractor to Playwright

### DIFF
--- a/src/angular-app/bellows/apps/public/signup/signup-app.component.html
+++ b/src/angular-app/bellows/apps/public/signup/signup-app.component.html
@@ -85,7 +85,7 @@
             <span role="alert" class="alert-danger" id="emailInvalid" data-ng-show="!$ctrl.emailValid">
                 Please enter a valid email address. An example of an email address: john@doe.com<br></span>
             <span role="alert" class="alert-danger" id="emailTaken" data-ng-show="$ctrl.emailExists">
-                {{$ctrl.takenEmail}} is taken. Please use another.<br></span>
+                {{$ctrl.takenEmail}} is taken. If this is you, you can <a href="/auth/login">login now</a> or <a href="/auth/forgot_password">reset your forgotten password</a>.<br></span>
             <span role="alert" class="alert-danger" id="passwordIsWeak" data-ng-show="$ctrl.passwordIsWeak">
                 Password is too weak.<br></span>
         </div>

--- a/test/e2e/pages/signup.page.ts
+++ b/test/e2e/pages/signup.page.ts
@@ -5,22 +5,36 @@ type Captcha = {
   blueSquareButton: Locator;
   yellowCircleButton: Locator;
   redTriangleButton: Locator;
+  setInvalidCaptcha: Function;
+  setValidCaptcha: Function;
 };
 
 export class SignupPage {
   readonly page: Page;
   readonly emailInput: Locator;
+  readonly emailInvalid: Locator;
+  readonly emailTaken: Locator;
+
   readonly nameInput: Locator;
   readonly passwordInput: Locator;
+  readonly passwordIsWeak: Locator;
+  readonly showPassword: Locator;
   readonly captchaDiv: Locator;
   readonly captcha: Captcha;
+  readonly captchaInvalid: Locator;
+  readonly signupButton: Locator;
   static readonly url: string = '/public/signup';
 
   constructor(page: Page) {
     this.page = page;
     this.emailInput = page.locator('#email');
+    this.emailInvalid = page.locator('#emailInvalid');
+    this.emailTaken = page.locator('#emailTaken');
+
     this.nameInput = page.locator('#name');
     this.passwordInput = page.locator('#password');
+    this.passwordIsWeak = page.locator('#passwordIsWeak');
+    this.showPassword = page.locator('data-ng-model="$ctrl.showPassword"');
 
     this.captchaDiv = page.locator('#pui-captcha');
     this.captcha = {
@@ -28,11 +42,43 @@ export class SignupPage {
       blueSquareButton: this.captchaDiv.locator('#captcha0'),
       yellowCircleButton: this.captchaDiv.locator('#captcha1'),
       redTriangleButton: this.captchaDiv.locator('#captcha2'),
-    }
+
+      setInvalidCaptcha: async () => {
+        await this.captcha.blueSquareButton.click();
+        if (await this.captcha.expectedItemName.innerText() === 'Blue Square') {
+          this.captcha.yellowCircleButton.click();
+        }
+      },
+
+      setValidCaptcha: async () => {
+        switch (await this.captcha.expectedItemName.innerText()) {
+          case 'Blue Square':
+            this.captcha.blueSquareButton.click();
+          case 'Yellow Circle':
+            this.captcha.yellowCircleButton.click();
+          case 'Red Triangle':
+            this.captcha.redTriangleButton.click();
+        }
+      }
+    };
+    this.captchaInvalid = page.locator('#captchaInvalid');
+
+    this.signupButton = page.locator('#submit');
   }
 
-  async goto() {
-    await this.page.goto(SignupPage.url);
+  async goto(email: string = '') {
+    let appendEmailtoURL: string = '';
+    if (email != '') {
+      appendEmailtoURL = '#!/?e=' + encodeURIComponent(email);
+    }
+    await this.page.goto(SignupPage.url + appendEmailtoURL);
     await expect(this.emailInput).toBeVisible();
+  }
+
+  async setInvalidCaptcha() {
+    await this.captcha.blueSquareButton.click();
+    if (await this.captcha.expectedItemName.innerText() === 'Blue Square') {
+      this.captcha.yellowCircleButton.click();
+    }
   }
 }

--- a/test/e2e/pages/signup.page.ts
+++ b/test/e2e/pages/signup.page.ts
@@ -83,11 +83,6 @@ export class SignupPage {
     await expect(this.emailInput).toBeVisible();
   }
 
-  async gotoExpectRedirect(redirectedToUrl: string) {
-    await this.page.goto(SignupPage.url);
-    expect(this.page.url()).toContain(redirectedToUrl);
-  }
-
   async setInvalidCaptcha() {
     await this.captcha.blueSquareButton.click();
     if (await this.captcha.expectedItemName.innerText() === 'Blue Square') {

--- a/test/e2e/signup.spec.ts
+++ b/test/e2e/signup.spec.ts
@@ -123,6 +123,7 @@ test.describe('E2E Signup app', () => {
 
   test('Redirects to projects page if already logged in', async ({ memberTab }) => {
     const signupPage = new SignupPage(memberTab);
-    await signupPage.gotoExpectRedirect('/app/projects');
+    await signupPage.page.goto(SignupPage.url);
+    expect(signupPage.page.url()).toContain('/app/projects');
   });
 });

--- a/test/e2e/signup.spec.ts
+++ b/test/e2e/signup.spec.ts
@@ -10,18 +10,6 @@ test.describe('E2E Signup app', () => {
     signupPage = new SignupPage(anonTab);
   })
 
-  // this name is not very descriptive
-  test('Can verify required information filled', async () => {
-    await signupPage.goto();
-
-    await expect(signupPage.signupButton).toBeDisabled();
-    await signupPage.nameInput.fill(constants.unusedName);
-    await signupPage.emailInput.fill(constants.unusedEmail);
-    await signupPage.passwordInput.fill(constants.passwordValid);
-    await signupPage.captcha.setInvalidCaptcha();
-    await expect(signupPage.signupButton).toBeEnabled();
-  });
-
   test('Cannot submit if email is invalid', async () => {
     await signupPage.goto();
 
@@ -47,7 +35,7 @@ test.describe('E2E Signup app', () => {
     await expect(signupPage.signupButton).not.toBeEnabled();
   });
 
-  test('Can submit if password not weak', async () => {
+  test('Can submit if the password is strong', async () => {
     await signupPage.goto();
 
     await signupPage.nameInput.fill(constants.unusedName);
@@ -79,9 +67,7 @@ test.describe('E2E Signup app', () => {
     await expect(signupPage.signupButton).toBeDisabled();
   });
 
-  // name is not good
-  // suggested name: invalid captcha allows submit but then displays error
-  test('Can submit a user registration request and captcha is invalid', async () => {
+  test('Captcha is invalid but user can still submit form', async () => {
     await signupPage.goto();
 
     await signupPage.nameInput.fill(constants.unusedName);

--- a/test/e2e/signup.spec.ts
+++ b/test/e2e/signup.spec.ts
@@ -1,0 +1,137 @@
+import { expect } from '@playwright/test';
+import { test } from './utils/fixtures';
+import { SignupPage } from './pages/signup.page';
+
+test.describe('E2E Signup app', () => {
+  const constants = require('./../testConstants.json');
+
+  // this name is not very descriptive
+  test('Can verify required information filled', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto();
+
+    await expect(signupPage.signupButton).toBeDisabled();
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.emailInput.fill(constants.unusedEmail);
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await signupPage.captcha.setInvalidCaptcha();
+    await expect(signupPage.signupButton).toBeEnabled();
+  });
+
+  test('Cannot submit if email is invalid', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto();
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.emailInput.fill(constants.emailNoAt);
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await signupPage.captcha.setInvalidCaptcha();
+    await expect(signupPage.emailInvalid).toBeVisible();
+    await expect(signupPage.signupButton).toBeDisabled();
+  });
+
+  test('Cannot submit if password is weak', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto();
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.emailInput.fill(constants.unusedEmail);
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await expect(signupPage.signupButton).toBeEnabled();
+    await signupPage.passwordInput.fill(constants.passwordTooShort);
+    await signupPage.captcha.setInvalidCaptcha();
+    await expect(signupPage.passwordIsWeak).toBeVisible();
+    await expect(signupPage.signupButton).not.toBeEnabled();
+  });
+
+  test('Can submit if password not weak', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto();
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.emailInput.fill(constants.unusedEmail);
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await signupPage.captcha.setInvalidCaptcha();
+    await expect(signupPage.passwordIsWeak).not.toBeVisible();
+    await expect(signupPage.signupButton).toBeEnabled();
+  });
+
+  test('Can submit if password is showing and not weak', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto();
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.emailInput.fill(constants.unusedEmail);
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await signupPage.showPassword.click();
+    await signupPage.captcha.setInvalidCaptcha();
+    await expect(signupPage.passwordIsWeak).not.toBeVisible();
+    await expect(signupPage.signupButton).toBeEnabled();
+  });
+
+  test('Cannot submit if captcha not selected', async ({ page }) => {
+
+    const signupPage = new SignupPage(page);
+    await signupPage.goto();
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.emailInput.fill(constants.unusedEmail);
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await expect(signupPage.signupButton).toBeDisabled();
+  });
+
+  test('Can submit a user registration request and captcha is invalid', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto();
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.emailInput.fill(constants.unusedEmail);
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await signupPage.captcha.setInvalidCaptcha();
+    await signupPage.signupButton.click();
+    await expect(signupPage.captchaInvalid).toBeVisible();
+  });
+
+  test('Finds the admin user (case insensitive) already exists', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto();
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.emailInput.fill(constants.adminEmail.toUpperCase());
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await signupPage.captcha.setValidCaptcha();
+    await expect(signupPage.signupButton).toBeEnabled();
+    await signupPage.signupButton.click();
+    await expect(signupPage.emailTaken).toBeVisible();
+  });
+
+  test('Can prefill email address that can\'t be changed', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto(constants.unusedEmail);
+    await expect(signupPage.emailInput).toBeDisabled();
+  });
+
+  test('Can prefill email address that already exists', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto(constants.adminEmail);
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await signupPage.captcha.setValidCaptcha();
+    await signupPage.signupButton.click();
+    await expect(signupPage.emailTaken).toBeVisible();
+  });
+
+  test('Can signup a new user', async ({ page }) => {
+    const signupPage = new SignupPage(page);
+    await signupPage.goto();
+    await signupPage.emailInput.fill(constants.unusedEmail);
+    await signupPage.nameInput.fill(constants.unusedName);
+    await signupPage.passwordInput.fill(constants.passwordValid);
+    await signupPage.captcha.setValidCaptcha();
+    await expect(signupPage.signupButton).toBeEnabled();
+    await signupPage.signupButton.click();
+
+    // Verify new user logged in and redirected to projects page
+    // maybe add await navigation
+    expect(page.url()).toContain('/app/projects');
+  });
+
+  test('Redirects to projects page if already logged in', async ({ memberTab }) => {
+    const signupPage = new SignupPage(memberTab);
+    await signupPage.goto();
+    expect(memberTab.url()).toContain('/app/projects');
+  });
+});


### PR DESCRIPTION
## Description
The following tests have been converted to playwright

Bellows E2E Signup app
✓ can verify required information filled
✓ cannot submit if email is invalid
✓ cannot submit if password is weak
✓ can submit if password not weak
✓ can submit if password is showing and not weak
✓ cannot submit if captcha not selected
✓ can submit a user registration request and captcha is invalid
✓ finds the admin user (case insensitive) already exists
✓ can prefill email address that can't be changed
✓ can prefill email address that already exists
✓ can signup a new user
✓ redirects to projects page if already logged in

For details/remarks regarding converting the above tests, refer to the spreadsheet; https://docs.google.com/spreadsheets/d/1w9wjfm-02QHLhv0ObPAKKlqnDWeag379GIXwOcRU4W0/edit#gid=0

Fixes # (no issue associated)

### Type of Change
E2E tests and signup page email-taken error text improvement

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works


