### PR TITLE
made stats clickable under the right circumstances

### DIFF
--- a/next-app/src/lib/stats/Stat.svelte
+++ b/next-app/src/lib/stats/Stat.svelte
@@ -1,11 +1,16 @@
 <script>
+    import { goto } from '$app/navigation'
+
 	export let title
 	export let value
 	export let icon = undefined
+	export let href = undefined
+
+	const clicked = () => href ? goto(href) : {}
 </script>
 
 <!-- https://daisyui.com/components/stat/ -->
-<div class='stat place-items-center'>
+<div class='stat place-items-center' class:href on:click={ clicked }>
 	<dt class=stat-title>{ title }</dt>
 	<dd class='stat-value text-primary'>{ value }</dd>
 
@@ -15,3 +20,9 @@
 		</div>
 	{/if}
 </div>
+
+<style>
+	.href {
+		cursor: pointer;
+	}
+</style>

--- a/next-app/src/routes/projects/[project_code]/+page.svelte
+++ b/next-app/src/routes/projects/[project_code]/+page.svelte
@@ -22,28 +22,32 @@
 	$: stats = [
 		{
 			title: 'Users',
-			value: Number(project.num_users).toLocaleString(),
+			value: project.num_users,
 			icon: PeopleIcon,
 		},
 		{
 			title: 'Entries',
-			value: Number(project.num_entries).toLocaleString(),
+			value: project.num_entries,
 			icon: NotesIcon,
+			url: `/app/lexicon/${ project.id }`,
 		},
 		{
 			title: 'Entries with audio',
-			value: Number(project.num_entries_with_audio).toLocaleString(),
+			value: project.num_entries_with_audio,
 			icon: VoiceIcon,
+			url: `/app/lexicon/${ project.id }#!/editor/entry/000000?filterBy=Audio`,
 		},
 		{
 			title: 'Entries with pictures',
-			value: Number(project.num_entries_with_pictures).toLocaleString(),
+			value: project.num_entries_with_pictures,
 			icon: ImagesIcon,
+			url: `/app/lexicon/${ project.id }#!/editor/entry/000000?filterBy=Pictures`,
 		},
 		{
 			title: 'Unresolved comments',
-			value: Number(project.num_unresolved_comments).toLocaleString(),
+			value: project.num_unresolved_comments,
 			icon: MessageAlertIcon,
+			url: `/app/lexicon/${ project.id }#!/editor/entry/000000?filterBy=Comments`,
 		},
 	]
 
@@ -67,8 +71,8 @@
 </PageHeader>
 
 <Stats class=max-w-full>
-	{#each stats as { title, value, icon }}
-		<Stats.Stat { title } { value } { icon } />
+	{#each stats as { title, value, icon, url }}
+		<Stats.Stat { title } value={ Number(value).toLocaleString() } { icon } href={ value && url } />
 	{/each}
 </Stats>
 


### PR DESCRIPTION
Fixes #1525 

## Description

The PR will make stat cards on the project dashboard clickable now.  I could not determine a deep link for the Users card so I left that one alone for now.

### Type of Change

- New feature (non-breaking change which adds functionality)

## Screenshots

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

Head to the dashboard for a project

- Ensure the users card is not clickable
- Ensure any cards with 0 value are not clickable
- Ensure any cards, other than Users, that have values, are clickable
- Ensure when a card is clickable, the cursor changes to a pointer finger when hovering over the card
- Ensure clicking on the cards goes to the correct page

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
