### PR TITLE
use GHA concurrency for PR builds and testing

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,6 @@ env:
   DOCKER_BUILDKIT: 1
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
-# https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre/67939898#67939898
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,12 @@ on:
 env:
   DOCKER_BUILDKIT: 1
 
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+# https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre/67939898#67939898
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

When a dev pushes new commits to a PR, it is possible that GHA is still running a current build and test workflow.  This change enables a concurrency policy that will cancel stale GHA workflows.  This is considered an efficiency improvement as otherwise GHA continues to build and test outdated code.

References:
[GHA Concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)
[Stack Overflow - How to cance GHA PR runs when you push a new commit](https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre/67939898#67939898)

### Type of Change

- infrastructure change

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## How to test

This is a GHA workflow change, and the new feature can be tested by pushing a commit to a PR branch while there is a current build running (tests usually).  The dev should see the currently running GHA cancelled automatically in favor of the new GHA workflow based upon the latest commit.

As part of this PR, I pushed an extra commit after the PR was submitted but within a few minutes, thereby resulting in a cancelled e2e test workflow as can be seen in the screenshot below:

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/3444521/203961105-edfb6fea-d6ee-4bab-9530-9c7a9329d385.png">

