### PR TITLE
Chore: Explicitly define & provide permissions for unit-tests workflow job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,10 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
 
+    permissions:
+      checks: write
+      pull-requests: write
+
     steps:
       -
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #1533

## Description

Explicitly give the `unit-tests` job write permissions for checks & pull-requests. Writer permissions are required, but dependabot PRs only get read permissions by default.

### Type of Change

- Automation improvement

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message