### PR TITLE
Move lfmerge container to separate pod using pod affinity

### DIFF
--- a/docker/deployment/Makefile
+++ b/docker/deployment/Makefile
@@ -10,9 +10,11 @@ list-contexts:
 list-config:
 	cat ~/.kube/config
 
-logs: logs-app logs-db logs-mail logs-next-app logs-next-proxy
+logs: logs-app logs-lfmerge logs-db logs-mail logs-next-app logs-next-proxy
 logs-app:
 	kubectl logs deploy/app
+logs-lfmerge:
+	kubectl logs deploy/lfmerge
 logs-next-app:
 	kubectl logs deploy/next-app
 logs-next-proxy:
@@ -24,6 +26,8 @@ logs-mail:
 
 shell-app:
 	kubectl exec -it deploy/app -- sh
+shell-lfmerge:
+	kubectl exec -it deploy/lfmerge -- sh
 shell-next-app:
 	kubectl exec -it deploy/next-app -- sh
 shell-next-proxy:
@@ -35,25 +39,27 @@ init-secrets:
 create-new-deployment-mail:
 	kubectl create deployment mail --image=juanluisbaptiste/postfix:1.0.0 --dry-run=client -o yaml > mail-deployment-new.yaml
 
-deploy-staging: deploy-db deploy-mail-staging deploy-app-staging deploy-next-proxy-staging deploy-next-app-staging
+deploy-staging: deploy-db deploy-mail-staging deploy-app-staging deploy-lfmerge-staging deploy-next-proxy-staging deploy-next-app-staging
 deploy-mail-staging:
 	sed -e s/{{SERVER_HOSTNAME}}/qa.languageforge.org/ mail-deployment.yaml | kubectl apply -f -
 deploy-app-staging:
 	sed -e s/{{WEBSITE}}/qa.languageforge.org/ app-deployment.yaml \
-  | sed -e s/{{VERSION_LFMERGE}}/$(VERSION_LFMERGE)/ \
   | sed -e s/{{VERSION}}/$(VERSION_APP)/ | kubectl apply -f -
+deploy-lfmerge-staging:
+	sed -e s/{{VERSION_LFMERGE}}/$(VERSION_LFMERGE)/ lfmerge-deployment.yaml | kubectl apply -f -
 deploy-next-proxy-staging:
 	sed -e s/{{WEBSITE}}/qa.languageforge.org/ next-proxy-deployment.yaml \
   | sed -e s/{{VERSION}}/$(VERSION_PROXY)/ | kubectl apply -f -
 deploy-next-app-staging:
 	sed -e s/{{VERSION}}/$(VERSION_NEXT_APP)/ next-app-deployment.yaml | kubectl apply -f -
-deploy-prod: deploy-db deploy-mail-prod deploy-app-prod deploy-next-proxy-prod deploy-next-app-prod
+deploy-prod: deploy-db deploy-mail-prod deploy-app-prod deploy-lfmerge-prod deploy-next-proxy-prod deploy-next-app-prod
 deploy-mail-prod:
 	sed -e s/{{SERVER_HOSTNAME}}/languageforge.org/ mail-deployment.yaml | kubectl apply -f -
 deploy-app-prod:
 	sed -e s/{{WEBSITE}}/languageforge.org/ app-deployment.yaml \
-  | sed -e s/{{VERSION_LFMERGE}}/$(VERSION_LFMERGE)/ \
   | sed -e s/{{VERSION}}/$(VERSION_APP)/ | kubectl apply -f -
+deploy-lfmerge-prod:
+	sed -e s/{{VERSION_LFMERGE}}/$(VERSION_LFMERGE)/ lfmerge-deployment.yaml | kubectl apply -f -
 deploy-next-proxy-prod:
 	sed -e s/{{WEBSITE}}/languageforge.org/ next-proxy-deployment.yaml \
   | sed -e s/{{VERSION}}/$(VERSION_PROXY)/ | kubectl apply -f -
