### PR TITLE
make empty projects display correctly for non-managers

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -109,12 +109,12 @@
                     </div>
                 </div>
             </div>
-            <div class="row" data-ng-show="$ctrl.entries.length == 0 && $ctrl.lecRights.canComment() && $ctrl.lecFinishedLoading">
+            <div class="row" data-ng-show="$ctrl.entries.length == 0 && $ctrl.lecFinishedLoading">
                 <div class="col">
                     <div class="lexiconItemListContainer" data-pui-when-scrolled="$ctrl.show.more()">
                         <div class="text-center no-entries" id="noEntries">
                             <h4>Looks like there are no entries yet.</h4>
-                            <button class="btn btn-primary" data-ng-show="$ctrl.lecRights.canEditEntry()" data-ng-click="$ctrl.navigateToLiftImport()"
+                            <button class="btn btn-primary" data-ng-if="$ctrl.lecRights.canEditEntry()" data-ng-click="$ctrl.navigateToLiftImport()"
                                     data-ng-hide="$ctrl.projectSettings.hasSendReceive">
                                 <i class="fa fa-upload"></i> Import entries from LIFT</button>
                             <button class="btn btn-primary" data-ng-click="$ctrl.syncProject()" data-ng-show="$ctrl.projectSettings.hasSendReceive">

--- a/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
+++ b/src/angular-app/languageforge/lexicon/editor/editor-list.view.html
@@ -109,12 +109,12 @@
                     </div>
                 </div>
             </div>
-            <div class="row" data-ng-show="$ctrl.entries.length == 0 && $ctrl.lecRights.canEditProject() && $ctrl.lecFinishedLoading">
+            <div class="row" data-ng-show="$ctrl.entries.length == 0 && $ctrl.lecRights.canComment() && $ctrl.lecFinishedLoading">
                 <div class="col">
                     <div class="lexiconItemListContainer" data-pui-when-scrolled="$ctrl.show.more()">
                         <div class="text-center no-entries" id="noEntries">
                             <h4>Looks like there are no entries yet.</h4>
-                            <button class="btn btn-primary" data-ng-click="$ctrl.navigateToLiftImport()"
+                            <button class="btn btn-primary" data-ng-show="$ctrl.lecRights.canEditEntry()" data-ng-click="$ctrl.navigateToLiftImport()"
                                     data-ng-hide="$ctrl.projectSettings.hasSendReceive">
                                 <i class="fa fa-upload"></i> Import entries from LIFT</button>
                             <button class="btn btn-primary" data-ng-click="$ctrl.syncProject()" data-ng-show="$ctrl.projectSettings.hasSendReceive">


### PR DESCRIPTION
Fixes #1605 

## Description

This allows the message "Looks like there are no entries yet." to appear for any member of the project (including commenters), and the two buttons to appear for any member of the project who can edit. Previously, with empty projects, these items only displayed if the member was a manager (to include owners and admins, but not editors or commenters).

![image](https://user-images.githubusercontent.com/56163492/202638940-3b7762b3-471d-4dd4-a2d4-7c6baadadd59.png)

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)
- UI change

## Screenshots

This is what we were seeing before, for anyone with permissions less than a manager's:
![image](https://user-images.githubusercontent.com/56163492/202639076-0ae6d1e9-b7dc-4f45-ac17-87d8b08883f1.png)

Now viewers and commenters will see this:
![image](https://user-images.githubusercontent.com/56163492/202640336-e680b412-e2fc-4535-9e9d-bd437327ebcd.png)

and editors, managers, and above will see this:
![image](https://user-images.githubusercontent.com/56163492/202638940-3b7762b3-471d-4dd4-a2d4-7c6baadadd59.png)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have enabled auto-merge (optional)

## How to test

1.Create an empty project and share it with another user, giving them only the (default) "can edit" permissions. Sign in as the other user and view the project. Verify that you see the message and can add entries if you like.
2.Create an empty project and share it with another user, giving them view or comment permissions only. Sign in as the other user and view the project. Verify that you see the message and can add entries if you like. 

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
