### PR TITLE
add .dockerignore to prevent vendor files from getting included

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# The .dockerignore file excludes files from the container build process.
+#
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+# Exclude locally vendored dependencies.
+src/vendor/
+
+# Exclude "build-time" ignore files.
+.dockerignore
+
+# Exclude git history and configuration.
+.gitignore
+.git


### PR DESCRIPTION
per the slack conversation files in `src/vendor` could be included from a developers machine into the docker image, this has the potential to break things unexpectedly. We should exclude all files in the vendor folder as those should only come from compose.