### PR TITLE
slim down vscode tasks.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,6 @@
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    "amodio.tsl-problem-matcher",
-    "msjsdiag.debugger-for-chrome",
     "ms-vscode-remote.remote-containers",
     "editorconfig.editorconfig",
     "dbaeumer.vscode-eslint",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,57 +4,15 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "webpack",
-      "type": "shell",
-      "windows": {
-        "command": "bash -c 'npm run webpack'"
-      },
-      "linux": {
-        "command": "npm run webpack"
-      },
-      "problemMatcher": "$awesometsc",
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "presentation": {
-        "reveal": "silent"
-      }
-    },
-    {
-      "label": "webpack-watch",
-      "type": "shell",
-      "isBackground": true,
-      "windows": {
-        "command": "bash -c 'npm run webpack:watch'"
-      },
-      "linux": {
-        "command": "npm run webpack:watch"
-      },
-      "presentation": {
-        "reveal": "silent"
-      },
-      "problemMatcher": []
-    },
-    {
       "label": "npm install",
       "type": "shell",
       "windows": {
         "command": "bash -c 'npm install'"
       },
-      "linux": {
-        "command": "npm install"
-      },
+      "command": "npm install",
       "presentation": {
         "reveal": "silent"
       },
-      "problemMatcher": []
-    },
-    {
-      "label": "Reset E2E tests",
-      "type": "process",
-      "command": "docker",
-      "args": ["compose", "restart", "app-for-e2e"],
       "problemMatcher": []
     }
   ]


### PR DESCRIPTION
- removed outdated tasks
- fixed up npm install task to work on MacOS and prevent task error in VSCode.
- removed unused workspace extension recommendations

Ref: https://code.visualstudio.com/docs/editor/tasks#_custom-tasks