### PR TITLE
Remove self (a tech support) from project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ e2e-tests:
 playwright-app:
     # delete any cached session storage state files if the service isn't running
 	docker compose ps app-for-playwright > /dev/null 2>&1 || $(MAKE) clean-test
-	docker compose up -d app-for-playwright
+	docker compose up -d app-for-playwright --build
     # wait until the app-for-playwright service is serving up HTTP before continuing
 	until curl localhost:3238 > /dev/null 2>&1; do sleep 1; done
 

--- a/src/Api/Model/Shared/Command/ProjectCommands.php
+++ b/src/Api/Model/Shared/Command/ProjectCommands.php
@@ -293,14 +293,14 @@ class ProjectCommands
 
     /**
      * Removes users from the project (two-way unlink)
-     * @param string $projectId
+     * @param string $aProjectId - might not be the session's current project. Any project that the user is part of.
      * @param array<string> $userIds
      * @return string $projectId
      * @throws \Exception
      */
-    public static function removeUsers($projectId, $userIds)
+    public static function removeUsers($aProjectId, $userIds)
     {
-        $project = new ProjectModel($projectId);
+        $project = new ProjectModel($aProjectId);
         foreach ($userIds as $userId) {
             // Guard against removing project owner
             if ($userId != $project->ownerRef->id) {
@@ -314,7 +314,7 @@ class ProjectCommands
             }
         }
 
-        return $projectId;
+        return $aProjectId;
     }
 
     /**

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -147,6 +147,9 @@ class RightsHelper
             case "project_removeUsers":
                 return $this->userHasProjectRight(Domain::USERS + Operation::DELETE);
 
+            case "project_removeSelf":
+                return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
+
             // Admin (system context)
             case "user_read":
             case "user_list":

--- a/src/Api/Model/Shared/Dto/RightsHelper.php
+++ b/src/Api/Model/Shared/Dto/RightsHelper.php
@@ -100,7 +100,6 @@ class RightsHelper
                 return $this->userHasProjectRight(Domain::USERS + Operation::EDIT);
             case "project_sendJoinRequest":
                 return true;
-
             case "project_getInviteLink":
                 return $this->userHasProjectRight(Domain::PROJECTS + Operation::VIEW);
 

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -455,10 +455,14 @@ class Sf
         ProjectCommands::removeJoinRequest($this->projectId, $userId);
     }
 
-    // REVIEW: should this be part of the general project API ?
-    public function project_removeUsers($aProjectId, $userIds)
+    public function project_removeUsers($userIds)
     {
-        return ProjectCommands::removeUsers($aProjectId, $userIds);
+        return ProjectCommands::removeUsers($this->projectId, $userIds);
+    }
+
+    public function project_removeSelf($aProjectId)
+    {
+        return ProjectCommands::removeUsers($aProjectId, [$this->userId]);
     }
 
     /**

--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -456,9 +456,9 @@ class Sf
     }
 
     // REVIEW: should this be part of the general project API ?
-    public function project_removeUsers($userIds)
+    public function project_removeUsers($aProjectId, $userIds)
     {
-        return ProjectCommands::removeUsers($this->projectId, $userIds);
+        return ProjectCommands::removeUsers($aProjectId, $userIds);
     }
 
     /**

--- a/src/angular-app/bellows/apps/projects/projects-app.component.html
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.html
@@ -34,18 +34,22 @@
                       items="$ctrl.projects" filtered-items="filteredProjects" visible-items="visibleProjects" select="">
                 <div data-ng-repeat="project in visibleProjects">
                     <div class="row align-items-center mb-3 project" data-ng-class="{active: $ctrl.isSelected(project)}">
-                        <div class="col-md-4">
+                        <div class="col-5">
                             <a data-ng-show="$ctrl.isInProject(project)" data-ng-href="/app/lexicon/{{project.id}}">
                                 <span class="larger-text">{{project.projectName}}</span></a>
                             <span data-ng-show="!$ctrl.isInProject(project)" class="larger-text">{{project.projectName}}</span>
                             <small class="text-muted"> {{project.projectCode}}</small>
                         </div>
-                        <div class="col-7 col-md-5" data-ng-show="$ctrl.rights.canEditProjects">
+                        <div class="col-3" data-ng-show="$ctrl.rights.canEditProjects">
                             <small class="text-muted">Dictionary</small>
                         </div>
-                        <div class="col-5 col-md-3 text-right" data-ng-show="$ctrl.rights.canEditProjects">
-                            <button id="techSupportButton" class="btn btn-std" data-ng-show="!$ctrl.isManager(project)"
-                                    data-ng-click="$ctrl.addTechSupportToProject(project)">
+                        <div class="col-2" data-ng-show="$ctrl.rights.canEditProjects">
+                            <button id="removeSelfButton" class="btn btn-std" data-ng-show="!$ctrl.isOwner(project) && $ctrl.isInProject(project)"
+                                    data-ng-click="$ctrl.removeSelfFromProject(project)">
+                                <i class="fa fa-chain-broken"></i> Leave this project</button>
+                        </div>
+                        <div class="col-2" data-ng-show="$ctrl.rights.canEditProjects">
+                            <button id="techSupportButton" class="btn btn-std" data-ng-show="!$ctrl.isManager(project)" ng-click="$ctrl.addTechSupportToProject(project)">
                                 <i class="fa fa-plus"></i> Tech Support</button>
                         </div>
                     </div>

--- a/src/angular-app/bellows/apps/projects/projects-app.component.ts
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.ts
@@ -6,22 +6,12 @@ import { BreadcrumbService } from '../../core/breadcrumbs/breadcrumb.service';
 import { SiteWideNoticeService } from '../../core/site-wide-notice-service';
 import { NoticeService } from '../../core/notice/notice.service';
 import { Session, SessionService } from '../../core/session.service';
-import { ModalService } from '../../../bellows/core/modal/modal.service';
 import { Project } from '../../shared/model/project.model';
-import { UserService } from '../../core/api/user.service';
-import { RolesService } from '../../core/api/roles.service';
 
 class Rights {
   canEditProjects: boolean;
   canCreateProject: boolean;
   showControlBar: boolean;
-}
-
-interface ViewModelProject {
-  id: string;
-  projectName: string;
-  appName: string;
-  role: string;
 }
 
 export class ProjectsAppController implements angular.IController {
@@ -35,25 +25,19 @@ export class ProjectsAppController implements angular.IController {
 
   static $inject = ['$window',
                     'projectService',
-                    'userService',
-                    'rolesService',
                     'sessionService',
                     'silNoticeService',
                     'breadcrumbService',
                     'siteWideNoticeService',
-                    'applicationHeaderService',
-                    'modalService'
+                    'applicationHeaderService'
                    ];
   constructor(private $window: angular.IWindowService,
               private projectService: ProjectService,
-              private userService: UserService,
-              private rolesService: RolesService,
               private sessionService: SessionService,
               private notice: NoticeService,
               private breadcrumbService: BreadcrumbService,
               private siteWideNoticeService: SiteWideNoticeService,
-              private applicationHeaderService: ApplicationHeaderService,
-              private modal: ModalService
+              private applicationHeaderService: ApplicationHeaderService
              ) { }
 
   async $onInit(): Promise<void> {
@@ -117,7 +101,7 @@ export class ProjectsAppController implements angular.IController {
   }
 
   removeSelfFromProject(project : Project): void {
-    this.projectService.removeUsers(project.id, [this.session.data.userId], result => {
+    this.projectService.removeSelfFromProject(project.id, result => {
       if(result.ok){
         this.notice.push(this.notice.SUCCESS, project.projectName + ' is no longer in your projects.');
         this.queryProjectsForUser();

--- a/src/angular-app/bellows/apps/projects/projects-app.component.ts
+++ b/src/angular-app/bellows/apps/projects/projects-app.component.ts
@@ -5,7 +5,8 @@ import { ApplicationHeaderService } from '../../core/application-header.service'
 import { BreadcrumbService } from '../../core/breadcrumbs/breadcrumb.service';
 import { SiteWideNoticeService } from '../../core/site-wide-notice-service';
 import { NoticeService } from '../../core/notice/notice.service';
-import { SessionService } from '../../core/session.service';
+import { Session, SessionService } from '../../core/session.service';
+import { ModalService } from '../../../bellows/core/modal/modal.service';
 import { Project } from '../../shared/model/project.model';
 import { UserService } from '../../core/api/user.service';
 import { RolesService } from '../../core/api/roles.service';
@@ -30,25 +31,32 @@ export class ProjectsAppController implements angular.IController {
   projects: Project[] = [];
   siteName: string;
   projectCount: number;
+  session: Session;
 
-  static $inject = ['$window', 'projectService',
+  static $inject = ['$window',
+                    'projectService',
                     'userService',
                     'rolesService',
-                    'sessionService', 'silNoticeService',
+                    'sessionService',
+                    'silNoticeService',
                     'breadcrumbService',
                     'siteWideNoticeService',
                     'applicationHeaderService',
+                    'modalService'
                    ];
-  constructor(private $window: angular.IWindowService, private projectService: ProjectService,
+  constructor(private $window: angular.IWindowService,
+              private projectService: ProjectService,
               private userService: UserService,
               private rolesService: RolesService,
-              private sessionService: SessionService, private notice: NoticeService,
+              private sessionService: SessionService,
+              private notice: NoticeService,
               private breadcrumbService: BreadcrumbService,
               private siteWideNoticeService: SiteWideNoticeService,
               private applicationHeaderService: ApplicationHeaderService,
+              private modal: ModalService
              ) { }
 
-  $onInit() {
+  async $onInit(): Promise<void> {
     this.applicationHeaderService.setPageName('My Projects');
     this.breadcrumbService.set('top', [{
           href: '/app/projects',
@@ -56,7 +64,8 @@ export class ProjectsAppController implements angular.IController {
         }]);
     this.siteWideNoticeService.displayNotices();
 
-    this.sessionService.getSession().then(session => {
+    await this.sessionService.getSession().then(session => {
+      this.session = session;
       this.rights.canEditProjects =
         session.hasSiteRight(this.sessionService.domain.PROJECTS, this.sessionService.operation.EDIT);
       this.rights.canCreateProject =
@@ -92,12 +101,25 @@ export class ProjectsAppController implements angular.IController {
     return project.role === 'project_manager' || project.role === 'tech_support';
   }
 
-  // Add user as Tech Support to a project
+  isOwner(project: Project): boolean {
+    if (typeof project.ownerId == 'string') {
+      return project.ownerId === this.session.data.userId;
+    }
+    return false;
+  }
+
   addTechSupportToProject(project: Project) {
     this.projectService.joinProject(project.id, 'tech_support', result => {
       if (result.ok) {
-        this.notice.push(this.notice.SUCCESS, 'You are now Tech Support for the \'' +
-          project.projectName + '\' project.');
+        this.$window.location.href = "/app/lexicon/" + project.id;
+      }
+    });
+  }
+
+  removeSelfFromProject(project : Project): void {
+    this.projectService.removeUsers(project.id, [this.session.data.userId], result => {
+      if(result.ok){
+        this.notice.push(this.notice.SUCCESS, project.projectName + ' is no longer in your projects.');
         this.queryProjectsForUser();
       }
     });

--- a/src/angular-app/bellows/apps/usermanagement/members.component.ts
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.ts
@@ -106,7 +106,7 @@ export class UserManagementMembersController implements angular.IController {
       return;
     }
 
-    this.projectService.removeUsers(this.project.id, userIds).then(() => {
+    this.projectService.removeUsers(userIds).then(() => {
       this.sessionService.getSession().then(session => {
         if (userIds.indexOf(session.userId()) !== -1) {
           // redirect if you just removed yourself from the project

--- a/src/angular-app/bellows/apps/usermanagement/members.component.ts
+++ b/src/angular-app/bellows/apps/usermanagement/members.component.ts
@@ -106,7 +106,7 @@ export class UserManagementMembersController implements angular.IController {
       return;
     }
 
-    this.projectService.removeUsers(userIds).then(() => {
+    this.projectService.removeUsers(this.project.id, userIds).then(() => {
       this.sessionService.getSession().then(session => {
         if (userIds.indexOf(session.userId()) !== -1) {
           // redirect if you just removed yourself from the project

--- a/src/angular-app/bellows/core/api/project.service.ts
+++ b/src/angular-app/bellows/core/api/project.service.ts
@@ -1,7 +1,7 @@
 import * as angular from 'angular';
 
 import {OfflineCacheService} from '../offline/offline-cache.service';
-import {Session, SessionService} from '../session.service';
+import {SessionService} from '../session.service';
 import {ApiService, JsonRpcCallback} from './api.service';
 
 export class ProjectService {
@@ -9,7 +9,6 @@ export class ProjectService {
   protected api: ApiService;
   protected sessionService: SessionService;
   private offlineCache: OfflineCacheService;
-  private $location: angular.ILocationService;
   private $q: angular.IQService;
 
   // noinspection TypeScriptFieldCanBeMadeReadonly
@@ -19,7 +18,6 @@ export class ProjectService {
     this.api = $injector.get('apiService');
     this.sessionService = $injector.get('sessionService');
     this.offlineCache = $injector.get('offlineCache');
-    this.$location = $injector.get('$location');
     this.$q = $injector.get('$q');
   }
 
@@ -103,8 +101,12 @@ export class ProjectService {
     return this.api.call('project_denyJoinRequest', [userId], callback);
   }
 
-  removeUsers(aProjectId: string, userIds: string[], callback?: JsonRpcCallback) {
-    return this.api.call('project_removeUsers', [aProjectId, userIds], callback);
+  removeUsers(userIds: string[], callback?: JsonRpcCallback) {
+    return this.api.call('project_removeUsers', [userIds], callback);
+  }
+
+  removeSelfFromProject(aProjectId: string, callback?: JsonRpcCallback) {
+    return this.api.call('project_removeSelf', [aProjectId], callback);
   }
 
   getDto(callback?: JsonRpcCallback) {

--- a/src/angular-app/bellows/core/api/project.service.ts
+++ b/src/angular-app/bellows/core/api/project.service.ts
@@ -103,8 +103,8 @@ export class ProjectService {
     return this.api.call('project_denyJoinRequest', [userId], callback);
   }
 
-  removeUsers(userIds: string[], callback?: JsonRpcCallback) {
-    return this.api.call('project_removeUsers', [userIds], callback);
+  removeUsers(aProjectId: string, userIds: string[], callback?: JsonRpcCallback) {
+    return this.api.call('project_removeUsers', [aProjectId, userIds], callback);
   }
 
   getDto(callback?: JsonRpcCallback) {

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.html
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.html
@@ -1,9 +1,10 @@
 <div class="btn-group" uib-dropdown dropdown-append-to-body is-open="status.isopen">
-  <button id="single-button" type="button" class="btn btn-primary text-dark bg-light role-indicator"
+  <button id="single-button-1" ng-if="!$ctrl.userIsTechSupport()" type="button" class="btn btn-primary text-dark bg-light role-indicator"
     uib-dropdown-toggle>
-    <i class="fa fa-{{ $ctrl.selectedRoleDetail.icon }}"></i> <span class="caret"></span>
+    <i class="fa fa-{{ $ctrl.selectedRoleDetail.icon }}"></i>
+    <span class="caret"></span>
   </button>
-  <div class="dropdown-menu dropdown-menu-right modal-dropdown" uib-dropdown-menu role="menu" aria-labelledby="single-button">
+  <div ng-if="!$ctrl.userIsTechSupport()" class="dropdown-menu dropdown-menu-right modal-dropdown" uib-dropdown-menu role="menu" aria-labelledby="single-button-1">
     <a href class="dropdown-item" role="menuitem" ng-repeat="roleDetail in $ctrl.roleDetails" ng-click="$ctrl.selectRoleDetail(roleDetail)">
       <i class="fa fa-{{ roleDetail.icon }}"></i>
       {{ roleDetail.description }} <i class="fa fa-check" ng-show="$ctrl.selectedRoleDetail == roleDetail"></i>
@@ -15,13 +16,38 @@
           make owner
       </a>
     </div>
-    <div ng-if="$ctrl.allowDelete">
+    <div>
       <div class="dropdown-divider"></div>
-      <a class="dropdown-item text-danger" role="menuitem" ng-if="$ctrl.allowDelete" ng-click="$ctrl.onDeleteTarget({$event: {target: $ctrl.target}})">
+      <a class="dropdown-item text-danger" role="menuitem" ng-click="$ctrl.onDeleteTarget({$event: {target: $ctrl.target}})">
         <i class="fa fa-times"></i>
         remove
     </a>
   </div>
+</div>
+<button id="single-button-2" ng-if="$ctrl.userIsTechSupport()" type="button" class="btn btn-primary text-dark bg-light role-indicator"
+uib-dropdown-toggle>
+  <i class="fa fa-cogs"></i>
+  <span class="caret"></span>
+</button>
+<div ng-if="$ctrl.userIsTechSupport()" class="dropdown-menu dropdown-menu-right modal-dropdown" uib-dropdown-menu role="menu" aria-labelledby="single-button-2">
+  <div class="dropdown-item">
+    <i class="fa fa-cogs"></i>
+    tech support
+  </div>
+  <div ng-if="$ctrl.currentUserIsOwnerOrAdmin() && !$ctrl.target.isInvitee">
+    <div class="dropdown-divider" ></div>
+    <a class="dropdown-item" role="menuitem" ng-click="$ctrl.onOwnershipTransfer({$event: {target: $ctrl.target}})">
+        <i class="fa fa-arrow-circle-o-up"></i>
+        make owner
+    </a>
+  </div>
+  <div>
+    <div class="dropdown-divider"></div>
+    <a class="dropdown-item text-danger" role="menuitem" ng-click="$ctrl.onDeleteTarget({$event: {target: $ctrl.target}})">
+      <i class="fa fa-times"></i>
+      remove
+  </a>
+</div>
 </div>
 </div>
 

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.ts
@@ -25,7 +25,7 @@ export class RoleDropdownController implements angular.IController {
   project: Project;
   session: Session;
   allowDisable: boolean;
-  allowDelete: boolean;
+  userIsTechSupport: () => boolean;
   currentUserIsOwnerOrAdmin: () => boolean;
   onRoleChanged: (params: { $event: { roleDetail: RoleDetail, target: any } }) => void;
   onDeleteTarget: (params: { $event: { target: any } }) => void;
@@ -96,8 +96,8 @@ export const RoleDropdownComponent: angular.IComponentOptions = {
     onOwnershipTransfer: '&',
     onRoleChanged: '&',
     onDeleteTarget: '&',
+    userIsTechSupport: '&',
     currentUserIsOwnerOrAdmin: '&',
-    allowDelete: '<'
   },
   controller: RoleDropdownController,
   templateUrl: '/angular-app/languageforge/lexicon/shared/share-with-others/role-dropdown.component.html'

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.html
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.html
@@ -30,14 +30,12 @@
                                 on-role-changed="$ctrl.onUserRoleChanged($event)"
                                 on-delete-target="$ctrl.onDeleteTarget($event)"
                                 on-ownership-transfer="$ctrl.onOwnershipTransfer($event)"
+                                user-is-tech-support="$ctrl.userIsTechSupport(user)"
                                 current-user-is-owner-or-admin="$ctrl.currentUserIsOwnerOrAdmin()"
                                 allow-delete="true"
                                 selected-role="user.role"
                                 roles="$ctrl.memberRoles"></role-dropdown>
         </div>
-        <i class="fa fa-times delete-member d-none d-md-block" ng-click="$ctrl.removeUser(user);"
-            ng-if="!$ctrl.userIsOwner(user) && !$ctrl.userIsCurrentUser(user)"></i>
-        <div class="delete-member d-none d-md-block" ng-if="$ctrl.userIsOwner(user) || $ctrl.userIsCurrentUser(user)"></div>
       </li>
       <div class="scroll-gradient" id="scroll-gradient-lower"></div>
     </ul>

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.ts
@@ -1,13 +1,14 @@
 import * as angular from 'angular';
 import { ProjectService } from '../../../../bellows/core/api/project.service';
-import { UserService } from '../../../../bellows/core/api/user.service';
 import { Session, SessionService } from '../../../../bellows/core/session.service';
 import { ModalService } from '../../../../bellows/core/modal/modal.service';
 import { UtilityService } from '../../../../bellows/core/utility.service';
-import { Project, ProjectRole } from '../../../../bellows/shared/model/project.model';
+import { NoticeService } from 'src/angular-app/bellows/core/notice/notice.service';
+import { Project, ProjectRole, ProjectRoles } from '../../../../bellows/shared/model/project.model';
 import { User } from '../../../../bellows/shared/model/user.model';
 import { LexRoles } from '../model/lexicon-project.model';
 import { RoleDetail } from './role-dropdown.component';
+import { SiteWideNoticeService } from 'src/angular-app/bellows/core/site-wide-notice-service';
 
 export class UserManagementController implements angular.IController {
   getAvatarUrl = UtilityService.getAvatarUrl;
@@ -21,13 +22,15 @@ export class UserManagementController implements angular.IController {
   memberRoles: ProjectRole[];
 
 
-  static $inject = ['$q', 'projectService', 'userService', 'sessionService','modalService'];
+
+  static $inject = ['$window', 'projectService', 'sessionService','modalService', 'silNoticeService', 'siteWideNoticeService'];
   constructor(
-    private readonly $q: angular.IQService,
+    private $window: angular.IWindowService,
     private readonly projectService: ProjectService,
-    private readonly userService: UserService,
     private readonly sessionService: SessionService,
-    private readonly modal: ModalService) { }
+    private readonly modal: ModalService,
+    private readonly notice: NoticeService,
+    private siteWideNoticeService: SiteWideNoticeService,) { }
 
   async $onInit(): Promise<void> {
     // TODO: actually hook anonymousUserRole up to the backend
@@ -47,9 +50,11 @@ export class UserManagementController implements angular.IController {
       LexRoles.OBSERVER
     ];
 
+    this.siteWideNoticeService.displayNotices();
     await this.sessionService.getSession().then((s) => {
         this.session = s;
       });
+    this.notice.checkUrlForNotices();
   }
 
   userIsCurrentUser(user: User): boolean {
@@ -77,6 +82,13 @@ export class UserManagementController implements angular.IController {
     })
   }
 
+  userIsTechSupport(user: User): boolean {
+    if (user.role === ProjectRoles.TECH_SUPPORT.key){
+      return true;
+    }
+    return false;
+  }
+
   currentUserIsOwnerOrAdmin(): boolean {
     if (typeof this.project.ownerRef == 'object') {
       return (this.project.ownerRef.id === this.session.data.userId) || this.sessionService.userIsAdmin();
@@ -87,7 +99,6 @@ export class UserManagementController implements angular.IController {
   onSpecialRoleChanged($event: {roleDetail: RoleDetail, target: string}) {
     if ($event.target === 'anonymous_user') {
       this.project.anonymousUserRole = $event.roleDetail.role.key;
-      console.log('TODO: actually set ' + $event.target + ' role to ' + $event.roleDetail.role.key);
     }
   }
 
@@ -112,15 +123,32 @@ export class UserManagementController implements angular.IController {
   removeUser(user: User) {
     const removeUserMessage = 'Are you sure you want to remove <b>' + user.username + '</b> from the <b>' + this.project.projectName + '</b> project?';
     this.modal.showModalSimple('Remove user', removeUserMessage, 'Cancel', 'Remove ' + user.username).then(() => {
-      this.projectService.removeUsers([user.id]).then(() => {
+      this.projectService.removeUsers(this.project.id, [user.id]).then(() => {
         this.loadMemberData();
+      });
+    });
+  }
+
+  removeSelfFromProject() {
+    const removeSelfMessage = 'Are you sure you want to remove yourself from <b>' + this.project.projectName + '</b>?';
+    this.modal.showModalSimple('Leave ' + this.project.projectName, removeSelfMessage, 'Cancel', 'Remove me from ' + this.project.projectName).then(() => {
+      this.projectService.removeUsers(this.project.id, [this.session.data.userId], async result => {
+        if(result.ok){
+          this.notice.push(this.notice.SUCCESS, this.project.projectName + ' is no longer in your projects.');
+          this.$window.location.href = '/app/projects';
+        }
       });
     });
   }
 
   onDeleteTarget($event: { target: any }) {
     if (($event.target as User).avatar_ref !== undefined) { // target is a User
-      this.removeUser($event.target);
+      if(this.userIsCurrentUser($event.target)){
+        this.removeSelfFromProject();
+      }
+      else{
+        this.removeUser($event.target);
+      }
     }
   }
 

--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/user-management.component.ts
@@ -123,7 +123,7 @@ export class UserManagementController implements angular.IController {
   removeUser(user: User) {
     const removeUserMessage = 'Are you sure you want to remove <b>' + user.username + '</b> from the <b>' + this.project.projectName + '</b> project?';
     this.modal.showModalSimple('Remove user', removeUserMessage, 'Cancel', 'Remove ' + user.username).then(() => {
-      this.projectService.removeUsers(this.project.id, [user.id]).then(() => {
+      this.projectService.removeUsers([user.id]).then(() => {
         this.loadMemberData();
       });
     });
@@ -132,7 +132,7 @@ export class UserManagementController implements angular.IController {
   removeSelfFromProject() {
     const removeSelfMessage = 'Are you sure you want to remove yourself from <b>' + this.project.projectName + '</b>?';
     this.modal.showModalSimple('Leave ' + this.project.projectName, removeSelfMessage, 'Cancel', 'Remove me from ' + this.project.projectName).then(() => {
-      this.projectService.removeUsers(this.project.id, [this.session.data.userId], async result => {
+      this.projectService.removeSelfFromProject(this.project.id, async result => {
         if(result.ok){
           this.notice.push(this.notice.SUCCESS, this.project.projectName + ' is no longer in your projects.');
           this.$window.location.href = '/app/projects';

--- a/test/e2e/pages/projects.page.ts
+++ b/test/e2e/pages/projects.page.ts
@@ -92,7 +92,15 @@ export class ProjectsPage extends BasePage {
     return this.projectAddTechSupportButtonLocator(projectName).isVisible();
   }
 
+  async projectHasLeaveProjectButton(projectName: string): Promise<boolean> {
+    return this.projectLeaveProjectButtonLocator(projectName).isVisible();
+  }
+
   projectAddTechSupportButtonLocator(projectName: string): Locator {
     return this.projectRow(projectName).locator('text=Tech Support');
+  }
+
+  projectLeaveProjectButtonLocator(projectName: string): Locator {
+    return this.projectRow(projectName).locator('text=Leave this project');
   }
 }

--- a/test/e2e/projects.spec.ts
+++ b/test/e2e/projects.spec.ts
@@ -102,18 +102,31 @@ test.describe('E2E Projects List app', () => {
       expect(await projectsPageAdmin.projectHasAddTechSupportButton(project5.name)).toBe(true);
 
       await projectsPageAdmin.projectAddTechSupportButtonLocator(project5.name).click();
+      await expect(await projectsPageAdmin.projectAddTechSupportButtonLocator(project5.name)).not.toBeVisible();
+    });
+
+
+    test('Should allow admin (tech support) to remove him- or herself from a project' , async () => {
+      expect(await projectsPageAdmin.projectIsLinked(project4.name)).toBe(true);
+      expect(await projectsPageAdmin.projectHasLeaveProjectButton(project4.name)).toBe(true);
+
+      await projectsPageAdmin.projectLeaveProjectButtonLocator(project4.name).click();
 
       const noticeElement = new NoticeElement(projectsPageAdmin.page);
       await expect(noticeElement.notice).toBeVisible();
-      await expect(noticeElement.notice).toContainText(`You are now Tech Support for the '${project5.name}' project.`);
-      await expect(await projectsPageAdmin.projectAddTechSupportButtonLocator(project5.name)).not.toBeVisible();
-      await expect(projectsPageAdmin.projectLink(project5.name)).toBeVisible();
+      await expect(noticeElement.notice).toContainText(`${project4.name} is no longer in your projects.`);
+      await expect(await projectsPageAdmin.projectLeaveProjectButtonLocator(project4.name)).not.toBeVisible();
+      await expect(projectsPageAdmin.projectLink(project4.name)).not.toBeVisible();
 
-      // admin is a contributor
-      expect(await projectsPageAdmin.projectIsLinked(project4.name)).toBe(true);
+      // admin is no longer a contributor
+      expect(await projectsPageAdmin.projectIsLinked(project4.name)).toBe(false);
       expect(await projectsPageAdmin.projectHasAddTechSupportButton(project4.name)).toBe(true);
+
     });
+
   });
+
+
 
   test.describe('Lexicon E2E Project Access', () => {
 

--- a/test/php/model/shared/commands/ProjectCommandsTest.php
+++ b/test/php/model/shared/commands/ProjectCommandsTest.php
@@ -281,7 +281,7 @@ class ProjectCommandsTest extends TestCase
 
         self::$environ->clean();
 
-        // setup project and users.  user1 is the project owner
+        // setup project and users.  user2 is the project owner
         $project = self::$environ->createProject(SF_TESTPROJECT, SF_TESTPROJECTCODE);
         $projectId = $project->id->asString();
         $user1Id = self::$environ->createUser("user1name", "User1 Name", "user1@example.com");
@@ -302,7 +302,7 @@ class ProjectCommandsTest extends TestCase
         self::$save["user1Id"] = $user1Id;
         self::$save["user2Id"] = $user2Id;
 
-        // remove users from project.  user1 still remains as project owner
+        // remove users from project.  user2 still remains as project owner
         $userIds = [$user1->id->asString(), $user2->id->asString()];
 
         ProjectCommands::removeUsers($projectId, $userIds);
@@ -319,7 +319,7 @@ class ProjectCommandsTest extends TestCase
         $sameUser1 = new UserModel(self::$save["user1Id"]);
         $sameUser2 = new UserModel(self::$save["user2Id"]);
 
-        // project still has project owner
+        // project still has project owner (user2)
         $this->assertEquals(1, $sameProject->listUsers()->count);
         $this->assertEquals(0, $sameUser1->listProjects()->count);
         $this->assertEquals(1, $sameUser2->listProjects()->count);


### PR DESCRIPTION
Fixes #1541
Fixes #1613

## Description

Now, in the projects list, admins can remove themselves from projects that they have been tech support for. 
I also added a notice to "remove" in the role dropdown of the user management component. 
Additionally, tech supports now have their own icons in the role-dropdowns in the user management component, and the "add tech support" button in the projects list now redirects to the project page immediately after the tech support adds him/herself.

### Type of Change

- New feature (non-breaking change which adds functionality)
- UI change

## Screenshots
Button to leave project in a tech support's project list:
![image](https://user-images.githubusercontent.com/56163492/204994185-e5333043-c5a5-45f7-b1b4-cf7e9f8a5319.png)

Tech support icons + dropdowns
![image](https://user-images.githubusercontent.com/56163492/204994071-e9f9bd47-7e31-48e9-8289-230e0d29c628.png)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## How to test

1. Sign in as an admin. Make a project and then transfer ownership of that project to someone else. Go back to the projects list and click "Leave this project". Observe that that project now has an option beside it to "+ Tech Support" back to the project if you would like.
2. Click on the "+ Tech support" button. Observe that it takes you directly to that project.

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
