### PR TITLE
remove platform line in docker-compose.yml and get GHA running again

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -337,7 +337,6 @@ services:
       dockerfile: docker/test-php/Dockerfile
     image: test-php
     container_name: test-php
-    platform: linux/amd64
     depends_on:
       - db
       - mail


### PR DESCRIPTION
## Description

Fixes the GHA runtime error
```
service.platform should be part of the service.build.platforms: "linux/amd64"
make: *** [Makefile:48: unit-tests-ci] Error 1
Error: Process completed with exit code 2.
```

I admit that I don't fully understand the error message in GHA and how it relates to our docker-compose.yml platform setting (a number of services have the platform directive, but they don't fail on GHA at the moment)

Removing this line appears to get GHA running, and I'm also still able to run the `make unit-tests` locally on MacOS without a specific platform designation, so perhaps "no harm done".

Fixes #1483 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

