### PR TITLE
On delete, remove all stored versions of the target media file

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -279,7 +279,7 @@ class LexUploadCommands
                 $data->errorMessage = $errorMsg;
                 return $response;
         }
-        $filePath = $folderPath . '/' . $fileName;
+        $filePath = $folderPath . '/' . $fileName; //Need to get both the original and potential converted file here 
         if (file_exists($filePath) and ! is_dir($filePath)) {
             if (unlink($filePath)) {
                 $data = new MediaResult();


### PR DESCRIPTION
Fixes #1491 

## Description

At times we are storing multiple versions of an audio file -- the original and the FLEx-compatible version. When a user deletes the audio for an entry, all the versions of the target delete file will now be removed, not just the specific version the entry points to. The code changed handles pictures as well as audio files, although pictures are not currently being converted or stored in different formats.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have added tests that prove my fix is effective or that my feature works

## How to test

- [ ] Record something on Language Forge. Save it. Look in the Docker container; see two files, one webm and one converted. Then delete this audio, from the Language Forge site. Look in the Docker container; both files should be gone.
- [ ] Upload some audio of MP3 or WAV type and check to see that even when the audio is not stored in multiple versions and there is only one file, delete works as expected.
- [ ] Upload an image and delete it. Verify that this works as expected.

## qa.languageforge.org testing

Testers: Check the box and put in a date/time to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Tester1 (YYYY-MM-DD HH:MM)
- [ ] Tester2 (YYYY-MM-DD HH:MM)
