### PR TITLE
Bump LfMerge version to pull in bugfix

### DIFF
--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.106
+FROM ghcr.io/sillsdev/lfmerge:2.0.108
 # Do not add anything to this Dockerfile, it should stay empty


### PR DESCRIPTION
## Description

Pull in an LfMerge bugfix that allows it to run again. The cause of the bug was that we switched to environment variables to feed LfMerge its settings (much easier to work with in Docker/Kubernetes than a config file), and the `sudo` command strips environment variables unless you whitelist them. So we whitelisted the `LFMERGE_*` variables, and now Send/Receive works again.

Fixes #1395.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Testing on your branch

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce.  Please also provide relevant test data as necessary.  These instructions will be used for QA testing below.

- [ ] Clone any project from Language Depot
- [ ] Run `docker logs -f lfmerge` to watch the Send/Receive happen; verify that it completes
- [ ] Edit that project and do a Send/Receive
- [ ] Run `docker logs -f lfmerge` to watch the Send/Receive happen
- [ ] (Optional) Using FieldWorks, clone that same project and verify that your changes made it to Language Depot

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
