### PR TITLE
remove GD PHP extension from base-php

### DIFF
--- a/docker/base-php/Dockerfile
+++ b/docker/base-php/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get -y install p7zip-full unzip curl tini ffmpeg && rm
 # see https://github.com/mlocati/docker-php-extension-installer
 # PHP extensions required by the LF application
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-RUN install-php-extensions gd mongodb intl
+RUN install-php-extensions mongodb intl
 
 # php customizations
 COPY docker/base-php/customizations.php.ini $PHP_INI_DIR/conf.d/


### PR DESCRIPTION
## Description

The [PHP GD extension](https://www.php.net/manual/en/book.image.php) is, as far as I can tell, no longer used in our PHP code.  It no doubt was used in the past but I cannot find any reference to methods it provides in our current PHP code, and I have personally run all unit and e2e tests locally without the extension and they all pass.

This feels like a safe removal.  This will also speed up build times for the base-php image, especial for PHP >= 7.4

### Type of Change

- Remove unused dependency

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have enabled auto-merge (optional)

## How to test

This is considered tested with unit and e2e tests all passing