### PR TITLE
utilize HTML `title` for tooltips

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
@@ -4,7 +4,7 @@
             <div data-ng-if="$ctrl.control.rights.canDeleteEntry() && $ctrl.isAtEditorEntry()" class="d-flex align-items-center justify-content-between">
 				Entry
 
-                <a href data-ng-click="$ctrl.deleteEntry()" class="text-danger" role="button">
+                <a href data-ng-click="$ctrl.deleteEntry()" class="text-danger" role="button" title="Delete this entry">
                     <span class="fa fa-trash"></span>
                 </a>
             </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-example.component.html
@@ -6,15 +6,15 @@
 			<span class="flex-grow"></span>
 
 			<div class="mr-4">
-				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button">
+				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button" title="Move this example up">
 					<span class="fa fa-arrow-up"></span>
 				</a>
-				<a href data-ng-show="$ctrl.index+1 < $ctrl.numExamples()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button">
+				<a href data-ng-show="$ctrl.index+1 < $ctrl.numExamples()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button" title="Move this example down">
 					<span class="fa fa-arrow-down"></span>
 				</a>
 			</div>
 
-			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button">
+			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button" title="Delete this example">
 				<span class="fa fa-trash"></span>
 			</a>
         </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
@@ -6,15 +6,15 @@
 			<span class="flex-grow"></span>
 
 			<div class="mr-4">
-				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button">
+				<a href data-ng-show="$ctrl.index > 0" data-ng-click="$ctrl.move($ctrl.index, -1)" class="mr-1" role="button" title="Move this meaning up">
 					<span class="fa fa-arrow-up"></span>
 				</a>
-				<a href data-ng-show="$ctrl.index+1 < $ctrl.numSenses()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button">
+				<a href data-ng-show="$ctrl.index+1 < $ctrl.numSenses()" data-ng-click="$ctrl.move($ctrl.index, 1)" class="mr-1" role="button" title="Move this meaning down">
 					<span class="fa fa-arrow-down"></span>
 				</a>
 			</div>
 
-			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button">
+			<a href data-ng-click="$ctrl.remove($ctrl.index)" class="text-danger" role="button" title="Delete this meaning">
 				<span class="fa fa-trash"></span>
 			</a>
         </div>


### PR DESCRIPTION
Fixes #1595 

## Description

Althought HTML's `title=` is a bit unreliable across browsers and ill-advised for a11y reasons, we've decided to go ahead with them for sake of those users who will benefit from them as toottips.

### Type of Change

- UI change

## Screenshots

https://user-images.githubusercontent.com/4412848/202000515-68d32195-3ea7-405b-972f-fce5bac11c50.mov

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

- Create an entry and hover over the trash can icon and ensure you see a tooltip.
- Create enough meanings to hover over the trash can, up and down arrow keys to see each of the tooltips and ensure they are correct.
- Create enough examples to hover over the trash can, up and down arrow keys to see each of the tooltips and ensure they are correct.

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
