### PR TITLE
hide comments and activity from project "observers"

### DIFF
--- a/next-app/src/lib/auth/index.ts
+++ b/next-app/src/lib/auth/index.ts
@@ -1,0 +1,11 @@
+// src/Api/Model/Shared/Rights/ProjectRoles.php
+// src/Api/Model/Shared/Rights/LexRoles.php
+const roles = [
+	'project_manager',
+	'contributor',
+	'tech_support',
+	'observer_with_comment',
+	'observer',
+]
+
+export const can_view_comments = role => roles.filter(_role => _role != 'observer').includes(role)

--- a/next-app/src/lib/auth/index.ts
+++ b/next-app/src/lib/auth/index.ts
@@ -9,3 +9,4 @@ const roles = [
 ]
 
 export const can_view_comments = role => roles.filter(_role => _role != 'observer').includes(role)
+export const can_view_activity = role => roles.filter(_role => ! _role.startsWith('observer')).includes(role)

--- a/next-app/src/lib/data/user.ts
+++ b/next-app/src/lib/data/user.ts
@@ -1,7 +1,7 @@
 import { throwError } from '$lib/error'
 import { sf } from '$lib/fetch/server'
 
-export async function current_user(cookie) {
+export async function fetch_current_user(cookie) {
 	const { userId, userProjectRole } = await sf({
 		name: 'session_getSessionData',
 		cookie,

--- a/next-app/src/lib/data/user.ts
+++ b/next-app/src/lib/data/user.ts
@@ -1,0 +1,18 @@
+import { throwError } from '$lib/error'
+import { sf } from '$lib/fetch/server'
+
+export async function current_user(cookie) {
+	const { userId, userProjectRole } = await sf({
+		name: 'session_getSessionData',
+		cookie,
+	})
+
+	if (! userId) {
+		throwError('User unknown', 404)
+	}
+
+	return {
+		id: userId,
+		role: userProjectRole,
+	}
+}

--- a/next-app/src/lib/fetch/client.ts
+++ b/next-app/src/lib/fetch/client.ts
@@ -23,25 +23,18 @@ async function customFetch(method, url, body) {
 		body = JSON.stringify(body)
 	}
 
-	let response = {}
-	try {
-		start(url)
-
-		response = await fetch(url, {
-			method,
-			headers,
-			body,
-		})
-	} catch (e) {
-		// these only occur for network errors, like these:
-		//	request made with a bad host, e.g., //httpbin
-		//	the host is refusing connections
-		//	client is offline, i.e., airplane mode or something
-		//	CORS preflight failures
-		throwError(e)
-	} finally {
-		stop(url)
-	}
+	start(url)
+	const response = await fetch(url, {
+		method,
+		headers,
+		body,
+	})
+	.catch (throwError) // these only occur for network errors, like these:
+						//	  * request made with a bad host, e.g., //httpbin
+						//	  * the host is refusing connections
+						//	  * client is offline, i.e., airplane mode or something
+						//	  * CORS preflight failures
+	.finally(() => stop(url))
 
 	// reminder: fetch does not throw exceptions for non-200 responses (https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)
 	if (! response.ok) {

--- a/next-app/src/lib/fetch/server.ts
+++ b/next-app/src/lib/fetch/server.ts
@@ -38,25 +38,21 @@ export async function sf(rpc) {
 async function customFetch(url, method, body, cookie) {
 	const bodyAsJSON = JSON.stringify(body)
 
-	let response : Response
-
-	try {
-		// https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Supplying_request_options
-		response = await fetch(url, {
-			method,
-			headers: {
-				'content-type': 'application/json',
-				cookie,
-			},
-			body: bodyAsJSON,
-		})
-	} catch (e) {
+	// https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Supplying_request_options
+	const response = await fetch(url, {
+		method,
+		headers: {
+			'content-type': 'application/json',
+			cookie,
+		},
+		body: bodyAsJSON,
+	}).catch(e => {
 		// these only occur for network errors, like these:
 		//	request made with a bad host, e.g., //httpbin
 		//	the host is refusing connections
 		console.log(`fetch/server.ts.customFetch caught error on ${url}=>${bodyAsJSON}: `, e)
 		throwError('NETWORK ERROR', 500)
-	}
+	})
 
 	if (! response.ok) {
 		console.log('fetch/server.ts.customFetch response !ok: ', await response.text())

--- a/next-app/src/routes/password/+server.ts
+++ b/next-app/src/routes/password/+server.ts
@@ -17,10 +17,6 @@ export async function PUT({ request }) {
 
 	const { id } = await fetch_current_user(cookie)
 
-	if (! id) {
-		throwError('User unknown', 404)
-	}
-
 	await sf({
 		name: 'change_password',
 		args: [id, password],

--- a/next-app/src/routes/password/+server.ts
+++ b/next-app/src/routes/password/+server.ts
@@ -1,4 +1,5 @@
 import { json } from '@sveltejs/kit'
+import { current_user } from '$lib/data/user'
 import { throwError } from '$lib/error'
 import { sf } from '$lib/fetch/server'
 
@@ -14,18 +15,15 @@ export async function PUT({ request }) {
 
 	const cookie = request.headers.get('cookie')
 
-	const { userId } = await sf({
-		name: 'session_getSessionData',
-		cookie,
-	})
+	const { id } = await current_user(cookie)
 
-	if (! userId) {
+	if (! id) {
 		throwError('User unknown', 404)
 	}
 
 	await sf({
 		name: 'change_password',
-		args: [userId, password],
+		args: [id, password],
 		cookie,
 	})
 

--- a/next-app/src/routes/password/+server.ts
+++ b/next-app/src/routes/password/+server.ts
@@ -15,7 +15,7 @@ export async function PUT({ request }) {
 
 	const cookie = request.headers.get('cookie')
 
-	const { id } = await current_user(cookie)
+	const { id } = await fetch_current_user(cookie)
 
 	if (! id) {
 		throwError('User unknown', 404)

--- a/next-app/src/routes/password/+server.ts
+++ b/next-app/src/routes/password/+server.ts
@@ -1,5 +1,5 @@
 import { json } from '@sveltejs/kit'
-import { current_user } from '$lib/data/user'
+import { fetch_current_user } from '$lib/data/user'
 import { throwError } from '$lib/error'
 import { sf } from '$lib/fetch/server'
 

--- a/next-app/src/routes/projects/[project_code]/+page.server.ts
+++ b/next-app/src/routes/projects/[project_code]/+page.server.ts
@@ -13,7 +13,7 @@ export async function load({ params: { project_code }, request: { headers }}) {
 		project: await get_project_info(args),
 	}
 
-	const { role } = await current_user(args.cookie)
+	const { role } = await fetch_current_user(args.cookie)
 	if (can_view_activity(role)) {
 		const last_30_days = {
 			start_date: daysAgo(30),

--- a/next-app/src/routes/projects/[project_code]/+page.server.ts
+++ b/next-app/src/routes/projects/[project_code]/+page.server.ts
@@ -14,15 +14,14 @@ export async function load({ params: { project_code }, request: { headers }}) {
 	}
 
 	const { role } = await current_user(args.cookie)
-	if (! can_view_activity(role)) {
-		return result
-	}
+	if (can_view_activity(role)) {
+		const last_30_days = {
+			start_date: daysAgo(30),
+			end_date: new Date(),
+		}
 
-	const last_30_days = {
-		start_date: daysAgo(30),
-		end_date: new Date(),
+		result.activities = await get_activities({ ...last_30_days, ...args })
 	}
-	result.activities = await get_activities({ ...last_30_days, ...args })
 
 	return result
 }

--- a/next-app/src/routes/projects/[project_code]/+page.server.ts
+++ b/next-app/src/routes/projects/[project_code]/+page.server.ts
@@ -1,5 +1,5 @@
-import { get_activities } from './activities/+server'
-import { get as get_project_info } from './meta/+server'
+import { fetch_activities } from './activities/+server'
+import { fetch_project_details } from './meta/+server'
 import { can_view_activity } from '$lib/auth'
 import { fetch_current_user } from '$lib/data/user'
 
@@ -10,7 +10,7 @@ export async function load({ params: { project_code }, request: { headers }}) {
 	}
 
 	const result = {
-		project: await get_project_info(args),
+		project: await fetch_project_details(args),
 	}
 
 	const { role } = await fetch_current_user(args.cookie)
@@ -20,7 +20,7 @@ export async function load({ params: { project_code }, request: { headers }}) {
 			end_date: new Date(),
 		}
 
-		result.activities = await get_activities({ ...last_30_days, ...args })
+		result.activities = await fetch_activities({ ...last_30_days, ...args })
 	}
 
 	return result

--- a/next-app/src/routes/projects/[project_code]/+page.server.ts
+++ b/next-app/src/routes/projects/[project_code]/+page.server.ts
@@ -1,7 +1,7 @@
 import { get_activities } from './activities/+server'
 import { get as get_project_info } from './meta/+server'
 import { can_view_activity } from '$lib/auth'
-import { current_user } from '$lib/data/user'
+import { fetch_current_user } from '$lib/data/user'
 
 export async function load({ params: { project_code }, request: { headers }}) {
 	const args = {

--- a/next-app/src/routes/projects/[project_code]/+page.svelte
+++ b/next-app/src/routes/projects/[project_code]/+page.svelte
@@ -76,13 +76,15 @@
 	{/each}
 </Stats>
 
-<h2>Activity</h2>
-<Activity { activities } />
+{#if activities}
+	<h2>Activity</h2>
+	<Activity { activities } />
 
-{#if only_showing_subset}
-	<footer class='flex justify-center mt-2'>
-		<Button on:click={ load_all_activities } class='btn-outline btn-xs sm:btn-sm'>
-			show all
-		</Button>
-	</footer>
+	{#if only_showing_subset}
+		<footer class='flex justify-center mt-2'>
+			<Button on:click={ load_all_activities } class='btn-outline btn-xs sm:btn-sm'>
+				show all
+			</Button>
+		</footer>
+	{/if}
 {/if}

--- a/next-app/src/routes/projects/[project_code]/+page.svelte
+++ b/next-app/src/routes/projects/[project_code]/+page.svelte
@@ -49,7 +49,7 @@
 			icon: MessageAlertIcon,
 			url: `/app/lexicon/${ project.id }#!/editor/entry/000000?filterBy=Comments`,
 		},
-	]
+	].filter(({ value }) => value !== undefined)
 
 	async function load_all_activities() {
 		activities = await GET(`/projects/${$page.params.project_code}/activities`)

--- a/next-app/src/routes/projects/[project_code]/activities/+server.ts
+++ b/next-app/src/routes/projects/[project_code]/activities/+server.ts
@@ -6,14 +6,14 @@ export async function GET({ params: { project_code }, request: { headers } }) {
 
 	await sf({ name: 'set_project', args: [ project_code ], cookie })
 
-	const activities = await get_activities({ cookie })
+	const activities = await fetch_activities({ cookie })
 
 	return json(activities)
 }
 
 // src/Api/Model/Shared/Dto/ActivityListDto.php
 // src/Api/Model/Shared/Dto/ActivityListDto.php->ActivityListModel.__construct
-export async function get_activities({ cookie, start_date, end_date }) {
+export async function fetch_activities({ cookie, start_date, end_date }) {
 	const args = {
 		name: 'activity_list_dto_for_current_project',
 		args: [

--- a/next-app/src/routes/projects/[project_code]/meta/+server.ts
+++ b/next-app/src/routes/projects/[project_code]/meta/+server.ts
@@ -2,7 +2,7 @@ import { can_view_comments } from '$lib/auth'
 import { fetch_current_user } from '$lib/data/user'
 import { sf } from '$lib/fetch/server'
 
-export async function get({ project_code, cookie }) {
+export async function fetch_project_details({ project_code, cookie }) {
 	const { id, projectName: name, users } = await sf({ name: 'set_project', args: [ project_code ], cookie })
 	const { entries, comments } = await sf({ name: 'lex_stats', cookie })
 

--- a/next-app/src/routes/projects/[project_code]/meta/+server.ts
+++ b/next-app/src/routes/projects/[project_code]/meta/+server.ts
@@ -1,5 +1,5 @@
 import { can_view_comments } from '$lib/auth'
-import { current_user } from '$lib/data/user'
+import { fetch_current_user } from '$lib/data/user'
 import { sf } from '$lib/fetch/server'
 
 export async function get({ project_code, cookie }) {

--- a/next-app/src/routes/projects/[project_code]/meta/+server.ts
+++ b/next-app/src/routes/projects/[project_code]/meta/+server.ts
@@ -16,7 +16,7 @@ export async function get({ project_code, cookie }) {
 		num_entries_with_pictures: entries.filter(has_picture).length,
 	}
 
-	const { role } = await current_user(cookie)
+	const { role } = await fetch_current_user(cookie)
 	if (can_view_comments(role)) {
 		const unresolved_comments = comments.filter(({ status }) => status !== 'resolved')
 


### PR DESCRIPTION
Fixes #1579 

## Description

This PR establishes some authorization around the visibility of comments to the appropriate project members.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

view of project dashboard when logged in as a project member with the "observer" role:

<img width="975" alt="image" src="https://user-images.githubusercontent.com/4412848/205387927-e5a37550-7341-4f7d-856b-84ef53006638.png">


view of the dashboard for all other roles:

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/4412848/205388026-c297a946-0c25-4471-8377-6d52b0b13e55.png">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have enabled auto-merge (optional)

## How to test

- View the project dashboard as an observer and ensure "unresolved comments" and the "Activity" section are not shown
- View the project dashboard as an observer (with comments) and ensure "unresolved comments" is shown and the "Activity" section is not shown
- View the project dashboard as any other role and ensure "unresolved comments" and "Activity" section is shown

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
