### PR TITLE
Refactor parseISO() to Date() in filters to fix sync date string disp…

### DIFF
--- a/src/angular-app/bellows/core/filters.ts
+++ b/src/angular-app/bellows/core/filters.ts
@@ -19,7 +19,7 @@ export type RelativeTimeFilterFunction = (timestamp?: string, timeFormat?: strin
 
 export function RelativeTimeFilter(): RelativeTimeFilterFunction {
   return (timestamp?: string, timeFormat?: string): string => {
-    const date = parseISO(timestamp);
+    const date = new Date(timestamp);
     const dateNow = new Date();
     if (isValid(date) && isValid(dateNow)) {
       return formatDistance(date, dateNow, { addSuffix: true });


### PR DESCRIPTION
## Description
The date/time display on a project's send/receive page was not displaying properly. 

Fixes # (issue)
Changed parseISO() to Date() to enable formatDistance method to work correctly.


### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Screenshots
![Screenshot from 2022-06-09 06-01-03](https://user-images.githubusercontent.com/7799495/172855642-e133746c-f0b6-4062-ab57-e527f4b384ce.png)

## Testing on your branch

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce.  Please also provide relevant test data as necessary.  These instructions will be used for QA testing below.

- [ ] Navigate to Settings, Synchronize. Last sync date string should display 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
