### PR TITLE
Convert to lowercase before email lookup

### DIFF
--- a/src/Api/Model/Shared/UserModel.php
+++ b/src/Api/Model/Shared/UserModel.php
@@ -313,7 +313,7 @@ class UserModel extends MapperModel
      */
     public function readByEmail($email)
     {
-        return $this->readByProperty('email', $email);
+        return $this->readByProperty('email', strtolower($email));
     }
 
     /**


### PR DESCRIPTION
## Description

This fixes an issue where a user could not login because they are accustomed to case-sensitive email addresses.  This is a simpler implementation of #1419 , given that we know that all our email addresses are already lowercase.

Fixes #1418 

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Testing on your branch

- [ ] Locally on develop, sign-up for an account and then login using your email address (lowercase).  Verify that it works.  Now, logout and login with part of the email typed with capital letters e.g. `Me@example.com` You will get an invalid username/password error.

- [ ] Now on this branch, repeat the testing and verify that capital letters in the email address login field do not make a difference.  You should be able to login using e.g. `ME@example.com` just fine. 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
