### PR TITLE
Reduce lfmerge container size

### DIFF
--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.110
+FROM ghcr.io/sillsdev/lfmerge:2.0.111
 # Do not add anything to this Dockerfile, it should stay empty


### PR DESCRIPTION
This PR bumps the `lfmerge` image version in order to reduce the size of the lfmerge image. The reduced size may not be immediately visible with this PR, as it will still have to download a 700 MB layer in the Docker image. But with the changes I've made to the lfmerge build process, that should be the last time that Docker image layer has to be downloaded, and subsequent lfmerge releases should be able to reuse the same layer.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
