### PR TITLE
Disable editing input systems

### DIFF
--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.html
@@ -106,26 +106,22 @@
             </tr>
             <tr style="background-color: initial">
                 <td></td>
-                <th class="text-left align-middle">
-                    <button type="button" class="btn btn-std" data-ng-click="$ctrl.fccAddInputSystem()"
-                            id="add-input-system-btn" title="Add an Input System">
-                        <i class="fa fa-plus"></i>
-                    </button>
-                </th>
-                <td colspan="6"></td>
-                <!--suppress JSUnusedLocalSymbols -->
-                <td data-ng-repeat="group in $ctrl.unifiedViewModel.inputSystems.selectAllColumns.groups"></td>
-                <td></td>
-            </tr>
-            <tr style="background-color: initial; height: 2rem">
-                <td></td>
-                <th></th>
                 <td colspan="6"></td>
                 <!--suppress JSUnusedLocalSymbols -->
                 <td data-ng-repeat="group in $ctrl.unifiedViewModel.inputSystems.selectAllColumns.groups"></td>
                 <td></td>
             </tr>
         </tbody>
+        <tr style="background-color: initial; height: 4rem">
+            <td></td>
+            <th class="text-left align-top">
+                <small>To add input systems, please use FieldWorks (FLEx).</small>
+            </th>
+            <td colspan="6"></td>
+            <!--suppress JSUnusedLocalSymbols -->
+            <td data-ng-repeat="group in $ctrl.unifiedViewModel.entryFields.selectAllColumns.groups"></td>
+            <td></td>
+        </tr>
         <tbody drag-to-reorder-bind="$ctrl.unifiedViewModel.entryFields.settings">
             <tr class="table-secondary" id="entry-header">
                 <th class="text-center align-top"></th>

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-input-systems.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-input-systems.component.html
@@ -1,12 +1,9 @@
+<div style="padding: 10px">
+    <small>To add input systems, please use FieldWorks (FLEx).</small>
+</div>
 <div class="row">
     <!-- Left column: input system list -->
     <div class="col-md-3">
-        <!-- control buttons -->
-        <div class="form-group">
-            <button class="btn btn-sm btn-primary" id="configuration-new-btn" data-ng-click="$ctrl.openNewLanguageModal($ctrl.suggestedLanguageCodes)">
-                <i class="fa fa-plus iconPadding"></i>New</button>
-        </div>
-
         <!-- picklist -->
         <dl class="picklists" style="height: 300px; overflow: auto;">
             <dt>Language Names</dt>
@@ -25,30 +22,6 @@
 
     <!-- Right column: input system setup -->
     <div class="col-md-9 settings-panel">
-        <!-- control buttons -->
-        <div uib-dropdown class="dropdown form-group btn-group">
-            <button uib-dropdown-toggle class="btn btn-sm btn-std pui-no-caret" id="configuration-dropdown-btn"><i class="fa fa-ellipsis-v"></i></button>
-            <div class="dropdown-menu" uib-dropdown-menu>
-                <a href class="dropdown-item" id="configuration-add-ipa-btn" tabindex="-1" data-ng-class="{disabled: $ctrl.newExists($ctrl.selects.special.optionsOrder[1])}"
-                   data-ng-click="$ctrl.addInputSystem($ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].language, $ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].inputSystem.languageName, $ctrl.selects.special.optionsOrder[1])">
-                    <i class="fa fa-plus"></i> Add IPA for
-                    <span class="notranslate">{{$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].inputSystem.languageName}}</span></a>
-                <a href class="dropdown-item" id="configuration-add-voice-btn" tabindex="-1" data-ng-class="{disabled: $ctrl.newExists($ctrl.selects.special.optionsOrder[2])}"
-                   data-ng-click="$ctrl.addInputSystem($ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].language, $ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].inputSystem.languageName, $ctrl.selects.special.optionsOrder[2])">
-                    <i class="fa fa-plus"></i> Add Voice for
-                    <span class="notranslate">{{$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].inputSystem.languageName}}</span></a>
-                <a href class="dropdown-item" id="configuration-add-variant-btn" tabindex="-1"
-                   data-ng-click="$ctrl.addInputSystem($ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].language, $ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].inputSystem.languageName, $ctrl.selects.special.optionsOrder[3])">
-                    <i class="fa fa-plus"></i> Add a variant of
-                    <span class="notranslate">{{$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].inputSystem.languageName}}</span></a>
-                <div class="dropdown-divider" data-ng-show="! $ctrl.isInputSystemInUse()"></div>
-                <a href class="dropdown-item" id="configuration-remove-btn" data-ng-show="! $ctrl.isInputSystemInUse()" tabindex="-1"
-                   data-ng-click="$ctrl.removeInputSystem($ctrl.selectedInputSystemId)">
-                    <i class="fa fa-trash"></i> Remove
-                    <span class="notranslate">{{$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].languageDisplayName()}}</span></a>
-            </div>
-        </div>
-
         <!-- settings -->
         <div class="card card-body bg-light" data-ng-show="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId]">
             <label class="col-form-label float-right">{{$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].inputSystem.tag}}</label>
