### PR TITLE
fixed asset versioning

### DIFF
--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -72,11 +72,20 @@ jobs:
         name: Build "next" images
         run: make build-next
       -
+        name: Verify version stamping
+        run: docker run --rm lf-app head build-version.txt version.php
+      -
         name: Unit Tests
         run: make unit-tests-ci
       -
+        name: Verify version stamping
+        run: docker run --rm lf-app head build-version.txt version.php
+      -
         name: Playwright E2E Tests
         run: make e2e-tests-ci
+      -
+        name: Verify version stamping
+        run: docker run --rm lf-app head build-version.txt version.php
       -
         name: Upload Playwright test results
         if: always()
@@ -97,10 +106,19 @@ jobs:
           docker tag lf-next-proxy ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_PROXY }}
           docker tag lf-next-app ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_NEXT_APP }}
       -
+        name: Verify version stamping
+        run: docker run --rm ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }} head build-version.txt version.php
+      -
         run: docker images
+      -
+        name: Verify version stamping
+        run: docker run --rm ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }} head build-version.txt version.php
       -
         name: Publish images
         run: docker push --all-tags ${{ steps.image.outputs.NAMESPACE }}
+      -
+        name: Verify version stamping
+        run: docker run --rm ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }} head build-version.txt version.php
 
     outputs:
       IMAGE_APP: ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }}

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -72,20 +72,11 @@ jobs:
         name: Build "next" images
         run: make build-next
       -
-        name: Verify version stamping
-        run: docker run --rm lf-app head build-version.txt version.php
-      -
         name: Unit Tests
         run: make unit-tests-ci
       -
-        name: Verify version stamping
-        run: docker run --rm lf-app head build-version.txt version.php
-      -
         name: Playwright E2E Tests
         run: make e2e-tests-ci
-      -
-        name: Verify version stamping
-        run: docker run --rm lf-app head build-version.txt version.php
       -
         name: Upload Playwright test results
         if: always()
@@ -106,9 +97,6 @@ jobs:
           docker tag lf-next-proxy ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_PROXY }}
           docker tag lf-next-app ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_NEXT_APP }}
       -
-        name: Verify version stamping
-        run: docker run --rm ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }} head build-version.txt version.php
-      -
         run: docker images
       -
         name: Verify version stamping
@@ -116,9 +104,6 @@ jobs:
       -
         name: Publish images
         run: docker push --all-tags ${{ steps.image.outputs.NAMESPACE }}
-      -
-        name: Verify version stamping
-        run: docker run --rm ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }} head build-version.txt version.php
 
     outputs:
       IMAGE_APP: ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }}

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         name: Verify version stamping
         run: |
           docker run --rm lf-app head build-version.txt version.php
-          docker run --rm lf-app head version.php | grep -q ${{ steps.image.outputs.TAG_APP }}x
+          docker run --rm lf-app head version.php | grep -q ${{ steps.image.outputs.TAG_APP }}
       -
         name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -2,9 +2,27 @@ name: Integrate changes and deploy
 
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
 on:
-  push:
-    branches:
-      - bugfix/cache-buster
+  workflow_call:
+    # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callinputs
+    inputs:
+      image-tag-app:
+        type: string
+        required: true
+      image-tag-proxy:
+        type: string
+        required: true
+      image-tag-next-app:
+        type: string
+        required: true
+
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets
+    secrets:
+      kube-context:
+        required: true
+      image-repo-username:
+        required: true
+      image-repo-password:
+        required: true
 
 jobs:
   integrate:
@@ -26,7 +44,15 @@ jobs:
         id: image
         run: |
           echo "NAMESPACE=sillsdev/web-languageforge" >> $GITHUB_OUTPUT
-          echo "TAG_APP=GOVOLS" >> $GITHUB_OUTPUT
+          echo "TAG_APP=${{ inputs.image-tag-app }}" >> $GITHUB_OUTPUT
+          echo "TAG_PROXY=${{ inputs.image-tag-proxy }}" >> $GITHUB_OUTPUT
+          echo "TAG_NEXT_APP=${{ inputs.image-tag-next-app }}" >> $GITHUB_OUTPUT
+          echo "LFMERGE_NAMESPACE=ghcr.io/sillsdev/lfmerge" >> $GITHUB_OUTPUT
+
+          # Get LfMerge tag from Dockerfile, fallback to "latest" as default if that fails
+          TAG_LFMERGE=$(head -n 1 docker/lfmerge/Dockerfile | cut -d: -f2)
+          TAG_LFMERGE=${TAG_LFMERGE:-latest}
+          echo "TAG_LFMERGE=${TAG_LFMERGE}" >> $GITHUB_OUTPUT
       -
         uses: actions/setup-node@v3
         with:
@@ -43,17 +69,56 @@ jobs:
           docker run --rm lf-app head build-version.txt version.php
           docker run --rm lf-app head version.php | grep -q ${{ steps.image.outputs.TAG_APP }}
       -
