### PR TITLE
Add .editorconfig entry for Makefiles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,11 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+; applies only to Makefiles
+[Makefile]
+indent_style = tab
+tab_width = 4
+
 ; applies only to JS, TS, and YML files
 [*.{js,ts,yml}]
 tab_width = 2


### PR DESCRIPTION
This will force Tab characters in Makefiles, reducing the amount of time we have to spend fussing with whitespace when we edit them.
