### PR TITLE
eliminate GHA deprecation warnings

### DIFF
--- a/.github/workflows/set-backlog-fields.yml
+++ b/.github/workflows/set-backlog-fields.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@7ce9ffdcdeb2ba82b01b51d6584a6a85872336d4
+        uses: tibdex/github-app-token@v1.7
         with:
           app_id: ${{ secrets.LFPROJECTBOARDAUTOMATION_APP_ID }}
           private_key: ${{ secrets.LFPROJECTBOARDAUTOMATION_PRIVATE_KEY }}
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           echo issue $ISSUE_NUMBER added to $REPO
-          
+
           gh api graphql -f query='
             query($issue_number:Int!, $org:String!) {
               repository(name:"web-languageforge", owner:$org) {
@@ -38,9 +38,9 @@ jobs:
                 }
               }
             }' -F issue_number=$ISSUE_NUMBER -f org=$ORGANIZATION > project_data.json
-          
+
           echo 'IN_PROJECT='$(jq '.data.repository.issue.projectNextItems[] | length' project_data.json) >> $GITHUB_ENV
-    
+
       - name: get required info for set operations
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
@@ -80,9 +80,9 @@ jobs:
                 }
               }
             }' -f project=$PROJECT_ID -f item=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
-          
+
           echo 'ITEM_ID='$item_id >> $GITHUB_ENV
-          
+
       - name: set project field
         if: env.IN_PROJECT == 0
         env:


### PR DESCRIPTION
## Description

There were some `set-output` deprecation warnings showing up in our workflows and it turned out to be in some of our third-party actions.  This PR will simply upgrade those to a version where the author has migrated away from `set-output`

One of the deps is currently working on a fix, keep an eye on https://github.com/mheap/github-action-required-labels/issues/42 to determine whether a change is needed in our `pull-request.yml -> require-label` step or not.

### Type of Change

- CI/CD update

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## How to test

- Ensure PR and `staging` workflows no longer have deprecation warnings.

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
