### PR TITLE
removes red circle from tab after stopping recorder

### DIFF
--- a/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
+++ b/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
@@ -55,6 +55,16 @@ export class AudioRecorderController implements angular.IController {
           }
         );
 
+        //Stopping the media stream tracks releases the red recording indicator from browser tabs
+        this.mediaRecorder.addEventListener("stop",
+          () => {
+            stream.getTracks().forEach(function(track) {
+              track.stop();
+            });
+          }
+        );
+
+
         this.recordingStartTime = new Date();
 
         this.interval = this.$interval(() => {


### PR DESCRIPTION
Fixes #1495

## Description

Browsers indicate that a media recording stream was opened with a red circle on the recording website's tab. Here is an update that makes it so that this red circle disappears unless the user is actively recording.

### Type of Change

- UI change

## Screenshots

![image](https://user-images.githubusercontent.com/56163492/193522376-df7712c5-4321-4976-8122-ee0e2dc9b03e.png)

Ending media stream tracks so that this circle will not linger on the browser tab.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

- [ ] Record something in Language Forge
- [ ] Notice whether the red recording symbol sticks around or goes away after you stop the recorder. (We want to see it go away)

## qa.languageforge.org testing

Testers: Check the box and put in a date/time to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Tester1 (YYYY-MM-DD HH:MM)
- [ ] Tester2 (YYYY-MM-DD HH:MM)