@@ -57,7 +30,7 @@
                 {{$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].languageDisplayName()}}</h3>
             <!-- unlisted language name -->
             <!--suppress HtmlFormInputWithoutLabel -->
-            <input type="text" id="languageName" style="font-size: 1.35em; color: black; font-weight: 700; border: 0; height: 32px; width: 365px"
+            <input type="text" id="languageName" style="font-size: 1.35em; color: black; font-weight: 700; height: 32px; width: 365px"
                 data-ng-model="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].inputSystem.languageName"
                 data-ng-show="$ctrl.isUnlistedLanguage($ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].language)">
             <div class="form-group">
@@ -80,16 +53,16 @@
             </div>
             <br>
             <p class="text-warning" data-ng-show="$ctrl.isInputSystemInUse()">
-                <small>Some settings are disabled because the Input System may already be in use.</small>
+                <small>Some settings are disabled. Please edit these in Fieldworks (FLEx).</small>
             </p>
             <div class="form-group">
                 <label class="col-form-label" for="special">Special</label>
                 <div class="controls">
-                    <select class="form-control custom-select" id="special"
+                    <input type="text" class="form-control" id="special"
                         data-ng-model="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].special"
-                        data-ng-disabled="$ctrl.isInputSystemInUse()"
                         data-ng-change="$ctrl.specialChanged($ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].special)"
-                        data-ng-options="$ctrl.selects.special.options[key] for key in $ctrl.selects.special.optionsOrder"></select>
+                        disabled>
+                    </input>
                 </div>
             </div>
 
@@ -98,18 +71,17 @@
             <div class="form-group" data-ng-show="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].special == $ctrl.selects.special.optionsOrder[1]">
                 <label class="col-form-label" for="purpose">Purpose</label>
                 <div class="controls">
-                    <select class="form-control custom-select" id="purpose"
+                    <input type="text" class="form-control" id="purpose"
                         data-ng-model="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].purpose"
-                        data-ng-disabled="$ctrl.isInputSystemInUse()"
-                        data-ng-options="$ctrl.selects.purpose.options[key] for key in $ctrl.selects.purpose.optionsOrder">
-                        <option value="">unspecified</option></select>
+                        disabled>
+                    </input>
                 </div>
                 <label class="col-form-label" for="ipaVariant">Variant (limited to letters or numbers, no spaces)</label>
                 <div class="controls">
                     <input type="text" class="form-control" id="ipaVariant" size="25"
                           model-transform-limit="35" model-transform-no-space data-ng-trim="false"
                            data-ng-model="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].variantString"
-                           data-ng-disabled="$ctrl.isInputSystemInUse()">
+                           disabled>
                 </div>
             </div>
             <!-- Voice -->
@@ -119,33 +91,31 @@
                     <input type="text" class="form-control" id="voiceVariant" size="25"
                            model-transform-limit="35" model-transform-no-space data-ng-trim="false"
                            data-ng-model="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].variantString"
-                           data-ng-disabled="$ctrl.isInputSystemInUse()">
+                           disabled>
                 </div>
             </div>
             <!-- Script / Region / Variant -->
             <div class="form-group" data-ng-show="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].special == $ctrl.selects.special.optionsOrder[3]">
                 <label class="col-form-label" for="script">Script</label>
                 <div class="controls">
-                    <select class="form-control custom-select" id="script"
+                    <input type="text" class="form-control" id="script"
                         data-ng-model="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].script"
-                        data-ng-disabled="$ctrl.isInputSystemInUse()"
-                        data-ng-options="key as option.join(', ') for (key, option) in $ctrl.selects.script.options">
-                        <option value="">-- select a script --</option></select>
+                        disabled>
+                    </input>
                 </div>
                 <label class="col-form-label" for="region">Region</label>
                 <div class="controls">
-                    <select class="form-control custom-select" id="region"
+                    <input type="text" class="form-control" id="region"
                         data-ng-model="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].region"
-                        data-ng-disabled="$ctrl.isInputSystemInUse()"
-                        data-ng-options="key as option for (key, option) in $ctrl.selects.region.options">
-                        <option value="">-- select a region --</option></select>
+                        disabled>
+                    </input>
                 </div>
                 <label class="col-form-label" for="variant">Variant (limited to letters or numbers, no spaces)</label>
                 <div class="controls">
                     <input type="text" class="form-control" id="variant" size="25"
                         model-transform-limit="35" model-transform-no-space data-ng-trim="false"
                         data-ng-model="$ctrl.iscInputSystemViewModels[$ctrl.selectedInputSystemId].variantString"
