### PR TITLE
Fix list field saving as well as all varieties of custom fields

### DIFF
--- a/src/Api/Model/Shared/DeepDiff/DeepDiffDecoder.php
+++ b/src/Api/Model/Shared/DeepDiff/DeepDiffDecoder.php
@@ -74,7 +74,7 @@ class DeepDiffDecoder
         $last = array_pop($allButLast);
         $target = $model;
         $value = $diff->getValue();
-        $customFieldsIdx = array_search('customFields', $allButLast);
+        $customFieldsIdx = array_search('customFields', $allButLast, true);
         $customFieldData = [];
         if ($customFieldsIdx !== false && $customFieldsIdx+2 <= count($path)) {
             // Custom fields need special handling


### PR DESCRIPTION
## Description

Fix saving list fields and custom fields.

Fixes #1248.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please provide screenshots / animations for any change that involves the UI.  Please provide animations to demonstrate user interaction / behavior changes

## Testing on your branch

- Create a new non-send/receive project (for speed)
- Load the TestLangProj.7z data into it (from the `test/common` directory)
- Add data to all the custom fields (except CustMultiPara because multi-paragraph fields are disabled in LF right now) of the first entry
- Also change the part of speech
- Click to another entry
- Click back to the first entry
- Verify that the data you added is still there
- Do a browser refresh (F5)
- Verify that the data you entered is *still* there
    - If this step fails, then the data made it into localStorage but did not actually make it into Mongo

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

Tests will come in a later PR, since writing them is non-trivial.

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
