### PR TITLE
Refactor jQuery-dependant selector

### DIFF
--- a/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.ts
+++ b/src/angular-app/languageforge/lexicon/shared/share-with-others/invite-member-form.component.ts
@@ -62,7 +62,7 @@ export class InviteMemberFormController implements angular.IController {
   }
 
   $postLink(): void {
-    angular.element('input[type=email]')[0].focus();
+    document.querySelector<HTMLElement>('input[type=email]').focus();
   }
 
   sendEmailInvite() {
@@ -101,7 +101,7 @@ export class InviteMemberFormController implements angular.IController {
   getInviteRole() {
     return this.reusableInviteLinkRoles.find(role => role.key === this.project.inviteToken.defaultRole);
   }
-  
+
   async copy() {
     await navigator.clipboard.writeText(this.inviteLink);
 


### PR DESCRIPTION
## Description

While QAing #1611 I bumped into this. `angular.element()` supports [very little if jQuery is not included](https://code.angularjs.org/1.8.2/docs/error/jqLite/nosel). So, it didn't like this selector anymore.

![image](https://user-images.githubusercontent.com/12587509/205649707-11e2c107-119c-426c-9eb0-0809e55c7360.png)
