### PR TITLE
Match emails case-insensitively

### DIFF
--- a/src/Api/Model/Shared/Mapper/MapperModel.php
+++ b/src/Api/Model/Shared/Mapper/MapperModel.php
@@ -69,6 +69,16 @@ class MapperModel extends ObjectForEncoding
     }
 
     /**
+     * @param string $property
+     * @param string $value
+     * @return boolean
+     */
+    public function readByPropertyInsensitive($property, $value)
+    {
+        return $this->_mapper->readByPropertyInsensitive($this, $property, $value);
+    }
+
+    /**
      * @param array $properties
      * @return boolean
      */

--- a/src/Api/Model/Shared/Mapper/MongoMapper.php
+++ b/src/Api/Model/Shared/Mapper/MongoMapper.php
@@ -261,6 +261,47 @@ class MongoMapper
 
     /**
      * @param mixed $model
+     * @param string $property
+     * @param string $value
+     * @return bool true on document found, false otherwise
+     * Note that unlike the read() method, readByProperty() does NOT throw an exception if no document is found
+     *
+     */
+    public function readByPropertyInsensitive($model, $property, $value)
+    {
+        CodeGuard::checkTypeAndThrow($value, 'string');
+        $escaped = \preg_quote($value);
+        return $this->readByPropertyRegex($model, $property, $escaped, 'i');
+    }
+
+    /**
+     * @param mixed $model
+     * @param string $property
+     * @param string $value
+     * @param string $options
+     * @return bool true on document found, false otherwise
+     * Note that unlike the read() method, readByProperty() does NOT throw an exception if no document is found
+     *
+     */
+    public function readByPropertyRegex($model, $property, $value, $options = '')
+    {
+        CodeGuard::checkTypeAndThrow($property, 'string');
+        CodeGuard::checkTypeAndThrow($value, 'string');
+        CodeGuard::checkTypeAndThrow($options, 'string');
+        $regex = array('$regex' => $value);
+        if ($options) {
+            $regex['$options'] = $options;
+        }
+        $data = $this->_collection->findOne(array($property => $regex));
+        if ($data != NULL) {
+            MongoDecoder::decode($model, $data, (string) $data['_id']);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @param mixed $model
      * @param array  $properties
      * @return bool
      */

--- a/src/Api/Model/Shared/UserModel.php
+++ b/src/Api/Model/Shared/UserModel.php
@@ -313,7 +313,12 @@ class UserModel extends MapperModel
      */
     public function readByEmail($email)
     {
-        return $this->readByProperty('email', $email);
+        // Try case-sensitive match first in case it matters (could happen)
+        $found = $this->readByProperty('email', $email);
+        if (! $found) {
+            // RFC 5321, section 2.4, recommends case-insensitive matching on email addresses
+            return $this->readByPropertyInsensitive('email', $email);
+        }
     }
 
     /**


### PR DESCRIPTION

## Description

Fixes #1418.

We try a case-sensitive match first in case it matters (there could be some email domains that treat "xyz@example.com" and "XYZ@example.com" as different addresses, and we want to be able to retrieve the correct one in the rare case where that could matter), but we then fall back to case-insensitive matching on email addresses for the vast majority of cases where that's the right thing.

This is a first pass at solving the issue. I haven't tested the code yet, so this is a draft PR instead of a full PR. Unit tests would be needed to make sure that the `readByPropertyInsensitive` function I just created will do the right thing.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please provide screenshots / animations for any change that involves the UI.  Please provide animations to demonstrate user interaction / behavior changes

## Testing on your branch

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce.  Please also provide relevant test data as necessary.  These instructions will be used for QA testing below.

TODO: Write tests, then write testing instructions.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
