### PR TITLE
optimize for building and debugging PHP tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ PhpUnitTests.xml
 docker/e2e-results.xml
 src/assets/*
 src/dist/*
+src/vendor/*
 !src/assets/.gitkeep
 src/cache/*
 !src/cache/.gitkeep

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -24,6 +24,7 @@ e2e-tests-ci:
 
 .PHONY: unit-tests
 unit-tests:
+	docker-compose build test-php
 	docker-compose run test-php
 
 .PHONY: unit-tests-ci

--- a/docker/test-php/Dockerfile
+++ b/docker/test-php/Dockerfile
@@ -3,10 +3,11 @@ FROM sillsdev/web-languageforge:base-php
 
 # ----- LINES BELOW COPIED FROM APP DOCKERFILE ----------
 WORKDIR /var/www/html
-COPY src/composer.json src/composer.lock /var/www/html/
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
-    && install-php-extensions @composer && composer install
+    && install-php-extensions @composer
+COPY src/composer.json src/composer.lock /var/www/html/
+RUN composer install
 
 # uncomment if you want xdebug in your local image
 #RUN install-php-extensions xdebug

--- a/docker/test-php/run.sh
+++ b/docker/test-php/run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
 cd /var/www/
+
+# optionally add `--filter nameOfTestYouWantToRun`
 src/vendor/bin/phpunit --configuration test/php/phpunit.xml --log-junit PhpUnitTests.xml


### PR DESCRIPTION
## Description
This is just a small PR that: 
- adds a build step to `make unit-tests` for easier rebuilding on code changes
- adds a comment about running single PHPUnit tests
- ignores /src/vendor folder, since having the composer installed vendor libraries available to the IDE is helpful for debugging in XDebug

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
