### PR TITLE
Keep WEBMs and convert to WEBM

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -102,9 +102,8 @@ class LexUploadCommands
                 // Convert to .wav if the result will be less than 1 MB (recording is shorter than 5.6 seconds)
                 // and .mp3 otherwise (recording is longer than 5.6 seconds)
                 $extensionlessFileName = substr($fileName, 0, strrpos($fileName, strtolower($fileExt)));
-                $convertedExtension = $audioDuration < 5.6 ? "wav" : "mp3";
-                $fileName = "$extensionlessFileName.$convertedExtension"; //$fileName ->> the converted file
-                `ffmpeg -i $tmpFilePath $fileName 2> /dev/null`; //original file is at the tmpFilePath. convert that file and save it to be $fileName
+                $fileName = "$extensionlessFileName.webm"; //$fileName ->> the converted file
+                `ffmpeg -i $tmpFilePath -acodec opus $fileName 2> /dev/null`; //original file is at the tmpFilePath. convert that file and save it to be $fileName
                 $filePath = self::mediaFilePath($folderPath, $fileNamePrefix, $fileName);
                 $moveOk = copy($fileName, $filePath);
 

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -90,7 +90,11 @@ class LexUploadCommands
             // convert audio file to mp3 or wav format if necessary
             // FLEx only supports mp3 or wav format as of 2022-09
 
-            if (strcmp(strtolower($fileExt), ".mp3") !== 0 && strcmp(strtolower($fileExt), ".wav") !== 0) {
+            if (
+                strcmp(strtolower($fileExt), ".mp3") !== 0 &&
+                strcmp(strtolower($fileExt), ".wav") !== 0 &&
+                strcmp(strtolower($fileExt), ".webm") !== 0
+            ) {
                 //First, find the duration of the file
                 $ffprobeCommand = `ffprobe -i $tmpFilePath -show_entries format=duration -v quiet -of csv="p=0" 2> /dev/null`;
                 $audioDuration = floatval($ffprobeCommand);

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -87,9 +87,6 @@ class LexUploadCommands
             $filePath = self::mediaFilePath($folderPath, $fileNamePrefix, $fileName);
             $moveOk = copy($tmpFilePath, $filePath);
 
-            // convert audio file to mp3 or wav format if necessary
-            // FLEx only supports mp3 or wav format as of 2022-09
-
             if (
                 strcmp(strtolower($fileExt), ".mp3") !== 0 &&
                 strcmp(strtolower($fileExt), ".wav") !== 0 &&
@@ -99,8 +96,6 @@ class LexUploadCommands
                 $ffprobeCommand = `ffprobe -i $tmpFilePath -show_entries format=duration -v quiet -of csv="p=0" 2> /dev/null`;
                 $audioDuration = floatval($ffprobeCommand);
 
-                // Convert to .wav if the result will be less than 1 MB (recording is shorter than 5.6 seconds)
-                // and .mp3 otherwise (recording is longer than 5.6 seconds)
                 $extensionlessFileName = substr($fileName, 0, strrpos($fileName, strtolower($fileExt)));
                 $fileName = "$extensionlessFileName.webm"; //$fileName ->> the converted file
                 `ffmpeg -i $tmpFilePath -acodec opus $fileName 2> /dev/null`; //original file is at the tmpFilePath. convert that file and save it to be $fileName

--- a/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
+++ b/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
@@ -40,14 +40,14 @@ export class AudioRecorderController implements angular.IController {
           async (e: { data: any }) => {
             this.chunks.push(e.data);
             var roughBlob = new Blob(this.chunks, {
-              type: "audio/webm; codecs=aflt",
+              type: "audio/webm; codecs=opus",
             });
             //In some browsers (Chrome, Edge, ...) navigator.mediaDevices.getUserMedia with MediaRecorder creates WEBM files without duration metadata  //2022-09
             //webmFixDuration appends missing duration metadata to a WEBM file blob.
             this.blob = await webmFixDuration(
               roughBlob,
               this.durationInMilliseconds,
-              "audio/webm; codecs=aflt"
+              "audio/webm; codecs=opus"
             );
             this.chunks = [];
             this.audioSrc = window.URL.createObjectURL(this.blob);

--- a/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
+++ b/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
@@ -40,14 +40,14 @@ export class AudioRecorderController implements angular.IController {
           async (e: { data: any }) => {
             this.chunks.push(e.data);
             var roughBlob = new Blob(this.chunks, {
-              type: "audio/webm; codecs=opus",
+              type: "audio/webm; codecs=aflt",
             });
             //In some browsers (Chrome, Edge, ...) navigator.mediaDevices.getUserMedia with MediaRecorder creates WEBM files without duration metadata  //2022-09
             //webmFixDuration appends missing duration metadata to a WEBM file blob.
             this.blob = await webmFixDuration(
               roughBlob,
               this.durationInMilliseconds,
-              "audio/webm; codecs=opus"
+              "audio/webm; codecs=aflt"
             );
             this.chunks = [];
             this.audioSrc = window.URL.createObjectURL(this.blob);


### PR DESCRIPTION
Fixes #1507 

## Description

Recently, it seems that the Geckofx .NET wrapper in FLEx has been updated to allow WEBM files. (Please see this issue for discussion of past difficulties with WEBM audio in FLEx: [](https://jira.sil.org/browse/LT-20864).)

So, instead of converting recordings and uploads to MP3 or WAV format, we can now keep recordings in WEBM and convert formats like OGG, FLAC, and M4A to WEBM for use with FLEx. With WEBM in opus codec, we can maintain higher audio quality and smaller file sizes for audio than with MP3. 

Note: although in one commit, I tested with aflt codec, we are going to continue to use opus codec.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- New feature (non-breaking change which adds functionality)

(This is really a change to the audio features, not a new feature. We hope, however, that it will enble users to do more with the audio they save, since it will be of better quality).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

Here is a folder of test files: 
[Audio Test Upload Files.zip](https://github.com/sillsdev/web-languageforge/files/9730261/Audio.Test.Upload.Files.zip)

- [ ] Record some audio in Language Forge. Save it, then click the three dots next to the sound player. Examine the file name. It should be a WEBM file still (not converted to MP3 or WAV).
- [ ] Upload OGG, FLAC, and M4A files. Click the three dots next to the sound player and examine the file names. They should be WEBM files.
- [ ] Upload an MP3 file. Click the three dots next to the sound player and examine the file name. It should be an MP3 file still (=not converted. This is the same as we were doing before.).
- [ ] Upload a WAV file. Click the three dots next to the sound player and examine the file name. It should be a WAV file still (=not converted. This is the same as we were doing before.).

## qa.languageforge.org testing

Testers: Check the box and put in a date/time to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Tester1 (YYYY-MM-DD HH:MM)
- [ ] Tester2 (YYYY-MM-DD HH:MM)
