### PR TITLE
switch to using mariadb for ld-db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,9 +204,8 @@ services:
       - MONGO_INITDB_DATABASE=scriptureforge
 
   ld-db:
-    image: mysql:5.7
+    image: mariadb:10.10
     container_name: ld-db
-    platform: linux/amd64
     # To access the MySQL database via localhost:3306 on your dev machine (e.g., in VS Code), uncomment the "ports" config below
     # Note that if you're running MySQL on your dev machine already, change the first number to something else, like 3307 and access localhost:3307
     # ports:
@@ -223,6 +222,7 @@ services:
 
   ld-api:
     image: sillsdev/web-languagedepot-api
+    platform: linux/amd64
     container_name: ld-api
     depends_on:
       - ld-db


### PR DESCRIPTION
## Description

This change addresses an issue seen on Apple Silicon/ARM only, whereby the most recent Docker version on MacOS is more strict when it encounters images not built for arm64.

Switching to mariadb from mysql fixes the issue as mariadb provides both amd64 and arm64 images.  mysql does not, or the package metadata is corrupt in some way that Docker is not expecting.

MariaDB is understood to be a drop-in replacement for MySQL.


This PR resolves the error I have seen on my machine:
```
[+] Running 1/2
 ⠿ ld-db Pulled                                                            2.5s
   ⠋ d410f4167eea Exists                                                   0.0s
   ⠋ 6306f106a056 Exists                                                   0.0s
   ⠋ bd0fb5a175fc Exists                                                   0.0s
 ⠿ db Error                                                                2.5s
Error response from daemon: no match for platform in manifest sha256:6306f106a056e24b3a2582a59a4c84cd199907f826eff27df36406f227cd9a7d: not found
make: *** [start] Error 1
```

### Type of Change

- Chore - switch dependency

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have enabled auto-merge (optional)

## How to test

ld-db, while it is included in our docker-compose file, is not shipped.  It is not present in QA or production.  This change works if LF builds without errors.