### PR TITLE
Semantic domains tests

### DIFF
--- a/test/e2e/pages/editor.page.ts
+++ b/test/e2e/pages/editor.page.ts
@@ -62,6 +62,7 @@ export class EditorPage {
   readonly entryCard: Locator;
   readonly senseCard: Locator;
   readonly exampleCardSelector: string;
+  readonly semanticDomainSelector: string;
 
   readonly actionMenu: ActionMenu;
 
@@ -101,6 +102,7 @@ export class EditorPage {
     this.entryCard = this.page.locator('.entry-card');
     this.senseCard = this.page.locator('[data-ng-repeat="sense in $ctrl.model.senses"]');
     this.exampleCardSelector = '.dc-example';
+    this.semanticDomainSelector = '.dc-semanticdomain-value';
 
     this.actionMenu = {
       toggleMenuButtonSelector: '.ellipsis-menu-toggle',

--- a/test/e2e/semantic-domains.spec.ts
+++ b/test/e2e/semantic-domains.spec.ts
@@ -1,0 +1,164 @@
+import { expect } from '@playwright/test';
+import { test } from './utils/fixtures';
+
+import { ProjectsPage } from './pages/projects.page';
+
+import { Project } from './utils/types';
+
+
+import constants from './testConstants.json';
+
+// import {browser, ExpectedConditions} from 'protractor';
+
+// import {BellowsLoginPage} from '../../../bellows/shared/login.page';
+// import {PageHeader} from '../../../bellows/shared/page-header.element';
+// import {ProjectsPage} from '../../../bellows/shared/projects.page';
+// import {Utils} from '../../../bellows/shared/utils';
+// import {EditorPage} from '../shared/editor.page';
+// import {ProjectSettingsPage} from '../shared/project-settings.page';
+
+test.describe('Lexicon E2E Semantic Domains Lazy Load', () => {
+  let projectsPageManager: ProjectsPage;
+  const project: Project = {
+    name: 'semantic_domainsprojects_spec_ts Project 04',
+    code: 'p04_projects_spec_ts__project_04',
+    id: ''
+  };
+  /*
+  const editorPage   = new EditorPage();
+  const header = new PageHeader();
+  const loginPage = new BellowsLoginPage();
+  const projectsPage = new ProjectsPage();
+  const projectSettingsPage = new ProjectSettingsPage();
+
+  const semanticDomain1dot1English = constants.testEntry1.senses[0].semanticDomain.values[0] + ' Sky';
+  const semanticDomain1dot1Thai = constants.testEntry1.senses[0].semanticDomain.values[0] + ' ท้องฟ้า';
+
+  test('should be using English Semantic Domain for manager', async () => {
+    await loginPage.loginAsManager();
+    await projectsPage.get();
+    await projectsPage.clickOnProject(constants.testProjectName);
+    await editorPage.edit.toListLink.click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
+    await browser.wait(ExpectedConditions.visibilityOf(await editorPage.edit.fields.last()), Utils.conditionTimeout);
+    expect<any>(await editorPage.edit.getFirstLexeme()).toEqual(constants.testEntry1.lexeme.th.value);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
+    expect<any>(await header.language.button.getText()).toEqual('English');
+  });
+
+  test('can change Project default language to Thai', async () => {
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.tabs.project.isDisplayed()).toBe(true);
+    expect<any>(await projectSettingsPage.projectTab.saveButton.isDisplayed()).toBe(true);
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelect.isDisplayed()).toBe(true);
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    expect<any>(await header.language.button.getText()).toEqual('ภาษาไทย');
+  });
+
+  test('should be using Thai Semantic Domain', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.edit.toListLink.click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
+    await browser.wait(ExpectedConditions.visibilityOf(await editorPage.edit.fields.last()), Utils.conditionTimeout);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
+  });
+
+  test('can change Project default language back to English', async () => {
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('English');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    expect<any>(await header.language.button.getText()).toEqual('English');
+  });
+
+  test('should be using English Semantic Domain', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.edit.toListLink.click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
+    await browser.wait(ExpectedConditions.visibilityOf(await editorPage.edit.fields.last()), Utils.conditionTimeout);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
+  });
+
+  test('can change Project default language back to Thai', async () => {
+    await browser.refresh();
+    await browser.wait(ExpectedConditions.visibilityOf(editorPage.edit.entryCountElem), Utils.conditionTimeout);
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+  });
+
+  test('should be using Thai Semantic Domain after refresh', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.edit.toListLink.click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
+    expect<any>(await editorPage.edit.entryCountElem.isDisplayed()).toBe(true);
+    await browser.refresh();
+    await browser.wait(ExpectedConditions.visibilityOf(editorPage.edit.entryCountElem), Utils.conditionTimeout);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1Thai);
+  });
+
+  test('can change user interface language', async () => {
+    expect<any>(await header.language.button.getText()).toEqual('ภาษาไทย');
+    await header.language.button.click();
+    await header.language.findItem('English').click();
+    expect<any>(await header.language.button.getText()).toEqual('English');
+  });
+
+  test('should still have Thai for Project default language', async () => {
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+  });
+
+  test('should be using English Semantic Domain', async () => {
+    await Utils.clickBreadcrumb(constants.testProjectName);
+    await editorPage.edit.toListLink.click();
+    await editorPage.browse.clickEntryByLexeme(constants.testEntry1.lexeme.th.value);
+    await browser.wait(ExpectedConditions.visibilityOf(await editorPage.edit.fields.last()), Utils.conditionTimeout);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
+  });
+
+  test('should be using English Semantic Domain after refresh', async () => {
+    expect<any>(await editorPage.edit.entryCountElem.isDisplayed()).toBe(true);
+    await browser.refresh();
+    await browser.wait(ExpectedConditions.visibilityOf(editorPage.edit.entryCountElem), Utils.conditionTimeout);
+    expect<any>(await editorPage.edit.semanticDomain.values.first().getText()).toEqual(semanticDomain1dot1English);
+  });
+
+  test('should still have Thai for Project default language', async () => {
+    await projectSettingsPage.getByLink();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+  });
+
+  test('can change user interface language to English', async () => {
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    await header.language.button.click();
+    await header.language.findItem('English').click();
+    expect<any>(await header.language.button.getText()).toEqual('English');
+  });
+
+  test('can change Project default language to match interface language twice', async () => {
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('English');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('English');
+    expect<any>(await header.language.button.getText()).toEqual('English');
+
+    await projectSettingsPage.projectTab.defaultLanguageSelect.sendKeys('ภาษาไทย');
+    await projectSettingsPage.projectTab.saveButton.click();
+    expect<any>(await projectSettingsPage.projectTab.defaultLanguageSelected.getText()).toContain('ภาษาไทย');
+    expect<any>(await header.language.button.getText()).toEqual('ภาษาไทย');
+  });
+
+  test('can change user interface language to back English', async () => {
+    await header.language.button.click();
+    await header.language.findItem('English').click();
+    expect<any>(await header.language.button.getText()).toEqual('English');
+  });
+*/
+});

--- a/test/e2e/semantic-domains.spec.ts
+++ b/test/e2e/semantic-domains.spec.ts
@@ -54,7 +54,9 @@ test.describe('Lexicon E2E Semantic Domains Lazy Load', () => {
     await expect(projectSettingsPage.projectTab.saveButton).toBeVisible();
     await expect(projectSettingsPage.projectTab.defaultInterfaceLanguageInput).toBeVisible();
     await expect(projectSettingsPage.projectTab.defaultInterfaceLanguageInput.locator('option[selected="selected"]')).toHaveText('English');
+    await projectSettingsPage.page.waitForTimeout(1000);
     await projectSettingsPage.projectTab.defaultInterfaceLanguageInput.selectOption({ label: 'ภาษาไทย - semantic domain only' });
+    await projectSettingsPage.page.waitForTimeout(2000);
 
     await projectSettingsPage.projectTab.saveButton.click();
     await expectOptionSelectedInSelectElement(projectSettingsPage.projectTab.defaultInterfaceLanguageInput, 'ภาษาไทย');

--- a/test/e2e/semantic-domains.spec.ts
+++ b/test/e2e/semantic-domains.spec.ts
@@ -5,6 +5,8 @@ import { ProjectsPage } from './pages/projects.page';
 
 import { Project } from './utils/types';
 
+import { addLexEntry, initTestProject } from './utils/testSetup';
+
 
 import constants from './testConstants.json';
 
@@ -19,11 +21,20 @@ import constants from './testConstants.json';
 
 test.describe('Lexicon E2E Semantic Domains Lazy Load', () => {
   let projectsPageManager: ProjectsPage;
+  let editorPage: EditorPage;
   const project: Project = {
     name: 'semantic_domainsprojects_spec_ts Project 04',
     code: 'p04_projects_spec_ts__project_04',
     id: ''
   };
+
+  test.beforeAll(async ({ request, managerTab, member, manager, admin,  }) => {
+    projectsPageManager = new ProjectsPage(managerTab);
+    editorPage = new EditorPage(managerTab);
+    project.id = await initTestProject(request, project.code, project.name, manager.username, [admin.username]);
+    await addLexEntry(request, constants.testProjectCode, constants.testEntry1);
+
+  });
   /*
   const editorPage   = new EditorPage();
   const header = new PageHeader();
@@ -34,6 +45,12 @@ test.describe('Lexicon E2E Semantic Domains Lazy Load', () => {
   const semanticDomain1dot1English = constants.testEntry1.senses[0].semanticDomain.values[0] + ' Sky';
   const semanticDomain1dot1Thai = constants.testEntry1.senses[0].semanticDomain.values[0] + ' ท้องฟ้า';
 
+  */
+  test.only('Should be using English Semantic Domain for manager', async () => {
+    await projectsPageManager.goto();
+    await projectsPageManager.page.pause();
+  });
+ /*
   test('should be using English Semantic Domain for manager', async () => {
     await loginPage.loginAsManager();
     await projectsPage.get();

--- a/test/e2e/utils/playwright-helpers.ts
+++ b/test/e2e/utils/playwright-helpers.ts
@@ -1,0 +1,14 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+/**
+ * Check whether the option that should be selected is selected.
+ * Playwright does not hava a way to directly get the text of the selected option.
+ * This function therefore works with the value.
+ * @param selectElement , \<select\>
+ * @param textShouldBeSelectedOption , e.g. 'Pizza Margherita' or a substring, e.g. 'Margherita'
+ */
+export async function expectOptionSelectedInSelectElement(selectElement: Locator, textShouldBeSelectedOption: string) {
+  const selectedValue: string = await selectElement.inputValue();
+  const shouldBeSelectedOption: Locator = selectElement.locator('option').filter({ hasText: textShouldBeSelectedOption });
+  await expect(shouldBeSelectedOption).toHaveAttribute('value', selectedValue);
+}


### PR DESCRIPTION
## Description

The following test has been converted to playwright
✓ should be using English Semantic Domain for manager

The other tests had to be combined to one large tests called *Can change Project default language to Thai & back and forth* as they were all dependent on each other
✓ can change Project default language to Thai
✓ should be using Thai Semantic Domain
✓ can change Project default language back to English
✓ should be using English Semantic Domain
✓ can change Project default language back to Thai
✓ should be using Thai Semantic Domain after refresh
✓ can change user interface language
✓ should still have Thai for Project default language
✓ should be using English Semantic Domain
✓ should be using English Semantic Domain after refresh
✓ should still have Thai for Project default language
✓ can change user interface language to English
✓ can change Project default language to match interface language twice
✓ can change user interface language to back English

For the conversion,  a helper function was needed which allows the developer to check the selected option of
a select dropdown. It is located in the file *playwright-helpers.ts*.

### Type of Change
- E2E test

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
