### PR TITLE
Fix alignment of image caption comment bubbles

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/_editor.scss
+++ b/src/angular-app/languageforge/lexicon/editor/_editor.scss
@@ -786,7 +786,7 @@ dc-entry .card {
     }
   }
   .dc-pictures {
-    .commentBubbleContainer {
+    .image-comment-bubble .commentBubbleContainer {
       right: -35px;
     }
     .dc-multitext {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.component.html
@@ -10,7 +10,8 @@
                 </div>
                 <div class="comment-bubble-group">
                     <img class="img-fluid" data-ng-src="{{$ctrl.getPictureUrl(picture)}}" data-ng-attr-title="{{$ctrl.getPictureDescription(picture)}}">
-                    <comment-bubble control="$ctrl.control"
+                    <comment-bubble class="image-comment-bubble"
+                                    control="$ctrl.control"
                                     field="$ctrl.fieldName"
                                     model="picture"
                                     picture="picture"


### PR DESCRIPTION
Fixes #1622

## Description

Fixes the alignment of the image caption comment bubbles that were offset.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/12587509/204537800-7ad7c139-faad-4053-a934-e6349ce38b97.png)

After:
![image](https://user-images.githubusercontent.com/12587509/204537851-9437c7e4-eccc-4a9a-a076-a371c7b5c60c.png)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)