### PR TITLE
Add playwright extension to recommendations and overhault docs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,14 +1,15 @@
 {
-	// See http://go.microsoft.com/fwlink/?LinkId=827846
-	// for the documentation about the extensions.json format
-	"recommendations": [
-		"amodio.tsl-problem-matcher",
-		"msjsdiag.debugger-for-chrome",
-		"ms-vscode-remote.remote-containers",
-		"editorconfig.editorconfig",
-		"dbaeumer.vscode-eslint",
-		"xdebug.php-pack",
-		"svelte.svelte-vscode",
-		"bradlc.vscode-tailwindcss"
-	]
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "amodio.tsl-problem-matcher",
+    "msjsdiag.debugger-for-chrome",
+    "ms-vscode-remote.remote-containers",
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "xdebug.php-pack",
+    "svelte.svelte-vscode",
+    "bradlc.vscode-tailwindcss",
+    "ms-playwright.playwright"
+  ]
 }

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -2,19 +2,52 @@
 
 Welcome!  We're glad that you are interested in helping develop Language Forge.
 
+  - [Development Environment Quick Start](#development-environment-quick-start)
+    - [Supported Development Environments](#supported-development-environments)
+    - [Project Setup](#project-setup)
+    - [Running the App Locally](#running-the-app-locally)
+  - [Tests](#tests)
+    - [Running Playwright E2E Tests](#running-playwright-e2e-tests)
+    - [Running Protractor E2E Tests](#running-protractor-e2e-tests)
+    - [Running Unit Tests](#running-unit-tests)
+  - [Other commands](#other-commands)
+    - [Cleanup](#cleanup)
+    - [Running dev](#running-dev)
+  - [Debugging](#debugging)
+    - [PHP Application Debugging](#php-application-debugging)
+    - [PHP Tests Debugging](#php-tests-debugging)
+    - [E2E Tests Debugging](#e2e-tests-debugging)
+  - [Style Guides](#style-guides)
+    - [PHP](#php)
+    - [JavaScript](#javascript)
+    - [Angular & TypeScript](#angular--typescript)
+
 ## Development Environment Quick Start ##
 
+### Supported Development Environments
+
+Development of Language Forge is supported using [VS Code](https://code.visualstudio.com/download) on either pure Linux or Windows using WSL ([`wsl --install`](https://learn.microsoft.com/en-us/windows/wsl/install)).
+
+On Windows, the project should be opened with the [Remote - WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) VS Code extension, so that all commands and extensions run on WSL.
+
+### Project Setup
+
 1. Install [Docker](https://www.docker.com/get-started).
-    1. Linux users will need some additional steps: Please visit https://docs.docker.com/compose/install for info on installing the engine and compose.
-    2. Windows users, use Ubuntu (WSL) and follow the instructions at https://docs.docker.com/engine/install/ubuntu/. Then permit your user (and not just "sudo") to contact the Docker daemon by running `sudo usermod -aG docker $yourUsername` and `sudo chmod 666 /var/run/docker.sock`. Optionally configure docker to start on boot with `printf '[boot]\ncommand="service docker start"\n' | sudo tee /etc/wsl.conf` (assuming `/etc/wsl.conf` is currently unused).
-3. Install [Make](https://www.gnu.org/software/make/): `sudo apt install make`.  This is actually optional but simplifies things a bit.
-4. Install [Node 16.14.0](https://nodejs.org/en/download/).  We recommend using a Node version manager e.g. [nvm](https://github.com/nvm-sh/nvm#installation-and-update).
-5. Clone the repo: `git clone -c core.symlinks=true https://github.com/sillsdev/web-languageforge`. Windows "Developer Mode" must be enabled before cloning to a Windows file system (NTFS/FAT) or the symbolic links won't be created.
-6. `cd web-languageforge/docker`
+    1. Linux users will need some additional steps. Visit https://docs.docker.com/compose/install for info on installing the engine and compose.
+    2. Windows users, use Ubuntu (WSL) and follow the instructions at https://docs.docker.com/engine/install/ubuntu/. Then:
+        1. Start docker: `sudo service docker start`.
+        2. Permit your user (and not just "sudo") to contact the Docker daemon: `sudo usermod -aG docker yourUsername && sudo chmod 666 /var/run/docker.sock`.
+        3. (Optional) Configure docker to start on boot: `printf '[boot]\ncommand="service docker start"\n' | sudo tee /etc/wsl.conf` (assuming `/etc/wsl.conf` is currently unused).
+3. Install [Make](https://www.gnu.org/software/make/): `sudo apt install make`.
+4. Install [Node 16.14.0](https://nodejs.org/en/download/).  We recommend using [nvm](https://github.com/nvm-sh/nvm#installation-and-update).
+5. Clone the repo: `git clone https://github.com/sillsdev/web-languageforge`.
+    1. Windows users, be sure to clone the project to the WSL file system (to keep VS Code, Git and the file system in sync)
 
 ### Running the App Locally
 
-1. `make`
+> Note: `make` rules can be run directly from the `docker` directory or with `npm run make` from any project sub-directory.
+
+1. `npm run make` or `cd docker && make`
 1. Within any browser, navigate to https://localhost
 1. Continue through any certificate warnings
 1. You should see a landing page, click "Login"
@@ -33,6 +66,8 @@ Welcome!  We're glad that you are interested in helping develop Language Forge.
 > then hit `http://192.168.161.99` from your phone or other device on the same network.
 >
 > NOTE: disabling cache on your device may not be trivial, you'll either need to wipe the site settings on your device's browser or you'll need to do it via USB debugging.
+
+## Tests
 
 ### Running Playwright E2E Tests
 
@@ -71,60 +106,7 @@ To quickly re-run the tests without going through the `make build` process, you 
 1. `make unit-tests`
 1. Test results will appear in your terminal
 
-## Style Guides ##
-
-PHP code conforms to [PSR-2](http://www.php-fig.org/psr/psr-2/).
-
-- Add `php-cs-fixer` globally installed with *composer* (http://cs.sensiolabs.org/). Here is how to add it to **PhpStorm** (https://hackernoon.com/how-to-configure-phpstorm-to-use-php-cs-fixer-1844991e521f). Use it with the parameters `fix --verbose "$FileDir$/$FileName$"`.
-
-JavaScript code conforms to [AirBNB JS style guide](https://github.com/airbnb/javascript).
-
-- Using PhpStorm with JSCS helps a lot with automating this (see the section below on PhpStorm [Coding Standard and Style](#coding-standard-and-style)).
-
-### AngularJS TypeScript Style Guide ###
-
-Our front-end and E2E tests are written in [**TypeScript**](https://www.typescriptlang.org).
-
-> Note: this repo is currently AngularJS (1.8) not Angular (2+).
-
-Our TypeScript follows the [Angular Style Guide](https://angular.io/guide/styleguide).
-
-Other useful resources:
-
-- [x] [angularjs-styleguide/typescript at master · toddmotto/angularjs-styleguide](https://github.com/toddmotto/angularjs-styleguide/tree/master/typescript#stateless-components)
-- [x] [AngularJS 1.x with TypeScript (or ES6) Best Practices by Martin McWhorter on CodePen](https://codepen.io/martinmcwhorter/post/angularjs-1-x-with-typescript-or-es6-best-practices)
-- [x] [What is best practice to create an AngularJS 1.5 component in Typescript? - Stack Overflow](https://stackoverflow.com/questions/35451652/what-is-best-practice-to-create-an-angularjs-1-5-component-in-typescript)
-- [x] [Don't Panic: Using ui-router as a Component Router](http://dontpanic.42.nl/2016/07/using-ui-router-as-component-router.html)
-- [x] [Lifecycle hooks in Angular 1.5](https://toddmotto.com/angular-1-5-lifecycle-hooks#onchanges)
-
-### Debugging E2E Tests
-
-You'll need the "Remote - Containers" extension (`ms-vscode-remote.remote-containers`) installed, and you'll need your version of Docker Compose to be at least 1.21. (The VS Code instructions say that the Ubuntu snap package for `docker-compose` is **not** supported, so if you don't have it installed already, go to https://github.com/docker/compose/releases and download an appropriate binary of the most recent release. On Linux, you should put that binary in `/usr/local/bin/docker-compose`, **not** in `/usr/bin`!)
-
-1. Run `docker-compose --version` and make sure it's at least version 1.21
-
-Now when you want to debug E2E tests, you can click on the small green square in the lower left corner of VS Code (it looks like `><`) and a menu will pop up. Choose **Reopen in Container**. This will build the `test-e2e` container and all its dependencies, and will then install VS Code inside the container and set up your local copy of VS Code to be communicating to the copy inside the container. For all intents and purposes, it will be as if you were running VS Code inside the container. If this is the first time you've done this, you might have to wait a minute or two: click on the "show log" link (lower right) if you want to see what's happening.
-
-Once you're running VS Code inside the `test-e2e` container, you can do the following to run E2E tests in debug mode:
-
-1. (Optional) Edit `.vscode/launch.json` inside the container and uncomment the `--` and `--specs=...` lines, and edit the second line with the filename(s) you want to run.
-1. Click on the Run and Debug icon on the left side of VS Code (looks like a "play" triangle with a bug icon in front of it)
-1. If **Debug E2E tests** isn't already selected in the dropdown, select it
-1. Set breakpoints in the tests you want to debug
-1. Click the green "play" icon just left of the debug dropdown
-
-**NOTE:** If you try to step out of a test function, you may find yourself inside a file called `primordials.js` which is part of Node. This is a [VS Code bug](https://github.com/microsoft/vscode-js-debug/issues/980) that has not yet been fixed (as of June 2021). If that happens, simply go back to your test file, set a new breakpoint, and then click the **Continue** icon (or press <kbd>F5</kbd>) in the debug toolbar to get back into your code.
-
-If you interrupt the E2E tests halfway through their run (easy to do when debugging), you might find that the test database gets into a situation where running the tests a second time causes lots of spurious failures. For example, if you interrupt the "change password" test right in the middle, after it has changed the test user's password but before it has reset the test user's password back to the original value, then a subsequent run of E2E tests will completely fail to run. If that's the case, you'll want to reset the E2E test app container so that it will re-run the test initialization script and reset the test database.
-
-To reset the E2E test app container, simply choose the **Reset and debug E2E tests** option in the debugging dropdown instead of the **Debug E2E tests** option. Now you should be able to run the E2E tests again.
-
-If you edit files in the `src` or `data` folders of the test container, these changes will be applied to the files in your Git repository. But to make those changes "stick", you might have to exit the test container and rebuild it. To do that:
-
-1. Exit the E2E container (click the green container menu in the lower left corner of VS Code and choose "Reopen folder locally")
-1. Hit `F1` or `Ctrl+Shift+P` and choose **Remote-Containers: Rebuild and Reopen in Container** (type "Rebuild" to find it quickly)
-
-After a minute or two, your source or test changes should be applied and you should see the result of your changes when you run the E2E tests again.
+## Other Commands
 
 ### Cleanup
 
@@ -137,17 +119,9 @@ After a minute or two, your source or test changes should be applied and you sho
 1. `make next-dev` will start the next app in development mode, i.e. changes to source code will immediately be reflected in the locally running app.  Access non-ssl: http://localhost
 > TODO: There is a desire to consolidate these into a single use case, `make dev`.
 
-### Visual Studio Code ###
-
-Visual Studio Code is a simple, free, cross-platform code editor. You can download VS Code from [here](https://code.visualstudio.com/).
-
-The first time you open VS Code in the `web-languageforge` directory, it will recommend a list of extensions that are useful for developing Language Forge.  Install all recommended extensions for the best experience.
-
-For Windows/WSL users, it is recommended to clone your repository to your Linux filesystem and open your repository folder with VS Code in WSL mode. Open the folder with VS Code, and run the Command "Reopen Folder in WSL." Using both VS Code and source code in the Windows filesystem could cause issues with code changes being reflected between the two filesystems.
-
-Chrome and PHP debugging have also been configured. Launch configurations are defined in the `.vscode/launch.json` file.
-
 ## Debugging ##
+
+> Launch configurations for Chrome and PHP debugging are defined in `.vscode/launch.json`.
 
 ### PHP Application Debugging ###
 
@@ -186,3 +160,63 @@ A [tutorial on YouTube is available showing how to use XDebug and VSCode](https:
 Additional considerations:
 
 If you encounter errors such as VSCode cannot find a file in the path "vendor", these source files are not available to VSCode as they are running inside Docker.  If you want to debug vendor libraries (not required), you will have to use Composer to download dependencies and put them in your source tree.
+
+### E2E Tests Debugging
+
+You'll need the "Remote - Containers" extension (`ms-vscode-remote.remote-containers`) installed, and you'll need your version of Docker Compose to be at least 1.21. (The VS Code instructions say that the Ubuntu snap package for `docker-compose` is **not** supported, so if you don't have it installed already, go to https://github.com/docker/compose/releases and download an appropriate binary of the most recent release. On Linux, you should put that binary in `/usr/local/bin/docker-compose`, **not** in `/usr/bin`!)
+
+1. Run `docker-compose --version` and make sure it's at least version 1.21
+
+Now when you want to debug E2E tests, you can click on the small green square in the lower left corner of VS Code (it looks like `><`) and a menu will pop up. Choose **Reopen in Container**. This will build the `test-e2e` container and all its dependencies, and will then install VS Code inside the container and set up your local copy of VS Code to be communicating to the copy inside the container. For all intents and purposes, it will be as if you were running VS Code inside the container. If this is the first time you've done this, you might have to wait a minute or two: click on the "show log" link (lower right) if you want to see what's happening.
+
+Once you're running VS Code inside the `test-e2e` container, you can do the following to run E2E tests in debug mode:
+
+1. (Optional) Edit `.vscode/launch.json` inside the container and uncomment the `--` and `--specs=...` lines, and edit the second line with the filename(s) you want to run.
+1. Click on the Run and Debug icon on the left side of VS Code (looks like a "play" triangle with a bug icon in front of it)
+1. If **Debug E2E tests** isn't already selected in the dropdown, select it
+1. Set breakpoints in the tests you want to debug
+1. Click the green "play" icon just left of the debug dropdown
+
+**NOTE:** If you try to step out of a test function, you may find yourself inside a file called `primordials.js` which is part of Node. This is a [VS Code bug](https://github.com/microsoft/vscode-js-debug/issues/980) that has not yet been fixed (as of June 2021). If that happens, simply go back to your test file, set a new breakpoint, and then click the **Continue** icon (or press <kbd>F5</kbd>) in the debug toolbar to get back into your code.
+
+If you interrupt the E2E tests halfway through their run (easy to do when debugging), you might find that the test database gets into a situation where running the tests a second time causes lots of spurious failures. For example, if you interrupt the "change password" test right in the middle, after it has changed the test user's password but before it has reset the test user's password back to the original value, then a subsequent run of E2E tests will completely fail to run. If that's the case, you'll want to reset the E2E test app container so that it will re-run the test initialization script and reset the test database.
+
+To reset the E2E test app container, simply choose the **Reset and debug E2E tests** option in the debugging dropdown instead of the **Debug E2E tests** option. Now you should be able to run the E2E tests again.
+
+If you edit files in the `src` or `data` folders of the test container, these changes will be applied to the files in your Git repository. But to make those changes "stick", you might have to exit the test container and rebuild it. To do that:
+
+1. Exit the E2E container (click the green container menu in the lower left corner of VS Code and choose "Reopen folder locally")
+1. Hit `F1` or `Ctrl+Shift+P` and choose **Remote-Containers: Rebuild and Reopen in Container** (type "Rebuild" to find it quickly)
+
+After a minute or two, your source or test changes should be applied and you should see the result of your changes when you run the E2E tests again.
+
+
+## Style Guides ##
+
+### PHP 
+
+PHP code conforms to [PSR-2](http://www.php-fig.org/psr/psr-2/).
+
+- Add `php-cs-fixer` globally installed with *composer* (http://cs.sensiolabs.org/). Here is how to add it to **PhpStorm** (https://hackernoon.com/how-to-configure-phpstorm-to-use-php-cs-fixer-1844991e521f). Use it with the parameters `fix --verbose "$FileDir$/$FileName$"`.
+
+### JavaScript
+
+JavaScript code conforms to [AirBNB JS style guide](https://github.com/airbnb/javascript).
+
+- Using PhpStorm with JSCS helps a lot with automating this (see the section below on PhpStorm [Coding Standard and Style](#coding-standard-and-style)).
+
+### Angular & TypeScript ###
+
+Our front-end and E2E tests are written in [**TypeScript**](https://www.typescriptlang.org).
+
+> Note: this repo is currently AngularJS (1.8) not Angular (2+).
+
+Our TypeScript follows the [Angular Style Guide](https://angular.io/guide/styleguide).
+
+Other useful resources:
+
+- [x] [angularjs-styleguide/typescript at master · toddmotto/angularjs-styleguide](https://github.com/toddmotto/angularjs-styleguide/tree/master/typescript#stateless-components)
+- [x] [AngularJS 1.x with TypeScript (or ES6) Best Practices by Martin McWhorter on CodePen](https://codepen.io/martinmcwhorter/post/angularjs-1-x-with-typescript-or-es6-best-practices)
+- [x] [What is best practice to create an AngularJS 1.5 component in Typescript? - Stack Overflow](https://stackoverflow.com/questions/35451652/what-is-best-practice-to-create-an-angularjs-1-5-component-in-typescript)
+- [x] [Don't Panic: Using ui-router as a Component Router](http://dontpanic.42.nl/2016/07/using-ui-router-as-component-router.html)
+- [x] [Lifecycle hooks in Angular 1.5](https://toddmotto.com/angular-1-5-lifecycle-hooks#onchanges)


### PR DESCRIPTION
## Description

The Playwright VS code extension is very handy and will presumably make it into the playwright "cheat sheet", so I've added it to the recommendations.

As I needed to set up the project a second time on my new laptop I got a fresh wave of inspiration to adapt the development docs according to me experience.

### Type of Change

- New IDE feature (non-breaking change which adds functionality)
- Docs update