### PR TITLE
Remove VS Code extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"juancasanova.awesometypescriptproblemmatcher",
+		"amodio.tsl-problem-matcher",
 		"msjsdiag.debugger-for-chrome",
 		"ms-vscode-remote.remote-containers",
 		"editorconfig.editorconfig",


### PR DESCRIPTION
## Description

In https://github.com/sillsdev/web-languageforge/pull/1422 we switched away from awesome-typescript-loader to ts-loader, but our VS Code extensions recommendation is still recommending a problem matcher extension that parses the awesome-typescript-loader syntax. We should stop recommending that extension now, and instead recommend a problem-matcher extension that parses the output of ts-loader.

(Problem matchers are how VS Code takes the output of a build process and turns it into the list found in the **View → Problems** menu. They're build-tool specific as they contain regexes to extract filenames, line numbers, etc. from that specific tool's output.)

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Testing on your branch

No testing required as this contains no code changes.

## Checklist

- [ ] I have performed a self-review of my own code
- [X] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
