### PR TITLE
Correct the naming and storage of FLEx-compatible audio files

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -105,8 +105,7 @@ class LexUploadCommands
 
             if (strcmp(strtolower($fileExt), ".mp3") !== 0 && strcmp(strtolower($fileExt), ".wav") !== 0) {
                 //First, find the duration of the file
-                $sanitizedTmpFilePath = escapeshellarg($tmpFilePath);
-                $ffprobeCommand = `ffprobe -i $sanitizedTmpFilePath -show_entries format=duration -v quiet -of csv="p=0" 2> /dev/null`;
+                $ffprobeCommand = `ffprobe -i $tmpFilePath -show_entries format=duration -v quiet -of csv="p=0" 2> /dev/null`;
                 $audioDuration = floatval($ffprobeCommand);
 
                 // Convert to .wav if the result will be less than 1 MB (recording is shorter than 5.6 seconds)
@@ -123,7 +122,7 @@ class LexUploadCommands
 
                 //unlink the original file as well, now that we've both stored it and made the converted copy
                 @unlink($tmpFilePath);
-                
+
             }
 
             // construct server response


### PR DESCRIPTION
Fixes #1496

## Description

This PR corrects code in LexUploadCommands.php in uploadFile(), which converts audio files from Language Forge into WAV or MP3 format for send/receive with FLEx if needed. Previously, part of this function was inadvertently rewriting the FLEx-compatible files so that they actually contained media of the original (not compatible) recording type. Thus, they were not playable in FLEx. 

The code has been corrected and we will confirm that the files are now playable when brought into FLEx.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [  ] I have added tests that prove my fix is effective or that my feature works

## How to test

- [ ] On qa.languageforge.org, open a project that is linked to FLEx and upload or record some audio of non-MP3, non-WAV type. Save it, and do a Send/Receive. Open FLEx and go to the audio field where your recording should be. Verify that the audio is there, and play it back. Make sure it's audible and sounds like the recording that's in Language Forge.
- [ ] Repeat the above step with a short recording (<5.6 s), a long recording (>5.6 s), and uploaded audio files of M4a, FLAC, and OGG types. Here is a folder of test audio files: 
[Audio Test Upload Files.zip](https://github.com/sillsdev/web-languageforge/files/9681369/Audio.Test.Upload.Files.zip)

## qa.languageforge.org testing

Testers: Check the box and put in a date/time to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Tester1 (YYYY-MM-DD HH:MM)
- [ ] Tester2 (YYYY-MM-DD HH:MM)
