### PR TITLE
Allow mobile users to create non-S/R projects

### DIFF
--- a/src/angular-app/languageforge/lexicon/new-project/non-send-receive/new-project-name.controller.html
+++ b/src/angular-app/languageforge/lexicon/new-project/non-send-receive/new-project-name.controller.html
@@ -3,8 +3,8 @@
         <div class="col-12 col-lg-8">
             <div class="text-center">
                 <h3 class="no-space-break">Choose a project name</h3>
-                <div class="alert alert-danger" role="alert">
-                    Creating a non-send/receive project in Language Forge is no longer recommended because of the lack of an export path.
+                <div class="alert alert-danger" role="alert" style='position: relative'>
+					Creating a non-send/receive project in Language Forge is no longer recommended because of the lack of an export path.
                     Instead, create a new project from Language Depot to enable Send/Receive with FieldWorks. Data can then be exported through FieldWorks.
                 </div>
             </div>
@@ -17,7 +17,6 @@
                                 <input class="form-control" type="text" id="project-name"
                                        data-ng-model="$ctrl.npnNewProject.projectName"
                                        data-ng-blur="$ctrl.npnCheckProjectCode()"
-                                       data-pui-auto-focus="true"
                                        maxlength="50"
                                        required placeholder="eg: My Dictionary"
                                        data-idle-validate="$ctrl.npnCheckProjectCode()"


### PR DESCRIPTION
## Description

An alert was covering the buttons used to create a new project in the scenario where it was a non-S/R project and the user was on a mobile device.

Fixes #1411 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Bug demo:

https://user-images.githubusercontent.com/4412848/176743057-ed16e066-52e2-4bc1-bded-2e79b126a060.mov

Corrected:

https://user-images.githubusercontent.com/4412848/176743248-93ee5c10-6e0b-4a6e-976c-27bedad1bc1e.mov

## Testing on your branch

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce.  Please also provide relevant test data as necessary.  These instructions will be used for QA testing below.

- [ ] Attempt to create a new non-S/R project while on a mobile device and ensure the Next button is visible to the user
- [ ] Attempt to create a new non-S/R project while on a desktop and ensure the Next button is visible to the user

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [x] Joseph (2022-07-05)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
