### PR TITLE
Add lfmerge deployment to GHA workflow

### DIFF
--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -115,6 +115,7 @@ jobs:
         uses: sillsdev/common-github-actions/install-kubectl@v1
       -
         run: |
-          kubectl --context ${{ secrets.kube-context }} set image deployment/app app=${{ needs.integrate.outputs.IMAGE_APP }} lfmerge=${{ needs.integrate.outputs.IMAGE_LFMERGE }}
+          kubectl --context ${{ secrets.kube-context }} set image deployment/app app=${{ needs.integrate.outputs.IMAGE_APP }}
           kubectl --context ${{ secrets.kube-context }} set image deployment/next-proxy next-proxy=${{ needs.integrate.outputs.IMAGE_PROXY }}
           kubectl --context ${{ secrets.kube-context }} set image deployment/next-app next-app=${{ needs.integrate.outputs.IMAGE_NEXT_APP }}
+          kubectl --context ${{ secrets.kube-context }} set image deployment/lfmerge lfmerge=${{ needs.integrate.outputs.IMAGE_LFMERGE }}


### PR DESCRIPTION

## Description

Now that the lfmerge container is in a separate pod, we also need to tweak the GHA workflow to update the proper Kubernetes deployment when the workflow runs. Instead of setting the `lfmerge` image in the `app` deployment, the `lfmerge` deployment is now the one that will contain the `lfmerge` image.

This really should have been included in #1407, but I forgot this one step.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Testing on your branch

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce.  Please also provide relevant test data as necessary.  These instructions will be used for QA testing below.

- [ ] Clone a project from Language Depot
- [ ] Verify that the clone completed and the data is there

Cloning just one project should be enough: if there are any problems with this deployment, they will cause lfmerge not to run at all, rather than having it run but fail half-way through.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
