### PR TITLE
Update PHP dependencies / add composer-dev container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ build-next:
 build-base-php:
 	docker build -t sillsdev/web-languageforge:base-php -f docker/base-php/Dockerfile .
 
+.PHONY: composer-dev
+composer-dev:
+	docker compose build composer-dev
+	docker compose run composer-dev
+
 .PHONY: clean
 clean:
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -299,6 +299,15 @@ services:
       - ./src/Api:/var/www/src/Api
       - ./src/Site:/var/www/src/Site
 
+  composer-dev:
+    build:
+      dockerfile: docker/composer-dev/Dockerfile
+    image: composer-dev
+    container_name: composer-dev
+    volumes:
+      - ./src/composer.json:/work/composer.json
+      - ./src/composer.lock:/work/composer.lock
+
 volumes:
   lf-caddy-config:
   lf-caddy-data:

--- a/docker/composer-dev/Dockerfile
+++ b/docker/composer-dev/Dockerfile
@@ -1,0 +1,10 @@
+FROM sillsdev/web-languageforge:base-php
+
+
+WORKDIR /work
+ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
+    && install-php-extensions @composer
+COPY src/composer.json src/composer.lock /work/
+
+CMD ["bash"]

--- a/src/composer.json
+++ b/src/composer.json
@@ -10,28 +10,25 @@
     }
   ],
   "require": {
-    "guzzlehttp/guzzle": "~6.0",
-    "litipk/php-jiffy": "^1.4",
-    "league/oauth2-client": "^2.2",
-    "league/oauth2-google": "^2.0",
-    "league/oauth2-facebook": "^2.0",
-    "mongodb/mongodb": "^1.0",
+    "guzzlehttp/guzzle": "^7",
+    "litipk/php-jiffy": "^1",
+    "league/oauth2-client": "^2",
+    "league/oauth2-google": "^2",
+    "league/oauth2-facebook": "^2",
+    "mongodb/mongodb": "^1",
     "ocramius/lazy-property": "dev-feature/factory",
-    "ramsey/uuid": "~3.0",
+    "ramsey/uuid": "^4.2",
     "silex/silex": "~1.3.2",
     "sillsdev/web-php-utilities": "dev-master",
-    "swiftmailer/swiftmailer": "v5.0.2",
+    "swiftmailer/swiftmailer": "^5",
     "symfony/security": "^2.7",
     "symfony/twig-bridge": "^2.7",
-    "twig/twig": "^2.0",
-    "twig/extensions": "~1.3.0",
-    "firebase/php-jwt": "^5.2",
+    "twig/twig": "^2",
+    "firebase/php-jwt": "^6.3",
     "silinternational/php-env": "^2.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0",
-    "phpunit/php-code-coverage": "^7.0",
-    "squizlabs/php_codesniffer": "^3.4"
+    "phpunit/phpunit": "^8"
   },
   "autoload": {
     "psr-4": {

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,27 +4,90 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "3dd615e38ab1514377cf096728102641",
+  "content-hash": "eccec4b570712b1442518540264ffcb8",
   "packages": [
     {
-      "name": "firebase/php-jwt",
-      "version": "v5.5.1",
+      "name": "brick/math",
+      "version": "0.9.3",
       "source": {
         "type": "git",
-        "url": "https://github.com/firebase/php-jwt.git",
-        "reference": "83b609028194aa042ea33b5af2d41a7427de80e6"
+        "url": "https://github.com/brick/math.git",
+        "reference": "ca57d18f028f84f777b2168cd1911b0dee2343ae"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/firebase/php-jwt/zipball/83b609028194aa042ea33b5af2d41a7427de80e6",
-        "reference": "83b609028194aa042ea33b5af2d41a7427de80e6",
+        "url": "https://api.github.com/repos/brick/math/zipball/ca57d18f028f84f777b2168cd1911b0dee2343ae",
+        "reference": "ca57d18f028f84f777b2168cd1911b0dee2343ae",
         "shasum": ""
       },
       "require": {
-        "php": ">=5.3.0"
+        "ext-json": "*",
+        "php": "^7.1 || ^8.0"
       },
       "require-dev": {
-        "phpunit/phpunit": ">=4.8 <=9"
+        "php-coveralls/php-coveralls": "^2.2",
+        "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.0",
+        "vimeo/psalm": "4.9.2"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Brick\\Math\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "description": "Arbitrary-precision arithmetic library",
+      "keywords": [
+        "Arbitrary-precision",
+        "BigInteger",
+        "BigRational",
+        "arithmetic",
+        "bigdecimal",
+        "bignum",
+        "brick",
+        "math"
+      ],
+      "support": {
+        "issues": "https://github.com/brick/math/issues",
+        "source": "https://github.com/brick/math/tree/0.9.3"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/BenMorel",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/brick/math",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2021-08-15T20:50:18+00:00"
+    },
+    {
+      "name": "firebase/php-jwt",
+      "version": "v6.3.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/firebase/php-jwt.git",
+        "reference": "ea7dda77098b96e666c5ef382452f94841e439cd"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/firebase/php-jwt/zipball/ea7dda77098b96e666c5ef382452f94841e439cd",
+        "reference": "ea7dda77098b96e666c5ef382452f94841e439cd",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.1||^8.0"
+      },
+      "require-dev": {
+        "guzzlehttp/guzzle": "^6.5||^7.4",
+        "phpspec/prophecy-phpunit": "^1.1",
+        "phpunit/phpunit": "^7.5||^9.5",
+        "psr/cache": "^1.0||^2.0",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0"
       },
       "suggest": {
         "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
@@ -54,43 +117,55 @@
       "keywords": ["jwt", "php"],
       "support": {
         "issues": "https://github.com/firebase/php-jwt/issues",
-        "source": "https://github.com/firebase/php-jwt/tree/v5.5.1"
+        "source": "https://github.com/firebase/php-jwt/tree/v6.3.2"
       },
-      "time": "2021-11-08T20:18:51+00:00"
+      "time": "2022-12-19T17:10:46+00:00"
     },
     {
       "name": "guzzlehttp/guzzle",
-      "version": "6.5.8",
+      "version": "7.5.0",
       "source": {
         "type": "git",
         "url": "https://github.com/guzzle/guzzle.git",
-        "reference": "a52f0440530b54fa079ce76e8c5d196a42cad981"
+        "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a52f0440530b54fa079ce76e8c5d196a42cad981",
-        "reference": "a52f0440530b54fa079ce76e8c5d196a42cad981",
+        "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b50a2a1251152e43f6a37f0fa053e730a67d25ba",
+        "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba",
         "shasum": ""
       },
       "require": {
         "ext-json": "*",
-        "guzzlehttp/promises": "^1.0",
-        "guzzlehttp/psr7": "^1.9",
-        "php": ">=5.5",
-        "symfony/polyfill-intl-idn": "^1.17"
+        "guzzlehttp/promises": "^1.5",
+        "guzzlehttp/psr7": "^1.9 || ^2.4",
+        "php": "^7.2.5 || ^8.0",
+        "psr/http-client": "^1.0",
+        "symfony/deprecation-contracts": "^2.2 || ^3.0"
+      },
+      "provide": {
+        "psr/http-client-implementation": "1.0"
       },
       "require-dev": {
+        "bamarni/composer-bin-plugin": "^1.8.1",
         "ext-curl": "*",
-        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-        "psr/log": "^1.1"
+        "php-http/client-integration-tests": "^3.0",
+        "phpunit/phpunit": "^8.5.29 || ^9.5.23",
+        "psr/log": "^1.1 || ^2.0 || ^3.0"
       },
       "suggest": {
+        "ext-curl": "Required for CURL handler support",
+        "ext-intl": "Required for Internationalized Domain Name (IDN) support",
         "psr/log": "Required for using the Log middleware"
       },
       "type": "library",
       "extra": {
+        "bamarni-bin": {
+          "bin-links": true,
+          "forward-command": false
+        },
         "branch-alias": {
-          "dev-master": "6.5-dev"
+          "dev-master": "7.5-dev"
         }
       },
       "autoload": {
@@ -139,11 +214,10 @@
         }
       ],
       "description": "Guzzle is a PHP HTTP client library",
-      "homepage": "http://guzzlephp.org/",
-      "keywords": ["client", "curl", "framework", "http", "http client", "rest", "web service"],
+      "keywords": ["client", "curl", "framework", "http", "http client", "psr-18", "psr-7", "rest", "web service"],
       "support": {
         "issues": "https://github.com/guzzle/guzzle/issues",
-        "source": "https://github.com/guzzle/guzzle/tree/6.5.8"
+        "source": "https://github.com/guzzle/guzzle/tree/7.5.0"
       },
       "funding": [
         {
@@ -159,7 +233,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2022-06-20T22:16:07+00:00"
+      "time": "2022-08-28T15:39:27+00:00"
     },
     {
       "name": "guzzlehttp/promises",
@@ -241,41 +315,47 @@
     },
     {
       "name": "guzzlehttp/psr7",
-      "version": "1.9.0",
+      "version": "2.4.3",
       "source": {
         "type": "git",
         "url": "https://github.com/guzzle/psr7.git",
-        "reference": "e98e3e6d4f86621a9b75f623996e6bbdeb4b9318"
+        "reference": "67c26b443f348a51926030c83481b85718457d3d"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/guzzle/psr7/zipball/e98e3e6d4f86621a9b75f623996e6bbdeb4b9318",
-        "reference": "e98e3e6d4f86621a9b75f623996e6bbdeb4b9318",
+        "url": "https://api.github.com/repos/guzzle/psr7/zipball/67c26b443f348a51926030c83481b85718457d3d",
+        "reference": "67c26b443f348a51926030c83481b85718457d3d",
         "shasum": ""
       },
       "require": {
-        "php": ">=5.4.0",
-        "psr/http-message": "~1.0",
-        "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+        "php": "^7.2.5 || ^8.0",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0",
+        "ralouphie/getallheaders": "^3.0"
       },
       "provide": {
+        "psr/http-factory-implementation": "1.0",
         "psr/http-message-implementation": "1.0"
       },
       "require-dev": {
-        "ext-zlib": "*",
-        "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+        "bamarni/composer-bin-plugin": "^1.8.1",
+        "http-interop/http-factory-tests": "^0.9",
+        "phpunit/phpunit": "^8.5.29 || ^9.5.23"
       },
       "suggest": {
         "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
       },
       "type": "library",
       "extra": {
+        "bamarni-bin": {
+          "bin-links": true,
+          "forward-command": false
+        },
         "branch-alias": {
-          "dev-master": "1.9-dev"
+          "dev-master": "2.4-dev"
         }
       },
       "autoload": {
-        "files": ["src/functions_include.php"],
         "psr-4": {
           "GuzzleHttp\\Psr7\\": "src/"
         }
@@ -312,13 +392,18 @@
           "name": "Tobias Schultze",
           "email": "webmaster@tubo-world.de",
           "homepage": "https://github.com/Tobion"
+        },
+        {
+          "name": "Márk Sági-Kazár",
+          "email": "mark.sagikazar@gmail.com",
+          "homepage": "https://sagikazarmark.hu"
         }
       ],
       "description": "PSR-7 message implementation that also provides common utility methods",
       "keywords": ["http", "message", "psr-7", "request", "response", "stream", "uri", "url"],
       "support": {
         "issues": "https://github.com/guzzle/psr7/issues",
-        "source": "https://github.com/guzzle/psr7/tree/1.9.0"
+        "source": "https://github.com/guzzle/psr7/tree/2.4.3"
       },
       "funding": [
         {
@@ -334,7 +419,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2022-06-20T21:43:03+00:00"
+      "time": "2022-10-26T14:07:24+00:00"
     },
     {
       "name": "jean85/pretty-package-versions",
@@ -587,22 +672,22 @@
     },
     {
       "name": "mongodb/mongodb",
-      "version": "1.13.1",
+      "version": "1.15.0",
       "source": {
         "type": "git",
         "url": "https://github.com/mongodb/mongo-php-library.git",
-        "reference": "0b8555705d2f9c12ab2e5cebee6b594cdfe6b4e0"
+        "reference": "3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/0b8555705d2f9c12ab2e5cebee6b594cdfe6b4e0",
-        "reference": "0b8555705d2f9c12ab2e5cebee6b594cdfe6b4e0",
+        "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8",
+        "reference": "3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8",
         "shasum": ""
       },
       "require": {
         "ext-hash": "*",
         "ext-json": "*",
-        "ext-mongodb": "^1.14.0",
+        "ext-mongodb": "^1.15.0",
         "jean85/pretty-package-versions": "^1.2 || ^2.0.1",
         "php": "^7.2 || ^8.0",
         "symfony/polyfill-php80": "^1.19"
@@ -610,12 +695,13 @@
       "require-dev": {
         "doctrine/coding-standard": "^9.0",
         "squizlabs/php_codesniffer": "^3.6",
-        "symfony/phpunit-bridge": "^5.2"
+        "symfony/phpunit-bridge": "^5.2",
+        "vimeo/psalm": "^4.28"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "1.13.x-dev"
+          "dev-master": "1.15.x-dev"
         }
       },
       "autoload": {
@@ -641,9 +727,9 @@
       "keywords": ["database", "driver", "mongodb", "persistence"],
       "support": {
         "issues": "https://github.com/mongodb/mongo-php-library/issues",
-        "source": "https://github.com/mongodb/mongo-php-library/tree/1.13.1"
+        "source": "https://github.com/mongodb/mongo-php-library/tree/1.15.0"
       },
-      "time": "2022-09-08T03:32:09+00:00"
+      "time": "2022-11-23T04:45:35+00:00"
     },
     {
       "name": "ocramius/lazy-property",
@@ -788,6 +874,95 @@
       "time": "2013-11-22T08:30:29+00:00"
     },
     {
+      "name": "psr/http-client",
+      "version": "1.0.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/php-fig/http-client.git",
+        "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+        "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0 || ^8.0",
+        "psr/http-message": "^1.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.0.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Psr\\Http\\Client\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "PHP-FIG",
+          "homepage": "http://www.php-fig.org/"
+        }
+      ],
+      "description": "Common interface for HTTP clients",
+      "homepage": "https://github.com/php-fig/http-client",
+      "keywords": ["http", "http-client", "psr", "psr-18"],
+      "support": {
+        "source": "https://github.com/php-fig/http-client/tree/master"
+      },
+      "time": "2020-06-29T06:28:15+00:00"
+    },
+    {
+      "name": "psr/http-factory",
+      "version": "1.0.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/php-fig/http-factory.git",
+        "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+        "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.0.0",
+        "psr/http-message": "^1.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.0.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Psr\\Http\\Message\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "PHP-FIG",
+          "homepage": "http://www.php-fig.org/"
+        }
+      ],
+      "description": "Common interfaces for PSR-7 HTTP message factories",
+      "keywords": ["factory", "http", "message", "psr", "psr-17", "psr-7", "request", "response"],
+      "support": {
+        "source": "https://github.com/php-fig/http-factory/tree/master"
+      },
+      "time": "2019-04-30T12:38:16+00:00"
+    },
+    {
       "name": "psr/http-message",
       "version": "1.0.1",
       "source": {
@@ -916,56 +1091,137 @@
       "time": "2019-03-08T08:55:37+00:00"
     },
     {
-      "name": "ramsey/uuid",
-      "version": "3.9.6",
+      "name": "ramsey/collection",
+      "version": "1.2.2",
       "source": {
         "type": "git",
-        "url": "https://github.com/ramsey/uuid.git",
-        "reference": "ffa80ab953edd85d5b6c004f96181a538aad35a3"
+        "url": "https://github.com/ramsey/collection.git",
+        "reference": "cccc74ee5e328031b15640b51056ee8d3bb66c0a"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/ramsey/uuid/zipball/ffa80ab953edd85d5b6c004f96181a538aad35a3",
-        "reference": "ffa80ab953edd85d5b6c004f96181a538aad35a3",
+        "url": "https://api.github.com/repos/ramsey/collection/zipball/cccc74ee5e328031b15640b51056ee8d3bb66c0a",
+        "reference": "cccc74ee5e328031b15640b51056ee8d3bb66c0a",
         "shasum": ""
       },
       "require": {
+        "php": "^7.3 || ^8",
+        "symfony/polyfill-php81": "^1.23"
+      },
+      "require-dev": {
+        "captainhook/captainhook": "^5.3",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+        "ergebnis/composer-normalize": "^2.6",
+        "fakerphp/faker": "^1.5",
+        "hamcrest/hamcrest-php": "^2",
+        "jangregor/phpstan-prophecy": "^0.8",
+        "mockery/mockery": "^1.3",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpstan/extension-installer": "^1",
+        "phpstan/phpstan": "^0.12.32",
+        "phpstan/phpstan-mockery": "^0.12.5",
+        "phpstan/phpstan-phpunit": "^0.12.11",
+        "phpunit/phpunit": "^8.5 || ^9",
+        "psy/psysh": "^0.10.4",
+        "slevomat/coding-standard": "^6.3",
+        "squizlabs/php_codesniffer": "^3.5",
+        "vimeo/psalm": "^4.4"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Ramsey\\Collection\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Ben Ramsey",
+          "email": "ben@benramsey.com",
+          "homepage": "https://benramsey.com"
+        }
+      ],
+      "description": "A PHP library for representing and manipulating collections.",
+      "keywords": ["array", "collection", "hash", "map", "queue", "set"],
+      "support": {
+        "issues": "https://github.com/ramsey/collection/issues",
+        "source": "https://github.com/ramsey/collection/tree/1.2.2"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/ramsey",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/ramsey/collection",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2021-10-10T03:01:02+00:00"
+    },
+    {
+      "name": "ramsey/uuid",
+      "version": "4.2.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/ramsey/uuid.git",
+        "reference": "fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/ramsey/uuid/zipball/fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df",
+        "reference": "fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df",
+        "shasum": ""
+      },
+      "require": {
+        "brick/math": "^0.8 || ^0.9",
         "ext-json": "*",
-        "paragonie/random_compat": "^1 | ^2 | ^9.99.99",
-        "php": "^5.4 | ^7.0 | ^8.0",
-        "symfony/polyfill-ctype": "^1.8"
+        "php": "^7.2 || ^8.0",
+        "ramsey/collection": "^1.0",
+        "symfony/polyfill-ctype": "^1.8",
+        "symfony/polyfill-php80": "^1.14"
       },
       "replace": {
         "rhumsaa/uuid": "self.version"
       },
       "require-dev": {
-        "codeception/aspect-mock": "^1 | ^2",
-        "doctrine/annotations": "^1.2",
-        "goaop/framework": "1.0.0-alpha.2 | ^1 | >=2.1.0 <=2.3.2",
-        "mockery/mockery": "^0.9.11 | ^1",
+        "captainhook/captainhook": "^5.10",
+        "captainhook/plugin-composer": "^5.3",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+        "doctrine/annotations": "^1.8",
+        "ergebnis/composer-normalize": "^2.15",
+        "mockery/mockery": "^1.3",
         "moontoast/math": "^1.1",
-        "nikic/php-parser": "<=4.5.0",
         "paragonie/random-lib": "^2",
-        "php-mock/php-mock-phpunit": "^0.3 | ^1.1 | ^2.6",
-        "php-parallel-lint/php-parallel-lint": "^1.3",
-        "phpunit/phpunit": ">=4.8.36 <9.0.0 | >=9.3.0",
+        "php-mock/php-mock": "^2.2",
+        "php-mock/php-mock-mockery": "^1.3",
+        "php-parallel-lint/php-parallel-lint": "^1.1",
+        "phpbench/phpbench": "^1.0",
+        "phpstan/extension-installer": "^1.0",
+        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan-mockery": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12",
+        "phpunit/phpunit": "^8.5 || ^9",
+        "slevomat/coding-standard": "^7.0",
         "squizlabs/php_codesniffer": "^3.5",
-        "yoast/phpunit-polyfills": "^1.0"
+        "vimeo/psalm": "^4.9"
       },
       "suggest": {
-        "ext-ctype": "Provides support for PHP Ctype functions",
-        "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
-        "ext-openssl": "Provides the OpenSSL extension for use with the OpenSslGenerator",
-        "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
-        "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+        "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
+        "ext-ctype": "Enables faster processing of character classification using ctype functions.",
+        "ext-gmp": "Enables faster math with arbitrary-precision integers using GMP.",
+        "ext-uuid": "Enables the use of PeclUuidTimeGenerator and PeclUuidRandomGenerator.",
         "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
-        "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
         "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "3.x-dev"
+          "dev-main": "4.x-dev"
+        },
+        "captainhook": {
+          "force-install": true
         }
       },
       "autoload": {
@@ -976,29 +1232,11 @@
       },
       "notification-url": "https://packagist.org/downloads/",
       "license": ["MIT"],
-      "authors": [
-        {
-          "name": "Ben Ramsey",
-          "email": "ben@benramsey.com",
-          "homepage": "https://benramsey.com"
-        },
-        {
-          "name": "Marijn Huizendveld",
-          "email": "marijn.huizendveld@gmail.com"
-        },
-        {
-          "name": "Thibaud Fabre",
-          "email": "thibaud@aztech.io"
-        }
-      ],
-      "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
-      "homepage": "https://github.com/ramsey/uuid",
+      "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
       "keywords": ["guid", "identifier", "uuid"],
       "support": {
         "issues": "https://github.com/ramsey/uuid/issues",
-        "rss": "https://github.com/ramsey/uuid/releases.atom",
-        "source": "https://github.com/ramsey/uuid",
-        "wiki": "https://github.com/ramsey/uuid/wiki"
+        "source": "https://github.com/ramsey/uuid/tree/4.2.3"
       },
       "funding": [
         {
@@ -1010,7 +1248,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2021-09-25T23:07:42+00:00"
+      "time": "2021-09-25T23:10:38+00:00"
     },
     {
       "name": "silex/silex",
@@ -1166,25 +1404,29 @@
     },
     {
       "name": "swiftmailer/swiftmailer",
-      "version": "v5.0.2",
+      "version": "v5.4.12",
       "source": {
         "type": "git",
         "url": "https://github.com/swiftmailer/swiftmailer.git",
-        "reference": "f3917ecef35a4e4d98b303eb9fee463bc983f379"
+        "reference": "181b89f18a90f8925ef805f950d47a7190e9b950"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/f3917ecef35a4e4d98b303eb9fee463bc983f379",
-        "reference": "f3917ecef35a4e4d98b303eb9fee463bc983f379",
+        "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/181b89f18a90f8925ef805f950d47a7190e9b950",
+        "reference": "181b89f18a90f8925ef805f950d47a7190e9b950",
         "shasum": ""
       },
       "require": {
-        "php": ">=5.2.4"
+        "php": ">=5.3.3"
+      },
+      "require-dev": {
+        "mockery/mockery": "~0.9.1",
+        "symfony/phpunit-bridge": "~3.2"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "5.1-dev"
+          "dev-master": "5.4-dev"
         }
       },
       "autoload": {
@@ -1194,24 +1436,22 @@
       "license": ["MIT"],
       "authors": [
         {
-          "name": "Fabien Potencier",
-          "email": "fabien@symfony.com",
-          "homepage": "http://fabien.potencier.org",
-          "role": "Lead Developer"
+          "name": "Chris Corbyn"
         },
         {
-          "name": "Chris Corbyn"
+          "name": "Fabien Potencier",
+          "email": "fabien@symfony.com"
         }
       ],
       "description": "Swiftmailer, free feature-rich PHP mailer",
-      "homepage": "http://swiftmailer.org",
-      "keywords": ["mail", "mailer"],
+      "homepage": "https://swiftmailer.symfony.com",
+      "keywords": ["email", "mail", "mailer"],
       "support": {
         "issues": "https://github.com/swiftmailer/swiftmailer/issues",
-        "source": "https://github.com/swiftmailer/swiftmailer/tree/v5.0.2"
+        "source": "https://github.com/swiftmailer/swiftmailer/tree/v5.4.12"
       },
       "abandoned": "symfony/mailer",
-      "time": "2013-08-30T12:35:21+00:00"
+      "time": "2018-07-31T09:26:32+00:00"
     },
     {
       "name": "symfony/debug",
@@ -1277,6 +1517,69 @@
       ],
       "abandoned": "symfony/error-handler",
       "time": "2020-10-24T10:57:07+00:00"
+    },
+    {
+      "name": "symfony/deprecation-contracts",
+      "version": "v2.5.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/deprecation-contracts.git",
+        "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+        "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "2.5-dev"
+        },
+        "thanks": {
+          "name": "symfony/contracts",
+          "url": "https://github.com/symfony/contracts"
+        }
+      },
+      "autoload": {
+        "files": ["function.php"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Nicolas Grekas",
+          "email": "p@tchwork.com"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "A generic function and convention to trigger deprecation notices",
+      "homepage": "https://symfony.com",
+      "support": {
+        "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
+      },
+      "funding": [
+        {
+          "url": "https://symfony.com/sponsor",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/fabpot",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2022-01-02T09:53:40+00:00"
     },
     {
       "name": "symfony/event-dispatcher",
@@ -1528,153 +1831,6 @@
       "keywords": ["compatibility", "ctype", "polyfill", "portable"],
       "support": {
         "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
-      },
-      "funding": [
-        {
-          "url": "https://symfony.com/sponsor",
-          "type": "custom"
-        },
-        {
-          "url": "https://github.com/fabpot",
-          "type": "github"
-        },
-        {
-          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-          "type": "tidelift"
-        }
-      ],
-      "time": "2022-11-03T14:55:06+00:00"
-    },
-    {
-      "name": "symfony/polyfill-intl-idn",
-      "version": "v1.27.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/symfony/polyfill-intl-idn.git",
-        "reference": "639084e360537a19f9ee352433b84ce831f3d2da"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da",
-        "reference": "639084e360537a19f9ee352433b84ce831f3d2da",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.1",
-        "symfony/polyfill-intl-normalizer": "^1.10",
-        "symfony/polyfill-php72": "^1.10"
-      },
-      "suggest": {
-        "ext-intl": "For best performance"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-main": "1.27-dev"
-        },
-        "thanks": {
-          "name": "symfony/polyfill",
-          "url": "https://github.com/symfony/polyfill"
-        }
-      },
-      "autoload": {
-        "files": ["bootstrap.php"],
-        "psr-4": {
-          "Symfony\\Polyfill\\Intl\\Idn\\": ""
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["MIT"],
-      "authors": [
-        {
-          "name": "Laurent Bassin",
-          "email": "laurent@bassin.info"
-        },
-        {
-          "name": "Trevor Rowbotham",
-          "email": "trevor.rowbotham@pm.me"
-        },
-        {
-          "name": "Symfony Community",
-          "homepage": "https://symfony.com/contributors"
-        }
-      ],
-      "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
-      "homepage": "https://symfony.com",
-      "keywords": ["compatibility", "idn", "intl", "polyfill", "portable", "shim"],
-      "support": {
-        "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.27.0"
-      },
-      "funding": [
-        {
-          "url": "https://symfony.com/sponsor",
-          "type": "custom"
-        },
-        {
-          "url": "https://github.com/fabpot",
-          "type": "github"
-        },
-        {
-          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-          "type": "tidelift"
-        }
-      ],
-      "time": "2022-11-03T14:55:06+00:00"
-    },
-    {
-      "name": "symfony/polyfill-intl-normalizer",
-      "version": "v1.27.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-        "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-        "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.1"
-      },
-      "suggest": {
-        "ext-intl": "For best performance"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-main": "1.27-dev"
-        },
-        "thanks": {
-          "name": "symfony/polyfill",
-          "url": "https://github.com/symfony/polyfill"
-        }
-      },
-      "autoload": {
-        "files": ["bootstrap.php"],
-        "psr-4": {
-          "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-        },
-        "classmap": ["Resources/stubs"]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["MIT"],
-      "authors": [
-        {
-          "name": "Nicolas Grekas",
-          "email": "p@tchwork.com"
-        },
-        {
-          "name": "Symfony Community",
-          "homepage": "https://symfony.com/contributors"
-        }
-      ],
-      "description": "Symfony polyfill for intl's Normalizer class and related functions",
-      "homepage": "https://symfony.com",
-      "keywords": ["compatibility", "intl", "normalizer", "polyfill", "portable", "shim"],
-      "support": {
-        "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
       },
       "funding": [
         {
@@ -2149,6 +2305,74 @@
       "time": "2022-11-03T14:55:06+00:00"
     },
     {
+      "name": "symfony/polyfill-php81",
+      "version": "v1.27.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/polyfill-php81.git",
+        "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/707403074c8ea6e2edaf8794b0157a0bfa52157a",
+        "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "1.27-dev"
+        },
+        "thanks": {
+          "name": "symfony/polyfill",
+          "url": "https://github.com/symfony/polyfill"
+        }
+      },
+      "autoload": {
+        "files": ["bootstrap.php"],
+        "psr-4": {
+          "Symfony\\Polyfill\\Php81\\": ""
+        },
+        "classmap": ["Resources/stubs"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Nicolas Grekas",
+          "email": "p@tchwork.com"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+      "homepage": "https://symfony.com",
+      "keywords": ["compatibility", "polyfill", "portable", "shim"],
+      "support": {
+        "source": "https://github.com/symfony/polyfill-php81/tree/v1.27.0"
+      },
+      "funding": [
+        {
+          "url": "https://symfony.com/sponsor",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/fabpot",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2022-11-03T14:55:06+00:00"
+    },
+    {
       "name": "symfony/polyfill-util",
       "version": "v1.27.0",
       "source": {
@@ -2422,6 +2646,7 @@
       "support": {
         "source": "https://github.com/symfony/security/tree/2.8"
       },
+      "abandoned": true,
       "time": "2019-04-16T10:01:12+00:00"
     },
     {
@@ -2570,69 +2795,17 @@
       "time": "2018-11-11T11:18:13+00:00"
     },
     {
-      "name": "twig/extensions",
-      "version": "v1.3.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/twigphp/Twig-extensions.git",
-        "reference": "449e3c8a9ffad7c2479c7864557275a32b037499"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/449e3c8a9ffad7c2479c7864557275a32b037499",
-        "reference": "449e3c8a9ffad7c2479c7864557275a32b037499",
-        "shasum": ""
-      },
-      "require": {
-        "twig/twig": "~1.20|~2.0"
-      },
-      "require-dev": {
-        "symfony/translation": "~2.3"
-      },
-      "suggest": {
-        "symfony/translation": "Allow the time_diff output to be translated"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.3-dev"
-        }
-      },
-      "autoload": {
-        "psr-0": {
-          "Twig_Extensions_": "lib/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["MIT"],
-      "authors": [
-        {
-          "name": "Fabien Potencier",
-          "email": "fabien@symfony.com"
-        }
-      ],
-      "description": "Common additional features for Twig that do not directly belong in core",
-      "homepage": "http://twig.sensiolabs.org/doc/extensions/index.html",
-      "keywords": ["i18n", "text"],
-      "support": {
-        "issues": "https://github.com/twigphp/Twig-extensions/issues",
-        "source": "https://github.com/twigphp/Twig-extensions/tree/master"
-      },
-      "abandoned": true,
-      "time": "2015-08-22T16:38:35+00:00"
-    },
-    {
       "name": "twig/twig",
-      "version": "v2.15.3",
+      "version": "v2.15.4",
       "source": {
         "type": "git",
         "url": "https://github.com/twigphp/Twig.git",
-        "reference": "ab402673db8746cb3a4c46f3869d6253699f614a"
+        "reference": "3e059001d6d597dd50ea7c74dd2464b4adea48d3"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/twigphp/Twig/zipball/ab402673db8746cb3a4c46f3869d6253699f614a",
-        "reference": "ab402673db8746cb3a4c46f3869d6253699f614a",
+        "url": "https://api.github.com/repos/twigphp/Twig/zipball/3e059001d6d597dd50ea7c74dd2464b4adea48d3",
+        "reference": "3e059001d6d597dd50ea7c74dd2464b4adea48d3",
         "shasum": ""
       },
       "require": {
@@ -2683,7 +2856,7 @@
       "keywords": ["templating"],
       "support": {
         "issues": "https://github.com/twigphp/Twig/issues",
-        "source": "https://github.com/twigphp/Twig/tree/v2.15.3"
+        "source": "https://github.com/twigphp/Twig/tree/v2.15.4"
       },
       "funding": [
         {
@@ -2695,36 +2868,36 @@
           "type": "tidelift"
         }
       ],
-      "time": "2022-09-28T08:40:08+00:00"
+      "time": "2022-12-27T12:26:20+00:00"
     }
   ],
   "packages-dev": [
     {
       "name": "doctrine/instantiator",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "source": {
         "type": "git",
         "url": "https://github.com/doctrine/instantiator.git",
-        "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+        "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-        "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+        "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+        "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
         "shasum": ""
       },
       "require": {
         "php": "^7.1 || ^8.0"
       },
       "require-dev": {
-        "doctrine/coding-standard": "^9",
+        "doctrine/coding-standard": "^9 || ^11",
         "ext-pdo": "*",
         "ext-phar": "*",
         "phpbench/phpbench": "^0.16 || ^1",
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-phpunit": "^1",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-        "vimeo/psalm": "^4.22"
+        "vimeo/psalm": "^4.30 || ^5.4"
       },
       "type": "library",
       "autoload": {
@@ -2746,7 +2919,7 @@
       "keywords": ["constructor", "instantiate"],
       "support": {
         "issues": "https://github.com/doctrine/instantiator/issues",
-        "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+        "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
       },
       "funding": [
         {
@@ -2762,7 +2935,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2022-03-03T08:28:38+00:00"
+      "time": "2022-12-30T00:15:36+00:00"
     },
     {
       "name": "myclabs/deep-copy",
@@ -3929,54 +4102,6 @@
         "source": "https://github.com/sebastianbergmann/version/tree/master"
       },
       "time": "2016-10-03T07:35:21+00:00"
-    },
-    {
-      "name": "squizlabs/php_codesniffer",
-      "version": "3.7.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-        "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-        "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
-        "shasum": ""
-      },
-      "require": {
-        "ext-simplexml": "*",
-        "ext-tokenizer": "*",
-        "ext-xmlwriter": "*",
-        "php": ">=5.4.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-      },
-      "bin": ["bin/phpcs", "bin/phpcbf"],
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "3.x-dev"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["BSD-3-Clause"],
-      "authors": [
-        {
-          "name": "Greg Sherwood",
-          "role": "lead"
-        }
-      ],
-      "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-      "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
-      "keywords": ["phpcs", "standards"],
-      "support": {
-        "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-        "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-        "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-      },
-      "time": "2022-06-18T07:21:10+00:00"
     },
     {
       "name": "theseer/tokenizer",


### PR DESCRIPTION
## Description

Removes these PHP dependencies:

- phpunit/php-code-coverage
- squizlabs/php_codesniffer
- twig/extensions

Updates a few small dependencies to the latest possible under PHP 7.3:

## Future Work (Upgrading these require application/test code changes to upgrade)
- PHPUnit
- Twig
- SwiftMailer
- Symfony
- Silex

Also introduces a new docker service/container called `composer-dev`

It is used for running composer commands in the environment (PHP w/ dependencies) of our application.

Run `make composer-dev` and you will be put into a running container with composer files volume mapped for easy editing/committing


### Type of Change

- PHP dependency upgrades

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## How to test

Considered tested if PHP and E2E tests are passing