### PR TITLE
Fix moving playwright.config.ts

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: test-results
+          path: test/e2e/test-results
 
   check-code-formatting:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@ test/php/\.phpunit\.result\.cache
 node_modules
 .DS_Store
 docker-scan-results.txt
-test-results/
-playwright-report/
+test-results
+test-storage-state
 *storageState.json

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ playwright-tests:
 .PHONY: playwright-app
 playwright-app:
     # delete any cached session storage state files if the service isn't running
-	docker compose ps app-for-playwright > /dev/null 2>&1 || rm -f *-storageState.json
+	docker compose ps app-for-playwright > /dev/null 2>&1 || $(MAKE) clean-test
 	docker compose up -d app-for-playwright
     # wait until the app-for-playwright service is serving up HTTP before continuing
 	until curl localhost:3238 > /dev/null 2>&1; do sleep 1; done
@@ -83,9 +83,12 @@ clean:
 	docker compose down
 	docker system prune -f
 
+clean-test:
+	cd test/e2e && npx rimraf test-storage-state test-results
+
 .PHONY: clean-powerwash
 clean-powerwash: clean
-	npx rimraf *storageState.json test-results
+	$(MAKE) clean-test
 	docker system prune -f --volumes
 	- docker rmi -f `docker images -q "lf-*"` sillsdev/web-languageforge:base-php
 	docker builder prune -f

--- a/test/e2e/semantic-domains.spec.ts
+++ b/test/e2e/semantic-domains.spec.ts
@@ -1,20 +1,13 @@
 import { expect } from '@playwright/test';
 import { test } from './utils/fixtures';
-
-import { ProjectsPage } from './pages/projects.page';
-
 import { Project } from './utils/types';
-
 import { addLexEntry, addPictureFileToProject, initTestProject } from './utils/testSetup';
-
-
 import constants from './testConstants.json';
 import { EditorPage } from './pages/editor.page';
 import { PageHeader } from './components/page-header.component';
 import { ProjectSettingsPage } from './pages/project-settings.page';
 
 test.describe('Lexicon E2E Semantic Domains Lazy Load', () => {
-  let projectsPageManager: ProjectsPage;
   let editorPage: EditorPage;
   let pageHeader: PageHeader;
   const project: Project = {
@@ -26,11 +19,10 @@ test.describe('Lexicon E2E Semantic Domains Lazy Load', () => {
   const semanticDomain1dot1English = constants.testEntry1.senses[0].semanticDomain.values[0] + ' Sky';
   const semanticDomain1dot1Thai = constants.testEntry1.senses[0].semanticDomain.values[0] + ' ท้องฟ้า';
 
-  test.beforeAll(async ({ request, managerTab, member, manager, admin, }) => {
+  test.beforeAll(async ({ request, managerTab, manager, admin, }) => {
     project.id = await initTestProject(request, project.code, project.name, manager.username, [admin.username]);
     await addPictureFileToProject(request, project.code, constants.testEntry1.senses[0].pictures[0].fileName);
     await addLexEntry(request, project.code, constants.testEntry1);
-    projectsPageManager = new ProjectsPage(managerTab);
     editorPage = new EditorPage(managerTab, project);
     pageHeader = new PageHeader(editorPage.page);
   });

--- a/test/e2e/utils/fixtures.ts
+++ b/test/e2e/utils/fixtures.ts
@@ -3,6 +3,7 @@ import { test as base } from '@playwright/test';
 import type { Browser, Page } from '@playwright/test';
 import type { E2EUsernames } from './e2e-users';
 import constants from '../testConstants.json';
+import { getStorageStatePath } from './user-tools';
 
 export type UserDetails = {
   username: string,
@@ -21,7 +22,7 @@ function setupUserDetails(obj: UserDetails, username: E2EUsernames) {
 }
 
 const userTab = (username: E2EUsernames) => async ({ browser, browserName }: { browser: Browser, browserName: string}, use: (r: UserTab) => Promise<void>) => {
-  const storageState = `${browserName}-${username}-storageState.json`;
+  const storageState = getStorageStatePath(browserName, username);
   const context = await browser.newContext({ storageState })
   const page = await context.newPage();
   const tab = page as UserTab;

--- a/test/e2e/utils/login.ts
+++ b/test/e2e/utils/login.ts
@@ -1,6 +1,7 @@
 import { Browser, Page } from '@playwright/test';
 import constants from '../testConstants.json';
 import type { E2EUsernames } from './e2e-users';
+import { getStorageStatePath } from './user-tools';
 
 export async function login(page: Page, username: string, password: string) {
   await page.goto('/auth/login');
@@ -34,7 +35,9 @@ export function loginAs(page: Page, name: E2EUsernames) {
   return login(page, username, password);
 }
 
-export async function getLoggedInPage(browser: Browser, name: string) {
-  const context = await browser.newContext({ storageState: `${name}-storageState.json` });
+export async function getLoggedInPage(browser: Browser, user: string) {
+  const browserName = browser.browserType().name();
+  const storageState = getStorageStatePath(browserName, user);
+  const context = await browser.newContext({ storageState });
   return await context.newPage();
 }


### PR DESCRIPTION
## Description

In #1557 I moved the playwright.config.ts file to the playwright test folder. But I overlooked a few things:
1) That affected where test results get stored
2) It affects where storageState.json files get created when running tests via VS-Code extension

So, I've fixed and standardized those things.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas