### PR TITLE
Run E2E tests from correct working directory

### DIFF
--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -59,6 +59,7 @@ jobs:
         run: make unit-tests-ci
       -
         name: Playwright E2E Tests
+        working-directory: .
         run: |
           docker-compose -f docker/docker-compose.yml up -d app-for-playwright
           npx playwright install


### PR DESCRIPTION
## Description

E2E tests assume they are being run from root of repo, not from `docker` directory, so they need `working_directory: .` in the GHA workflow file.

Fixes #1369.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)