-                        data-ng-disabled="$ctrl.isInputSystemInUse()">
+                        disabled>
                 </div>
             </div>
             </div>

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-input-systems.component.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-input-systems.component.ts
@@ -64,14 +64,6 @@ export class InputSystemsConfigurationController implements angular.IController 
     ) {
       this.selectInputSystem(this.iscInputSystemsList[0].uuid);
     }
-
-    const addInputSystemChange = changes.iscAddInputSystem as angular.IChangesObject<boolean>;
-    if (addInputSystemChange != null && addInputSystemChange.currentValue) {
-      this.openNewLanguageModal(this.suggestedLanguageCodes);
-      this.iscOnUpdate({ $event: {
-        addInputSystem: false
-      } });
-    }
   }
 
   isInputSystemInUse(): boolean {
@@ -174,34 +166,6 @@ export class InputSystemsConfigurationController implements angular.IController 
   // noinspection JSMethodCanBeStatic
   isUnlistedLanguage(code: string): boolean {
     return (code === 'qaa');
-  }
-
-  openNewLanguageModal(suggestedLanguageCodes: any): void {
-    const modalInstance = this.$modal.open({
-      templateUrl: '/angular-app/languageforge/lexicon/shared/select-new-language.modal.html',
-      windowTopClass: 'modal-select-language',
-      controller: ['$scope', '$uibModalInstance',
-        (scope: any, $modalInstance: angular.ui.bootstrap.IModalInstanceService) => {
-          scope.selected = {
-            code: '',
-            language: {}
-          };
-          scope.add = () => {
-            $modalInstance.close(scope.selected);
-          };
-
-          scope.close = $modalInstance.dismiss;
-
-          scope.suggestedLanguageCodes = suggestedLanguageCodes;
-        }
-      ]
-    });
-
-    modalInstance.result.then((selected: any) => {
-      this.addInputSystem(selected.code, selected.language.name,
-        this.selects.special.optionsOrder[0]);
-    }, () => { });
-
   }
 
 }

