### PR TITLE
Change 'docker-compose' to 'docker compose'

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,11 +3,11 @@
 .PHONY: start
 start: build
     # starts the entire runtime infrastructure
-	docker-compose up -d ssl
+	docker compose up -d ssl
 
 .PHONY: dev
 dev: start
-	docker-compose up -d ui-builder
+	docker compose up -d ui-builder
 
 .PHONY: playwright-tests
 playwright-tests:
@@ -18,7 +18,7 @@ playwright-tests:
     # delete any cached session storage state files if the service isn't running
 	docker compose ps app-for-playwright > /dev/null 2>&1 || rm -f ../*-storageState.json
 
-	docker-compose up -d app-for-playwright
+	docker compose up -d app-for-playwright
 
     # wait until the app-for-playwright service is serving up HTTP before continuing
 	until curl localhost:3238 > /dev/null 2>&1; do sleep 1; done
@@ -27,32 +27,32 @@ playwright-tests:
 
 .PHONY: e2e-tests
 e2e-tests:
-	docker-compose build app-for-e2e test-e2e
-	docker-compose restart app-for-e2e || docker-compose up -d app-for-e2e
-	docker-compose run -e TEST_SPECS=$(TEST_SPECS) test-e2e
+	docker compose build app-for-e2e test-e2e
+	docker compose restart app-for-e2e || docker compose up -d app-for-e2e
+	docker compose run -e TEST_SPECS=$(TEST_SPECS) test-e2e
 
 .PHONY: e2e-tests-ci
 e2e-tests-ci:
-	docker-compose build app-for-e2e test-e2e
-	docker-compose run -e GITHUB_ACTIONS=1 --name e2etests test-e2e
+	docker compose build app-for-e2e test-e2e
+	docker compose run -e GITHUB_ACTIONS=1 --name e2etests test-e2e
 	docker cp e2etests:/data/e2e-output/junitresults.xml e2e-results.xml
 	docker rm e2etests
 
 .PHONY: unit-tests
 unit-tests:
-	docker-compose build test-php
-	docker-compose run test-php
+	docker compose build test-php
+	docker compose run test-php
 
 .PHONY: unit-tests-ci
 unit-tests-ci:
-	docker-compose run --name unittests test-php
+	docker compose run --name unittests test-php
 	docker cp unittests:/var/www/PhpUnitTests.xml .
 	docker rm unittests
 
 .PHONY: build
 build:
 	npm install
-	docker-compose build mail app lfmerge ld-api next-proxy next-app
+	docker compose build mail app lfmerge ld-api next-proxy next-app
 
 .PHONY: scan
 # https://docs.docker.com/engine/scan
@@ -71,14 +71,14 @@ build-next:
 
 .PHONY: clean
 clean:
-	docker-compose down
+	docker compose down
 	docker system prune -f
 
 .PHONY: clean-volumes
 clean-volumes:
-	docker-compose down -v
+	docker compose down -v
 	docker system prune -f --volumes
 
 .PHONY: clean-powerwash
 clean-powerwash: clean-volumes
-	docker-compose down --rmi all
+	docker compose down --rmi all


### PR DESCRIPTION
## Description

Current Docker versions use 'docker compose' syntax. In accordance with this, instances of of 'docker-compose' in docker/Makefile have been changed to 'docker compose.'

Fixes #1451

### Type of Change

syntax update

## Testing on your branch

Running commands from the Makefile

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
