### PR TITLE
change delete-project chicken page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3276,14 +3276,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001315",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001315.tgz",
-      "integrity": "sha512-5v7LFQU4Sb/qvkz7JcZkvtSH1Ko+1x2kgo3ocdBeMGZSOFpuE1kkm0kpTwLtWeFrw5qw08ulLxJjVIXIS8MkiQ==",
+      "version": "1.0.30001426",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
+      "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -14270,9 +14276,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001315",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001315.tgz",
-      "integrity": "sha512-5v7LFQU4Sb/qvkz7JcZkvtSH1Ko+1x2kgo3ocdBeMGZSOFpuE1kkm0kpTwLtWeFrw5qw08ulLxJjVIXIS8MkiQ==",
+      "version": "1.0.30001426",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
+      "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
       "dev": true
     },
     "caseless": {

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -192,6 +192,9 @@ class RightsHelper
                 return $this->userHasSiteRight(Domain::PROJECTS + Operation::DELETE) ||
                     $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
 
+            case "project_transferOwnership":
+                return $this->userHasSiteRight(Domain::PROJECTS + Operation::DELETE);
+
             case "projectcode_exists":
                 return $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
 

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -189,8 +189,7 @@ class RightsHelper
                 return $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
 
             case "project_delete":
-                return $this->userHasSiteRight(Domain::PROJECTS + Operation::DELETE) ||
-                    $this->userHasSiteRight(Domain::PROJECTS + Operation::CREATE);
+                return $this->userHasSiteRight(Domain::PROJECTS + Operation::DELETE);
 
             case "project_transferOwnership":
                 return $this->userHasSiteRight(Domain::PROJECTS + Operation::DELETE);

--- a/src/Api/Model/Shared/ProjectModel.php
+++ b/src/Api/Model/Shared/ProjectModel.php
@@ -189,8 +189,6 @@ class ProjectModel extends MapperModel
      */
     public function addUser($userId, $role)
     {
-        ProjectModelMongoMapper::instance();
-        //        $ProjectModelMongoMapper::mongoID($userId)
         $model = new ProjectRoleModel();
         $model->role = $role;
         $this->users[$userId] = $model;

--- a/src/Api/Model/Shared/Rights/SystemRoles.php
+++ b/src/Api/Model/Shared/Rights/SystemRoles.php
@@ -26,6 +26,7 @@ class SystemRoles extends RolesBase
         $rights = [];
         self::grantAllOnDomain($rights, Domain::USERS);
         self::grantAllOnDomain($rights, Domain::PROJECTS);
+        $rights[] = Domain::PROJECTS + Operation::DELETE;
         self::$_rights[self::SYSTEM_ADMIN] = $rights;
     }
 

--- a/src/Api/Model/Shared/Rights/SystemRoles.php
+++ b/src/Api/Model/Shared/Rights/SystemRoles.php
@@ -26,7 +26,6 @@ class SystemRoles extends RolesBase
         $rights = [];
         self::grantAllOnDomain($rights, Domain::USERS);
         self::grantAllOnDomain($rights, Domain::PROJECTS);
-        $rights[] = Domain::PROJECTS + Operation::DELETE;
         self::$_rights[self::SYSTEM_ADMIN] = $rights;
     }
 

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -463,6 +463,11 @@ class Sf
         return ProjectCommands::updateUserRole($this->projectId, $userId, $role);
     }
 
+    public function project_transferOwnership($newOwnerId)
+    {
+        return ProjectCommands::transferOwnership($this->projectId, $this->userId, $newOwnerId);
+    }
+
     public function project_acceptJoinRequest($userId, $role)
     {
         UserCommands::acceptJoinRequest($this->projectId, $userId, $this->website, $role);

--- a/src/angular-app/bellows/apps/siteadmin/site-admin-archived-projects.component.ts
+++ b/src/angular-app/bellows/apps/siteadmin/site-admin-archived-projects.component.ts
@@ -23,7 +23,7 @@ export class SiteAdminArchivedProjectsController implements angular.IController 
     'silNoticeService', 'modalService'];
   constructor(private projectService: ProjectService, private sessionService: SessionService,
               private notice: NoticeService, private modalService: ModalService) {}
