### PR TITLE
Tell CS Code make extension where the makefile is

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,5 @@
   "phpcs.composerJsonPath": "src",
   "php.suggest.basic": false,
   "git.ignoreLimitWarning": true,
+  "makefile.makeDirectory": "docker",
 }


### PR DESCRIPTION
## Description

The makefile extension (ms-vscode.makefile-tools) complains that it can't find the makefile entrypoint, because our makefile is not in the root of the project. This minor change will prevent it from showing the warning.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message

## How to test

Open VS code. No more "makefile entrypoint not found" popups. (They've potentially already been explicitly suppressed).