### PR TITLE
Don't toggle new comment field when opening/closing replies

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.html
@@ -26,7 +26,7 @@
                                 parent-get-sense-label="$ctrl.getSenseLabel(regardingField, contextGuid)"
                                 plus-one-comment="$ctrl.plusOneComment(commentId)"
                                 set-comment-interactive-status="$ctrl.setCommentInteractiveStatus(id, visible)"
-                                toggle-show-new-comment="$ctrl.toggleShowNewComment()"></dc-comment>
+                                ></dc-comment>
                 </div>
             </div>
         </div>

--- a/src/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/comment/comments-right-panel.component.ts
@@ -153,10 +153,6 @@ export class CommentsRightPanelController implements angular.IController {
       this.commentService.comments.counts.userPlusOne[commentId] != null);
   }
 
-  toggleShowNewComment = (): void => {
-    this.showNewComment = !this.showNewComment;
-  }
-
   getSenseLabel = (regardingField: string, contextGuid: string): string => {
     if (regardingField == null || this.control.config == null) {
       return '';

--- a/src/angular-app/languageforge/lexicon/editor/comment/dc-comment.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/comment/dc-comment.component.ts
@@ -26,7 +26,6 @@ export class CommentController implements angular.IController {
   parentGetSenseLabel: (params: { regardingField: string, contextGuid: string }) => string;
   plusOneComment: (params: { commentId: string }) => void;
   setCommentInteractiveStatus: (params: { id: string, visible: boolean }) => void;
-  toggleShowNewComment: () => void;
 
   getAvatarUrl = UtilityService.getAvatarUrl;
   showNewReplyForm = true;
@@ -56,7 +55,6 @@ export class CommentController implements angular.IController {
   }
 
   showCommentReplies(): void {
-    this.toggleShowNewComment();
     this.comment.showRepliesContainer = !this.comment.showRepliesContainer;
     this.setCommentInteractiveStatus({ id: this.comment.id, visible: this.comment.showRepliesContainer });
     this.getSenseLabel();
@@ -256,8 +254,7 @@ export const CommentComponent: angular.IComponentOptions = {
     loadComments: '&',
     parentGetSenseLabel: '&',
     plusOneComment: '&',
-    setCommentInteractiveStatus: '&',
-    toggleShowNewComment: '&'
+    setCommentInteractiveStatus: '&'
   },
   controller: CommentController,
   templateUrl: '/angular-app/languageforge/lexicon/editor/comment/dc-comment.component.html'


### PR DESCRIPTION
Fixes #1620

## Description

Stop closing/hiding "new comment" field when opening/closing replies.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

The "New converstion thread" is now always visible:
![image](https://user-images.githubusercontent.com/12587509/204523425-1dc3b16c-8ad9-441f-a551-769513f7b065.png)
![image](https://user-images.githubusercontent.com/12587509/204523526-0195367c-720c-4ad0-938b-a5cca347501b.png)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## How to test

Please describe how to test and/or verify your changes. Provide instructions so we can reproduce. Please also provide relevant test data as necessary. These instructions will be used for QA testing below.

- Create 2 comments on 1 field
- Click "comments" (i.e. replies) on 1st comment
- Observe: new comment field is still visible
- Click "comments" on 2nd comment
- Observe: All 3 fields are now visible

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
