### PR TITLE
improved delete and move UX on entry, meaning and examples

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -860,3 +860,37 @@ form.submitted .ng-invalid {
   outline: none;
   border: 3px solid #f00;
 }
+
+// approach derived from some MDN articles and https://dev.to/link2twenty/native-html-tooltips-3od1
+[data-tooltip] {
+  position: relative;
+  cursor: help;
+}
+
+[data-tooltip]::after {
+  opacity: 0;
+  pointer-events: none;
+
+  position: absolute;
+  right: 1rem;
+  top: -0.5rem;
+  z-index: 99;
+
+  content: attr(data-tooltip);
+  padding: 1rem;
+  white-space: nowrap;
+
+  border-radius: 3px;
+  box-shadow: 0 0 5px 2px rgba(100, 100, 100, 0.6);
+  background-color: whitesmoke;
+
+  transform: translateX(0);
+  transition: all 500ms cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+[data-tooltip]:hover::after {
+  opacity: 1;
+
+  transform: translateX(-1rem);
+  transition-duration: 750ms;
+}

--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -860,37 +860,3 @@ form.submitted .ng-invalid {
   outline: none;
   border: 3px solid #f00;
 }
-
-// approach derived from some MDN articles and https://dev.to/link2twenty/native-html-tooltips-3od1
-[data-tooltip] {
-  position: relative;
-  cursor: help;
-}
-
-[data-tooltip]::after {
-  opacity: 0;
-  pointer-events: none;
-
-  position: absolute;
-  right: 1rem;
-  top: -0.5rem;
-  z-index: 99;
-
-  content: attr(data-tooltip);
-  padding: 1rem;
-  white-space: nowrap;
-
-  border-radius: 3px;
-  box-shadow: 0 0 5px 2px rgba(100, 100, 100, 0.6);
-  background-color: whitesmoke;
-
-  transform: translateX(0);
-  transition: all 500ms cubic-bezier(0.25, 0.8, 0.25, 1);
-}
-
-[data-tooltip]:hover::after {
-  opacity: 1;
-
-  transform: translateX(-1rem);
-  transition-duration: 750ms;
-}

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
@@ -1,21 +1,19 @@
 <div class="dc-entry">
     <div class="card card-outline-primary entry-card">
         <div class="card-header">
-            <div data-ng-if="$ctrl.control.rights.canDeleteEntry() && $ctrl.isAtEditorEntry()"
-                class="dropdown float-right" uib-dropdown>
-                <a class="btn ellipsis-menu-toggle pui-no-caret" uib-dropdown-toggle>
-                    <span class="fa fa-ellipsis-v"></span>
+            <div data-ng-if="$ctrl.control.rights.canDeleteEntry() && $ctrl.isAtEditorEntry()" class="d-flex align-items-center justify-content-between">
+				Entry
+
+                <a href data-ng-click="$ctrl.deleteEntry()" class="text-danger" role="button" data-tooltip="Delete this entry">
+                    <span class="fa fa-trash"></span>
                 </a>
-                <div class="dropdown-menu-right" uib-dropdown-menu>
-                    <a href data-ng-click="$ctrl.deleteEntry()" class="dropdown-item">Delete Entry</a>
-                </div>
             </div>
             <div class="comment-bubble-entry">
                 <comment-bubble control="$ctrl.control" field="$ctrl.fieldName" model="$ctrl.model" parent-context-guid="$ctrl.contextGuid"></comment-bubble>
             </div>
-            &nbsp;Entry
         </div>
-        <div class="card-body">
+
+		<div class="card-body">
             <dc-fieldrepeat config="$ctrl.config" model="$ctrl.model" control="$ctrl.control" parent-context-guid="$ctrl.contextGuid"></dc-fieldrepeat>
         </div>
     </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
@@ -4,7 +4,7 @@
             <div data-ng-if="$ctrl.control.rights.canDeleteEntry() && $ctrl.isAtEditorEntry()" class="d-flex align-items-center justify-content-between">
 				Entry
 
-                <a href data-ng-click="$ctrl.deleteEntry()" class="text-danger" role="button" data-tooltip="Delete this entry">
+                <a href data-ng-click="$ctrl.deleteEntry()" class="text-danger" role="button">
                     <span class="fa fa-trash"></span>
                 </a>
             </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.html
@@ -6,15 +6,15 @@
 			<span class="flex-grow"></span>
 
 			<div class="mr-4">
-				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button" data-tooltip="Move this example up">
+				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button">
 					<span class="fa fa-arrow-up"></span>
 				</a>
-				<a href data-ng-show="$ctrl.index+1 < $ctrl.numExamples()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button"  data-tooltip="Move this example down">
+				<a href data-ng-show="$ctrl.index+1 < $ctrl.numExamples()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button">
 					<span class="fa fa-arrow-down"></span>
 				</a>
 			</div>
 
-			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button" data-tooltip="Delete this example">
+			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button">
 				<span class="fa fa-trash"></span>
 			</a>
         </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.html
@@ -1,23 +1,23 @@
 <div class="dc-example card">
     <div class="card-header">
-        <div data-ng-show="$ctrl.control.rights.canEditEntry() && $ctrl.isAtEditorEntry()"
-             class="dropdown float-right" uib-dropdown>
-            <a class="btn ellipsis-menu-toggle pui-no-caret" uib-dropdown-toggle>
-                <span class="fa fa-ellipsis-v"></span>
-            </a>
-            <div class="dropdown-menu-right" uib-dropdown-menu>
-                <a href data-ng-click="$ctrl.remove($ctrl.index)" class="dropdown-item">
-                    <span class="fa fa-trash"></span> Delete Example {{$ctrl.index+1}}
-                </a>
-                <a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="dropdown-item">
-                    <span class="fa fa-arrow-up"></span> Move Up
-                </a>
-                <a href data-ng-show="$ctrl.index+1 < $ctrl.numExamples()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="dropdown-item">
-                    <span class="fa fa-arrow-down"></span> Move Down
-                </a>
-            </div>
+        <div data-ng-if="$ctrl.control.rights.canEditEntry() && $ctrl.isAtEditorEntry()" class="d-flex align-items-center">
+			Example <span class="notranslate pl-1">{{$ctrl.index+1}}</span>
+
+			<span class="flex-grow"></span>
+
+			<div class="mr-4">
+				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button" data-tooltip="Move this example up">
+					<span class="fa fa-arrow-up"></span>
+				</a>
+				<a href data-ng-show="$ctrl.index+1 < $ctrl.numExamples()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button"  data-tooltip="Move this example down">
+					<span class="fa fa-arrow-down"></span>
+				</a>
+			</div>
+
+			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button" data-tooltip="Delete this example">
+				<span class="fa fa-trash"></span>
+			</a>
         </div>
-        Example <span class="notranslate">{{$ctrl.index+1}}</span>
     </div>
     <div class="card-body">
         <dc-fieldrepeat config="$ctrl.config" model="$ctrl.model" control="$ctrl.control" parent-context-guid="$ctrl.contextGuid"></dc-fieldrepeat>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
@@ -14,7 +14,7 @@
 				</a>
 			</div>
 
-			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button" data-tooltip="Delete this entry">
+			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button" data-tooltip="Delete this meaning">
 				<span class="fa fa-trash"></span>
 			</a>
         </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
@@ -6,15 +6,15 @@
 			<span class="flex-grow"></span>
 
 			<div class="mr-4">
-				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button" data-tooltip="Move this meaning up">
+				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button">
 					<span class="fa fa-arrow-up"></span>
 				</a>
-				<a href data-ng-show="$ctrl.index+1 < $ctrl.numSenses()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button"  data-tooltip="Move this meaning down">
+				<a href data-ng-show="$ctrl.index+1 < $ctrl.numSenses()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button">
 					<span class="fa fa-arrow-down"></span>
 				</a>
 			</div>
 
-			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button" data-tooltip="Delete this meaning">
+			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button">
 				<span class="fa fa-trash"></span>
 			</a>
         </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
@@ -1,23 +1,23 @@
 <div class="dc-sense card">
     <div class="meaning-label card-header">
-        <div data-ng-if="$ctrl.control.rights.canEditEntry() && $ctrl.isAtEditorEntry()"
-            class="dropdown float-right" uib-dropdown>
-            <a class="btn ellipsis-menu-toggle pui-no-caret" uib-dropdown-toggle>
-                <span class="fa fa-ellipsis-v"></span>
-            </a>
-            <div class="dropdown-menu-right" uib-dropdown-menu>
-                <a href data-ng-click="$ctrl.remove($ctrl.index)" class="dropdown-item">
-                    <span class="fa fa-trash"></span> Delete Meaning {{$ctrl.index+1}}
-                </a>
-                <a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="dropdown-item">
-                    <span class="fa fa-arrow-up"></span> Move Up
-                </a>
-                <a href data-ng-show="$ctrl.index+1 < $ctrl.numSenses()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="dropdown-item">
-                    <span class="fa fa-arrow-down"></span> Move Down
-                </a>
-            </div>
+        <div data-ng-if="$ctrl.control.rights.canEditEntry() && $ctrl.isAtEditorEntry()" class="d-flex align-items-center">
+            Meaning <span class="notranslate pl-1">{{$ctrl.index+1}}</span>
+
+			<span class="flex-grow"></span>
+
+			<div class="mr-4">
+				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button" data-tooltip="Move this meaning up">
+					<span class="fa fa-arrow-up"></span>
+				</a>
+				<a href data-ng-show="$ctrl.index+1 < $ctrl.numSenses()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button"  data-tooltip="Move this meaning down">
+					<span class="fa fa-arrow-down"></span>
+				</a>
+			</div>
+
+			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button" data-tooltip="Delete this entry">
+				<span class="fa fa-trash"></span>
+			</a>
         </div>
-        Meaning <span class="notranslate">{{$ctrl.index+1}}</span>
     </div>
     <div class="card-body">
         <dc-fieldrepeat config="$ctrl.config" model="$ctrl.model" control="$ctrl.control" parent-context-guid="$ctrl.contextGuid"></dc-fieldrepeat>

--- a/test/e2e/editor-entry.spec.ts
+++ b/test/e2e/editor-entry.spec.ts
@@ -523,8 +523,7 @@ test.describe('Lexicon E2E Entry Editor and Entries List', () => {
 
         test('Senses can be reordered and deleted', async () => {
           await editorPageManager.goto({entryId: lexEntriesIds[2]});
-          await editorPageManager.senseCard.first().locator(editorPageManager.actionMenu.toggleMenuButtonSelector).first().click();
-          await editorPageManager.senseCard.first().locator(editorPageManager.actionMenu.moveDownButtonSelector).first().click();
+          await editorPageManager.senseCard.first().locator(editorPageManager.moveDownButtonSelector).first().click();
           await expect(editorPageManager.getTextarea(
             editorPageManager.senseCard.first(), 'Definition', 'en'))
             .toHaveValue(constants.testMultipleMeaningEntry1.senses[1].definition.en.value);
@@ -586,8 +585,7 @@ test.describe('Lexicon E2E Entry Editor and Entries List', () => {
 
           // remove new word to restore original word count
           await editorPageManager.entriesListPage.clickOnEntry(constants.testEntry3.lexeme.th.value);
-          await editorPageManager.entryCard.first().locator(editorPageManager.actionMenu.toggleMenuButtonSelector).first().click();
-          await editorPageManager.entryCard.first().locator(editorPageManager.actionMenu.deleteCardButtonSelector).first().click();
+          await editorPageManager.entryCard.first().locator(editorPageManager.deleteCardButtonSelector).first().click();
 
           const confirmModal = new ConfirmModalElement(editorPageManager.page);
           await confirmModal.confirmButton.click();

--- a/test/e2e/pages/editor.page.ts
+++ b/test/e2e/pages/editor.page.ts
@@ -37,9 +37,9 @@ export class EditorPage extends BasePage {
   readonly exampleCardSelector = '.dc-example';
   readonly semanticDomainSelector = '.dc-semanticdomain-value';
 
-  readonly deleteCardButtonSelector = 'a > .fa-trash';
-  readonly moveDownButtonSelector = 'a > .fa-arrow-down';
-  readonly moveUpButtonSelector = 'a > .fa-arrow-up';
+  readonly deleteCardButtonSelector = 'a[data-ng-click^="$ctrl.delete"], a[data-ng-click^="$ctrl.remove"]';
+  readonly moveDownButtonSelector = 'a[data-ng-click="$ctrl.move($ctrl.index, 1)"]:not(.ng-hide)';
+  readonly moveUpButtonSelector = 'a[data-ng-click="$ctrl.move($ctrl.index, -1)"]:not(.ng-hide)';
 
   readonly compactEntryListContainer = this.page.locator('#compactEntryListContainer');
   readonly compactEntryListItem = this.compactEntryListContainer.locator('.lexiconListItemCompact');

--- a/test/e2e/pages/editor.page.ts
+++ b/test/e2e/pages/editor.page.ts
@@ -1,5 +1,4 @@
 import { expect, Locator, Page } from '@playwright/test';
-import { fail } from 'assert';
 import { Project } from '../utils/types';
 import { BasePage, GotoOptions } from './base-page';
 import { ConfigurationPage } from './configuration.page';
@@ -34,16 +33,13 @@ export class EditorPage extends BasePage {
   };
 
   readonly entryCard = this.page.locator('.entry-card');
-  readonly senseCard = this.page.locator('[data-ng-repeat="sense in $ctrl.model.senses"]');
+  readonly senseCard = this.page.locator('.dc-sense.card');
   readonly exampleCardSelector = '.dc-example';
   readonly semanticDomainSelector = '.dc-semanticdomain-value';
 
-  readonly actionMenu = {
-    toggleMenuButtonSelector: '.ellipsis-menu-toggle',
-    deleteCardButtonSelector: '.dropdown-item:has-text("Delete")',
-    moveDownButtonSelector: '.dropdown-item:has-text("Move Down")',
-    moveUpButtonSelector: '.dropdown-item:has-text("Move Up")'
-  };
+  readonly deleteCardButtonSelector = 'a > .fa-trash';
+  readonly moveDownButtonSelector = 'a > .fa-arrow-down';
+  readonly moveUpButtonSelector = 'a > .fa-arrow-up';
 
   readonly compactEntryListContainer = this.page.locator('#compactEntryListContainer');
   readonly compactEntryListItem = this.compactEntryListContainer.locator('.lexiconListItemCompact');


### PR DESCRIPTION
Fixes #1537 

## Description

This PR changes the UI in accordance with some developer observations of users struggling with how to perform some activities on their dictionary entries.

### Type of Change

- UI change

## Screenshots

### Entry 

<img width="771" alt="image" src="https://user-images.githubusercontent.com/4412848/200656374-ca3b0045-7996-4e4c-bfc0-91adf4129eab.png">

### Meaning

<img width="764" alt="image" src="https://user-images.githubusercontent.com/4412848/200656555-c2d918c2-2956-4622-b153-4fdf0be92705.png">

<img width="775" alt="image" src="https://user-images.githubusercontent.com/4412848/200656604-4ea53ca7-7eee-4bd0-82ea-16efa36b968c.png">

<img width="753" alt="image" src="https://user-images.githubusercontent.com/4412848/200656635-b49c74e6-a24f-481b-9965-b4a8fa0907ed.png">

### Example

<img width="720" alt="image" src="https://user-images.githubusercontent.com/4412848/200656726-47af3bf9-9bbd-40c2-92cf-c56970f13903.png">

### Tooltips

https://user-images.githubusercontent.com/4412848/200657385-8f6fcc8b-527f-41e7-9bea-0a8c76dec26c.mov

### Mobile

looks good but I do demonstrate the widely-known issue of hover behavior on mobile devices... we can either live with it, consider bringing popper or some other 3rd-party lib in, remove the tooltips entirely or utilize more javascript to isolate hovers to appropriate devices.

https://user-images.githubusercontent.com/4412848/200659475-dff5cb87-8371-4e8a-9d11-3fd6ea6a634c.mov



## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce. Please also provide relevant test data as necessary. These instructions will be used for QA testing below.

- Add an entry, hover over it ensuring the tooltip content is correct and ensure the entry is actually deleted
- Add a few meanings, hover over the movement and delete icons ensuring the tooltip content is correct and ensure the meaning is actually moved and/or deleted
- Add a few examples, hover over the movement and delete icons ensuring the tooltip content is correct and ensure the example is actually moved and/or deleted

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
