### PR TITLE
only install chromium for playwright

### DIFF
--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -79,7 +79,7 @@ jobs:
       #   working-directory: .
       #   run: |
       #     docker-compose -f docker/docker-compose.yml up -d app-for-playwright
-      #     npx playwright install
+      #     npx playwright install chromium
       #     npx playwright test
       -
         name: Log in to Docker Hub

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,7 +53,7 @@ jobs:
         # see https://playwright.dev/docs/ci#github-actions
         run: |
           docker-compose -f docker/docker-compose.yml up -d app-for-playwright
-          npx playwright install
+          npx playwright install chromium
           npx playwright test
 
   # protractor-tests:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -23,7 +23,7 @@ playwright-tests:
     # wait until the app-for-playwright service is serving up HTTP before continuing
 	until curl localhost:3238 > /dev/null 2>&1; do sleep 1; done
 
-	cd .. && npx playwright install && npx playwright test
+	cd .. && npx playwright install chromium && npx playwright test
 
 .PHONY: e2e-tests
 e2e-tests:


### PR DESCRIPTION
## Description

When installing browsers for Playwright, only install chromium, as that is the only browser that we are currently using.  This make our build more efficient by skipping downloading browsers that we never use.

### Type of Change

- build optimization

### Screenshots

Before this change, we download Firefox, Webkit and Chromium as seen in the GHA build below:
<img width="835" alt="image" src="https://user-images.githubusercontent.com/3444521/190119657-a1bb15cb-c8cd-4e60-b258-31c54afebf38.png">

After this PR, we only download Chromium (FFMPEG is always downloaded)

<img width="835" alt="image" src="https://user-images.githubusercontent.com/3444521/190122355-6f72475e-4d40-47b9-bada-4723f008b470.png">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
