### PR TITLE
Upload playwright results when workflow fails

### DIFF
--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -79,6 +79,7 @@ jobs:
         run: make e2e-tests-ci
       -
         name: Upload Playwright test results
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: test-results

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -87,6 +87,7 @@ jobs:
 
       -
         name: Upload Playwright test results
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: test-results


### PR DESCRIPTION
## Description

I removed this `if` in #1636, because I thought it was unnecessary  (of course I only tested the success case in that PR).
It's actually pretty crucial 😆, because without it our results don't get saved when there's a test failure. Oops.

### Type of Change

- Testing Bug fix