### PR TITLE
Legacy app needed a little more memory based on testing in staging

### DIFF
--- a/docker/deployment/app-deployment.yaml
+++ b/docker/deployment/app-deployment.yaml
@@ -101,7 +101,7 @@ spec:
             memory: 110Mi
             cpu: 0.1
           limits:
-            memory: 200Mi
+            memory: 500Mi
         volumeMounts:
           - mountPath: /var/www/html/assets
             name: assets


### PR DESCRIPTION
## Description

With some larger projects, I was finding the legacy app would not respond to `lex-stat-all` calls without shutting down the connection.  I bumped the memory and it worked fine.  This PR will make those resource configs more permanent.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- k8s config change

## Screenshots

N/A

## Testing on your branch

- [ ] Simply hit the project landing page for larger projects, e.g., `qxh-flex`


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
