### PR TITLE
Fixed bug where num of entries was being limited to 1,000 on project dashboard

### DIFF
--- a/next-app/src/routes/projects/[project_code]/meta/+server.ts
+++ b/next-app/src/routes/projects/[project_code]/meta/+server.ts
@@ -6,7 +6,7 @@ export async function get({ project_code, cookie }) {
 		{ entries, comments }
 	] = await Promise.all([
 		sf({ name: 'project_read_by_code', args: [ project_code ], cookie }),
-		sf({ name: 'lex_stats', args: [ project_code ], cookie }),
+		sf({ name: 'lex_stats_all', args: [ project_code ], cookie }),
 	])
 
 	const entries_with_picture = entries.filter(has_picture)

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -239,6 +239,7 @@ class RightsHelper
             case 'lex_dbeDtoFull':
             case 'lex_dbeDtoUpdatesOnly':
             case 'lex_stats':
+            case 'lex_stats_all':
                 return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
 
                 // case 'lex_entry_read':

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -558,6 +558,18 @@ class Sf
         throw new UserUnauthorizedException("User $this->userId is not a member of project $projectCode");
 	}
 
+	public function lex_stats_all($projectCode)
+	{
+		$projectModel = ProjectModel::getByProjectCode($projectCode);
+        $user = new UserModel($this->userId);
+
+        if ($user->isMemberOfProject($projectModel->id->asString())) {
+            return LexDbeDto::encode($projectModel->id->asString(), $this->userId, 1);
+        }
+
+        throw new UserUnauthorizedException("User $this->userId is not a member of project $projectCode");
+	}
+
     public function lex_dbeDtoFull($browserId, $offset)
     {
         $sessionLabel = 'lexDbeFetch_' . $browserId;


### PR DESCRIPTION
## Description

The number of entries on the project dashboard were being limited to 1,000.

Fixes #1460 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

<img width="660" alt="image" src="https://user-images.githubusercontent.com/4412848/189988358-79e869a9-b3cd-4164-b863-25964153e495.png">

## Testing on your branch

- [ ] Visit the project landing page for a project with more than 1,000 entries, e.g., test-rwr-flex, qxh-flex.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
