### PR TITLE
eliminate gha deprecation warnings

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,9 @@ name: Build and Test
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
 on:
   pull_request:
+  push:
+    branches:
+      - chore/eliminate-gha-deprecation-warnings
 
 env:
   DOCKER_BUILDKIT: 1
@@ -20,7 +23,7 @@ jobs:
     outputs:
       status: ${{ steps.check-labels.outputs.status }}
     steps:
-      - uses: mheap/github-action-required-labels@v2
+      - uses: mheap/github-action-required-labels@v3
         id: check-labels
         with:
           mode: exactly

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - chore/eliminate-gha-deprecation-warnings
+      - chore/elliminate-gha-deprecation-warnings
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,9 +3,6 @@ name: Build and Test
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
 on:
   pull_request:
-  push:
-    branches:
-      - chore/elliminate-gha-deprecation-warnings
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,7 +29,7 @@ jobs:
           mode: exactly
           count: 1
           labels: "bug, feature, engineering, security fix, testing"
-      - uses: mheap/github-action-required-labels@v2
+      - uses: mheap/github-action-required-labels@v3
         with:
           mode: exactly
           count: 0


### PR DESCRIPTION
## Description

This is a follow-up to #1665 since the dependency was a major upgrade, one more change was required.

### Type of Change

- CI/CD update

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## How to test

- Ensure PR and staging workflows no longer have deprecation warnings.

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
