### PR TITLE
Fix bug where Part of Speech wasn't saving

### DIFF
--- a/src/Api/Model/Shared/DeepDiff/DeepDiffDecoder.php
+++ b/src/Api/Model/Shared/DeepDiff/DeepDiffDecoder.php
@@ -122,10 +122,16 @@ class DeepDiffDecoder
     private static function setValue(&$target, $last, $value) {
         if ($target instanceof \Api\Model\Languageforge\Lexicon\LexMultiText) {
             $target->form($last, $value);
+        } else if ($target instanceof \Api\Model\Languageforge\Lexicon\LexValue) {
+            $target->value($value);  // TODO: Test this
         } else if ($target instanceof \ArrayObject) {
             $target[$last] = $value;
         } else {
-            $target->$last = $value;
+            if ($target->$last instanceof \Api\Model\Languageforge\Lexicon\LexValue) {
+                $target->$last->value($value);
+            } else {
+                $target->$last = $value;
+            }
         }
     }
 


### PR DESCRIPTION
Should also fix the bug with other fields like list fields, as the root cause of the bug was the same.

## Description

The Part of Speech field wasn't saving properly due to an error in the DeepDiffDecoder logic. It was working when I tested it, but then I made a change to fix saving MultiText fields and failed to notice that that change would have an effect on list fields like Part of Speech. (Because both MultiText fields and list fields end with a path component called "value" in the final position, and that's what I was checking for).

Fixes #1248.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Testing on your branch

- Load a project
- Have at least two lexical entries
- Change the part of speech of entry 1
- Go to entry 2
- Go back to entry 1
- Verify that the part of speech change was kept

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

I'll add E2E regression tests later, but I've verified the fix works by manual testing. I'd like to get this merged and deployed today if possible.

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
