### PR TITLE
Bump LfMerge to fix build error

### DIFF
--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.119
+FROM ghcr.io/sillsdev/lfmerge:2.0.120
 # Do not add anything to this Dockerfile, it should stay empty

--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.118
+FROM ghcr.io/sillsdev/lfmerge:2.0.119
 # Do not add anything to this Dockerfile, it should stay empty


### PR DESCRIPTION

## Description

The 2.0.118 build failed to build one of the four DbVersions due to a network error while downloading dependencies. I've adjusted the LfMerge build to exit immediately if any step returns a non-zero exit code, so that sort of undetected error shouldn't happen again. The 2.0.119 build has all the DbVersions built correctly, and should replace 2.0.118.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please provide screenshots / animations for any change that involves the UI.  Please provide animations to demonstrate user interaction / behavior changes

## Testing on your branch

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce.  Please also provide relevant test data as necessary.  These instructions will be used for QA testing below.

- [ ] Clone a project whose name does not start with `test` (delete and re-clone if necessary)
- [ ] Clone a project whose name DOES start with `test`

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
