### PR TITLE
Disable adding to options lists

### DIFF
--- a/src/angular-app/bellows/shared/pick-list-editor.component.html
+++ b/src/angular-app/bellows/shared/pick-list-editor.component.html
@@ -7,19 +7,6 @@
         </select>
     </div>
     <div class="row">
-        <div class="col-12 clearfix">
-            <div class="input-group">
-               <input class="form-control" id="new-value" data-ng-model="$ctrl.newValue" data-on-enter="$ctrl.pickAddItem()" name="newValue"
-                      type="text" placeholder="new value" no-dirty-check>
-                <span class="input-group-btn">
-                    <a class="btn btn-primary add-item-to-list" href data-ng-click="$ctrl.pickAddItem()">
-                        <i class="fa fa-plus iconPadding" aria-hidden="true"></i>Add to List</a>
-                </span>
-            </div>
-        </div>
-    </div>
-    <br>
-    <div class="row">
         <div class="col-12 clearfix" drag-to-reorder-bind="$ctrl.items">
             <div data-ng-repeat="item in $ctrl.items" class="picklist-group" dtr-draggable>
                 <i class="fa fa-arrows-v" title="Drag this to re-order items"></i>

--- a/src/angular-app/bellows/shared/pick-list-editor.module.ts
+++ b/src/angular-app/bellows/shared/pick-list-editor.module.ts
@@ -25,14 +25,15 @@ export class PickListEditorController implements angular.IController {
     }
   }
 
-  pickAddItem(): void {
-    if (this.newValue) {
-      const key = PickListEditorController.keyFromValue(this.newValue);
-      this.items.push({ key, value: this.newValue });
-      this.isDeletable[key] = true;
-      this.newValue = undefined;
-    }
-  }
+  //Used in adding an item to the Options lists under Configuration, which is currently disabled in Language Forge 2022-10
+  // pickAddItem(): void {
+  //   if (this.newValue) {
+  //     const key = PickListEditorController.keyFromValue(this.newValue);
+  //     this.items.push({ key, value: this.newValue });
+  //     this.isDeletable[key] = true;
+  //     this.newValue = undefined;
+  //   }
+  // }
 
   pickRemoveItem(index: number): void {
     delete this.isDeletable[this.items[index].key];

--- a/src/angular-app/bellows/shared/pick-list-editor.module.ts
+++ b/src/angular-app/bellows/shared/pick-list-editor.module.ts
@@ -25,15 +25,6 @@ export class PickListEditorController implements angular.IController {
     }
   }
 
-  //Used in adding an item to the Options lists under Configuration, which is currently disabled in Language Forge 2022-10
-  // pickAddItem(): void {
-  //   if (this.newValue) {
-  //     const key = PickListEditorController.keyFromValue(this.newValue);
-  //     this.items.push({ key, value: this.newValue });
-  //     this.isDeletable[key] = true;
-  //     this.newValue = undefined;
-  //   }
-  // }
 
   pickRemoveItem(index: number): void {
     delete this.isDeletable[this.items[index].key];

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-option-lists.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-option-lists.component.html
@@ -18,7 +18,9 @@
     <div class="col-md-9">
         <div class="card card-body bg-light settings-panel" id="picklistEditorFieldset">
             <h3 class="col-form-label">{{$ctrl.olcOptionListsDirty[$ctrl.currentListIndex].name}}</h3>
-            <i>(At this time {{$ctrl.olcOptionListsDirty[$ctrl.currentListIndex].name}} items cannot be deleted)</i>
+            <div style="padding: 10px">
+                <small>To add or remove items from this list, please use FieldWorks (FLEx).</small>
+            </div>
             <div class="controls">
                 <picklist-editor items="$ctrl.olcOptionListsDirty[$ctrl.currentListIndex].items"></picklist-editor>
             </div>


### PR DESCRIPTION
Fixes #1552 

## Description

Because options added or deleted in Language Forge are not being received into FLEx properly, we want to disable adding (deletion is already disabled) them in Language Forge. Because we may wish to restore this functionality in the future, with a better architecture to ensure synchronization, this PR takes out as little code as possible while preventing users from making these edits for the time being.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/56163492/198207565-a619d78a-ef66-4b42-989c-d1c6e1e39160.png)

After:
![image](https://user-images.githubusercontent.com/56163492/198207666-85f2414c-80e8-4f4f-8f1a-f6b6354f04bf.png)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

General smoke test, and:
Navigate to the Options List tab of Configuration. Ensure that the text input and '+ Add to List' button are removed and a message at the top of each options list node reads "To add or remove items from this list, please use FieldWorks (FLEx)."

## qa.languageforge.org testing

Testers: Check the box and put in a date/time to sign-off/attest the feature works as expected on qa.languageforge.org

- [ ] Tester1 (YYYY-MM-DD HH:MM)
- [ ] Tester2 (YYYY-MM-DD HH:MM)
