### PR TITLE
refactored session mgmt between legacy and next apps

### DIFF
--- a/next-app/src/routes/projects/[project_code]/meta/+server.ts
+++ b/next-app/src/routes/projects/[project_code]/meta/+server.ts
@@ -6,7 +6,7 @@ export async function get({ project_code, cookie }) {
 		{ entries, comments }
 	] = await Promise.all([
 		sf({ name: 'project_read_by_code', args: [ project_code ], cookie }),
-		sf({ name: 'lex_stats_all', args: [ project_code ], cookie }),
+		sf({ name: 'lex_stats', cookie }),
 	])
 
 	const entries_with_picture = entries.filter(has_picture)

--- a/next-app/src/routes/projects/[project_code]/meta/+server.ts
+++ b/next-app/src/routes/projects/[project_code]/meta/+server.ts
@@ -1,13 +1,9 @@
 import { sf } from '$lib/fetch/server'
 
 export async function get({ project_code, cookie }) {
-	const [
-		{ id, projectName: name, users },
-		{ entries, comments }
-	] = await Promise.all([
-		sf({ name: 'project_read_by_code', args: [ project_code ], cookie }),
-		sf({ name: 'lex_stats', cookie }),
-	])
+	const { id, projectName: name, users } = await sf({ name: 'set_project', args: [ project_code ], cookie })
+
+	const { entries, comments } = await sf({ name: 'lex_stats', cookie })
 
 	const entries_with_picture = entries.filter(has_picture)
 	const entries_with_audio = entries.filter(has_audio)

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -234,7 +234,6 @@ class RightsHelper
             case "lex_dbeDtoFull":
             case "lex_dbeDtoUpdatesOnly":
             case "lex_stats":
-            case "lex_stats_all":
                 return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
 
             // case 'lex_entry_read':

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -134,7 +134,7 @@ class RightsHelper
 
             case "message_send":
             case "project_read":
-            case "project_read_by_code":
+            case "set_project":
             case "project_settings":
             case "project_updateSettings":
             case "project_readSettings":

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -491,12 +491,14 @@ class Sf
         return ProjectCommands::readProject($id);
     }
 
-    public function project_read_by_code($projectCode)
+    public function set_project($projectCode)
     {
         $projectModel = ProjectModel::getByProjectCode($projectCode);
         $user = new UserModel($this->userId);
         if ($user->isMemberOfProject($projectModel->id->asString())) {
-            return $this->project_read($projectModel->id->asString());
+            $projectId = $projectModel->id->asString();
+            $this->app["session"]->set("projectId", $projectId);
+            return $projectId;
         }
         throw new UserUnauthorizedException("User $this->userId is not a member of project $projectCode");
     }

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -494,12 +494,17 @@ class Sf
     public function set_project($projectCode)
     {
         $projectModel = ProjectModel::getByProjectCode($projectCode);
+        $projectId = $projectModel->id->asString();
         $user = new UserModel($this->userId);
-        if ($user->isMemberOfProject($projectModel->id->asString())) {
-            $projectId = $projectModel->id->asString();
+
+        if ($user->isMemberOfProject($projectId)) {
             $this->app["session"]->set("projectId", $projectId);
-            return $projectId;
+
+            $projectModel->id = $projectId;
+
+            return $projectModel;
         }
+
         throw new UserUnauthorizedException("User $this->userId is not a member of project $projectCode");
     }
 
@@ -566,7 +571,7 @@ class Sf
             return LexDbeDto::encode($projectModel->id->asString(), $this->userId, 1);
         }
 
-        throw new UserUnauthorizedException("User $this->userId is not a member of project $projectCode");
+        throw new UserUnauthorizedException("User $this->userId is not a member of project $projectModel->projectCode");
     }
 
     public function lex_dbeDtoFull($browserId, $offset)

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -557,24 +557,12 @@ class Sf
         return LexProjectDto::encode($this->projectId);
     }
 
-    public function lex_stats($projectCode)
+    public function lex_stats()
     {
-        $projectModel = ProjectModel::getByProjectCode($projectCode);
+        $projectModel = ProjectModel::getById($this->projectId);
         $user = new UserModel($this->userId);
 
-        if ($user->isMemberOfProject($projectModel->id->asString())) {
-            return LexDbeDto::encode($projectModel->id->asString(), $this->userId);
-        }
-
-        throw new UserUnauthorizedException("User $this->userId is not a member of project $projectCode");
-    }
-
-    public function lex_stats_all($projectCode)
-    {
-        $projectModel = ProjectModel::getByProjectCode($projectCode);
-        $user = new UserModel($this->userId);
-
-        if ($user->isMemberOfProject($projectModel->id->asString())) {
+        if ($user->isMemberOfProject($this->projectId)) {
             return LexDbeDto::encode($projectModel->id->asString(), $this->userId, 1);
         }
 

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -835,6 +835,7 @@ class Sf
             "user_calculate_username",
             "check_unique_identity",
             "session_getSessionData",
+            "set_project",
         ];
         return in_array($methodName, $methods);
     }


### PR DESCRIPTION
## Description

The LFNext app is trying remain stateless while continuing to utilize the legacy app's backend which is very session-based so this PR will serve to establish the legacy app's needed session state.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (see #1536 for initial sighting)

## Screenshots

N/A

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

- Visit the editor, then return to the project list and go straight to the dashboard
- Delete a project and then go to a dashboard from the project list

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
