### PR TITLE
Fix saving custom fields on senses and examples

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -1157,6 +1157,9 @@ export class LexiconEditorController implements angular.IController {
   }
 
   private prepCustomFieldsForUpdate(data: any): any {
+    if (Array.isArray(data)) {
+      return data.map(item => this.prepCustomFieldsForUpdate(item));
+    }
     data.customFields = {};
     for (const fieldName in data) {
       if (data.hasOwnProperty(fieldName)) {


### PR DESCRIPTION
## Description

We were treating every field as an object, but the senses and example fields are actually arrays of objects. This was resulting in custom fields not being sent to the server in the right format, so the server was simply not seeing any custom field changes in senses or examples: only custom fields at the entry level were being saved.

Fixes #1375.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Testing on your branch

See #1375's repro steps.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
