### PR TITLE
Move Makefile and docker-compose.yml to repo root

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 
   // Update the 'dockerComposeFile' list if you have more compose files or use different names.
   // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
-  "dockerComposeFile": ["../docker/docker-compose.yml", "docker-compose.yml"],
+  "dockerComposeFile": ["../docker-compose.yml", "docker-compose.yml"],
 
   // The 'service' property is the name of the service for the container that VS Code should
   // use. Update this value and .devcontainer/docker-compose.yml to the real service name.

--- a/.github/workflows/build-and-publish-next.yml
+++ b/.github/workflows/build-and-publish-next.yml
@@ -12,10 +12,6 @@ jobs:
       # https://docs.docker.com/develop/develop-images/build_enhancements/
       DOCKER_BUILDKIT: 1
 
-    defaults:
-      run:
-        working-directory: docker
-
     steps:
       -
         uses: actions/checkout@v2

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -32,10 +32,6 @@ jobs:
       # https://docs.docker.com/develop/develop-images/build_enhancements/
       DOCKER_BUILDKIT: 1
 
-    defaults:
-      run:
-        working-directory: docker
-
     steps:
       -
         uses: actions/checkout@v2
@@ -53,7 +49,7 @@ jobs:
           echo ::set-output name=TAG_NEXT_APP::${{ inputs.image-tag-next-app }}
           echo ::set-output name=LFMERGE_NAMESPACE::ghcr.io/sillsdev/lfmerge
           # Get LfMerge tag from Dockerfile, fallback to "latest" as default if that fails
-          TAG_LFMERGE=$(head -n 1 lfmerge/Dockerfile | cut -d: -f2)
+          TAG_LFMERGE=$(head -n 1 docker/lfmerge/Dockerfile | cut -d: -f2)
           TAG_LFMERGE=${TAG_LFMERGE:-latest}
           echo ::set-output name=TAG_LFMERGE::${TAG_LFMERGE}
       -
@@ -76,9 +72,8 @@ jobs:
         run: make unit-tests-ci
       # -
       #   name: E2E Tests
-      #   working-directory: .
       #   run: |
-      #     docker-compose -f docker/docker-compose.yml up -d app-for-playwright
+      #     docker-compose -f docker-compose.yml up -d app-for-playwright
       #     npx playwright install chromium
       #     npx playwright test
       -

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,11 +4,6 @@ name: Build and Test
 on:
   pull_request:
 
-defaults:
-  run:
-    shell: bash
-    working-directory: docker
-
 env:
   DOCKER_BUILDKIT: 1
 
@@ -29,7 +24,7 @@ jobs:
         with:
           check_name: Unit Test Results
           github_token: ${{ github.token }}
-          files: docker/PhpUnitTests.xml
+          files: PhpUnitTests.xml
 
   build-app-run-e2e-tests:
     runs-on: ubuntu-latest
@@ -67,9 +62,8 @@ jobs:
 
       -
         name: Playwright E2E Tests
-        working-directory: .
         # see https://playwright.dev/docs/ci#github-actions
-        run: npm run make playwright-tests
+        run: make playwright-tests
 
       -
         name: Upload test results
@@ -91,7 +85,6 @@ jobs:
           cache: "npm"
       -
         name: Run prettier check
-        working-directory: .
         run: npx prettier --check .
 
   # protractor-tests:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,5 @@
   "phpcs.composerJsonPath": "src",
   "php.suggest.basic": false,
   "git.ignoreLimitWarning": true,
-  "makefile.makeDirectory": "docker",
   "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -53,11 +53,8 @@
     {
       "label": "Reset E2E tests",
       "type": "process",
-      "command": "docker-compose",
-      "args": ["restart", "app-for-e2e"],
-      "options": {
-        "cwd": "docker"
-      },
+      "command": "docker",
+      "args": ["compose", "restart", "app-for-e2e"],
       "problemMatcher": []
     }
   ]

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,14 @@ playwright-tests:
 	docker compose down
 
     # delete any cached session storage state files if the service isn't running