@@ -62,7 +68,7 @@ deploy-next-app-prod:
 deploy-db:
 	kubectl apply -f db-deployment.yaml
 
-delete: delete-app delete-mail delete-db delete-next-proxy delete-next-app
+delete: delete-app delete-lfmerge delete-mail delete-db delete-next-proxy delete-next-app
 delete-db: # does NOT delete the volume, i.e., the data in the database
 	kubectl delete deployment,service db
 delete-db-data:
@@ -75,6 +81,8 @@ delete-app-assets:
 	kubectl delete pvc lf-project-assets
 delete-app-sendreceive-data:
 	kubectl delete pvc lfmerge-sendreceive-data
+delete-lfmerge: # does NOT delete the volumes, e.g., the send/receive webwork folder
+	kubectl delete deployment,service lfmerge
 delete-next-proxy:
 	kubectl delete deployment,service next-proxy
 	kubectl delete ingress languageforge-app

--- a/docker/deployment/app-deployment.yaml
+++ b/docker/deployment/app-deployment.yaml
@@ -173,13 +173,13 @@ spec:
           - name: LFMERGE_MONGO_HOSTNAME
             value: db
           - name: LFMERGE_MONGO_PORT
-            value: 27017
+            value: "27017"
           - name: LFMERGE_MONGO_MAIN_DB_NAME
             value: scriptureforge
           - name: LFMERGE_MONGO_DB_NAME_PREFIX
             value: sf_
           - name: LFMERGE_VERBOSE_PROGRESS
-            value: true
+            value: "true"
           - name: MONGODB_CONN
             valueFrom:
               secretKeyRef:

--- a/docker/deployment/lfmerge-deployment.yaml
+++ b/docker/deployment/lfmerge-deployment.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: app
-  name: app
+    app: lfmerge
+  name: lfmerge
 spec:
   type: ClusterIP
   clusterIP: None
@@ -14,7 +14,7 @@ spec:
     port: 80
     targetPort: 80
   selector:
-    app: app
+    app: lfmerge
 
 ---
 
@@ -53,22 +53,29 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: app
-  name: app
+    app: lfmerge
+  name: lfmerge
 spec:
   selector:
     matchLabels:
-      app: app
+      app: lfmerge
   template:
     # https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates
     metadata:
       labels:
-        app: app
+        app: lfmerge
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - app
+            topologyKey: kubernetes.io/hostname
       volumes:
-      - name: assets
-        persistentVolumeClaim:
-          claimName: lf-project-assets
       - name: sendreceive-data
         persistentVolumeClaim:
           claimName: lfmerge-sendreceive-data
@@ -79,73 +86,40 @@ spec:
           - 'sh'
           - '-c'
           - |-
-            mkdir /var/lib/languageforge/lexicon/sendreceive/state
-            chown www-data:www-data /var/www/html/assets /var/lib/languageforge/lexicon/sendreceive /var/lib/languageforge/lexicon/sendreceive/state
+            mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/state /var/lib/languageforge/lexicon/sendreceive/syncqueue /var/lib/languageforge/lexicon/sendreceive/webwork /var/lib/languageforge/lexicon/sendreceive/Templates
+            chown www-data:www-data /var/lib/languageforge/lexicon/sendreceive /var/lib/languageforge/lexicon/sendreceive/state /var/lib/languageforge/lexicon/sendreceive/syncqueue /var/lib/languageforge/lexicon/sendreceive/webwork /var/lib/languageforge/lexicon/sendreceive/Templates
         volumeMounts:
-          - mountPath: /var/www/html/assets
-            name: assets
           - mountPath: /var/lib/languageforge/lexicon/sendreceive
             name: sendreceive-data
       containers:
-      - name: app
-        image: sillsdev/web-languageforge:{{VERSION}}
+      - name: lfmerge
+        image: ghcr.io/sillsdev/lfmerge:{{VERSION_LFMERGE}}
         imagePullPolicy: Always
         volumeMounts:
