### PR TITLE
Simplified make's clean targets

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -74,12 +74,8 @@ clean:
 	docker compose down
 	docker system prune -f
 
-.PHONY: clean-volumes
-clean-volumes:
-	docker compose down -v
-	docker system prune -f --volumes
-
 .PHONY: clean-powerwash
-clean-powerwash: clean-volumes
+clean-powerwash: clean
+	docker system prune -f --volumes
 	docker rmi -f `docker images -q "lf-*"`
 	docker builder prune -f

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -127,8 +127,7 @@ After a minute or two, your source or test changes should be applied and you sho
 ### Cleanup
 
 1. `make clean` is the most common, it shuts down and cleans up running containers
-1. less commonly, if you need to blow away shared artifacts from previous runs, simply `make clean-volumes`
-1. rarely needed but for a "start from scratch" environment, `make clean-powerwash`.
+1. `make clean-powerwash` for those times when you want to "start from scratch" again, i.e., blow away your database, shared assets and built images
 
 ### Running dev
 


### PR DESCRIPTION
## Description

Over time, I've come to realize that the `clean-volumes` target wasn't really understood well and therefore unused.  I decide to simply get rid of that use case altogether.

### Type of Change

- DX improvement

## Screenshots

N/A

## Testing on your branch

- [ ] `make clean` should still shut down all services and clean up stopped containers
- [ ] `make clean-powerwash` should get rid of all volumes, built images, dangling resources as well as build caches

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