--- a/test/app/languageforge/lexicon-traversal.e2e-spec.ts
+++ b/test/app/languageforge/lexicon-traversal.e2e-spec.ts
@@ -24,10 +24,6 @@ describe('Lexicon E2E Page Traversal', () => {
       await configurationPage.tabs.unified.click();
       await configurationPage.unifiedPane.inputSystem.addGroupButton.click();
       await browser.$('body').sendKeys(protractor.Key.ESCAPE);
-      await browser.wait(
-        ExpectedConditions.elementToBeClickable(configurationPage.unifiedPane.inputSystem.addInputSystemButton),
-        constants.conditionTimeout);
-      await configurationPage.unifiedPane.inputSystem.addInputSystemButton.click();
       await browser.$('body').sendKeys(protractor.Key.ESCAPE);
       await browser.wait(ExpectedConditions.elementToBeClickable(configurationPage.tabs.unified), constants.conditionTimeout);
       await configurationPage.tabs.unified.click();

--- a/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/config-fields.e2e-spec.ts
@@ -45,7 +45,6 @@ describe('Lexicon E2E Configuration Fields', () => {
     expect<any>(await configPage.applyButton.isDisplayed()).toBe(true);
     expect<any>(await configPage.applyButton.isEnabled()).toBe(false);
     await configPage.tabs.unified.click();
-    expect<any>(await configPage.unifiedPane.inputSystem.addInputSystemButton.isDisplayed()).toBe(true);
   });
 
   it('check Apply button is enabled on changes', async () => {

--- a/test/app/languageforge/lexicon/settings/config-input-systems.e2e-spec.ts
+++ b/test/app/languageforge/lexicon/settings/config-input-systems.e2e-spec.ts
@@ -65,50 +65,6 @@ describe('Lexicon E2E Configuration Input Systems', () => {
     expect<any>(await configPage.inputSystemsPane.moreButtonGroup.remove.isDisplayed()).toBe(false);
   });
 
-  describe('Select a new Input System Language modal', async () => {
-
-    it('can open the new language modal', async () => {
-      expect<any>(await configPage.inputSystemsPane.newButton.isEnabled()).toBe(true);
-      await configPage.inputSystemsPane.newButton.click();
-      expect<any>(await configPage.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(true);
-    });
-
-    it('can search for a language', async () => {
-      expect<any>(await configPage.modal.selectLanguage.languageRows.count()).toBe(0);
-      await configPage.modal.selectLanguage.searchLanguageInput.sendKeys(firstLanguage + protractor.Key.ENTER);
-      expect<any>(await configPage.modal.selectLanguage.languageRows.first().isPresent()).toBe(true);
-      expect<any>(await configPage.modal.selectLanguage.firstLanguageName.getText()).toEqual(firstLanguage);
-      expect<any>(await configPage.modal.selectLanguage.languageRows.last().isPresent()).toBe(true);
-      expect<any>(await configPage.modal.selectLanguage.lastLanguageName.getText()).toEqual(lastLanguage);
-    });
-
-    it('can clear language search', async () => {
-      expect<any>(await configPage.modal.selectLanguage.searchLanguageInput.getAttribute('value')).toEqual(firstLanguage);
-      await configPage.modal.selectLanguage.clearSearchButton.click();
-      expect<any>(await configPage.modal.selectLanguage.searchLanguageInput.getAttribute('value')).toEqual('');
-      expect<any>(await configPage.modal.selectLanguage.languageRows.count()).toBe(0);
-    });
-
-    it('can select language', async () => {
-      await configPage.modal.selectLanguage.searchLanguageInput.sendKeys(firstLanguage + protractor.Key.ENTER);
-      expect<any>(await configPage.modal.selectLanguage.addButton.isPresent()).toBe(true);
-      expect<any>(await configPage.modal.selectLanguage.addButton.isEnabled()).toBe(false);
-      await configPage.modal.selectLanguage.languageRows.last().click();
-      expect<any>(await configPage.modal.selectLanguage.addButton.isEnabled()).toBe(true);
-      expect<any>(await configPage.modal.selectLanguage.addButton.getText()).toEqual('Add ' + lastLanguage);
-      await configPage.modal.selectLanguage.languageRows.first().click();
-      expect<any>(await configPage.modal.selectLanguage.addButton.isEnabled()).toBe(true);
-      expect<any>(await configPage.modal.selectLanguage.addButton.getText()).toEqual('Add ' + firstLanguage);
-    });
-
-    it('can add language', async () => {
-      await configPage.modal.selectLanguage.addButton.click();
-      expect<any>(await configPage.modal.selectLanguage.searchLanguageInput.isPresent()).toBe(false);
-      expect<any>(await configPage.applyButton.isEnabled()).toBe(true);
-    });
-
-  });
-
   it('new Input System is selected', async () => {
     expect<any>(await configPage.inputSystemsPane.selectedInputSystem.displayName.getText()).toEqual(firstLanguage);
     expect<any>(await configPage.inputSystemsPane.selectedInputSystem.tag.getText()).toEqual('mi');

--- a/test/app/languageforge/lexicon/shared/configuration.page.ts
+++ b/test/app/languageforge/lexicon/shared/configuration.page.ts
@@ -57,8 +57,7 @@ export class ConfigurationPage {
       removeGroupButton: (groupIndex: number) => {
         return this.activePane.element(by.id('table-header'))
           .element(by.className('remove-button-group-' + groupIndex));
-      },
-      addInputSystemButton: this.activePane.element(by.id('add-input-system-btn'))
+      }
     },
     entry: {
       addGroupButton: this.activePane.element(by.id('add-group-entry-btn')),


### PR DESCRIPTION
Fixes #1553

## Description
Input systems should not be edited in Language Forge, only in FLEx.

In this PR:

-Got rid of the 'three dots menu' that allowed adding input systems, on the "Input Systems" tab in Configuration
-Kept selectors for RTL language, language abbreviation, and font name
-Other settings for writing systems are displayed but not editable (special, purpose, variant, region), with a message to that effect
-Got rid of "+ New" buttons in the input systems tab and under "Input Systems" in the base configuration page
-Got rid of the modal for adding a new writing system, formerly attached to these buttons

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/56163492/197953514-d27fd8d3-70dd-43a7-8f2e-06c9322a0e2b.png)

After:
![image](https://user-images.githubusercontent.com/56163492/197953885-559e3b6b-224a-4e04-a677-6e313c36b118.png)


Before:
![image](https://user-images.githubusercontent.com/56163492/197953971-93790670-b7ea-40bf-8e2b-e098cee3e265.png)

After:
![image](https://user-images.githubusercontent.com/56163492/197954066-082a215a-8455-4a16-a1de-a3b8e2bb17c5.png)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

General smoke test, and:
Navigate to the Configuration page. Ensure that the '+' below the Input Systems is gone and there is a message saying 'To edit input systems, please use Fieldworks (FLEx).'

Navigate to the Input Systems tab of Configuration. Ensure that the three dots menu is gone from the top left-middle of the screen; ensure that the '+ New' button for adding a new input system is gone; ensure that the fields below the message reading 'Some settings are disabled; please edit these in Fieldworks (FLEx)' are disabled and are regular text inputs (not selectors).

- [ ] Test A
- [ ] Test B

## qa.languageforge.org testing

Testers: Check the box and put in a date/time to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Tester1 (YYYY-MM-DD HH:MM)
- [ ] Tester2 (YYYY-MM-DD HH:MM)
