### PR TITLE
Temporarily revert project list links to avoid dashboard 500 errors and unblock users

### DIFF
--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -57,7 +57,7 @@
                             {% endif %}
                             {% for project in projects %}
                                 <a class="dropdown-item"
-                                   href="{{ '/projects/'~project.projectCode }}">{{ project.projectName }}</a>
+                                   href="{{ '/app/lexicon/'~project.id }}">{{ project.projectName }}</a>
                             {% endfor %}
                         </div>
                     </li>

--- a/src/angular-app/bellows/apps/projects/projects-app.component.html
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.html
@@ -48,9 +48,12 @@
                 <div data-ng-repeat="project in visibleProjects">
                     <div class="row align-items-center mb-3" data-ng-class="{active: $ctrl.isSelected(project)}">
                         <div class="col-md-4">
-                            <a data-ng-show="$ctrl.isInProject(project)" data-ng-href="/projects/{{project.projectCode}}">
+                            <a data-ng-show="$ctrl.isInProject(project)" data-ng-href="/app/lexicon/{{project.id}}">
                                 <span class="larger-text">{{project.projectName}}</span></a>
+                            <a data-ng-show="$ctrl.isInProject(project)" data-ng-href="/projects/{{project.projectCode}}">
+                                <span>(Dashboard)</span></a>
                             <span data-ng-show="!$ctrl.isInProject(project)" class="larger-text">{{project.projectName}}</span>
+                            <small class="text-muted"> {{project.projectCode}}</small>
                         </div>
                         <div class="col-7 col-md-5" data-ng-show="$ctrl.rights.canEditProjects">
                             <small class="text-muted">{{$ctrl.projectTypeNames[project.appName]}}</small>

--- a/src/angular-app/bellows/apps/projects/projects-app.component.html
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.html
@@ -46,7 +46,7 @@
             <listview hide-if-empty="true" search="$ctrl.queryProjectsForUser()" items-filter="projectFilter"
                       items="$ctrl.projects" filtered-items="filteredProjects" visible-items="visibleProjects" select="">
                 <div data-ng-repeat="project in visibleProjects">
-                    <div class="row align-items-center mb-3" data-ng-class="{active: $ctrl.isSelected(project)}">
+                    <div class="row align-items-center mb-3 project" data-ng-class="{active: $ctrl.isSelected(project)}">
                         <div class="col-md-4">
                             <a data-ng-show="$ctrl.isInProject(project)" data-ng-href="/app/lexicon/{{project.id}}">
                                 <span class="larger-text">{{project.projectName}}</span></a>

--- a/test/e2e/pages/projects.page.ts
+++ b/test/e2e/pages/projects.page.ts
@@ -137,7 +137,7 @@ export class ProjectsPage {
 
   async findProjectRow(projectName: string): Promise<Locator> {
     await this.goto();
-    const rowLocator = this.page.locator(`css=[data-ng-class="{active: $ctrl.isSelected(project)}"]:has(span:has-text("${projectName}"))`);
+    const rowLocator = this.page.locator(`.project:has(span:has-text("${projectName}"))`);
     if (await rowLocator.count() == 1) {
       return rowLocator;
     }
@@ -145,15 +145,14 @@ export class ProjectsPage {
   }
 
   async projectIsLinked(projectName: string): Promise<boolean> {
-    const rowLocator: Locator = await this.findProjectRow(projectName);
-    expect(rowLocator).not.toBeUndefined();
-    return rowLocator.locator('a').isVisible();
+    const projectLink = await this.projectLinkLocator(projectName);
+    return projectLink.isVisible();
   }
 
   async projectLinkLocator(projectName: string): Promise<Locator> {
     const rowLocator: Locator = await this.findProjectRow(projectName);
     expect(rowLocator).not.toBeUndefined();
-    return rowLocator.locator('a');
+    return rowLocator.locator(`a:has-text("${projectName}")`);
   }
 
   async projectHasAddTechSupportButton(projectName: string): Promise<boolean> {


### PR DESCRIPTION
This PR duplicates the hotfix to master PR #1544 , but this time as a proper PR against develop.

In this PR I need to fix up the playwright tests to suit after changing the project board links, since playwright tests are failing with this change.

The description below is a copy of the PR #1544 description and details.

Fixes #1540 
Workaround for  #1536 

This PR is directly against the master branch, intended to be shipped quickly.  Unfortunately, develop branch would not build for me on mac (see Slack channel for details).

## Description

Based upon my workshop this morning and observing multiple projects experiencing 500 errors in the dashboard, some consistently, this commit reverts the project page links to go directly to the lexicon app, instead of the dashboard.

This can be reverted back to the dashboard once we have more confidence that dashboard is stable and does not block users from getting to the app.

### Type of Change

- Temporary (emergency) workaround for blocked users, intended to be reverted at a later date

## Screenshots

<img width="708" alt="image" src="https://user-images.githubusercontent.com/3444521/196647911-aae840a7-e66f-418e-8ef2-4275b5753006.png">

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

  .  The (dashboard) link goes to the dashboard.  In this way users are not blocked for projects that are currently experiencing 500 errors.

- [ ] The project page should contain multiple links per project
- [ ] The main link goes directly to the lexicon app
- [ ] The (dashboard) link goes to the dashboard for that project
- [ ] There is a grey project code also visible in the project row
- [ ] The "My Projects" list in the lexicon app contains links that go directly to the lexical app and avoids the dashboard

## qa.languageforge.org testing

Testers: Check the box and put in a date/time to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Tester1 (YYYY-MM-DD HH:MM)
- [ ] Tester2 (YYYY-MM-DD HH:MM)
