### PR TITLE
Make label check use current labels

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   require-label:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     outputs:
       status: ${{ steps.check-labels.outputs.status }}
     steps:


### PR DESCRIPTION
## Description

The new label check GHA is problematic in that it currently only respects the labels on the PR at creation time. By adding the token we implicitly tell/enable it to access the "live" labels.

I noticed it here: https://github.com/sillsdev/web-languageforge/pull/1637

The [documenation](https://github.com/marketplace/actions/require-labels) is a bit confusing to me:
![image](https://user-images.githubusercontent.com/12587509/205966687-282b7ef7-9c8f-4844-8f48-90e955f764f0.png)

But I tested it [in my fork](https://github.com/myieye/web-languageforge/pull/17). In that PR I last did it backwards: first suceed and then fail.