### PR TITLE
add Makefile target for building base-php

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ next-dev: build
 build-next:
 	docker compose build next-proxy next-app
 
+.PHONY: build-base-php
+build-base-php:
+	docker build -t sillsdev/web-languageforge:base-php -f docker/base-php/Dockerfile .
+
 .PHONY: clean
 clean:
 	docker compose down


### PR DESCRIPTION
## Description

The base-php image is updated every once in a while.  It is normally build locally by a dev and then manually pushed to Dockerhub via GHA.  This PR provides a make target to build base-php locally.

### Type of Change

- chore
## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message

## How to test

- run `make build-base-php` locally and confirm that it works

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
