### PR TITLE
build multi-arch arm64/amd64 base-php image

### DIFF
--- a/.github/workflows/build-and-publish-base-php.yml
+++ b/.github/workflows/build-and-publish-base-php.yml
@@ -15,8 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build and tag base image
-        run: docker build -t ${{ env.IMAGE }} -f docker/base-php/Dockerfile .
+      - uses: docker/setup-qemu-action@v2
+
+      - uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
@@ -24,6 +27,5 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Publish image
-        run: |
-          docker push ${{ env.IMAGE }}
+      - name: Build, tag and push image
+        run: docker buildx build --push --platform linux/amd64,linux/arm64 -t ${{ env.IMAGE }} -f docker/base-php/Dockerfile .


### PR DESCRIPTION
fixes #1398

## Description

This changes the base-php build to use buildx for multi-arch builds for both linux/amd64 and linux/arm64
Both images are published to https://hub.docker.com/r/sillsdev/web-languageforge/tags

The base-php image is now being built with this method, [as seen here (manual trigger)](https://github.com/sillsdev/web-languageforge/actions/runs/3852970907/jobs/6565532643): 

### Type of Change

- engineering

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## Future Work

Doing a multi-architecture build using buildx and qemu on a x86 GHA runner (that is all that is available) is extremely slow due to arm64 emulation.  GHA may launch an arm runner, but until they do, there is an option to pay for an arm runner if you don't want to host your own (which we could).  See https://buildjet.com/for-github-actions/pricing

## How to test

Passing unit and E2E tests are sufficient testing for this PR