### PR TITLE
adjust audio input system regex to be more inclusive

### DIFF
--- a/src/angular-app/bellows/core/utility.service.ts
+++ b/src/angular-app/bellows/core/utility.service.ts
@@ -24,7 +24,7 @@ export class UtilityService {
   }
 
   static isAudio(tag: string): boolean {
-    const tagAudioPattern = /^\w{2,3}-Zxxx-x(-\w{2,3})*-[aA][uU][dD][iI][oO]$/;
+    const tagAudioPattern = /^\w{2,3}-Zxxx-x-.*[aA][uU][dD][iI][oO]$/;
     return tagAudioPattern.test(tag);
   }
 


### PR DESCRIPTION
Fixes #1601 

## Description

Per a user's report, their audio input system was not properly detected in LF due to a too-strict regex.  This loosens the regex a bit to allow LF to properly identify the field as an audio input system.

With this change, a tag must have "-Zxxx" and end with "audio"

Before this change, a non-standard input system tag like `lwl-Zxxx-x-minority-audio` is not detected as an audio input system (although FLEx handles it fine).  After this change, this input system tag should work.

Please note that extra careful testing will be necessary for this PR since I cannot verify that my code change actually works.  I only have my phone with me and do not have a dev environment to test locally.

I used regex101 to test my regex and verify it against two strings to make sure they both work:
`lwl-Zxxx-x-audio`
`lwl-Zxxx-x-minority-audio`

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Refer to the reported bug for screenshots.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title/description of this PR which will be used as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test

An input system having the tag lwl-Zxxx-x-minority-audio ought to show up fine as an audio input system with this change.  I have imported the problem project into QA and so we can verify that the change makes a difference there in QA before shipping this fix.

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
