### PR TITLE
Local and GitHub playwright testing improvements

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,6 +55,12 @@ jobs:
           docker-compose -f docker/docker-compose.yml up -d app-for-playwright
           npx playwright install chromium
           npx playwright test
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: test-results
 
   # protractor-tests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,6 +47,22 @@ jobs:
         run: |
           npm ci
           docker-compose build app
+      - name: Get installed Playwright version
+        id: playwright-version
+        # https://github.com/microsoft/playwright/issues/7249#issuecomment-1201476980
+        run: echo -n "::set-output name=version::$(npm ls @playwright/test --json | jq --raw-output '.dependencies["@playwright/test"].version')"
+
+        # https://github.com/microsoft/playwright/issues/7249#issuecomment-1154603556
+      - name: Cache playwright browsers
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: '~/.cache/ms-playwright'
+          # Make each playwright version use its own cache in case it uses different browser versions
+          # Cache entries are deleted if not accessed for 7 days
+          # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+          key: 'playwright-${{ steps.playwright-version.outputs.version }}'
+
       -
         name: Playwright E2E Tests
         working-directory: .

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -23,7 +23,7 @@ playwright-tests:
     # wait until the app-for-playwright service is serving up HTTP before continuing
 	until curl localhost:3238 > /dev/null 2>&1; do sleep 1; done
 
-	cd .. && npx playwright install chromium && npx playwright test
+	cd .. && npx playwright install chromium && npx playwright test $(params)
 
 .PHONY: e2e-tests
 e2e-tests:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "webpack:dev:watch": "webpack -w --config webpack-dev.config.js",
     "webpack:prd": "webpack --config webpack-prd.config.js",
     "compile-test-e2e": "tsc -p test/app",
-    "test-e2e": "protractor test/app/protractorConf.js"
+    "test-e2e": "protractor test/app/protractorConf.js",
+    "make": "cd docker && make"
   },
   "license": "MIT",
   "repository": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,8 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? 'github' : 'html',
+  outputDir: 'test-results', // referenced in pull-request.yml
+  reporter: process.env.CI ? [['github'], ['list']] : [['html', {outputFolder: 'test-results/_html-report'}]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
@@ -40,6 +41,7 @@ const config: PlaywrightTestConfig = {
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
   },
 
   /* Configure projects for major browsers */

--- a/test/e2e/utils/globalSetup.ts
+++ b/test/e2e/utils/globalSetup.ts
@@ -32,8 +32,10 @@ export default async function globalSetup(config: FullConfig) {
     const browser = await projectBrowser.launch();
     const context = await browser.newContext({ baseURL });
     for (const user of usersToCreate) {
-      createUser(context.request, user);
+      await createUser(context.request, user);
     }
+    await context.close();
+
     // Now log in as each user and ensure there's a storage state saved
     const sessionLifetime = 365 * 24 * 60 * 60 * 1000;  // 1 year, in milliseconds
     const now = new Date();
@@ -48,6 +50,7 @@ export default async function globalSetup(config: FullConfig) {
       const page = await context.newPage();
       await loginAs(page, user);
       await context.storageState({ path });
+      await context.close();
     }
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,7 @@
     "max-classes-per-file": [false],
     "radix": { "severity": "warning" },
     "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore", "allow-pascal-case"],
-    "no-console": false
+    "no-console": false,
+    "no-floating-promises": true
   }
 }


### PR DESCRIPTION
## Description

Various minor playwright improvements:
- Cache playwright browsers in GHA (per playwright version as documented). Not a huge performance boost, but not a huge change either
- Upload the playwright results as a GitHub artifact, which is then available for download (see screenshot)
- Allow passing playwright params to make file. E.g. `make playwright-tests params="--headed"`
- Allow running make files with npm (I find it very handy for the commands to be directory independent) E.g. `npm run make playwright-tests params="--headed"`
- Wait for forgotten promise in `globalSetup.ts` and add ts-lint rule to watch for cases like this
- Close browserContexts in `globalSetup.ts`, because: (1) it's documented as best practice, (2) it doesn't break anything and (3) it eliminates a potential culprit of "socket hang up" mentioned in #1402

### Type of Change

- New feature

## Screenshots

![image](https://user-images.githubusercontent.com/12587509/191271441-3af22c76-73ed-4f16-910a-2e2e961f44b5.png)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