-          - mountPath: /var/www/html/assets
-            name: assets
           - mountPath: /var/lib/languageforge/lexicon/sendreceive
             name: sendreceive-data
         env:
-          - name: DATABASE
-            value: scriptureforge
           - name: ENVIRONMENT
             value: production
-          - name: WEBSITE
-            value: {{WEBSITE}}
-          - name: MAIL_HOST
-            value: mail
           - name: LFMERGE_LOGGING_DEST
             value: syslog
-          - name: MONGODB_CONN
-            valueFrom:
-              secretKeyRef:
-                key: MONGODB_CONN
-                name: app
-          - name: REMEMBER_ME_SECRET
-            valueFrom:
-              secretKeyRef:
-                key: REMEMBER_ME_SECRET
-                name: app
-          - name: LDAPI_BASE_URL
-            valueFrom:
-              secretKeyRef:
-                key: LDAPI_BASE_URL
-                name: ld-api
-          - name: LANGUAGE_DEPOT_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                key: LANGUAGE_DEPOT_API_TOKEN
-                name: ld-api
-          - name: FACEBOOK_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                key: FACEBOOK_CLIENT_ID
-                name: oauth
-          - name: FACEBOOK_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                key: FACEBOOK_CLIENT_SECRET
-                name: oauth
-          - name: GOOGLE_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                key: GOOGLE_CLIENT_ID
-                name: oauth
-          - name: GOOGLE_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                key: GOOGLE_CLIENT_SECRET
-                name: oauth
+          - name: LFMERGE_BASE_DIR
+            value: /var/lib/languageforge/lexicon/sendreceive
+          - name: LFMERGE_WEBWORK_DIR
+            value: webwork
+          - name: LFMERGE_TEMPLATES_DIR
+            value: Templates
+          - name: LFMERGE_MONGO_HOSTNAME
+            value: db
+          - name: LFMERGE_MONGO_PORT
+            value: "27017"
+          - name: LFMERGE_MONGO_MAIN_DB_NAME
+            value: scriptureforge
+          - name: LFMERGE_MONGO_DB_NAME_PREFIX
+            value: sf_
+          - name: LFMERGE_VERBOSE_PROGRESS
+            value: "true"
+          # TODO: Rename to LANGUAGE_DEPOT_TRUST_TOKEN
           - name: LD_TRUST_TOKEN
             valueFrom:
               secretKeyRef:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -78,8 +78,8 @@ services:
 
   lfmerge:
     build:
-      context: ..
-      dockerfile: docker/lfmerge/Dockerfile
+      context: lfmerge
+      dockerfile: Dockerfile
       args:
         - ENVIRONMENT=development
     image: lfmerge


### PR DESCRIPTION
## Description

As a follow-up to #1389, this PR moves the lfmerge container into a separate pod, using pod affinity to ensure that it will be assigned to the same node as the main app. (Since they share a persistent volume, this is necessary so that the volume can be mounted in ReadWriteOnce mode instead of ReadWriteMany — ReadWriteMany greatly limits the number of storage backends available, while ReadWriteOnce is a lot easier for storage backends to use. (I see https://longhorn.io/blog/longhorn-v1.1.0/ from January 2021 that announces ReadWriteMany availability in Longhorn, so perhaps the pod affinity can be gotten rid of at some point).

Fixes #1406.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- New feature (non-breaking change which adds functionality)

## Screenshots

Please provide screenshots / animations for any change that involves the UI.  Please provide animations to demonstrate user interaction / behavior changes

## Testing on your branch

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce.  Please also provide relevant test data as necessary.  These instructions will be used for QA testing below.

- [ ] Ensure LF app still builds with `make`
- [ ] Clone a project with Send/Receive and make sure LfMerge still runs

This PR makes basically no changes to the docker-compose build (one very minor change), so I don't expect it to have any effect. Most of the testing will need to be on the QA server.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