+        name: Build "next" images
+        run: make build-next
+      -
+        name: Unit Tests
+        run: make unit-tests-ci
+      -
+        name: Playwright E2E Tests
+        run: make e2e-tests-ci
+      -
+        name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: test-results
+      -
         name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          username: ${{ secrets.image-repo-username }}
+          password: ${{ secrets.image-repo-password }}
       -
         name: Tag images
         run: |
           docker tag lf-app ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }}
+          docker tag lf-next-proxy ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_PROXY }}
+          docker tag lf-next-app ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_NEXT_APP }}
       -
         run: docker images
       -
         name: Publish images
         run: docker push --all-tags ${{ steps.image.outputs.NAMESPACE }}
+
+    outputs:
+      IMAGE_APP: ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }}
+      IMAGE_PROXY: ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_PROXY }}
+      IMAGE_NEXT_APP: ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_NEXT_APP }}
+      IMAGE_LFMERGE: ${{ steps.image.outputs.LFMERGE_NAMESPACE }}:${{ steps.image.outputs.TAG_LFMERGE }}
+
+  deploy:
+    runs-on: [self-hosted, languageforge]
+
+    needs: integrate
+
+    steps:
+      -
+        uses: sillsdev/common-github-actions/install-kubectl@v1
+      -
+        run: |
+          kubectl --context ${{ secrets.kube-context }} set image deployment/app app=${{ needs.integrate.outputs.IMAGE_APP }}
+          kubectl --context ${{ secrets.kube-context }} set image deployment/next-proxy next-proxy=${{ needs.integrate.outputs.IMAGE_PROXY }}
+          kubectl --context ${{ secrets.kube-context }} set image deployment/next-app next-app=${{ needs.integrate.outputs.IMAGE_NEXT_APP }}
+          kubectl --context ${{ secrets.kube-context }} set image deployment/lfmerge lfmerge=${{ needs.integrate.outputs.IMAGE_LFMERGE }}

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -43,8 +43,17 @@ jobs:
           docker compose run --rm app cat build-version.txt version.php
           docker compose run --rm app cat version.php | grep ${{ steps.image.outputs.TAG_APP }}
       -
+        name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.image-repo-username }}
+          password: ${{ secrets.image-repo-password }}
+      -
         name: Tag images
         run: |
           docker tag lf-app ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }}
       -
         run: docker images
+      -
+        name: Publish images
+        run: docker push --all-tags ${{ steps.image.outputs.NAMESPACE }}

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -46,8 +46,8 @@ jobs:
         name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.image-repo-username }}
-          password: ${{ secrets.image-repo-password }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       -
         name: Tag images
         run: |

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -40,8 +40,8 @@ jobs:
       -
         name: Verify version stamping
         run: |
-          docker run --rm lf-app cat build-version.txt version.php
-          docker run --rm lf-app cat version.php | grep ${{ steps.image.outputs.TAG_APP }}
+          docker run --rm lf-app head build-version.txt version.php
+          docker run --rm lf-app head version.php | grep ${{ steps.image.outputs.TAG_APP }}
       -
         name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         name: Verify version stamping
         run: |
           docker run --rm lf-app head build-version.txt version.php
-          docker run --rm lf-app head version.php | grep ${{ steps.image.outputs.TAG_APP }}
+          docker run --rm lf-app head version.php | grep -q ${{ steps.image.outputs.TAG_APP }}
       -
         name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -40,8 +40,8 @@ jobs:
       -
         name: Verify version stamping
         run: |
-          docker compose run --rm app cat build-version.txt version.php
-          docker compose run --rm app cat version.php | grep ${{ steps.image.outputs.TAG_APP }}
+          docker run --rm lf-app cat build-version.txt version.php
+          docker run --rm lf-app cat version.php | grep ${{ steps.image.outputs.TAG_APP }}
       -
         name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -2,27 +2,9 @@ name: Integrate changes and deploy
 
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
 on:
-  workflow_call:
-    # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callinputs
-    inputs:
-      image-tag-app:
-        type: string
-        required: true
-      image-tag-proxy:
-        type: string
-        required: true
-      image-tag-next-app:
-        type: string
-        required: true
-
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets
-    secrets:
-      kube-context:
-        required: true
-      image-repo-username:
-        required: true
-      image-repo-password:
-        required: true
+  push:
+    branches:
+      - bugfix/cache-buster
 
 jobs:
   integrate:
@@ -44,15 +26,7 @@ jobs:
         id: image
         run: |
           echo "NAMESPACE=sillsdev/web-languageforge" >> $GITHUB_OUTPUT
-          echo "TAG_APP=${{ inputs.image-tag-app }}" >> $GITHUB_OUTPUT
-          echo "TAG_PROXY=${{ inputs.image-tag-proxy }}" >> $GITHUB_OUTPUT
-          echo "TAG_NEXT_APP=${{ inputs.image-tag-next-app }}" >> $GITHUB_OUTPUT
-          echo "LFMERGE_NAMESPACE=ghcr.io/sillsdev/lfmerge" >> $GITHUB_OUTPUT
-
-          # Get LfMerge tag from Dockerfile, fallback to "latest" as default if that fails
-          TAG_LFMERGE=$(head -n 1 docker/lfmerge/Dockerfile | cut -d: -f2)
-          TAG_LFMERGE=${TAG_LFMERGE:-latest}
-          echo "TAG_LFMERGE=${TAG_LFMERGE}" >> $GITHUB_OUTPUT
+          echo "TAG_APP=GOVOLS" >> $GITHUB_OUTPUT
       -
         uses: actions/setup-node@v3
         with:
@@ -69,56 +43,8 @@ jobs:
           docker compose run --rm app cat build-version.txt version.php
           docker compose run --rm app cat version.php | grep ${{ steps.image.outputs.TAG_APP }}
       -
-        name: Build "next" images
-        run: make build-next
-      -
-        name: Unit Tests
-        run: make unit-tests-ci
-      -
-        name: Playwright E2E Tests
-        run: make e2e-tests-ci
-      -
-        name: Upload Playwright test results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-results
-          path: test-results
-      -
-        name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.image-repo-username }}
-          password: ${{ secrets.image-repo-password }}
-      -
         name: Tag images
         run: |
           docker tag lf-app ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }}
