### PR TITLE
Correct the syntax for codec selection

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -98,7 +98,7 @@ class LexUploadCommands
 
                 $extensionlessFileName = substr($fileName, 0, strrpos($fileName, strtolower($fileExt)));
                 $fileName = "$extensionlessFileName.webm"; //$fileName ->> the converted file
-                `ffmpeg -i $tmpFilePath -acodec opus $fileName 2> /dev/null`; //original file is at the tmpFilePath. convert that file and save it to be $fileName
+                `ffmpeg -i $tmpFilePath -c:a libopus $fileName 2> /dev/null`; //original file is at the tmpFilePath. convert that file and save it to be $fileName
                 $filePath = self::mediaFilePath($folderPath, $fileNamePrefix, $fileName);
                 $moveOk = copy($fileName, $filePath);
 


### PR DESCRIPTION
Fixes #1518 

## Description

I previously used the wrong ffmpeg option for setting the codec for the output file of conversion to WEBM. As a result, the converted files had an incompatible codec and container. This PR uses the right option, and files are successfully converted from OGG, FLAC, or M4A formats to WEBM format. I have verified the fix by playing back the files on Language Forge, as well as downloading them and inspecting them with ffprobe. Once this PR is staged, I will verify that the converted files work in FLEx.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
Here is a folder of test files:
[Audio Test Upload Files.zip](https://github.com/sillsdev/web-languageforge/files/9730261/Audio.Test.Upload.Files.zip)

- [ ] Upload the OGG, FLAC, and M4A files. Click the three dots next to the sound player and examine the file names. They should be WEBM files. Play them. They should play back in Language Forge. Download them and inspect the file size. It should be >0KB. 

## qa.languageforge.org testing

Testers: Check the box and put in a date/time to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Tester1 (YYYY-MM-DD HH:MM)
- [ ] Tester2 (YYYY-MM-DD HH:MM)