-	docker compose ps app-for-playwright > /dev/null 2>&1 || rm -f ../*-storageState.json
+	docker compose ps app-for-playwright > /dev/null 2>&1 || rm -f *-storageState.json
 
 	docker compose up -d app-for-playwright
 
     # wait until the app-for-playwright service is serving up HTTP before continuing
 	until curl localhost:3238 > /dev/null 2>&1; do sleep 1; done
 
-	cd .. && npx playwright install chromium && npx playwright test $(params)
+	npx playwright install chromium && npx playwright test $(params)
 
 .PHONY: e2e-tests
 e2e-tests:
@@ -57,7 +57,7 @@ build:
 .PHONY: scan
 # https://docs.docker.com/engine/scan
 scan:
-	docker build -t lf-app:prod -f app/Dockerfile --platform linux/amd64 ..
+	docker build -t lf-app:prod -f docker/app/Dockerfile --platform linux/amd64 .
 	docker login
 	-docker scan --accept-license lf-app:prod > docker-scan-results.txt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.5'
 services:
   ui-builder:
     build:
-      context: ..
+      context: .
       dockerfile: docker/ui-builder/Dockerfile
     image: lf-ui-builder
     container_name: lf-ui-builder
@@ -13,20 +13,20 @@ services:
       - lf-ui-dist:/data/src/dist
 
       # for developer convenience volume map
-      - ../webpack.config.js:/data/webpack.config.js
-      - ../webpack-dev.config.js:/data/webpack-dev.config.js
-      - ../webpack-prd.config.js:/data/webpack-prd.config.js
-      - ../package.json:/data/package.json
-      - ../package-lock.json:/data/package-lock.json
+      - ./webpack.config.js:/data/webpack.config.js
+      - ./webpack-dev.config.js:/data/webpack-dev.config.js
+      - ./webpack-prd.config.js:/data/webpack-prd.config.js
+      - ./package.json:/data/package.json
+      - ./package-lock.json:/data/package-lock.json
 
       # needed these volume maps so changes to typescript/scss would be reflected in running app, actually rebundled and output to dist which is then shared to the app container.
-      - ../src/angular-app:/data/src/angular-app
-      - ../src/sass:/data/src/sass
-      - ../src/Site/views/languageforge/theme/default/sass:/data/src/Site/views/languageforge/theme/default/sass
+      - ./src/angular-app:/data/src/angular-app
+      - ./src/sass:/data/src/sass
+      - ./src/Site/views/languageforge/theme/default/sass:/data/src/Site/views/languageforge/theme/default/sass
 
   app:
     build:
-      context: ..
+      context: .
       dockerfile: docker/app/Dockerfile
       args:
         - ENVIRONMENT=development
@@ -68,17 +68,17 @@ services:
       - lf-ui-dist:/var/www/html/dist
 
       # for developer convenience
-      - ../src/index.php:/var/www/src/index.php
-      - ../src/config.php:/var/www/src/config.php
-      - ../src/Api:/var/www/src/Api
-      - ../src/Site:/var/www/src/Site
+      - ./src/index.php:/var/www/src/index.php
+      - ./src/config.php:/var/www/src/config.php
+      - ./src/Api:/var/www/src/Api
+      - ./src/Site:/var/www/src/Site
 
       # needed this volume mapping so changes to partials would be reflected in running app.
-      - ../src/angular-app:/var/www/src/angular-app
+      - ./src/angular-app:/var/www/src/angular-app
 
   lfmerge:
     build:
-      context: lfmerge
+      context: docker/lfmerge
       dockerfile: Dockerfile
       args:
         - ENVIRONMENT=development
@@ -126,7 +126,7 @@ services:
       - lf-caddy-config:/config
 
       # for developer convenience
-      - ./ssl/Caddyfile:/etc/caddy/Caddyfile
+      - ./docker/ssl/Caddyfile:/etc/caddy/Caddyfile
 
   next-proxy-dev:
     image: caddy
@@ -143,11 +143,11 @@ services:
       - NEXT_APP=next-app-dev:3000
     volumes:
       # for developer convenience
-      - ./next-app/dev/Caddyfile:/etc/caddy/Caddyfile
+      - ./docker/next-app/dev/Caddyfile:/etc/caddy/Caddyfile
 
   next-app-dev:
     build:
-      context: ../next-app
+      context: next-app
       dockerfile: ../docker/next-app/dev/Dockerfile
     image: lf-next-app-dev
     container_name: lf-next-app-dev
@@ -156,12 +156,12 @@ services:
     command: npm run dev-w-host
     volumes:
       # for developer convenience
-      - ../next-app/src:/app/src
-      - ../next-app/static:/app/static
+      - ./next-app/src:/app/src
+      - ./next-app/static:/app/static
 
   next-proxy:
     build:
-      context: next-app
+      context: docker/next-app
       dockerfile: Dockerfile.proxy
     image: lf-next-proxy
     container_name: lf-next-proxy
@@ -175,7 +175,7 @@ services:
 
   next-app:
     build:
-      context: ../next-app
+      context: next-app
       dockerfile: ../docker/next-app/Dockerfile.next-app
     image: lf-next-app
     container_name: lf-next-app
@@ -228,7 +228,7 @@ services:
       - MYSQL_PASSWORD=not-a-secret
       - MYSQL_ROOT_PASSWORD=also-not-a-secret
     volumes:
-      - ./test-ld/schemas-and-data.sql:/docker-entrypoint-initdb.d/schemas-and-data.sql
+      - ./docker/test-ld/schemas-and-data.sql:/docker-entrypoint-initdb.d/schemas-and-data.sql
 
   ld-api:
     image: sillsdev/web-languagedepot-api
@@ -247,7 +247,7 @@ services:
 
   test-e2e:
     build:
-      context: ..
+      context: .
       dockerfile: docker/test-e2e/Dockerfile
       args:
         - ENVIRONMENT=development
@@ -265,20 +265,20 @@ services:
     command: sh -c "/wait && /run.sh"
     volumes:
       # for developer convenience
-      - ../src:/data/src
-      - ../typings:/data/typings
-      - ../webpack.config.js:/data/webpack.config.js
-      - ../webpack-dev.config.js:/data/webpack-dev.config.js
-      - ../webpack-prd.config.js:/data/webpack-prd.config.js
-      - ../package.json:/data/package.json
-      - ../package-lock.json:/data/package-lock.json
+      - ./src:/data/src
+      - ./typings:/data/typings
+      - ./webpack.config.js:/data/webpack.config.js
+      - ./webpack-dev.config.js:/data/webpack-dev.config.js
+      - ./webpack-prd.config.js:/data/webpack-prd.config.js
+      - ./package.json:/data/package.json
+      - ./package-lock.json:/data/package-lock.json
 # uncomment on dev machine for convenience but don't commit - it messes up the e2e test run by
 # clobbering the JS files produced by tsc in the built image.
 #      - ../test:/data/test
 
   app-for-e2e:
     build:
-      context: ..
+      context: .
       dockerfile: docker/app-for-e2e/Dockerfile
     image: app-for-e2e
     container_name: app-for-e2e
@@ -300,7 +300,7 @@ services:
 
   app-for-playwright:
     build:
-      context: ..
+      context: .
       dockerfile: docker/app/Dockerfile
       args:
         - ENVIRONMENT=development
@@ -328,12 +328,12 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - ../test/e2e/utils/TestControl.php:/var/www/src/Api/Service/TestControl.php
-      - ../test/e2e/shared-files:/tmp/e2e-shared-files
+      - ./test/e2e/utils/TestControl.php:/var/www/src/Api/Service/TestControl.php
+      - ./test/e2e/shared-files:/tmp/e2e-shared-files
 
   test-php:
     build:
-      context: ..
+      context: .
       dockerfile: docker/test-php/Dockerfile
     image: test-php
     container_name: test-php
@@ -357,9 +357,9 @@ services:
     command: sh -c "/wait && /run.sh"
     volumes:
       # for developer convenience
-      - ../test:/var/www/test
-      - ../src/Api:/var/www/src/Api
-      - ../src/Site:/var/www/src/Site
+      - ./test:/var/www/test
+      - ./src/Api:/var/www/src/Api
+      - ./src/Site:/var/www/src/Site
 
 volumes:
   lf-caddy-config:

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -46,13 +46,13 @@ On Windows, the project should be opened with the [Remote - WSL](https://marketp
 
 ### Running the App Locally
 
-> Note: `make` rules can be run directly from the `docker` directory or with `npm run make` from any project sub-directory.
+> Note: `make` rules can be run directly from the root directory or with `npm run make` from any project sub-directory.
 
-1. `npm run make` or `cd docker && make`
-1. Within any browser, navigate to https://localhost
-1. Continue through any certificate warnings
-1. You should see a landing page, click "Login"
-1. Use `admin` and `password` to login
+1. `make` or `npm run make`
+2. Within any browser, navigate to https://localhost
+3. Continue through any certificate warnings
+4. You should see a landing page, click "Login"
+5. Use `admin` and `password` to login
 
 Note: The application is accessible via HTTP or HTTPS. HTTPS is required for service-worker functionality.
 

--- a/next-app/README.md
+++ b/next-app/README.md
@@ -6,7 +6,7 @@ See [Developer Guide](docs/DEVELOPER.md) for the quick start instructions.
 
 ### Alternate local development (full infrastructure)
 
-From within the `/docker` directory, `make next-dev` and access app via http://localhost
+From the project root directory, `make next-dev` and access app via http://localhost
 
 ### Alternate local development (limited)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1912,13 +1912,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.2.tgz",
-      "integrity": "sha512-6qPznIR4Fw02OMbqXUPMG6bFFg1hDVNEdihKy0t9K0dmRbus1DyP5Q5XFQhGwEHQkLG5hrSfBuu9CW/foqhQHQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.25.2"
+        "playwright-core": "1.27.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7756,9 +7756,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.2.tgz",
-      "integrity": "sha512-0yTbUE9lIddkEpLHL3u8PoCL+pWiZtj5A/j3U7YoNjcmKKDGBnCrgHJMzwd2J5vy6l28q4ki3JIuz7McLHhl1A==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -13125,13 +13125,13 @@
       }
     },
     "@playwright/test": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.2.tgz",
-      "integrity": "sha512-6qPznIR4Fw02OMbqXUPMG6bFFg1hDVNEdihKy0t9K0dmRbus1DyP5Q5XFQhGwEHQkLG5hrSfBuu9CW/foqhQHQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.25.2"
+        "playwright-core": "1.27.1"
       }
     },
     "@polka/url": {
@@ -17699,9 +17699,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.2.tgz",
-      "integrity": "sha512-0yTbUE9lIddkEpLHL3u8PoCL+pWiZtj5A/j3U7YoNjcmKKDGBnCrgHJMzwd2J5vy6l28q4ki3JIuz7McLHhl1A==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
       "dev": true
     },
     "popper.js": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "webpack:prd": "webpack --config webpack-prd.config.js",
     "compile-test-e2e": "tsc -p test/app",
     "test-e2e": "protractor test/app/protractorConf.js",
-    "make": "cd docker && make",
+    "make": "make",
     "prepare": "husky install"
   },
   "license": "MIT",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -101,7 +101,7 @@ const config: PlaywrightTestConfig = {
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'docker-compose -f docker/docker-compose.yml up app-for-playwright',
+    command: 'docker-compose -f docker-compose.yml up app-for-playwright',
     port: 3238,
     timeout: 15 * 1000,
     reuseExistingServer: true,

--- a/test/e2e/playwright_guide/playwright_cheatsheet.md
+++ b/test/e2e/playwright_guide/playwright_cheatsheet.md
@@ -3,11 +3,10 @@
 ## Most simple
 
 1. install VSCode Extension: [_Playwright Test for VSCode_](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright)
-1. `cd docker`
-1. `make`
-1. run tests directly with the extension in the side bar
-1. ![Screenshot showing VSCode Playwright extension](playwright_extension_sidebar.png "Playwright Test for VSCode")
-1. or run tests directly from the spec files
+2. `make`
+3. run tests directly with the extension in the side bar
+4. ![Screenshot showing VSCode Playwright extension](playwright_extension_sidebar.png "Playwright Test for VSCode")
+5. or run tests directly from the spec files
 
 ![Screenshot showing extension in the file](playwright_extension_in_test_file.png)
 
@@ -17,7 +16,6 @@
 
 ## Simple
 
-1. `cd docker`
 1. `make playwright-tests`
    This commands executes the playwright tests. Execution is specified in the makefile.
 
@@ -25,7 +23,6 @@
 
 ### Setup
 
-1. `cd docker`
 1. `make`
 1. `cd ..`
 1. `npx playwright test`


### PR DESCRIPTION
Fixes #1511

## Description

Makefiles as well as docker-compose.yml are expected to be in the project root, so this PR moves them both there.

### Type of Change

- Repo restructure

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message