### PR TITLE
add new issues to "incoming" column in backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: Bug report
 about: Create a report to help us improve
 title: 'bug: '
-labels: triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,6 @@
 name: Feature request
 about: Suggest an idea for this project
 title: 'feat: '
-labels: triage
 assignees: ''
 
 ---

--- a/.github/workflows/set-backlog-fields.yml
+++ b/.github/workflows/set-backlog-fields.yml
@@ -61,11 +61,11 @@ jobs:
                 }
               }
             }' -f org=$ORGANIZATION > project_data.json
-            
+
           echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
           echo 'FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "ProductOwner") | .id' project_data.json) >> $GITHUB_ENV
-          echo 'TRIAGE_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "ProductOwner") | .settings | fromjson.options[] | select(.name=="Triage") | .id' project_data.json) >> $GITHUB_ENV
-        
+          echo 'INCOMING_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "ProductOwner") | .settings | fromjson.options[] | select(.name=="Incoming") | .id' project_data.json) >> $GITHUB_ENV
+
       - name: Add issue to project
         if: env.IN_PROJECT == 0
         env:
@@ -105,5 +105,5 @@ jobs:
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f field=$FIELD_ID -f field_value=${{ env.TRIAGE_ID }}
-            
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f field=$FIELD_ID -f field_value=${{ env.INCOMING_ID }}
+


### PR DESCRIPTION
## Description

I added a new column in the backlog called "incoming".  This is different than the "triage" column in that new issues are easily visible here and are manually moved to the triage column for further processing/sorting before "accepted".

### Type of Change

- process change

## Screenshots
![image](https://user-images.githubusercontent.com/3444521/192935700-aebffde6-122a-433a-97da-7aefbc631d31.png)

## Testing on your branch

Once this is merged, I'll create a new issue and test that it does in fact go into the "incoming" column

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