-  
+
   $onInit() {
     this.sessionService.getSession().then((session) => {
       const hasRight = session.hasSiteRight(this.sessionService.domain.PROJECTS, this.sessionService.operation.DELETE);

--- a/src/angular-app/bellows/core/api/json-rpc.service.ts
+++ b/src/angular-app/bellows/core/api/json-rpc.service.ts
@@ -79,6 +79,7 @@ export class JsonRpcService {
       }
 
       if (typeof response.data === 'string') {
+        console.log(response.data);
         this.error.notify('RPC Error', response.data);
         return;
       }

--- a/src/angular-app/bellows/core/api/project.service.ts
+++ b/src/angular-app/bellows/core/api/project.service.ts
@@ -122,6 +122,10 @@ export class ProjectService {
     return this.api.call('project_updateUserRole', [userId, role], callback);
   }
 
+  transferOwnership(newOwnerId: string, callback?: JsonRpcCallback){
+    return this.api.call('project_transferOwnership', [newOwnerId], callback);
+  }
+
   acceptJoinRequest(userId: string, role: string, callback?: JsonRpcCallback) {
     return this.api.call('project_acceptJoinRequest', [userId, role], callback);
   }

--- a/src/angular-app/bellows/shared/delete-project.component.html
+++ b/src/angular-app/bellows/shared/delete-project.component.html
@@ -1,5 +1,5 @@
 <div class="form-group row">
-    <label class="col-12" for="deletebox">Confirm deletion by typing DELETE into the box below</label>
+    <label class="col-12" for="deletebox">Confirm deletion by typing DELETE into the box below.</label>
     <div class="col-md-4">
         <input data-ng-model="deleteBoxText" class="form-control" type="text" id="deletebox">
     </div>
@@ -12,4 +12,4 @@
             <i class="fa fa-trash"></i> Delete this project</button>
     </div>
 </div>
-<div class="text-error">Only project owners can delete a project, and this action cannot be undone</div>
+<div class="text-error">Only project owners and site admins can delete a project, and this action cannot be undone.</div>

--- a/src/angular-app/languageforge/lexicon/settings/project-settings.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/project-settings.component.html
@@ -25,12 +25,6 @@
                             {{$ctrl.project.projectCode}}
                         </div>
                     </div>
-                    <div class="form-group row">
-                        <label class="col-form-label col-12">Project Owner</label>
-                        <div data-testid="e2e-test-project-owner" class="controls col-12 notranslate">
-                            {{$ctrl.project.ownerRef.username}}
-                        </div>
-                    </div>
                     <!--
                     <div class="form-group row">
                         <div class="controls col-12">

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.html
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.html
@@ -8,9 +8,19 @@
       <i class="fa fa-{{ roleDetail.icon }}"></i>
       {{ roleDetail.description }} <i class="fa fa-check" ng-show="$ctrl.selectedRoleDetail == roleDetail"></i>
     </a>
+    <div class="dropdown-divider"></div>
+    <a class="dropdown-item" role="menuitem">
+      <div ng-click="$ctrl.onOwnershipTransfer({$event: {target: $ctrl.target}})">
+        <i class="fa fa-arrow-circle-o-up"></i>
+        make owner
+      </div>
+    </a>
     <div class="dropdown-divider" ng-if="$ctrl.allowDelete"></div>
-    <li class="dropdown-item" role="menuitem" ng-if="$ctrl.allowDelete">
-      <div ng-click="$ctrl.onDeleteTarget({$event: {target: $ctrl.target}})" class="text-danger">remove</div>
+    <a class="dropdown-item" role="menuitem" ng-if="$ctrl.allowDelete">
+      <div ng-click="$ctrl.onDeleteTarget({$event: {target: $ctrl.target}})" class="text-danger">
+        <i class="fa fa-times"></i>
+        remove
+      </a>
     </li>
   </div>
 </div>

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.ts
@@ -1,5 +1,6 @@
 import * as angular from 'angular';
-import { ProjectRole } from '../../../../bellows/shared/model/project.model';
+import { Session } from 'src/angular-app/bellows/core/session.service';
+import { Project, ProjectRole } from '../../../../bellows/shared/model/project.model';
 import { User } from '../../../../bellows/shared/model/user.model';
 import { LexRoles } from '../model/lexicon-project.model';
 
@@ -20,10 +21,14 @@ export class RoleDropdownController implements angular.IController {
   roleDetails: RoleDetail[];
   selectedRoleDetail: RoleDetail;
   selectedRole: ProjectRole;
+  projectUrl = 'http://languageforge.org/app/lexicon/real_project_url';
+  project: Project;
+  session: Session;
   allowDisable: boolean;
   allowDelete: boolean;
   onRoleChanged: (params: { $event: { roleDetail: RoleDetail, target: any } }) => void;
   onDeleteTarget: (params: { $event: { target: any } }) => void;
+  onOwnershipTransfer: (params: { $event: { target: any } }) => void;
 
   static $inject = ['$scope'];
   constructor(private readonly $scope: angular.IScope) { }
@@ -78,13 +83,20 @@ export class RoleDropdownController implements angular.IController {
     }
   }
 
+  makeOwner(): void {
+    this.onOwnershipTransfer({ $event: { target: this.target } });
+  }
+
 }
 
 export const RoleDropdownComponent: angular.IComponentOptions = {
   bindings: {
+    project: '<',
+    session: '<',
     target: '<',
     roles: '<',
     selectedRole: '<',
+    onOwnershipTransfer: '&',
     onRoleChanged: '&',
     onDeleteTarget: '&',
     allowDelete: '<'

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.html
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.html
@@ -29,6 +29,7 @@
                                 target="user"
                                 on-role-changed="$ctrl.onUserRoleChanged($event)"
                                 on-delete-target="$ctrl.onDeleteTarget($event)"
+                                on-ownership-transfer="$ctrl.onOwnershipTransfer($event)"
                                 allow-delete="true"
                                 selected-role="user.role"
                                 roles="$ctrl.memberRoles"></role-dropdown>

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.ts
@@ -58,6 +58,15 @@ export class UserManagementController implements angular.IController {
     });
   }
 
+  onOwnershipTransfer($event: {target: Partial<User>}) {
+    var newOwnerId = $event.target.id;
+    this.projectService.transferOwnership(newOwnerId).then(() => {
+      this.loadMemberData();
+      this.project.ownerRef.id = newOwnerId;
+    });
+  }
+
+
   onSpecialRoleChanged($event: {roleDetail: RoleDetail, target: string}) {
     if ($event.target === 'anonymous_user') {
       this.project.anonymousUserRole = $event.roleDetail.role.key;

--- a/test/php/model/shared/commands/ProjectCommandsTest.php
+++ b/test/php/model/shared/commands/ProjectCommandsTest.php
@@ -750,6 +750,135 @@ class ProjectCommandsTest extends TestCase
         $this->assertEquals(2, $usersDto["userCount"]);
     }
 
+    public function testTransferOwnership_ownerTransfersOwnership_ownershipTransferredSucceeded()
+    {
+        self::$environ->clean();
+
+        // setup parameters: previous owner, new owner, project, and params
+        $previousOwnerId = self::$environ->createUser("previous owner", "Previous Owner", "previousOwner@example.com");
+        $newOwnerId = self::$environ->createUser("new owner", "New Owner", "newOwner@example.com");
+        $previousOwner = new UserModel($previousOwnerId);
+        $newOwner = new UserModel($newOwnerId);
+        $project = ProjectCommands::createProject(
+            SF_TESTPROJECT,
+            SF_TESTPROJECTCODE,
+            LfProjectModel::LEXICON_APP,
+            $previousOwnerId,
+            self::$environ->website
+        );
+        $projectId = $project->id->asString();
+
+        // previous owner and new owner are both already members of the project. New owner doesn't have to be a manager.
+        ProjectCommands::updateUserRole($projectId, $previousOwnerId, ProjectRoles::MANAGER);
+        ProjectCommands::updateUserRole($projectId, $newOwnerId, ProjectRoles::CONTRIBUTOR);
+
+        // previous owner transfers project ownership to the new owner
+        $updatedOwnerId = ProjectCommands::transferOwnership($projectId, $previousOwnerId, $newOwnerId);
+
+        // read updated project data from the database
+        $project = new ProjectModel($projectId);
+
+        // ensure that project's owner was updated and that previous and new owners are managers
+        $this->assertEquals($newOwnerId, $project->ownerRef);
+        $this->assertEquals($project->users[$newOwnerId]->role, ProjectRoles::MANAGER);
+        $this->assertEquals($project->users[$previousOwnerId]->role, ProjectRoles::MANAGER);
+    }
+
+    public function testTransferOwnership_adminTransfersOwnership_ownershipTransferredSucceeded()
+    {
+        self::$environ->clean();
+
+        // setup parameters: previous owner, new owner, transferrer (admin), project, and params
+        $previousOwnerId = self::$environ->createUser("previous owner", "Previous Owner", "previousOwner@example.com");
+        $newOwnerId = self::$environ->createUser("new owner", "New Owner", "newOwner@example.com");
+        $adminWhoTransfersOwnershipId = self::$environ->createUser(
+            "admin who transfers ownership",
+            "Admin Transferrer",
+            "admin@example.com"
+        );
+        $previousOwner = new UserModel($previousOwnerId);
+        $newOwner = new UserModel($newOwnerId);
+        $adminWhoTransfersOwnership = new UserModel($adminWhoTransfersOwnershipId);
+        $project = ProjectCommands::createProject(
+            SF_TESTPROJECT,
+            SF_TESTPROJECTCODE,
+            LfProjectModel::LEXICON_APP,
+            $previousOwnerId,
+            self::$environ->website
+        );
+        $projectId = $project->id->asString();
+
+        // admin who transfers is a system admin. previous owner and new owner are both already members of the project. New owner doesn't have to be a manager.
+        ProjectCommands::updateUserRole($projectId, $previousOwnerId, ProjectRoles::MANAGER);
+        ProjectCommands::updateUserRole($projectId, $newOwnerId, ProjectRoles::CONTRIBUTOR);
+        $adminWhoTransfersOwnership->role = SystemRoles::SYSTEM_ADMIN;
+
+        // admin transfers project ownership to the new owner
+        $updatedOwnerId = ProjectCommands::transferOwnership($projectId, $adminWhoTransfersOwnershipId, $newOwnerId);
+
+        // read updated project data from the database
+        $project = new ProjectModel($projectId);
+
+        // ensure that project's owner was updated and that previous and new owners are managers
+        $this->assertEquals($newOwnerId, $project->ownerRef);
+        $this->assertEquals($project->users[$newOwnerId]->role, ProjectRoles::MANAGER);
+        $this->assertEquals($project->users[$previousOwnerId]->role, ProjectRoles::MANAGER);
+    }
+
+    public function testTransferOwnership_userIsNotOwnerOrAdmin_throwsException()
+    {
+        $this->expectException(UserUnauthorizedException::class);
+        self::$environ->clean();
+
+        // setup parameters: current user who's not an owner or admin, new owner, project, and params
+        $currentUserId = self::$environ->createUser("current user", "Current User", "currentUser@example.com");
+        $newOwnerId = self::$environ->createUser("new owner", "New Owner", "newOwner@example.com");
+        $ownerId = self::$environ->createUser("owner", "Owner", "owner@example.com");
+        $currentUser = new UserModel($currentUserId);
+        $newOwner = new UserModel($newOwnerId);
+        $project = ProjectCommands::createProject(
+            SF_TESTPROJECT,
+            SF_TESTPROJECTCODE,
+            LfProjectModel::LEXICON_APP,
+            ownerId,
+            self::$environ->website
+        );
+        $projectId = $project->id->asString();
+
+        // current user and new owner are both already members of the project. But the current user is not the owner, even though they're a manager
+        ProjectCommands::updateUserRole($projectId, $currentUserId, ProjectRoles::MANAGER);
+        ProjectCommands::updateUserRole($projectId, $newOwnerId, ProjectRoles::CONTRIBUTOR);
+
+        // current user tries to transfer project ownership to the new owner; throws exception
+        $updatedOwnerId = ProjectCommands::transferOwnership($projectId, $currentUserId, $newOwnerId);
+    }
+
+    public function testTransferOwnership_newOwnerIsNotAProjectMember_throwsException()
+    {
+        $this->expectException(UserUnauthorizedException::class);
+        self::$environ->clean();
+
+        // setup parameters: owner, target owner, project, and params
+        $ownerId = self::$environ->createUser("owner", "Owner", "owner@example.com");
+        $targetOwnerId = self::$environ->createUser("target owner", "Target Owner", "targetOwner@example.com");
+        $owner = new UserModel($ownerId);
+        $targetOwner = new UserModel($targetOwnerId);
+        $project = ProjectCommands::createProject(
+            SF_TESTPROJECT,
+            SF_TESTPROJECTCODE,
+            LfProjectModel::LEXICON_APP,
+            ownerId,
+            self::$environ->website
+        );
+        $projectId = $project->id->asString();
+
+        // owner is part of the project, but the target owner is not
+        ProjectCommands::updateUserRole($projectId, $ownerId, ProjectRoles::MANAGER);
+
+        // owner tries to transfer project ownership to the target owner; throws exception
+        $updatedOwnerId = ProjectCommands::transferOwnership($projectId, $ownerId, $targetOwnerId);
+    }
+
     public function testUpdateUserRole_userIsAdminAndSetTechSupportRole_techSupportRoleSet()
     {
         self::$environ->clean();


### PR DESCRIPTION
Fixes #1561 

## Description

We want to make it clear that site admins as well as project owners can delete projects. This is a common step in resetting someone's project.

### Type of Change

- UI change

## Screenshots

![image](https://user-images.githubusercontent.com/56163492/201880443-1735d042-fe2e-4f2c-befb-f761cdfa2d36.png)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

Under Settings > Project Settings, view the Delete tab and make sure the message says that site admins can delete projects as well as project owners.

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
