### PR TITLE
allow m4a audio uploads

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,6 +9,19 @@ start: build
 dev: start
 	docker-compose up -d ui-builder
 
+.PHONY: playwright-tests
+playwright-tests:
+
+    # delete any cached session storage state files if the service isn't running
+	docker compose ps app-for-playwright > /dev/null 2>&1 || rm -f ../*-storageState.json
+
+	docker-compose up -d app-for-playwright
+
+    # wait until the app-for-playwright service is serving up HTTP before continuing
+	until curl localhost:3238 > /dev/null 2>&1; do sleep 1; done
+
+	cd .. && npx playwright install && npx playwright test
+
 .PHONY: e2e-tests
 e2e-tests:
 	docker-compose build app-for-e2e test-e2e

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -265,6 +265,11 @@ services:
     command: sh -c "/wait && /run.sh"
 
   app-for-playwright:
+    build:
+      context: ..
+      dockerfile: docker/app/Dockerfile
+      args:
+        - ENVIRONMENT=development
     image: lf-app
     container_name: app-for-playwright
     platform: linux/amd64

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -52,6 +52,10 @@ class LexUploadCommands
 
         $allowedTypes = array(
             "application/octet-stream",
+
+            // allow m4a audio uploads, which curiously has a mime type of video/mp4
+            "video/mp4",
+
             "audio/mpeg",
             "audio/x-mpeg",
             "audio/mp3",
@@ -68,6 +72,7 @@ class LexUploadCommands
             ".mp3",
             ".mpa",
             ".mpg",
+            ".m4a",
             ".wav"
         );
 


### PR DESCRIPTION
## Description

`.m4a` is an increasingly common and default audio extension and file format that LF should support.

Fixes #1383 which was reported by an user.

### Type of Change

- New feature (non-breaking change which adds functionality)

## Screenshots

Before this change:
![image](https://user-images.githubusercontent.com/3444521/163765798-2d37cf19-60bc-4a67-bf4b-34736379c0ab.png)

After this change:
![image](https://user-images.githubusercontent.com/3444521/163765874-b3c952a3-3d9c-4f86-a59c-857b070b6d55.png)

## Testing on your branch

- [x] Record a .m4a audio file in your favorite default audio recorder on desktop or mobile device.  Upload the file to LF and see that it works.
- [x] Playback the .m4a audio file uploaded above and ensure it plays back ok

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
