### PR TITLE
Fix flaky test by waiting for specific URL

### DIFF
--- a/test/e2e/signup.spec.ts
+++ b/test/e2e/signup.spec.ts
@@ -117,16 +117,16 @@ test.describe('E2E Signup app', () => {
     await signupPage.signupButton.click();
 
     // Verify new user logged in and redirected to projects page
-    await signupPage.page.waitForNavigation({waitUntil: "networkidle"});
+    await signupPage.page.waitForURL("**/app/projects");
     expect(signupPage.page.url()).toContain('/app/projects');
   });
 
   test('Redirects to projects page if already logged in', async ({ memberTab }) => {
-    const signupPage = new SignupPage(memberTab);
+    const signupPageMember = new SignupPage(memberTab);
     await Promise.all([
-      signupPage.page.waitForNavigation({waitUntil: "networkidle"}),
-      signupPage.page.goto(SignupPage.url),
+      signupPageMember.page.waitForURL("**/app/projects"),
+      signupPageMember.page.goto(SignupPage.url),
     ]);
-    expect(signupPage.page.url()).toContain('/app/projects');
+    expect(signupPageMember.page.url()).toContain('/app/projects');
   });
 });


### PR DESCRIPTION
## Description

By using playwright's built tools for waiting for the URL we want, we can wait for exactly what we want to verify rather than wait for the network to be idle.

Fixes #1481 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)