### PR TITLE
Rework Makefile to remove npm-ci target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,14 @@ dev: start
 	docker compose up -d ui-builder
 
 .PHONY: playwright-tests-ci
-playwright-tests-ci: npm-ci playwright-tests
+playwright-tests-ci:
+	npm ci
+	$(MAKE) playwright-tests
 
 .PHONY: playwright-tests
 playwright-tests:
+	npm install
+
     # stop any containers that are running
 	docker compose down
 
@@ -70,10 +74,6 @@ next-dev: build
 .PHONY: build-next
 build-next:
 	docker compose build next-proxy next-app
-
-.PHONY: npm-ci
-npm-ci:
-	npm ci
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
## Description

This seems cleaner than having a target for a single command.
`$(MAKE)` is the recommended way rather than simply `make`

This change will result in `make playwright-tests-ci` running `npm ci` and then also `npm install`, but I think that's harmless and is simpler than introducing more make targets or make variables with shell `if`s.