### PR TITLE
Repair audio seeking

### DIFF
--- a/src/angular-app/bellows/shared/sound-player.component.html
+++ b/src/angular-app/bellows/shared/sound-player.component.html
@@ -7,5 +7,5 @@
     </span>
     <!--suppress HtmlFormInputWithoutLabel -->
     <!--The step value is very small to handle a bug encountered where the slider stops after its last full step, before reaching the end 2022-09-->
-    <input id="slider" class="seek-slider" type="range" min="0" max="{{$ctrl.durationInSeconds()}}" step="0.0000000000000001" value="0">
+    <input class="seek-slider" type="range" min="0" max="{{$ctrl.durationInSeconds()}}" step="0.0000000000000001" value="0">
 </span>

--- a/src/angular-app/bellows/shared/sound-player.component.html
+++ b/src/angular-app/bellows/shared/sound-player.component.html
@@ -7,5 +7,5 @@
     </span>
     <!--suppress HtmlFormInputWithoutLabel -->
     <!--The step value is very small to handle a bug encountered where the slider stops after its last full step, before reaching the end 2022-09-->
-    <input class="seek-slider" type="range" min="0" max="{{$ctrl.durationInSeconds()}}" step="0.0000000000000001" value="0">
+    <input id="slider" class="seek-slider" type="range" min="0" max="{{$ctrl.durationInSeconds()}}" step="0.0000000000000001" value="0">
 </span>

