### PR TITLE
allow lf-app to run on ARM for Apple Silicon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
         - ENVIRONMENT=development
     image: lf-app
     container_name: lf-app
-    platform: linux/amd64
     depends_on:
       - db
       - mail
@@ -243,7 +242,6 @@ services:
         - ENVIRONMENT=development
     image: lf-e2e-app
     container_name: e2e-app
-    platform: linux/amd64
     depends_on:
       - db
       - mail


### PR DESCRIPTION
## Description

Now that base-php is available for arm64 and amd64, we can remove the platform=linux/amd64 requirement for the lf-app and e2e app.

We have a working LF app running on ARM!

### Type of Change

- Docker

## Screenshots

Local dev on Apple Silicon can see that the app is now running natively and not under amd64 emulation:
![image](https://user-images.githubusercontent.com/3444521/210958057-f890c93d-6cec-4829-84ae-ae84219a946d.png)


## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## How to test

Local dev on Apple Silicon can verify that lf-app is running natively and not under emulation (see screenshot above from Docker desktop)