### PR TITLE
add scroll behavior to my projects dropdown

### DIFF
--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -31,7 +31,7 @@
                             <span>My Projects</span>
                             <i class="fa fa-bars"></i>
                         </a>
-                        <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu id="myProjectDropdownMenu" aria-labelledby="myProjectDropdown">
+                        <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu id="myProjectDropdownMenu" aria-labelledby="myProjectDropdown" style="max-height: 80vh; overflow-y: auto">
                             {% verbatim %}
                             <div data-ng-switch="$ctrl.projectTypesBySite().length" data-ng-show="$ctrl.rights.canCreateProject">
                                 <div data-ng-switch-when="1">


### PR DESCRIPTION
Fixes #1539 

## Description

This PR provides some vertical scroll behavior to the "My Projects" dropdown just in the current user has more projects than VH.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- New feature (non-breaking change which adds functionality)

## Screenshots

see issue for reference

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

- Log in with an account that has some/many projects on it (or make your window small enough to trigger the scroll) and open the "My Projects" dropdown in the header.  You should see the scroll behavior.

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
