### PR TITLE
remove siteName from project list query

### DIFF
--- a/src/Api/Model/Shared/Dto/UserProfileEncoder.php
+++ b/src/Api/Model/Shared/Dto/UserProfileEncoder.php
@@ -21,7 +21,6 @@ class UserProfileEncoder extends JsonEncoder
         if ($key != "projects") {
             return parent::encodeReferenceList($key, $model);
         }
-        $domain = UrlHelper::getHostname();
         $result = array_map(function ($id) use ($domain) {
             CodeGuard::checkTypeAndThrow($id, "Api\Model\Shared\Mapper\Id");
             /** @var Id $id */
@@ -33,7 +32,6 @@ class UserProfileEncoder extends JsonEncoder
                 // userProfilePropertiesEnabled is type ArrayOf, so testing for empty() didn't work
                 if (
                     !$projectModel->isArchived &&
-                    $projectModel->siteName == $domain &&
                     count($projectModel->userProperties->userProfilePropertiesEnabled) > 0
                 ) {
                     $projectDto = [];

--- a/src/Api/Model/Shared/ProjectListModel.php
+++ b/src/Api/Model/Shared/ProjectListModel.php
@@ -11,7 +11,7 @@ class ProjectListModel extends MapperListModel
         parent::__construct(
             ProjectModelMongoMapper::instance(),
             [],
-            ["projectName", "language", "projectCode", "siteName", "appName"]
+            ["projectName", "language", "projectCode", "appName"]
         );
     }
 }

--- a/src/Api/Model/Shared/ProjectList_UserModel.php
+++ b/src/Api/Model/Shared/ProjectList_UserModel.php
@@ -3,7 +3,6 @@
 namespace Api\Model\Shared;
 
 use Api\Model\Shared\Mapper\MapperListModel;
-use Api\Library\Shared\UrlHelper;
 
 /**
  * List of projects of which a user is a member
@@ -13,12 +12,8 @@ class ProjectList_UserModel extends MapperListModel
 {
     public function __construct()
     {
-        $this->_site = UrlHelper::getHostname();
         parent::__construct(ProjectModelMongoMapper::instance());
     }
-
-    /** @var string */
-    private $_site;
 
     /**
      * Reads all published projects or all archived projects
@@ -27,11 +22,11 @@ class ProjectList_UserModel extends MapperListModel
     public function readAll($isArchivedList = false)
     {
         if ($isArchivedList) {
-            $query = ["siteName" => ['$in' => [$this->_site]], "isArchived" => true];
+            $query = ["isArchived" => true];
         } else {
-            $query = ["siteName" => ['$in' => [$this->_site]], "isArchived" => ['$ne' => true]];
+            $query = ["isArchived" => ['$ne' => true]];
         }
-        $fields = ["projectName", "projectCode", "appName", "siteName", "ownerRef"];
+        $fields = ["projectName", "projectCode", "appName", "ownerRef"];
 
         $this->_mapper->readList($this, $query, $fields);
     }
@@ -44,10 +39,9 @@ class ProjectList_UserModel extends MapperListModel
     {
         $query = [
             "users." . $userId => ['$exists' => true],
-            "siteName" => ['$in' => [$this->_site]],
             "isArchived" => ['$ne' => true],
         ];
-        $fields = ["projectName", "projectCode", "appName", "siteName", "ownerRef"];
+        $fields = ["projectName", "projectCode", "appName", "ownerRef"];
 
         $this->_mapper->readList($this, $query, $fields);
 

--- a/src/angular-app/bellows/apps/siteadmin/site-admin-users.component.html
+++ b/src/angular-app/bellows/apps/siteadmin/site-admin-users.component.html
@@ -53,7 +53,7 @@
                             project<span ng-show="user.projects.length > 1">s</span>) </span>
                             <span ng-repeat="project in user.projects">
                                 <a class="username-styling"
-                                   data-ng-href="http://{{project.siteName}}/app/{{project.appName}}/{{project.id}}">
+                                   data-ng-href="/app/{{project.appName}}/{{project.id}}">
                                     {{project.projectCode}}</a><span ng-show="!$last">, </span></span>
                         </td>
                     </tr>

--- a/src/angular-app/bellows/core/navbar.controller.ts
+++ b/src/angular-app/bellows/core/navbar.controller.ts
@@ -20,7 +20,6 @@ export class NavbarController implements angular.IController {
   interfaceConfig: InterfaceConfig;
   currentUserIsProjectManager: boolean;
   displayShareButton: boolean;
-  siteName: string;
   isLexiconProject: boolean = false;
 
   static $inject = [
@@ -75,7 +74,6 @@ export class NavbarController implements angular.IController {
 
       this.rights.canCreateProject =
         session.hasSiteRight(this.sessionService.domain.PROJECTS, this.sessionService.operation.CREATE);
-      this.siteName = session.baseSite();
     });
     this.$scope.$on('$locationChangeStart', (event, next, current) => {
       if (current.includes('/lexicon') && !current.includes('/new-project')) {

--- a/test/php/model/shared/UserModelTest.php
+++ b/test/php/model/shared/UserModelTest.php
@@ -145,7 +145,6 @@ class UserModelTest extends TestCase
                     "ownerRef" => $userId,
                     "id" => $p1,
                     "appName" => "lexicon",
-                    "siteName" => UrlHelper::getHostname(),
                     "projectCode" => "p1Code",
                 ],
                 [
@@ -153,7 +152,6 @@ class UserModelTest extends TestCase
                     "ownerRef" => $userId,
                     "id" => $p2,
                     "appName" => "lexicon",
-                    "siteName" => UrlHelper::getHostname(),
                     "projectCode" => "p2Code",
                 ],
             ],


### PR DESCRIPTION
## Description

This removes the siteName from the ProjectList_UserModel query so that all projects for the user show up regardless of sitename encoded in the database.

It also removes a few unused references from the front-end.

This is a follow up PR to #1592 to allow projects to show in the project list regardless of the siteName data in mongo.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## How to test

After this PR, QA should show all projects appropriately in the project list.

Additionally, the site admin user list contains links to projects for each user.  These links should still work.  click on one to verify it works.
![image](https://user-images.githubusercontent.com/3444521/204558983-178e5b83-343d-4639-b290-683a9a1e2d29.png)


## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