-          docker tag lf-next-proxy ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_PROXY }}
-          docker tag lf-next-app ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_NEXT_APP }}
       -
         run: docker images
-      -
-        name: Publish images
-        run: docker push --all-tags ${{ steps.image.outputs.NAMESPACE }}
-
-    outputs:
-      IMAGE_APP: ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }}
-      IMAGE_PROXY: ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_PROXY }}
-      IMAGE_NEXT_APP: ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_NEXT_APP }}
-      IMAGE_LFMERGE: ${{ steps.image.outputs.LFMERGE_NAMESPACE }}:${{ steps.image.outputs.TAG_LFMERGE }}
-
-  deploy:
-    runs-on: [self-hosted, languageforge]
-
-    needs: integrate
-
-    steps:
-      -
-        uses: sillsdev/common-github-actions/install-kubectl@v1
-      -
-        run: |
-          kubectl --context ${{ secrets.kube-context }} set image deployment/app app=${{ needs.integrate.outputs.IMAGE_APP }}
-          kubectl --context ${{ secrets.kube-context }} set image deployment/next-proxy next-proxy=${{ needs.integrate.outputs.IMAGE_PROXY }}
-          kubectl --context ${{ secrets.kube-context }} set image deployment/next-app next-app=${{ needs.integrate.outputs.IMAGE_NEXT_APP }}
-          kubectl --context ${{ secrets.kube-context }} set image deployment/lfmerge lfmerge=${{ needs.integrate.outputs.IMAGE_LFMERGE }}

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         name: Verify version stamping
         run: |
           docker run --rm lf-app head build-version.txt version.php
-          docker run --rm lf-app head version.php | grep -q ${{ steps.image.outputs.TAG_APP }}
+          docker run --rm lf-app head version.php | grep -q ${{ steps.image.outputs.TAG_APP }}x
       -
         name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -99,9 +99,6 @@ jobs:
       -
         run: docker images
       -
-        name: Verify version stamping
-        run: docker run --rm ${{ steps.image.outputs.NAMESPACE }}:${{ steps.image.outputs.TAG_APP }} head build-version.txt version.php
-      -
         name: Publish images
         run: docker push --all-tags ${{ steps.image.outputs.NAMESPACE }}
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,11 +5,12 @@ on:
   push:
     branches:
       - develop
+      - bugfix/cache-buster
 
 jobs:
   staging:
         # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses
-        uses: sillsdev/web-languageforge/.github/workflows/integrate-and-deploy.yml@develop
+        uses: sillsdev/web-languageforge/.github/workflows/integrate-and-deploy.yml@bugfix/cache-buster
         with:
           image-tag-app: develop-$(date +%Y%m%d)-${{ github.sha }}
           image-tag-proxy: develop-next-proxy-$(date +%Y%m%d)-${{ github.sha }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,12 +5,11 @@ on:
   push:
     branches:
       - develop
-      - bugfix/cache-buster
 
 jobs:
   staging:
         # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses
-        uses: sillsdev/web-languageforge/.github/workflows/integrate-and-deploy.yml@bugfix/cache-buster
+        uses: sillsdev/web-languageforge/.github/workflows/integrate-and-deploy.yml@develop
         with:
           image-tag-app: develop-$(date +%Y%m%d)-${{ github.sha }}
           image-tag-proxy: develop-next-proxy-$(date +%Y%m%d)-${{ github.sha }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,7 +241,7 @@ services:
       dockerfile: docker/app/Dockerfile
       args:
         - ENVIRONMENT=development
-    image: lf-app
+    image: lf-app-for-playwright
     container_name: app-for-playwright
     platform: linux/amd64
     depends_on:


### PR DESCRIPTION
## Description

We noticed during the last release that the cache buster for assets was messed up.  It turns out to be a problem with the timing in which (and how) the E2E tests were being run.  This PR fixes that.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have enabled auto-merge (optional)

## How to test

- ensure the `v=` on assets in the devtools is not `9.9.9`.

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
