### PR TITLE
fix 2 playwright tests that broke from UI change

### DIFF
--- a/test/e2e/pages/entries-list.page.ts
+++ b/test/e2e/pages/entries-list.page.ts
@@ -20,7 +20,7 @@ export class EntriesListPage {
 
     this.totalNumberOfEntries = this.page.locator('#totalNumberOfEntries');
 
-    this.filterInput = this.page.locator('[placeholder="Filter Entries"]');
+    this.filterInput = this.page.locator('[placeholder="Search"]');
     this.filterInputClearButton = this.page.locator('.clear-search-button');
     this.matchCount = this.page.locator('#totalNumberOfEntries >> span');
 


### PR DESCRIPTION


## Description

The recent PR 1446 changed the placeholder text of the search box, which broke the playwright tests. However no one noticed because the tests were turned off for PRs in 493233cab4545fec07d5f1ef940ffd3692212fc0

Before this PR, the four failing tests are:
```
4 failed
    [chromium] › editor-entry.spec.ts:49:5 › Lexicon E2E Entry Editor and Entries List › Entries List › Entries list has correct number of entries 
    [chromium] › editor-entry.spec.ts:53:5 › Lexicon E2E Entry Editor and Entries List › Entries List › Search function works correctly 
    [chromium] › editor-entry.spec.ts:540:9 › Lexicon E2E Entry Editor and Entries List › Entry Editor › Audio › Manager › Back to browse page, create new word, check word count, modify new word, autosaves changes, new word visible in editor and list 
    [chromium] › interface-language.spec.ts:26:3 › Interface Language picker › Can change user interface language to French, stays in French also on other pages, can change back to English 
```

After this PR, there are two known failing playwright tests:

```
2 failed
    [chromium] › editor-entry.spec.ts:49:5 › Lexicon E2E Entry Editor and Entries List › Entries List › Entries list has correct number of entries 
    [chromium] › interface-language.spec.ts:26:3 › Interface Language picker › Can change user interface language to French, stays in French also on other pages, can change back to English 
```

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message