### PR TITLE
Hide prev/next entry control on mobile

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -11,7 +11,7 @@
                             <span class="d-none d-md-inline-block">List</span></a>
                     </div>
                     <div class="float-right" data-ng-show="$ctrl.isAtEditorEntry()">
-                        <div class="btn-group dc-rendered-on-desktop" ng-form="validateGoto" ng-hide="$ctrl.entryListModifiers.filterActive()">
+                        <div class="btn-group hide-on-mobile" ng-form="validateGoto" ng-hide="$ctrl.entryListModifiers.filterActive()">
                             <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1)">
                                 <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
                             </button>
@@ -43,7 +43,7 @@
                 </div>
             </div>
         </div>
-        <div class="row dc-rendered-on-desktop" data-ng-if="$ctrl.isAtEditorEntry()">
+        <div class="row hide-on-mobile" data-ng-if="$ctrl.isAtEditorEntry()">
             <div class="col">
                 <div class="word-definition-title">
                     <dc-rendered config="$ctrl.lecConfig.entry" global-config="$ctrl.lecConfig"

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.html
@@ -11,7 +11,7 @@
                             <span class="d-none d-md-inline-block">List</span></a>
                     </div>
                     <div class="float-right" data-ng-show="$ctrl.isAtEditorEntry()">
-                        <div class="btn-group" ng-form="validateGoto" ng-hide="$ctrl.entryListModifiers.filterActive()">
+                        <div class="btn-group dc-rendered-on-desktop" ng-form="validateGoto" ng-hide="$ctrl.entryListModifiers.filterActive()">
                             <button class="btn btn-std" data-ng-click="$ctrl.skipToEntry(-1)" ng-disabled="!$ctrl.canSkipToEntry(-1)">
                                 <span class="fa fa-arrow-left"></span> <span class="d-none d-lg-inline-block">Previous</span>
                             </button>

--- a/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
+++ b/src/angular-app/languageforge/lexicon/editor/field/_dc-rendered.scss
@@ -26,7 +26,7 @@
   }
 }
 @include media-breakpoint-down(sm) {
-  .dc-rendered-on-desktop {
+  .hide-on-mobile {
     display: none;
   }
 }


### PR DESCRIPTION
## Description

Added  "dc-rendered-on-desktop" class to parent button bar div to hide it on mobile.

Fixes #1290

### Type of Change

- UI change Hide button bar on mobile

## Screenshots
### Desktop(chrome)
![Screenshot from 2022-03-30 07-54-02](https://user-images.githubusercontent.com/7799495/160864899-401b8b8b-8855-4931-9224-e321d6f1f895.png)
### Mobile(android)
![Screenshot_20220328-175348](https://user-images.githubusercontent.com/7799495/160865503-83b073a3-fa76-4c25-b4ec-8671d0b7d39a.png)


## Testing on your branch

- [ ] Navigate to Editor on desktop browser. The button bar will display.
- [ ] Navigate to Editor on mobile browser. The button bar will be hidden.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
