### PR TITLE
Migrate to docker "space" compose

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
   // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
   // "shutdownAction": "none",
 
-  "initializeCommand": "cd docker && docker-compose build --build-arg ENVIRONMENT=development app && docker-compose build --build-arg ENVIRONMENT=development app-for-e2e test-e2e && docker-compose up -d app-for-e2e",
+  "initializeCommand": "cd docker && docker compose build --build-arg ENVIRONMENT=development app && docker compose build --build-arg ENVIRONMENT=development app-for-e2e test-e2e && docker compose up -d app-for-e2e",
 
   // Uncomment the next line to run commands after the container is created - for example installing docker.
   "onCreateCommand": "apk add docker"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       # To transfer custom launch.json and so on
       - ./test-e2e/.vscode:/data/.vscode:cached
 
-      # Forwards the local Docker socket to the container so we can do things like `docker-compose restart app-for-e2e`
+      # Forwards the local Docker socket to the container so we can do things like `docker compose restart app-for-e2e`
       - /var/run/docker.sock:/var/run/docker.sock
 
       # So that any changes you make in the E2E test files while debugging will also be changed in the Git repo

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -38,7 +38,7 @@ jobs:
       -
         run: |
           docker --version
-          docker-compose --version
+          docker compose version
       -
         name: Establish image name
         id: image
@@ -62,8 +62,8 @@ jobs:
       -
         name: Build legacy app
         run: |
-          docker-compose build --build-arg ENVIRONMENT=production --build-arg BUILD_VERSION=${{ steps.image.outputs.TAG_APP }} app
-          docker-compose run --rm app cat /var/www/html/build-version.txt /var/www/html/version.php
+          docker compose build --build-arg ENVIRONMENT=production --build-arg BUILD_VERSION=${{ steps.image.outputs.TAG_APP }} app
+          docker compose run --rm app cat /var/www/html/build-version.txt /var/www/html/version.php
       -
         name: Build "next" images
         run: make build-next
@@ -73,7 +73,7 @@ jobs:
       # -
       #   name: E2E Tests
       #   run: |
-      #     docker-compose -f docker-compose.yml up -d app-for-playwright
+      #     docker compose -f docker-compose.yml up -d app-for-playwright
       #     npx playwright install chromium
       #     npx playwright test
       -

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -121,7 +121,7 @@ The easiest way to get the `TEST_SPECS` variable set up correctly is to go into 
 1. `make e2e-tests`
 
 To quickly re-run the tests without going through the `make build` process, you can restart the `app-for-e2e` container and run the tests as follows:
-`docker-compose restart app-for-e2e && docker-compose run -e TEST_SPECS= test-e2e` where the relative path to the test spec file is optionally given after the `=` sign.
+`docker compose restart app-for-e2e && docker compose run -e TEST_SPECS= test-e2e` where the relative path to the test spec file is optionally given after the `=` sign.
 
 ### Running Unit Tests
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -101,7 +101,7 @@ const config: PlaywrightTestConfig = {
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'docker-compose up app-for-playwright',
+    command: 'docker compose up app-for-playwright',
     port: 3238,
     timeout: 15 * 1000,
     reuseExistingServer: true,


### PR DESCRIPTION
Fixes #1531 

## Description

Simplifications made in #1535 made `docker-compose` [no longer like](https://github.com/sillsdev/web-languageforge/actions/runs/3282439415/jobs/5405848258) our `docker-compose.yml`:

```
The Compose file is invalid because:
Service ui-builder has neither an image nor a build context specified. At least one must be provided.
```

So, migrating remaining usages of `docker-compose` seems like a good idea. I'm not an expert here. Are there other side effects? 🤷 I did try running (simplified versions) of the changed commands locally and they seemed fine.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
