### PR TITLE
had to ensure app and lfmerge run on same node

### DIFF
--- a/docker/deployment/app-deployment.yaml
+++ b/docker/deployment/app-deployment.yaml
@@ -65,6 +65,23 @@ spec:
       labels:
         app: app
     spec:
+      affinity:
+        # required to ensure this container makes it to lfmerge's dedicated node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - lfmerge
+            weight: 1
+      # required to ensure this container makes it to lfmerge's dedicated node
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+        value: lfmerge
       volumes:
       - name: assets
         persistentVolumeClaim:

--- a/docker/deployment/lfmerge-deployment.yaml
+++ b/docker/deployment/lfmerge-deployment.yaml
@@ -76,7 +76,7 @@ spec:
                 values:
                 - lfmerge
             weight: 1
-        # need to keep this on the same pod as the app since inotify only gets notification wwhen updates occur on the same kernal
+        # need to keep this on the same pod as the app since inotify only gets notification when updates occur on the same kernel
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/docker/deployment/lfmerge-deployment.yaml
+++ b/docker/deployment/lfmerge-deployment.yaml
@@ -76,6 +76,16 @@ spec:
                 values:
                 - lfmerge
             weight: 1
+        # need to keep this on the same pod as the app since inotify only gets notification wwhen updates occur on the same kernal
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - app
+            topologyKey: kubernetes.io/hostname
       # required to ensure this container makes it to a dedicated node (so it doesn't crash other containers when it blows up)
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
## Description

We learned that lfmerge's inotify will only receive messages from the kernel when the kernel is the same kernel used to write the files into place, i.e., lf-app  in this case.  Therefore, app and lfmerge must run on the same node until another mechanism can be considered that will work in a remote nfs environment.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue) (introduced in #1433 )

## Screenshots

N/A

## Testing on your branch

- [ ] A simple S/R smoke test will suffice

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
