### PR TITLE
Admins can view delete tab

### DIFF
--- a/src/Api/Model/Shared/Rights/SystemRoles.php
+++ b/src/Api/Model/Shared/Rights/SystemRoles.php
@@ -26,6 +26,7 @@ class SystemRoles extends RolesBase
         $rights = [];
         self::grantAllOnDomain($rights, Domain::USERS);
         self::grantAllOnDomain($rights, Domain::PROJECTS);
+        $rights[] = Domain::PROJECTS + Operation::DELETE;
         self::$_rights[self::SYSTEM_ADMIN] = $rights;
     }
 

--- a/src/angular-app/bellows/shared/delete-project.component.html
+++ b/src/angular-app/bellows/shared/delete-project.component.html
@@ -1,5 +1,5 @@
 <div class="form-group row">
-    <label class="col-12" for="deletebox">Confirm deletion by typing DELETE into the box below</label>
+    <label class="col-12" for="deletebox">Confirm deletion by typing DELETE into the box below.</label>
     <div class="col-md-4">
         <input data-ng-model="deleteBoxText" class="form-control" type="text" id="deletebox">
     </div>
@@ -12,4 +12,4 @@
             <i class="fa fa-trash"></i> Delete this project</button>
     </div>
 </div>
-<div class="text-error">Only project owners can delete a project, and this action cannot be undone</div>
+<div class="text-error">Only a project owner or an admin can delete a project, and this action cannot be undone.</div>

--- a/src/angular-app/languageforge/lexicon/settings/project-settings.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/project-settings.component.html
@@ -53,7 +53,7 @@
                 <pui-archive-project pui-action-in-progress="$ctrl.actionInProgress"></pui-archive-project>
             </form>
         </uib-tab>
-        <uib-tab heading="Delete" data-ng-show="$ctrl.lpsRights.canDeleteProject()">
+        <uib-tab heading="Delete" data-ng-show="$ctrl.currentUserIsOwnerOrAdmin()">
             <form class="card card-body bg-light">
                 <pui-delete-project></pui-delete-project>
             </form>

--- a/src/angular-app/languageforge/lexicon/settings/project-settings.component.ts
+++ b/src/angular-app/languageforge/lexicon/settings/project-settings.component.ts
@@ -2,7 +2,7 @@ import * as angular from 'angular';
 
 import {ApplicationHeaderService} from '../../../bellows/core/application-header.service';
 import {NoticeService} from '../../../bellows/core/notice/notice.service';
-import {SessionService} from '../../../bellows/core/session.service';
+import {Session, SessionService} from '../../../bellows/core/session.service';
 import {InterfaceConfig} from '../../../bellows/shared/model/interface-config.model';
 import {SemanticDomainsService} from '../../core/semantic-domains/semantic-domains.service';
 import {LexiconProjectService} from '../core/lexicon-project.service';
@@ -17,6 +17,7 @@ export class LexiconProjectSettingsController implements angular.IController {
 
   project: LexiconProject = {} as LexiconProject;
   actionInProgress: boolean = false;
+  session: Session;
 
   static $inject = ['applicationHeaderService',
     'silNoticeService', 'sessionService',
@@ -65,10 +66,15 @@ export class LexiconProjectSettingsController implements angular.IController {
     });
   }
 
+  currentUserIsOwnerOrAdmin(){
+    return this.project.ownerRef.id === this.session.data.userId || this.session.hasSiteRight(this.sessionService.domain.USERS, this.sessionService.operation.VIEW);
+  }
+
 }
 
 export const LexiconProjectSettingsComponent: angular.IComponentOptions = {
   bindings: {
+    session: '<',
     lpsProject: '<',
     lpsRights: '<',
     lpsInterfaceConfig: '<',


### PR DESCRIPTION
Fixes #1561

## Description

Now admins who are not the owner of a project can see and use the option to delete a project under that project's Project Settings.

### Type of Change

Only keep lines below that describe this change, then delete the rest.

- Bug fix (non-breaking change which fixes an issue)
- UI change

## Screenshots

Here you can see that this admin is not the owner of the project:
![image](https://user-images.githubusercontent.com/56163492/202659638-d4714926-14a4-4276-a770-ba987ccef661.png)

but the admin is still shown the delete tab:
![image](https://user-images.githubusercontent.com/56163492/202659694-3d9dc905-1711-4ed7-b80e-498b11d7901c.png)

which the admin uses and then the project is deleted:
![image](https://user-images.githubusercontent.com/56163492/202659802-f57fea04-f5e8-4dd7-aa9b-b28c03b12048.png)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have enabled auto-merge (optional)

## How to test

As an admin, view a project that you do not own.
Navigate to Settings>Project Settings, and then the delete tab. Verify that the delete tab is there, and verify that the deletion of the project works for the non-owner admin. 

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
