### PR TITLE
refactor activity call into consistent convention

### DIFF
--- a/next-app/src/routes/projects/[project_code]/activities/+server.ts
+++ b/next-app/src/routes/projects/[project_code]/activities/+server.ts
@@ -4,23 +4,24 @@ import { sf } from '$lib/fetch/server'
 export async function GET({ params: { project_code }, request: { headers } }) {
 	const cookie = headers.get('cookie')
 
-	const activities = await get_activities({ project_code, cookie })
+	await sf({ name: 'set_project', args: [ project_code ], cookie })
+
+	const activities = await get_activities({ cookie })
 
 	return json(activities)
 }
 
 // src/Api/Model/Shared/Dto/ActivityListDto.php
 // src/Api/Model/Shared/Dto/ActivityListDto.php->ActivityListModel.__construct
-export async function get_activities({ project_code, cookie, start_date, end_date }) {
+export async function get_activities({ cookie, start_date, end_date }) {
 	const args = {
-		name: 'activity_list_dto_for_project',
+		name: 'activity_list_dto_for_current_project',
 		args: [
-			project_code,
 			{
 				startDate: start_date,
 				endDate: end_date,
 				limit: start_date || end_date ? 50 : 0,
-			}
+			},
 		],
 		cookie,
 	}

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -210,9 +210,6 @@ class RightsHelper
             case "activity_list_dto_for_current_project":
                 return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW_OWN);
 
-            case "activity_list_dto_for_project":
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::VIEW_OWN);
-
             case "activity_list_dto_for_lexical_entry":
                 return $this->userHasProjectRight(Domain::ENTRIES + Operation::VIEW);
 

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -438,16 +438,6 @@ class Sf
         return ActivityListDto::getActivityForOneProject($projectModel, $this->userId, $filterParams);
     }
 
-    public function activity_list_dto_for_project($projectCode, $filterParams = [])
-    {
-        $projectModel = ProjectModel::getByProjectCode($projectCode);
-        $user = new UserModel($this->userId);
-        if ($user->isMemberOfProject($projectModel->id->asString())) {
-            return ActivityListDto::getActivityForOneProject($projectModel, $this->userId, $filterParams);
-        }
-        throw new UserUnauthorizedException("User $this->userId is not a member of project $projectCode");
-    }
-
     public function activity_list_dto_for_lexical_entry($entryId, $filterParams = [])
     {
         $projectModel = ProjectModel::getById($this->projectId);


### PR DESCRIPTION
Fixes #1576 

## Description

This PR extends the convention of keeping the stateless calls into the LFNext portions of the app in sync with the stateful requirements of the legacy app.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

- Simply hitting the project dashboard on a project with activity and ensuring there are no failures is a good test.
- While on the dashboard for a project, ensure the "Show all" works as well
- Also ensure clicking on "work on this project" and coming back to the dashboard retains correct project

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
