### PR TITLE
need to ensure the only way to the dashboard is through the editor

### DIFF
--- a/src/angular-app/bellows/apps/projects/projects-app.component.html
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.html
@@ -50,8 +50,6 @@
                         <div class="col-md-4">
                             <a data-ng-show="$ctrl.isInProject(project)" data-ng-href="/app/lexicon/{{project.id}}">
                                 <span class="larger-text">{{project.projectName}}</span></a>
-                            <a data-ng-show="$ctrl.isInProject(project)" data-ng-href="/projects/{{project.projectCode}}">
-                                <span>(Dashboard)</span></a>
                             <span data-ng-show="!$ctrl.isInProject(project)" class="larger-text">{{project.projectName}}</span>
                             <small class="text-muted"> {{project.projectCode}}</small>
                         </div>


### PR DESCRIPTION
Fixes portions of #1536 

## Description

Authorization checks expect the "current" project to be loaded into session state on the server so when users were trying to get to the dashboard without first going to the editor, the "current" project state was out of sync or missing, therefore authz checks were failing.

This PR simply forces navigation to the dashboard to be done through the editor, ensuring the correct project data is loaded into server session.

### Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

N/A

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce. Please also provide relevant test data as necessary. These instructions will be used for QA testing below.

- [ ] Ensure project links in the header dropdown, "My Projects" take you into the editor
- [ ] Ensure project links on the "My projects" page take you into the editor
- [ ] Ensure the project link in the breadcrumbs will take you into the dashboard

## qa.languageforge.org testing

Testers: Check the box and put in a date/time to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Tester1 (YYYY-MM-DD HH:MM)
- [ ] Tester2 (YYYY-MM-DD HH:MM)
