### PR TITLE
Bugfix/use media recorder

### DIFF
--- a/docker/base-php/Dockerfile
+++ b/docker/base-php/Dockerfile
@@ -4,7 +4,8 @@ FROM php:7.3.28-apache
 # p7zip-full - used by LF application for unzipping lexicon uploads
 # unzip - used by LF application for unzipping lexicon uploads
 # curl - used by LF application
-RUN apt-get update && apt-get -y install p7zip-full unzip curl tini && rm -rf /var/lib/apt/lists/*
+# ffmpeg - used by LF audio upload method
+RUN apt-get update && apt-get -y install p7zip-full unzip curl tini ffmpeg && rm -rf /var/lib/apt/lists/*
 
 # see https://github.com/mlocati/docker-php-extension-installer
 # PHP extensions required by the LF application

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "font-awesome": "^4.7.0",
         "intl-tel-input": "9.2.7",
         "jquery": "^3.6.0",
-        "lamejs": "^1.2.0",
         "localforage": "^1.7.1",
         "ng-drag-to-reorder": "^1.0.8",
         "ng-file-upload": "12.0.4",
@@ -30,6 +29,7 @@
         "npm-run-all": "^4.1.5",
         "oclazyload": "^1.1.0",
         "offline-js": "0.7.11",
+        "webm-fix-duration": "^1.0.1",
         "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
@@ -43,6 +43,7 @@
         "@types/bootstrap": "^3.3.35",
         "@types/core-js": "^0.9.42",
         "@types/deep-diff": "^1.0.1",
+        "@types/dom-mediacapture-record": "^1.0.11",
         "@types/intl-tel-input": "0.0.7",
         "@types/jasmine": "^2.8.4",
         "@types/jasminewd2": "^2.0.3",
@@ -2154,6 +2155,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/deep-diff/-/deep-diff-1.0.1.tgz",
       "integrity": "sha512-cZIq2GFcPmW0/M7dtLuphyoU8f3zpTcBgV+wkFFJ0CK0lwRVGGLaBSJZ98qs4LjtLimPq1Bb2VJnhGn6SEE4IA==",
+      "dev": true
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.11.tgz",
+      "integrity": "sha512-ODVOH95x08arZhbQOjH3no7Iye64akdO+55nM+IGtTzpu2ACKr9CQTrI//CCVieIjlI/eL+rK1hQjMycxIgylQ==",
       "dev": true
     },
     "node_modules/@types/eslint": {
@@ -6121,14 +6128,6 @@
         "immediate": "~3.0.5"
       }
     },
-    "node_modules/lamejs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/lamejs/-/lamejs-1.2.0.tgz",
-      "integrity": "sha1-Aln4PbRmYUGntnG4yqY2nZUXfQg=",
-      "dependencies": {
-        "use-strict": "1.0.1"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -9910,11 +9909,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/use-strict": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
-      "integrity": "sha1-C7gNlPSaSgUZK4Sox9NOlfGn46A="
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10154,6 +10148,11 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
+    },
+    "node_modules/webm-fix-duration": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webm-fix-duration/-/webm-fix-duration-1.0.1.tgz",
+      "integrity": "sha512-KaL2yq5BQ1ngRlWVpwQ0bI8INW3ZMzrbPfz8L50GvZHhReCeG5+zKqzk4BcpK6vEdMRHSxoNHn/ixiDqVdKZTw=="
     },
     "node_modules/webpack": {
       "version": "5.27.1",
@@ -12631,6 +12630,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/deep-diff/-/deep-diff-1.0.1.tgz",
       "integrity": "sha512-cZIq2GFcPmW0/M7dtLuphyoU8f3zpTcBgV+wkFFJ0CK0lwRVGGLaBSJZ98qs4LjtLimPq1Bb2VJnhGn6SEE4IA==",
+      "dev": true
+    },
+    "@types/dom-mediacapture-record": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.11.tgz",
+      "integrity": "sha512-ODVOH95x08arZhbQOjH3no7Iye64akdO+55nM+IGtTzpu2ACKr9CQTrI//CCVieIjlI/eL+rK1hQjMycxIgylQ==",
       "dev": true
     },
     "@types/eslint": {
@@ -15785,14 +15790,6 @@
         }
       }
     },
-    "lamejs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/lamejs/-/lamejs-1.2.0.tgz",
-      "integrity": "sha1-Aln4PbRmYUGntnG4yqY2nZUXfQg=",
-      "requires": {
-        "use-strict": "1.0.1"
-      }
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -18713,11 +18710,6 @@
         }
       }
     },
-    "use-strict": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
-      "integrity": "sha1-C7gNlPSaSgUZK4Sox9NOlfGn46A="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -18908,6 +18900,11 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
+    },
+    "webm-fix-duration": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webm-fix-duration/-/webm-fix-duration-1.0.1.tgz",
+      "integrity": "sha512-KaL2yq5BQ1ngRlWVpwQ0bI8INW3ZMzrbPfz8L50GvZHhReCeG5+zKqzk4BcpK6vEdMRHSxoNHn/ixiDqVdKZTw=="
     },
     "webpack": {
       "version": "5.27.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "font-awesome": "^4.7.0",
     "intl-tel-input": "9.2.7",
     "jquery": "^3.6.0",
-    "lamejs": "^1.2.0",
     "localforage": "^1.7.1",
     "ng-drag-to-reorder": "^1.0.8",
     "ng-file-upload": "12.0.4",
@@ -45,6 +44,7 @@
     "npm-run-all": "^4.1.5",
     "oclazyload": "^1.1.0",
     "offline-js": "0.7.11",
+    "webm-fix-duration": "^1.0.1",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
@@ -58,6 +58,7 @@
     "@types/bootstrap": "^3.3.35",
     "@types/core-js": "^0.9.42",
     "@types/deep-diff": "^1.0.1",
+    "@types/dom-mediacapture-record": "^1.0.11",
     "@types/intl-tel-input": "0.0.7",
     "@types/jasmine": "^2.8.4",
     "@types/jasminewd2": "^2.0.3",

--- a/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
+++ b/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
@@ -1,24 +1,98 @@
-import * as angular from 'angular';
-import * as lamejs from 'lamejs';
-
-declare var webkitAudioContext: {
-  new(): AudioContext;
-};
+import { webmFixDuration } from "webm-fix-duration";
+import * as angular from "angular";
 
 export class AudioRecorderController implements angular.IController {
+  static $inject = ["$interval", "$scope"];
 
-  static $inject = ['$interval', '$scope'];
-  constructor(private $interval: angular.IIntervalService, private $scope: angular.IScope) {}
-
+  mediaRecorder: MediaRecorder;
+  chunks: string[] = [];
   isRecording = false;
   hasRecorded = false;
+  recordingStartTime: Date;
   audioSrc: string;
   blob: Blob;
   recordingTime: string;
   errorMessage: string;
-  stopMediaStream: () => void;
   callback: (blob: Blob) => void;
+  durationInMilliseconds: number;
   interval: angular.IPromise<void>;
+
+  constructor(
+    private $interval: angular.IIntervalService,
+    private $scope: angular.IScope
+  ) {}
+
+  private startRecording() {
+    this.recordingTime = "0:00";
+
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(
+      (stream) => {
+        this.mediaRecorder = new MediaRecorder(stream);
+
+        this.$scope.$apply(() => {
+          this.hasRecorded = true;
+          this.errorMessage = null;
+          this.isRecording = true;
+        });
+
+        this.mediaRecorder.addEventListener(
+          "dataavailable",
+          async (e: { data: any }) => {
+            this.chunks.push(e.data);
+            var roughBlob = new Blob(this.chunks, {
+              type: "audio/webm; codecs=opus",
+            });
+            //In some browsers (Chrome, Edge, ...) navigator.mediaDevices.getUserMedia with MediaRecorder creates WEBM files without duration metadata  //2022-09
+            //webmFixDuration appends missing duration metadata to a WEBM file blob.
+            this.blob = await webmFixDuration(
+              roughBlob,
+              this.durationInMilliseconds,
+              "audio/webm; codecs=opus"
+            );
+            this.chunks = [];
+            this.audioSrc = window.URL.createObjectURL(this.blob);
+            this.$scope.$digest();
+          }
+        );
+
+        this.recordingStartTime = new Date();
+
+        this.interval = this.$interval(() => {
+          const seconds = Math.floor(
+            (new Date().getTime() - this.recordingStartTime.getTime()) / 1000
+          );
+          this.recordingTime =
+            Math.floor(seconds / 60) +
+            ":" +
+            (seconds % 60 < 10 ? "0" : "") +
+            (seconds % 60);
+        }, 1000);
+
+        this.mediaRecorder.start();
+      },
+      (err) => {
+        this.$scope.$apply(() => {
+          this.errorMessage = "Unable to record audio from your microphone.";
+          this.isRecording = false;
+          this.hasRecorded = false;
+        });
+
+        console.error(err);
+      }
+    );
+  }
+
+  private stopRecording() {
+    this.durationInMilliseconds = Math.floor(
+      new Date().getTime() - this.recordingStartTime.getTime()
+    );
+
+    this.mediaRecorder.stop();
+
+    if (this.interval) {
+      this.$interval.cancel(this.interval);
+    }
+  }
 
   toggleRecording() {
     if (this.isRecording) this.stopRecording();
@@ -27,7 +101,9 @@ export class AudioRecorderController implements angular.IController {
   }
 
   close() {
-    this.stopRecording();
+    if (this.isRecording) {
+      this.stopRecording();
+    }
     this.callback(null);
   }
 
@@ -36,132 +112,26 @@ export class AudioRecorderController implements angular.IController {
   }
 
   recordingSupported() {
-    return navigator.mediaDevices && navigator.mediaDevices.enumerateDevices && navigator.mediaDevices.getUserMedia &&
-      ((window as any).AudioContext || (window as any).webkitAudioContext);
+    return (
+      navigator.mediaDevices &&
+      navigator.mediaDevices.enumerateDevices &&
+      navigator.mediaDevices.getUserMedia &&
+      ((window as any).AudioContext || (window as any).webkitAudioContext)
+    );
   }
 
   $onDestroy() {
-    this.stopRecording();
-  }
-
-  private startRecording() {
-    this.recordingTime = '0:00';
-
-    navigator.mediaDevices.getUserMedia({audio: true}).then(stream => {
-
-      this.$scope.$apply(() => {
-        this.hasRecorded = true;
-        this.errorMessage = null;
-        this.isRecording = true;
-      });
-
-      const recordingStartTime = new Date();
-      // webkit prefix required for Safari
-      const context = (window as any).AudioContext ? new AudioContext() : new webkitAudioContext();
-      const bufferSize = 0;
-      const channels = 1;
-      const processor = context.createScriptProcessor(bufferSize, channels, channels);
-      context.createMediaStreamSource(stream).connect(processor);
-      processor.connect(context.destination);
-      const sampleRate = context.sampleRate;
-      const bitrate = 128;
-      const mp3Encoder = new MP3Encoder(channels, sampleRate, bitrate);
-
-      function handleAudioData(event: AudioProcessingEvent) {
-        mp3Encoder.appendData(event.inputBuffer.getChannelData(0));
-      }
-      processor.addEventListener('audioprocess', handleAudioData);
-
-      mp3Encoder.onMp3Blob(blob => {
-        this.blob = blob;
-        this.audioSrc = URL.createObjectURL(blob);
-      });
-
-      this.interval = this.$interval(() => {
-        const seconds = Math.floor((new Date().getTime() - recordingStartTime.getTime()) / 1000);
-        this.recordingTime = Math.floor(seconds / 60) + ':' + (seconds % 60 < 10 ? '0' : '') + seconds % 60;
-      }, 1000);
-
-      this.stopMediaStream = () => {
-        processor.removeEventListener('audioprocess', handleAudioData);
-        mp3Encoder.end();
-        stream.getAudioTracks()[0].stop();
-      };
-
-    }, err => {
-      this.$scope.$apply(() => {
-        this.errorMessage = 'Unable to record audio from your microphone.';
-        this.isRecording = false;
-        this.hasRecorded = false;
-      });
-      console.error(err);
-    });
-  }
-
-  private stopRecording() {
-    if (this.interval) this.$interval.cancel(this.interval);
-    if (this.stopMediaStream) this.stopMediaStream();
-  }
-
-}
-
-export class MP3Encoder {
-
-  constructor(private channels: number, private sampleRate: number, private bitrate: number) {}
-
-  buffer: Float32Array[] = [];
-  mp3BlobListeners: Array<(data: Blob) => void> = [];
-
-  lame = new lamejs.Mp3Encoder(this.channels, this.sampleRate, this.bitrate);
-
-  appendData(data: Float32Array) {
-    // copy the data, because Chromium 66.0.3359.139 overwrites it (FF 60.0.1 does not)
-    this.buffer.push(data.slice(0, data.length));
-  }
-
-  end() {
-    // Flatten the buffer array while converting it from Float32 to Int16
-    const pcmData = new Int16Array(this.buffer.length * this.buffer[0].length);
-
-    // max and min 16-bit values
-    const max = 0x7FFF;
-    const min = 0x8000;
-    let index = 0;
-    for (let i = 0, len1 = this.buffer.length; i < len1; ++i) {
-      const chunk = this.buffer[i];
-      for (let j = 0, len2 = chunk.length; j < len2; ++j) {
-        pcmData[index] = chunk[j] < 0 ? chunk[j] * min : chunk[j] * max;
-        ++index;
-      }
+    if (this.isRecording) {
+      this.stopRecording();
     }
-
-    const blockSize = 1152;
-    const mp3Data: Int8Array[] = [];
-
-    let encoded: Int8Array;
-    for (let i = 0; i < pcmData.length; i += blockSize) {
-      const chunk = pcmData.subarray(i, i + blockSize);
-      // This line takes the most time of this function, about 90%
-      encoded = this.lame.encodeBuffer(chunk);
-      if (chunk.length > 0) mp3Data.push(new Int8Array(encoded));
-    }
-
-    encoded = this.lame.flush();
-    if (encoded.length > 0) mp3Data.push(new Int8Array(encoded));
-    const blob = new Blob(mp3Data, {type: 'audio/mp3'});
-
-    this.mp3BlobListeners.forEach(cb => cb(blob));
-  }
-
-  onMp3Blob(cb: (data: Blob) => void) {
-    this.mp3BlobListeners.push(cb);
   }
 }
 
 export const AudioRecorderComponent: angular.IComponentOptions = {
   bindings: {
-    callback: '<' // TODO probably change to > or <, not sure which
+    callback: "<",
   },
   controller: AudioRecorderController,
-  templateUrl: '/angular-app/bellows/shared/audio-recorder/audio-recorder.component.html'
+  templateUrl:
+    "/angular-app/bellows/shared/audio-recorder/audio-recorder.component.html",
 };

--- a/src/angular-app/bellows/shared/sound-player.component.html
+++ b/src/angular-app/bellows/shared/sound-player.component.html
@@ -6,5 +6,6 @@
         {{$ctrl.currentTime()}} / {{$ctrl.duration()}}
     </span>
     <!--suppress HtmlFormInputWithoutLabel -->
-    <input class="seek-slider" type="range" min="0" max="{{$ctrl.durationInSeconds()}}" value="0">
+    <!--The step value is very small to handle a bug encountered where the slider stops after its last full step, before reaching the end 2022-09-->
+    <input class="seek-slider" type="range" min="0" max="{{$ctrl.durationInSeconds()}}" step="0.0000000000000001" value="0">
 </span>

--- a/src/angular-app/bellows/shared/sound-player.component.ts
+++ b/src/angular-app/bellows/shared/sound-player.component.ts
@@ -4,15 +4,19 @@ export class SoundController implements angular.IController {
   puiUrl: string;
 
   audioElement = document.createElement('audio');
+
   playing = false;
 
   private isUserMovingSlider: boolean = false;
   private slider: HTMLInputElement;
 
   static $inject = ['$scope', '$element'];
-  constructor(private $scope: angular.IScope, private $element: angular.IRootElementService) { }
+
+  constructor(private $scope: angular.IScope, private $element: angular.IRootElementService) {}
 
   $onInit(): void {
+
+
     this.slider = this.$element.find('.seek-slider').get(0) as HTMLInputElement;
 
     this.audioElement.addEventListener('ended', () => {
@@ -21,13 +25,9 @@ export class SoundController implements angular.IController {
           this.togglePlayback();
         }
 
-        this.audioElement.currentTime = 0;
       });
     });
 
-    this.audioElement.addEventListener('loadedmetadata', () => {
-      this.$scope.$digest();
-    });
 
     const previousFormattedTime: string = null;
     this.audioElement.addEventListener('timeupdate', () => {
@@ -65,21 +65,37 @@ export class SoundController implements angular.IController {
   }
 
   $onDestroy(): void {
-    this.audioElement.pause();
+    if (!this.audioElement.paused){
+      this.audioElement.pause();
+    }
   }
 
   iconClass(): string {
     return this.playing ? 'fa-pause' : 'fa-play';
   }
 
+
+  async playAudio() {
+    try{
+      let loadedAudioPlayer = await this.audioElement.play();
+      return loadedAudioPlayer;
+    } catch (e) {
+
+    }
+  }
+
   togglePlayback(): void {
     this.playing = !this.playing;
 
     if (this.playing) {
-      this.audioElement.play();
+      this.audioElement.currentTime = 0;
+      this.playAudio();
     } else {
-      this.audioElement.pause();
+      if(!this.audioElement.paused){
+        this.audioElement.pause();
+      }
     }
+
   }
 
   currentTimeInSeconds(): number {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-audio.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-audio.component.ts
@@ -1,3 +1,4 @@
+
 import * as angular from 'angular';
 import { format, addMinutes } from 'date-fns';
 
@@ -145,7 +146,7 @@ export class FieldAudioController implements angular.IController {
   audioRecorderCallback = (blob: Blob) => {
     if (blob) {
       const date = new Date();
-      const fileName = 'recording_' + format(addMinutes(date, date.getTimezoneOffset()), 'yyyy_MM_dd_HH_mm_ss') + '.mp3';
+      const fileName = 'recording_' + format(addMinutes(date, date.getTimezoneOffset()), 'yyyy_MM_dd_HH_mm_ss') + '.webm';
       const file = new File([blob], fileName);
       this.uploadAudio(file);
     }


### PR DESCRIPTION
## Description

MediaRecorder is the most current API for audio recording in browser. With MediaRecorder, Language Forge will capture audio in WEBM containers with Opus codec. 

ffmpeg is added as a dependency to perform audio conversions. The audio files are converted and stored as either .wav or .mp3 files to accommodate send/receive with Fieldworks software. If the recording is short enough (<6 s), based on settings in conversion to WAV, it will be within the 1MB file size limit. Recordings longer than 6 seconds are converted to MP3. 

webm-fix-duration is added as a small (25 KB) dependency. Currently, navigator.mediaDevices.getUserMedia with MediaRecorder returns WEBM file blobs that have no duration metadata. This affects the display of the sound player as well as decisions for encoding. The webm-fix-duration package takes care of that by appending the duration data to the blob so it may be accessed by the app.

Fixes #1382
Fixes #1381
Fixes #1399 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

The UI works as before. In the console here, see saved files converted to .wav and .mp3.

![image](https://user-images.githubusercontent.com/56163492/191479975-34ae7f50-1fbd-435b-a906-c6fd62640316.png)


## Testing on your branch

- [ ] Test the following in Chrome, Firefox, Edge, and Safari, as well as on iOS and Android mobile devices.
To test on mobile, install ngrok and run:
`./ngrok http http://localhost`
in a bash terminal. The same command with https://localhost may not work, so be careful to try http://localhost in particular. You will get a URL that you can use for testing from a mobile device.

1. Open the HTML docker container in lf-app. Open assets/lexicon/sf_my_dictionary/audio. This is where all saved recordings and uploaded audio files go.
2. Record a short (<6 second) clip online, play it back, and save it. See if it is found in the container twice: once in the .webm format  and once as a .wav file.
3. Record a longer (>6 second) clip online, play it back, and save it. See if it is found in the container twice: once in the .webm format  and once as an .mp3 file.
4. Upload a long and a short clip of each of these file types: .ogg, .flac, .m4a. See if they are found in the container twice, with conversion to .wav for the short files and .mp3 for the long files.
5. Upload an .mp3 and a .wav file to see if these files are stored in the container "as-is"; no conversion, no second copy. Here is a folder of test files to use: [Audio Test Upload Files.zip](https://github.com/sillsdev/web-languageforge/files/9642997/Audio.Test.Upload.Files.zip)
- [ ] See if files added online come into FLEx via Send/Receive.

## Checklist


- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works -- have not done this, maybe I can learn.

## qa.languageforge.org testing

Reviewers: add/replace your name below and check the box to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Reviewer1 (YYYY-MM-DD HH:MM)
- [ ] Reviewer2 (YYYY-MM-DD HH:MM)
