### PR TITLE
Bugfix/integrate not uploading playwright results

### DIFF
--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -79,11 +79,11 @@ jobs:
         run: make e2e-tests-ci
       -
         name: Upload Playwright test results
-        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: test/e2e/test-results
+          if-no-files-found: error
       -
         name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -80,10 +80,10 @@ jobs:
       -
         name: Upload Playwright test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: test-results
+          path: test/e2e/test-results
       -
         name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -85,11 +85,11 @@ jobs:
 
       -
         name: Upload Playwright test results
-        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: test/e2e/test-results
+          if-no-files-found: error
 
   check-code-formatting:
     runs-on: ubuntu-latest

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -51,7 +51,7 @@ const config: PlaywrightTestConfig = {
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
-    screenshot: 'only-on-failure',
+    screenshot: 'on',
   },
 
   /* Configure projects for major browsers */

--- a/test/e2e/utils/playwright-helpers.ts
+++ b/test/e2e/utils/playwright-helpers.ts
@@ -2,7 +2,7 @@ import { expect, Locator } from '@playwright/test';
 
 export const toHaveSelectedOption = async (select: Locator, option: {label?: string, value?: string}) => {
   if (option.label === undefined && option.value === undefined) {
-    throw new  Error('At least one of either label or value must be set');
+    throw new Error('At least one of either label or value must be set');
   }
 
   const value = await select.inputValue();


### PR DESCRIPTION
## Description

I noticed on a [failed deployment](https://github.com/sillsdev/web-languageforge/actions/runs/3627940183/jobs/6118378744) that E2E test results were not being uploaded. The reason was that I moved the results, but didn't adapt the action. 😞

I didn't notice this, because we expect there to be no files if tests are all green. But, I think it makes sense to always save results, because:
1) It's a bit confusing to only save results sometimes
2) Saving results is free
3) It can be valuable to be able to compare failed results to successful results

Note: I opted to only **always** save screenshots, **not** traces. The only reason is that the upload takes quite a long time if we include traces. That's because our results our sadly quite messy/bloated due to how we manage pages.

### Type of Change

- Tesitng automation fix

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have enabled auto-merge (optional)

## How to test

Check out the sample PR here: https://github.com/myieye/web-languageforge/actions/runs/3629878852/jobs/6122583829
(Before I opted not to always include traces)