### PR TITLE
Use make file for running playwright tests on GH

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,14 +63,11 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
           key: 'playwright-${{ steps.playwright-version.outputs.version }}'
 
-      -
-        name: Playwright E2E Tests
+      - name: Playwright E2E Tests
         working-directory: .
         # see https://playwright.dev/docs/ci#github-actions
-        run: |
-          docker-compose -f docker/docker-compose.yml up -d app-for-playwright
-          npx playwright install chromium
-          npx playwright test
+        run: npm run make playwright-tests
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Description

Fixes #1402.

Rather than duplicating the steps of running our E2E tests in the GitHub workflow and the make file, we should use the makefile in the workflow as well.

The make file already explicitly waits until the app server returns an HTTP response before running the tests. That's why this change should fix #1402.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

![image](https://user-images.githubusercontent.com/12587509/192227559-3eb5e3de-bf5d-4c3f-b1ea-b139a54d88a4.png)

## Testing on your branch

An workflox execution with this change can be viewed here: https://github.com/myieye/web-languageforge/actions/runs/3126086474/jobs/5071174693

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message