### PR TITLE
remove obsolete COPY line in ui-builder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -38,7 +38,6 @@ next-app/**/.env.*
 
 ## Extras
 # Libraries and generated code
-src/js/lib/
 src/Site/views/languageforge/theme/default/page/home/assets/
 *.generated-data.*
 

--- a/docker/ui-builder/Dockerfile
+++ b/docker/ui-builder/Dockerfile
@@ -13,7 +13,6 @@ COPY webpack.config.js webpack-dev.config.js webpack-prd.config.js tsconfig.json
 # copy in src local files
 COPY src/angular-app ./src/angular-app
 COPY src/appManifest ./src/appManifest
-COPY src/js ./src/js
 COPY src/json ./src/json
 COPY src/sass ./src/sass
 COPY src/Site/views ./src/Site/views


### PR DESCRIPTION
## Description

This COPY line should have been removed as part of #1669
This PR fixes a local dev error when running ui-builder e.g. `make dev` or `make e2e-tests`

### Type of Change

- Fix broken build

## Screenshots

This is the error a dev will encounter before this PR is merged
![image](https://user-images.githubusercontent.com/3444521/210925845-0dd07951-9171-4adb-aec5-5560062159f9.png)


## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have enabled auto-merge (optional)

## How to test

`make e2e-tests` should build and run locally without error