--- a/src/angular-app/bellows/shared/sound-player.component.ts
+++ b/src/angular-app/bellows/shared/sound-player.component.ts
@@ -16,7 +16,7 @@ export class SoundController implements angular.IController {
 
   $onInit(): void {
 
-    this.slider = document.getElementById('slider') as HTMLInputElement;
+    this.slider = this.$element[0].querySelector('.seek-slider') as HTMLInputElement;
     this.audioElement.currentTime = 0;
 
     //So that duration appears immediately once it is available

--- a/src/angular-app/bellows/shared/sound-player.component.ts
+++ b/src/angular-app/bellows/shared/sound-player.component.ts
@@ -16,7 +16,8 @@ export class SoundController implements angular.IController {
 
   $onInit(): void {
 
-    this.slider = this.$element.find('.seek-slider').get(0) as HTMLInputElement;
+    this.slider = document.getElementById('slider') as HTMLInputElement;
+    this.audioElement.currentTime = 0;
 
     //So that duration appears immediately once it is available
     this.audioElement.addEventListener('durationchange', () => {
@@ -92,7 +93,6 @@ export class SoundController implements angular.IController {
     this.playing = !this.playing;
 
     if (this.playing) {
-      this.audioElement.currentTime = 0;
       this.playAudio();
     } else {
       if(!this.audioElement.paused){

--- a/test/e2e/editor-entry.spec.ts
+++ b/test/e2e/editor-entry.spec.ts
@@ -323,31 +323,15 @@ test.describe('Lexicon E2E Entry Editor and Entries List', () => {
         });
 
 
-        test('Slider is present and updates with seeking', async ({ page }) => {
+        test('Slider is present and updates with seeking', async () => {
           await editorPageManager.goto();
           await expect(audio.locator(editorPageManager.audioPlayer.slider)).toBeVisible();
           const slider = audio.locator(editorPageManager.audioPlayer.slider);
           let originalTime = (await audio.locator(editorPageManager.audioPlayer.audioProgressTime).innerText()).substring(3, 4);
-
-          let isCompleted = false;
-
-          if (slider){
-            while (!isCompleted){
-              let bounds = await slider.boundingBox();
-              let yMiddle = bounds.y + bounds.height/2;
-              if(bounds){
-                await page.mouse.move(bounds.x, yMiddle);
-                await page.mouse.down();
-                await page.mouse.move(bounds.x + 1, yMiddle);
-                await page.mouse.up();
-                let time = (await audio.locator(editorPageManager.audioPlayer.audioProgressTime).innerText()).substring(3, 4);
-                if (time != originalTime){
-                  isCompleted = true;
-                }
-              }
-            }
-          }
-
+          let bounds = await slider.boundingBox();
+          let yMiddle = bounds.y + bounds.height/2;
+          await editorPageManager.page.mouse.click(bounds.x+200, yMiddle);
+          await expect(audio.locator(editorPageManager.audioPlayer.audioProgressTime)).toContainText("0:01 / 0:02");
         });
 
 

--- a/test/e2e/editor-entry.spec.ts
+++ b/test/e2e/editor-entry.spec.ts
@@ -322,6 +322,35 @@ test.describe('Lexicon E2E Entry Editor and Entries List', () => {
           await expect(audio.locator(editorPageManager.audioPlayer.downloadButtonSelector)).not.toBeVisible();
         });
 
+
+        test('Slider is present and updates with seeking', async ({ page }) => {
+          await editorPageManager.goto();
+          await expect(audio.locator(editorPageManager.audioPlayer.slider)).toBeVisible();
+          const slider = audio.locator(editorPageManager.audioPlayer.slider);
+          let originalTime = (await audio.locator(editorPageManager.audioPlayer.audioProgressTime).innerText()).substring(3, 4);
+
+          let isCompleted = false;
+
+          if (slider){
+            while (!isCompleted){
+              let bounds = await slider.boundingBox();
+              let yMiddle = bounds.y + bounds.height/2;
+              if(bounds){
+                await page.mouse.move(bounds.x, yMiddle);
+                await page.mouse.down();
+                await page.mouse.move(bounds.x + 1, yMiddle);
+                await page.mouse.up();
+                let time = (await audio.locator(editorPageManager.audioPlayer.audioProgressTime).innerText()).substring(3, 4);
+                if (time != originalTime){
+                  isCompleted = true;
+                }
+              }
+            }
+          }
+
+        });
+
+
         test('File upload drop box is displayed when Upload is clicked & not displayed if upload cancelled (manager)', async () => {
           await editorPageManager.goto();
           const dropbox = editorPageManager.entryCard.locator(editorPageManager.dropbox.dragoverFieldSelector);

--- a/test/e2e/pages/editor.page.ts
+++ b/test/e2e/pages/editor.page.ts
@@ -50,7 +50,9 @@ export class EditorPage extends BasePage {
     playIconSelector: 'i.fa-play',
     dropdownToggleSelector: 'a.dropdown-toggle',
     uploadButtonSelector: 'button.upload-audio',
-    downloadButtonSelector: 'a.buttonAppend'
+    downloadButtonSelector: 'a.buttonAppend',
+    slider: '#slider',
+    audioProgressTime: 'span.audio-progress'
   };
 
   readonly dropbox = {

--- a/test/e2e/pages/editor.page.ts
+++ b/test/e2e/pages/editor.page.ts
@@ -51,7 +51,7 @@ export class EditorPage extends BasePage {
     dropdownToggleSelector: 'a.dropdown-toggle',
     uploadButtonSelector: 'button.upload-audio',
     downloadButtonSelector: 'a.buttonAppend',
-    slider: '#slider',
+    slider: 'input.seek-slider',
     audioProgressTime: 'span.audio-progress'
   };
 


### PR DESCRIPTION
Fixes #1644 

## Description

This PR brings changes to the initialization of the slider input (we are no longer using jquery for that). This ensures that the audio element's current time updates as seeking and playing events occur. By changing the audio element's play/pause logic so that its current time is not reset to 0, we allow for seeking and starting playback in the middle of an audio clip.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Current time changes with seeking & play
![image](https://user-images.githubusercontent.com/56163492/207223305-eb0c511e-b1c2-440e-9907-f8de1e60957e.png)


## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have enabled auto-merge (optional)

## How to test

Go to a project with audio available in entries, e.g., test-chris-02 in staging.
Move the slider and verify that the current time changes with it.
Click play and verify that the audio starts from the updated time.

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
