### PR TITLE
Update/Add links under Help/About menu

### DIFF
--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -16,15 +16,14 @@
                 </span>
                 <ul class="nav navbar-nav">
                     <li class="nav-item" uib-dropdown>
-                        <a class="nav-link" uib-dropdown-toggle href id="helpDropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-life-ring"></i> <span>Help</span></a>
+                        <a class="nav-link" uib-dropdown-toggle href id="helpDropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-question-circle"></i> <span>About</span></a>
                         <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu aria-labelledby="helpDropdown">
-                            {% if projectId is not empty %}
-                                <a class="dropdown-item" target="_blank" href="https://hlp.sh/t/_/GsubLqNFYR2?~id={{projectId}}">Start Language Forge Tour</a>
-                            {% endif %}
-                            <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge/how-to">Tutorials and How-Tos</a>
-                            <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge">Community Support</a>
-                            <a class="dropdown-item" target="_blank" href="mailto:issues@languageforge.org">Report a Problem<br />(email issues@languageforge.org)</a>
-                            <a class="dropdown-item" target="_blank" href="https://github.com/sillsdev/web-languageforge/releases">What's new in the app?</a>
+                            <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/t/w/5454"><i class="fa fa-gift"></i> What's New?</a>
+                            <a class="dropdown-item" target="_blank" href="https://www.youtube.com/playlist?list=PLJLUPwIFOI8d8lmQVAcBapyw87jCtmDNA"><i class="fa fa-youtube-play"></i> Videos</a>
+                            <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge"><i class="fa fa-users"></i> Community Support</a>
+                            <a class="dropdown-item" target="_blank" href="https://github.com/sillsdev/web-languageforge/releases"><i class="fa fa-github"></i> GitHub Releases</a>
+                            <a class="dropdown-item" target="_blank" href="https://github.com/sillsdev/web-languageforge/wiki/Known-Issues-and-Limitations"><i class="fa fa-exclamation-triangle"></i> Known Issues and Limitations</a>
+                            <a class="dropdown-item" target="_blank" href="mailto:issues@languageforge.org"><i class="fa fa-envelope"></i> Report a Problem<br />(email issues@languageforge.org)</a>
                         </div>
                     </li>
                     <li class="nav-item dropdown" uib-dropdown>

--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -21,7 +21,6 @@
                             <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/t/w/5454"><i class="fa fa-gift"></i> What's New?</a>
                             <a class="dropdown-item" target="_blank" href="https://www.youtube.com/playlist?list=PLJLUPwIFOI8d8lmQVAcBapyw87jCtmDNA"><i class="fa fa-youtube-play"></i> Videos</a>
                             <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge"><i class="fa fa-users"></i> Community Support</a>
-                            <a class="dropdown-item" target="_blank" href="https://github.com/sillsdev/web-languageforge/releases"><i class="fa fa-github"></i> GitHub Releases</a>
                             <a class="dropdown-item" target="_blank" href="https://github.com/sillsdev/web-languageforge/wiki/Known-Issues-and-Limitations"><i class="fa fa-exclamation-triangle"></i> Known Issues and Limitations</a>
                             <a class="dropdown-item" target="_blank" href="mailto:issues@languageforge.org"><i class="fa fa-envelope"></i> Report a Problem<br />(email issues@languageforge.org)</a>
                         </div>


### PR DESCRIPTION
## Description

Initiated by user feedback, this PR updates some links under the "Help" menu, now renamed to "About".  Summary of changes:

- Remove the How To / Tutorials link.  This just pointed to the community site under a sub-category called How To / Tutorials.  It's not well maintained.
- Removed the tour link (we no longer pay for HelpHero - it never worked very well)
- Add a link to YouTube videos
- Add a link to Known issues and limitations on GH wiki
- Rename "What's new in the app" to "What's New" and link to the post that @alex-larkin maintains for release summaries
- Add a link to github releases (because it's cool)
- re ordered the links a bit
- added font awesome v4 icons

Fixes # (not sure if there is an issue yet)

### Type of Change

- UI change

## Screenshots

### Old Menu

![image](https://user-images.githubusercontent.com/3444521/162208228-42395870-dd9e-4740-a59d-47c9dfb0433b.png)


### New Menu

![image](https://user-images.githubusercontent.com/3444521/162208120-3747070d-c307-41e0-a841-430d2b227b05.png)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
