### PR TITLE
Fix bug cloning FW8 projects

### DIFF
--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.111
+FROM ghcr.io/sillsdev/lfmerge:2.0.115
 # Do not add anything to this Dockerfile, it should stay empty


### PR DESCRIPTION
## Description

Found and fixed an LfMerge build issue that was causing the LfMerge build for FieldWorks 8.2 to be incorrectly pulling in the DLLs from FieldWorks 8.3. This was causing older projects, such as my test-rmunn-04 project, to fail to clone correctly.

LfMerge version 2.0.115 has the bugfix; this is the version we should deploy next time we push a Language Forge release.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please provide screenshots / animations for any change that involves the UI.  Please provide animations to demonstrate user interaction / behavior changes

## Testing on your branch

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce.  Please also provide relevant test data as necessary.  These instructions will be used for QA testing below.

- [ ] Clone a project created with FW 8.2 (see below for how to tell)
- [ ] Delete the project and clone it again
- [ ] Verify that it cloned correctly *both* times

The "delete and re-clone" step is necessary because if a previous clone attempt is still in the `webwork` directory, LfMerge will use that to figure out the correct DbVersion to use. The bug only triggers when there is no previous clone attempt in `webwork` and LfMerge has to run a Mercurial clone process in order to figure out the correct DbVersion. By deleting the project, you ensure that its `webwork` folder will be emptied and so the second clone attempt will work.

To identify projects suitable for using for this test, run `hg clone https://username:password@hg-public.languagedepot.org/projectCode` on a project you have access to in Language Depot. Then enter that project's directory and run `hg log`, or `hg log | less` if `hg log` doesn't pipe through `less` by default on your machine. Look at the branch numbers for each commit. Are they all 7000068 or earlier? Then this project is suitable. Are any of them 7000070 or 7000072 (or 7500000.7000072)? Then that project won't be a suitable test to see if this bug was squashed.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [X] Robin Munn (2022-05-26 15:59)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
