### PR TITLE
Clarify use of title & description in merge commits and add auto-merge reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,9 +22,10 @@ Please provide screenshots / animations for any change that involves the UI. Ple
 ## Checklist
 
 - [ ] I have performed a self-review of my own code
-- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
+- [ ] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have enabled auto-merge (optional)
 
 ## How to test
 


### PR DESCRIPTION
## Description

As far as I can tell, only the title of a PR is used in the PR's commit message.