### PR TITLE
upgrade PHPUnit to version 9.5 (latest version)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,8 +302,8 @@ services:
   composer-dev:
     build:
       dockerfile: docker/composer-dev/Dockerfile
-    image: composer-dev
-    container_name: composer-dev
+    image: lf-composer-dev
+    container_name: lf-composer-dev
     volumes:
       - ./src/composer.json:/work/composer.json
       - ./src/composer.lock:/work/composer.lock

--- a/src/composer.json
+++ b/src/composer.json
@@ -28,7 +28,7 @@
     "silinternational/php-env": "^2.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8"
+    "phpunit/phpunit": "^9"
   },
   "autoload": {
     "psr-4": {

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "eccec4b570712b1442518540264ffcb8",
+  "content-hash": "d2449b529538a4390358d652937682cb",
   "packages": [
     {
       "name": "brick/math",
@@ -2987,6 +2987,55 @@
       "time": "2022-03-03T13:19:32+00:00"
     },
     {
+      "name": "nikic/php-parser",
+      "version": "v4.15.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/nikic/PHP-Parser.git",
+        "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+        "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+        "shasum": ""
+      },
+      "require": {
+        "ext-tokenizer": "*",
+        "php": ">=7.0"
+      },
+      "require-dev": {
+        "ircmaxell/php-yacc": "^0.0.7",
+        "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+      },
+      "bin": ["bin/php-parse"],
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "4.9-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "PhpParser\\": "lib/PhpParser"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["BSD-3-Clause"],
+      "authors": [
+        {
+          "name": "Nikita Popov"
+        }
+      ],
+      "description": "A PHP parser written in PHP",
+      "keywords": ["parser", "php"],
+      "support": {
+        "issues": "https://github.com/nikic/PHP-Parser/issues",
+        "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
+      },
+      "time": "2022-11-12T15:38:23+00:00"
+    },
+    {
       "name": "phar-io/manifest",
       "version": "2.0.3",
       "source": {
@@ -3091,40 +3140,44 @@
     },
     {
       "name": "phpunit/php-code-coverage",
-      "version": "7.0.15",
+      "version": "9.2.23",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-        "reference": "819f92bba8b001d4363065928088de22f25a3a48"
+        "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/819f92bba8b001d4363065928088de22f25a3a48",
-        "reference": "819f92bba8b001d4363065928088de22f25a3a48",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
+        "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
         "shasum": ""
       },
       "require": {
         "ext-dom": "*",
+        "ext-libxml": "*",
         "ext-xmlwriter": "*",
-        "php": ">=7.2",
-        "phpunit/php-file-iterator": "^2.0.2",
-        "phpunit/php-text-template": "^1.2.1",
-        "phpunit/php-token-stream": "^3.1.3 || ^4.0",
-        "sebastian/code-unit-reverse-lookup": "^1.0.1",
-        "sebastian/environment": "^4.2.2",
-        "sebastian/version": "^2.0.1",
-        "theseer/tokenizer": "^1.1.3"
+        "nikic/php-parser": "^4.14",
+        "php": ">=7.3",
+        "phpunit/php-file-iterator": "^3.0.3",
+        "phpunit/php-text-template": "^2.0.2",
+        "sebastian/code-unit-reverse-lookup": "^2.0.2",
+        "sebastian/complexity": "^2.0",
+        "sebastian/environment": "^5.1.2",
+        "sebastian/lines-of-code": "^1.0.3",
+        "sebastian/version": "^3.0.1",
+        "theseer/tokenizer": "^1.2.0"
       },
       "require-dev": {
-        "phpunit/phpunit": "^8.2.2"
+        "phpunit/phpunit": "^9.3"
       },
       "suggest": {
-        "ext-xdebug": "^2.7.2"
+        "ext-pcov": "*",
+        "ext-xdebug": "*"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "7.0-dev"
+          "dev-master": "9.2-dev"
         }
       },
       "autoload": {
@@ -3144,7 +3197,7 @@
       "keywords": ["coverage", "testing", "xunit"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-        "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.15"
+        "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.23"
       },
       "funding": [
         {
@@ -3152,32 +3205,32 @@
           "type": "github"
         }
       ],
-      "time": "2021-07-26T12:20:09+00:00"
+      "time": "2022-12-28T12:41:10+00:00"
     },
     {
       "name": "phpunit/php-file-iterator",
-      "version": "2.0.5",
+      "version": "3.0.6",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-        "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5"
+        "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
-        "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+        "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.1"
+        "php": ">=7.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "2.0.x-dev"
+          "dev-master": "3.0-dev"
         }
       },
       "autoload": {
@@ -3197,7 +3250,7 @@
       "keywords": ["filesystem", "iterator"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-        "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.5"
+        "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
       },
       "funding": [
         {
@@ -3205,26 +3258,91 @@
           "type": "github"
         }
       ],
-      "time": "2021-12-02T12:42:26+00:00"
+      "time": "2021-12-02T12:48:52+00:00"
     },
     {
-      "name": "phpunit/php-text-template",
-      "version": "1.2.1",
+      "name": "phpunit/php-invoker",
+      "version": "3.1.1",
       "source": {
         "type": "git",
-        "url": "https://github.com/sebastianbergmann/php-text-template.git",
-        "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+        "url": "https://github.com/sebastianbergmann/php-invoker.git",
+        "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-        "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+        "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
         "shasum": ""
       },
       "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.3"
+      },
+      "require-dev": {
+        "ext-pcntl": "*",
+        "phpunit/phpunit": "^9.3"
+      },
+      "suggest": {
+        "ext-pcntl": "*"
       },
       "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "3.1-dev"
+        }
+      },
+      "autoload": {
+        "classmap": ["src/"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["BSD-3-Clause"],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Invoke callables with a timeout",
+      "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+      "keywords": ["process"],
+      "support": {
+        "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+        "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/sebastianbergmann",
+          "type": "github"
+        }
+      ],
+      "time": "2020-09-28T05:58:55+00:00"
+    },
+    {
+      "name": "phpunit/php-text-template",
+      "version": "2.0.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/php-text-template.git",
+        "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+        "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.3"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^9.3"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.0-dev"
+        }
+      },
       "autoload": {
         "classmap": ["src/"]
       },
@@ -3242,34 +3360,40 @@
       "keywords": ["template"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-        "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+        "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
       },
-      "time": "2015-06-21T13:50:34+00:00"
+      "funding": [
+        {
+          "url": "https://github.com/sebastianbergmann",
+          "type": "github"
+        }
+      ],
+      "time": "2020-10-26T05:33:50+00:00"
     },
     {
       "name": "phpunit/php-timer",
-      "version": "2.1.3",
+      "version": "5.0.3",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/php-timer.git",
-        "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
+        "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
-        "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+        "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.1"
+        "php": ">=7.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "2.1-dev"
+          "dev-master": "5.0-dev"
         }
       },
       "autoload": {
@@ -3289,7 +3413,7 @@
       "keywords": ["timer"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-        "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
+        "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
       },
       "funding": [
         {
@@ -3297,74 +3421,20 @@
           "type": "github"
         }
       ],
-      "time": "2020-11-30T08:20:02+00:00"
-    },
-    {
-      "name": "phpunit/php-token-stream",
-      "version": "4.0.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-        "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/a853a0e183b9db7eed023d7933a858fa1c8d25a3",
-        "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3",
-        "shasum": ""
-      },
-      "require": {
-        "ext-tokenizer": "*",
-        "php": "^7.3 || ^8.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "4.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": ["src/"]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["BSD-3-Clause"],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        }
-      ],
-      "description": "Wrapper around PHP's tokenizer extension.",
-      "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-      "keywords": ["tokenizer"],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-        "source": "https://github.com/sebastianbergmann/php-token-stream/tree/master"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "abandoned": true,
-      "time": "2020-08-04T08:28:15+00:00"
+      "time": "2020-10-26T13:16:10+00:00"
     },
     {
       "name": "phpunit/phpunit",
-      "version": "8.5.31",
+      "version": "9.5.27",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/phpunit.git",
-        "reference": "33c126b09a42de5c99e5e8032b54e8221264a74e"
+        "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33c126b09a42de5c99e5e8032b54e8221264a74e",
-        "reference": "33c126b09a42de5c99e5e8032b54e8221264a74e",
+        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
+        "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
         "shasum": ""
       },
       "require": {
@@ -3375,37 +3445,40 @@
         "ext-mbstring": "*",
         "ext-xml": "*",
         "ext-xmlwriter": "*",
-        "myclabs/deep-copy": "^1.10.0",
+        "myclabs/deep-copy": "^1.10.1",
         "phar-io/manifest": "^2.0.3",
         "phar-io/version": "^3.0.2",
-        "php": ">=7.2",
-        "phpunit/php-code-coverage": "^7.0.12",
-        "phpunit/php-file-iterator": "^2.0.4",
-        "phpunit/php-text-template": "^1.2.1",
-        "phpunit/php-timer": "^2.1.2",
-        "sebastian/comparator": "^3.0.5",
-        "sebastian/diff": "^3.0.2",
-        "sebastian/environment": "^4.2.3",
-        "sebastian/exporter": "^3.1.5",
-        "sebastian/global-state": "^3.0.0",
-        "sebastian/object-enumerator": "^3.0.3",
-        "sebastian/resource-operations": "^2.0.1",
-        "sebastian/type": "^1.1.3",
-        "sebastian/version": "^2.0.1"
+        "php": ">=7.3",
+        "phpunit/php-code-coverage": "^9.2.13",
+        "phpunit/php-file-iterator": "^3.0.5",
+        "phpunit/php-invoker": "^3.1.1",
+        "phpunit/php-text-template": "^2.0.3",
+        "phpunit/php-timer": "^5.0.2",
+        "sebastian/cli-parser": "^1.0.1",
+        "sebastian/code-unit": "^1.0.6",
+        "sebastian/comparator": "^4.0.8",
+        "sebastian/diff": "^4.0.3",
+        "sebastian/environment": "^5.1.3",
+        "sebastian/exporter": "^4.0.5",
+        "sebastian/global-state": "^5.0.1",
+        "sebastian/object-enumerator": "^4.0.3",
+        "sebastian/resource-operations": "^3.0.3",
+        "sebastian/type": "^3.2",
+        "sebastian/version": "^3.0.2"
       },
       "suggest": {
         "ext-soap": "*",
-        "ext-xdebug": "*",
-        "phpunit/php-invoker": "^2.0.0"
+        "ext-xdebug": "*"
       },
       "bin": ["phpunit"],
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "8.5-dev"
+          "dev-master": "9.5-dev"
         }
       },
       "autoload": {
+        "files": ["src/Framework/Assert/Functions.php"],
         "classmap": ["src/"]
       },
       "notification-url": "https://packagist.org/downloads/",
@@ -3422,7 +3495,7 @@
       "keywords": ["phpunit", "testing", "xunit"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-        "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.31"
+        "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.27"
       },
       "funding": [
         {
@@ -3438,32 +3511,136 @@
           "type": "tidelift"
         }
       ],
-      "time": "2022-10-28T05:57:37+00:00"
+      "time": "2022-12-09T07:31:23+00:00"
     },
     {
-      "name": "sebastian/code-unit-reverse-lookup",
-      "version": "1.0.2",
+      "name": "sebastian/cli-parser",
+      "version": "1.0.1",
       "source": {
         "type": "git",
-        "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-        "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
+        "url": "https://github.com/sebastianbergmann/cli-parser.git",
+        "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
-        "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+        "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+        "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
         "shasum": ""
       },
       "require": {
-        "php": ">=5.6"
+        "php": ">=7.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "1.0.x-dev"
+          "dev-master": "1.0-dev"
+        }
+      },
+      "autoload": {
+        "classmap": ["src/"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["BSD-3-Clause"],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Library for parsing CLI options",
+      "homepage": "https://github.com/sebastianbergmann/cli-parser",
+      "support": {
+        "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+        "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/sebastianbergmann",
+          "type": "github"
+        }
+      ],
+      "time": "2020-09-28T06:08:49+00:00"
+    },
+    {
+      "name": "sebastian/code-unit",
+      "version": "1.0.8",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/code-unit.git",
+        "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+        "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.3"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^9.3"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.0-dev"
+        }
+      },
+      "autoload": {
+        "classmap": ["src/"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["BSD-3-Clause"],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Collection of value objects that represent the PHP code units",
+      "homepage": "https://github.com/sebastianbergmann/code-unit",
+      "support": {
+        "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+        "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/sebastianbergmann",
+          "type": "github"
+        }
+      ],
+      "time": "2020-10-26T13:08:54+00:00"
+    },
+    {
+      "name": "sebastian/code-unit-reverse-lookup",
+      "version": "2.0.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+        "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+        "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.3"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^9.3"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.0-dev"
         }
       },
       "autoload": {
@@ -3481,7 +3658,7 @@
       "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
       "support": {
         "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-        "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
+        "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
       },
       "funding": [
         {
@@ -3489,34 +3666,34 @@
           "type": "github"
         }
       ],
-      "time": "2020-11-30T08:15:22+00:00"
+      "time": "2020-09-28T05:30:19+00:00"
     },
     {
       "name": "sebastian/comparator",
-      "version": "3.0.5",
+      "version": "4.0.8",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/comparator.git",
-        "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770"
+        "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
-        "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
+        "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+        "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.1",
-        "sebastian/diff": "^3.0",
-        "sebastian/exporter": "^3.1"
+        "php": ">=7.3",
+        "sebastian/diff": "^4.0",
+        "sebastian/exporter": "^4.0"
       },
       "require-dev": {
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "3.0-dev"
+          "dev-master": "4.0-dev"
         }
       },
       "autoload": {
@@ -3547,7 +3724,7 @@
       "keywords": ["comparator", "compare", "equality"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/comparator/issues",
-        "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.5"
+        "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
       },
       "funding": [
         {
@@ -3555,33 +3732,86 @@
           "type": "github"
         }
       ],
-      "time": "2022-09-14T12:31:48+00:00"
+      "time": "2022-09-14T12:41:17+00:00"
     },
     {
-      "name": "sebastian/diff",
-      "version": "3.0.3",
+      "name": "sebastian/complexity",
+      "version": "2.0.2",
       "source": {
         "type": "git",
-        "url": "https://github.com/sebastianbergmann/diff.git",
-        "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+        "url": "https://github.com/sebastianbergmann/complexity.git",
+        "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
-        "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+        "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+        "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.1"
+        "nikic/php-parser": "^4.7",
+        "php": ">=7.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^8.0",
-        "symfony/process": "^2 || ^3.3 || ^4"
+        "phpunit/phpunit": "^9.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "3.0-dev"
+          "dev-master": "2.0-dev"
+        }
+      },
+      "autoload": {
+        "classmap": ["src/"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["BSD-3-Clause"],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Library for calculating the complexity of PHP code units",
+      "homepage": "https://github.com/sebastianbergmann/complexity",
+      "support": {
+        "issues": "https://github.com/sebastianbergmann/complexity/issues",
+        "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/sebastianbergmann",
+          "type": "github"
+        }
+      ],
+      "time": "2020-10-26T15:52:27+00:00"
+    },
+    {
+      "name": "sebastian/diff",
+      "version": "4.0.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/diff.git",
+        "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+        "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.3"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^9.3",
+        "symfony/process": "^4.2 || ^5"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "4.0-dev"
         }
       },
       "autoload": {
@@ -3604,7 +3834,7 @@
       "keywords": ["diff", "udiff", "unidiff", "unified diff"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/diff/issues",
-        "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
+        "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
       },
       "funding": [
         {
@@ -3612,27 +3842,27 @@
           "type": "github"
         }
       ],
-      "time": "2020-11-30T07:59:04+00:00"
+      "time": "2020-10-26T13:10:38+00:00"
     },
     {
       "name": "sebastian/environment",
-      "version": "4.2.4",
+      "version": "5.1.4",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/environment.git",
-        "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
+        "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
-        "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+        "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+        "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.1"
+        "php": ">=7.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.3"
       },
       "suggest": {
         "ext-posix": "*"
@@ -3640,7 +3870,7 @@
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "4.2-dev"
+          "dev-master": "5.1-dev"
         }
       },
       "autoload": {
@@ -3659,7 +3889,7 @@
       "keywords": ["Xdebug", "environment", "hhvm"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/environment/issues",
-        "source": "https://github.com/sebastianbergmann/environment/tree/4.2.4"
+        "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
       },
       "funding": [
         {
@@ -3667,34 +3897,34 @@
           "type": "github"
         }
       ],
-      "time": "2020-11-30T07:53:42+00:00"
+      "time": "2022-04-03T09:37:03+00:00"
     },
     {
       "name": "sebastian/exporter",
-      "version": "3.1.5",
+      "version": "4.0.5",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/exporter.git",
-        "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6"
+        "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/73a9676f2833b9a7c36968f9d882589cd75511e6",
-        "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6",
+        "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+        "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.0",
-        "sebastian/recursion-context": "^3.0"
+        "php": ">=7.3",
+        "sebastian/recursion-context": "^4.0"
       },
       "require-dev": {
         "ext-mbstring": "*",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "3.1.x-dev"
+          "dev-master": "4.0-dev"
         }
       },
       "autoload": {
@@ -3725,11 +3955,11 @@
         }
       ],
       "description": "Provides the functionality to export PHP variables for visualization",
-      "homepage": "http://www.github.com/sebastianbergmann/exporter",
+      "homepage": "https://www.github.com/sebastianbergmann/exporter",
       "keywords": ["export", "exporter"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/exporter/issues",
-        "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.5"
+        "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
       },
       "funding": [
         {
@@ -3737,30 +3967,30 @@
           "type": "github"
         }
       ],
-      "time": "2022-09-14T06:00:17+00:00"
+      "time": "2022-09-14T06:03:37+00:00"
     },
     {
       "name": "sebastian/global-state",
-      "version": "3.0.2",
+      "version": "5.0.5",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/global-state.git",
-        "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921"
+        "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/de036ec91d55d2a9e0db2ba975b512cdb1c23921",
-        "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921",
+        "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+        "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.2",
-        "sebastian/object-reflector": "^1.1.1",
-        "sebastian/recursion-context": "^3.0"
+        "php": ">=7.3",
+        "sebastian/object-reflector": "^2.0",
+        "sebastian/recursion-context": "^4.0"
       },
       "require-dev": {
         "ext-dom": "*",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.3"
       },
       "suggest": {
         "ext-uopz": "*"
@@ -3768,7 +3998,7 @@
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "3.0-dev"
+          "dev-master": "5.0-dev"
         }
       },
       "autoload": {
@@ -3787,7 +4017,7 @@
       "keywords": ["global state"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/global-state/issues",
-        "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.2"
+        "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
       },
       "funding": [
         {
@@ -3795,34 +4025,87 @@
           "type": "github"
         }
       ],
-      "time": "2022-02-10T06:55:38+00:00"
+      "time": "2022-02-14T08:28:10+00:00"
     },
     {
-      "name": "sebastian/object-enumerator",
-      "version": "3.0.4",
+      "name": "sebastian/lines-of-code",
+      "version": "1.0.3",
       "source": {
         "type": "git",
-        "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-        "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
+        "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+        "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
-        "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+        "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+        "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.0",
-        "sebastian/object-reflector": "^1.1.1",
-        "sebastian/recursion-context": "^3.0"
+        "nikic/php-parser": "^4.6",
+        "php": ">=7.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^9.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "3.0.x-dev"
+          "dev-master": "1.0-dev"
+        }
+      },
+      "autoload": {
+        "classmap": ["src/"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["BSD-3-Clause"],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Library for counting the lines of code in PHP source code",
+      "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+      "support": {
+        "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+        "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/sebastianbergmann",
+          "type": "github"
+        }
+      ],
+      "time": "2020-11-28T06:42:11+00:00"
+    },
+    {
+      "name": "sebastian/object-enumerator",
+      "version": "4.0.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+        "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+        "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.3",
+        "sebastian/object-reflector": "^2.0",
+        "sebastian/recursion-context": "^4.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^9.3"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "4.0-dev"
         }
       },
       "autoload": {
@@ -3840,7 +4123,7 @@
       "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
       "support": {
         "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-        "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
+        "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
       },
       "funding": [
         {
@@ -3848,32 +4131,32 @@
           "type": "github"
         }
       ],
-      "time": "2020-11-30T07:40:27+00:00"
+      "time": "2020-10-26T13:12:34+00:00"
     },
     {
       "name": "sebastian/object-reflector",
-      "version": "1.1.2",
+      "version": "2.0.4",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/object-reflector.git",
-        "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+        "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
-        "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+        "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+        "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.0"
+        "php": ">=7.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^9.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "1.1-dev"
+          "dev-master": "2.0-dev"
         }
       },
       "autoload": {
@@ -3891,7 +4174,7 @@
       "homepage": "https://github.com/sebastianbergmann/object-reflector/",
       "support": {
         "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-        "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
+        "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
       },
       "funding": [
         {
@@ -3899,32 +4182,32 @@
           "type": "github"
         }
       ],
-      "time": "2020-11-30T07:37:18+00:00"
+      "time": "2020-10-26T13:14:26+00:00"
     },
     {
       "name": "sebastian/recursion-context",
-      "version": "3.0.1",
+      "version": "4.0.4",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/recursion-context.git",
-        "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+        "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
-        "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+        "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+        "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.0"
+        "php": ">=7.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^9.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "3.0.x-dev"
+          "dev-master": "4.0-dev"
         }
       },
       "autoload": {
@@ -3950,7 +4233,7 @@
       "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
       "support": {
         "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-        "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
+        "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
       },
       "funding": [
         {
@@ -3958,29 +4241,32 @@
           "type": "github"
         }
       ],
-      "time": "2020-11-30T07:34:24+00:00"
+      "time": "2020-10-26T13:17:30+00:00"
     },
     {
       "name": "sebastian/resource-operations",
-      "version": "2.0.2",
+      "version": "3.0.3",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/resource-operations.git",
-        "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
+        "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
-        "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+        "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+        "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.1"
+        "php": ">=7.3"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^9.0"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "2.0-dev"
+          "dev-master": "3.0-dev"
         }
       },
       "autoload": {
@@ -3998,7 +4284,7 @@
       "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
       "support": {
         "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-        "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.2"
+        "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
       },
       "funding": [
         {
@@ -4006,32 +4292,32 @@
           "type": "github"
         }
       ],
-      "time": "2020-11-30T07:30:19+00:00"
+      "time": "2020-09-28T06:45:17+00:00"
     },
     {
       "name": "sebastian/type",
-      "version": "1.1.4",
+      "version": "3.2.0",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/type.git",
-        "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4"
+        "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/0150cfbc4495ed2df3872fb31b26781e4e077eb4",
-        "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+        "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+        "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
         "shasum": ""
       },
       "require": {
-        "php": ">=7.2"
+        "php": ">=7.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^8.2"
+        "phpunit/phpunit": "^9.5"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "1.1-dev"
+          "dev-master": "3.2-dev"
         }
       },
       "autoload": {
@@ -4050,7 +4336,7 @@
       "homepage": "https://github.com/sebastianbergmann/type",
       "support": {
         "issues": "https://github.com/sebastianbergmann/type/issues",
-        "source": "https://github.com/sebastianbergmann/type/tree/1.1.4"
+        "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
       },
       "funding": [
         {
@@ -4058,29 +4344,29 @@
           "type": "github"
         }
       ],
-      "time": "2020-11-30T07:25:11+00:00"
+      "time": "2022-09-12T14:47:03+00:00"
     },
     {
       "name": "sebastian/version",
-      "version": "2.0.1",
+      "version": "3.0.2",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/version.git",
-        "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+        "reference": "c6c1022351a901512170118436c764e473f6de8c"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-        "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+        "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+        "reference": "c6c1022351a901512170118436c764e473f6de8c",
         "shasum": ""
       },
       "require": {
-        "php": ">=5.6"
+        "php": ">=7.3"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "2.0.x-dev"
+          "dev-master": "3.0-dev"
         }
       },
       "autoload": {
@@ -4099,9 +4385,15 @@
       "homepage": "https://github.com/sebastianbergmann/version",
       "support": {
         "issues": "https://github.com/sebastianbergmann/version/issues",
-        "source": "https://github.com/sebastianbergmann/version/tree/master"
+        "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
       },
-      "time": "2016-10-03T07:35:21+00:00"
+      "funding": [
+        {
+          "url": "https://github.com/sebastianbergmann",
+          "type": "github"
+        }
+      ],
+      "time": "2020-09-28T06:39:44+00:00"
     },
     {
       "name": "theseer/tokenizer",

--- a/test/php/library/shared/communicate/CommunicateTest.php
+++ b/test/php/library/shared/communicate/CommunicateTest.php
@@ -49,10 +49,10 @@ class CommunicateTest extends TestCase
         // What's in the delivery?
         $expectedTo = [$user->email => $user->name];
         $this->assertEquals($expectedTo, $delivery->to);
-        $this->assertNotRegExp("/" . SF_TESTPROJECT . "/", $delivery->subject);
-        $this->assertRegExp("/Name/", $delivery->content);
-        $this->assertRegExp("/" . $user->validationKey . "/", $delivery->content);
-        $this->assertNotRegExp("/" . SF_TESTPROJECT . "/", $delivery->content);
+        $this->assertDoesNotMatchRegularExpression("/" . SF_TESTPROJECT . "/", $delivery->subject);
+        $this->assertMatchesRegularExpression("/Name/", $delivery->content);
+        $this->assertMatchesRegularExpression("/" . $user->validationKey . "/", $delivery->content);
+        $this->assertDoesNotMatchRegularExpression("/" . SF_TESTPROJECT . "/", $delivery->content);
     }
 
     public function testSendSignup_WithProject_PropertiesToFromBodyOk()
@@ -70,9 +70,9 @@ class CommunicateTest extends TestCase
         // What's in the delivery?
         $expectedTo = [$user->email => $user->name];
         $this->assertEquals($expectedTo, $delivery->to);
-        $this->assertRegExp("/Language Forge/", $delivery->subject);
-        $this->assertRegExp("/Name/", $delivery->content);
-        $this->assertRegExp("/" . $user->validationKey . "/", $delivery->content);
+        $this->assertMatchesRegularExpression("/Language Forge/", $delivery->subject);
+        $this->assertMatchesRegularExpression("/Name/", $delivery->content);
+        $this->assertMatchesRegularExpression("/" . $user->validationKey . "/", $delivery->content);
     }
 
     public function testSendInvite_PropertiesFromToBodyOk()
@@ -92,9 +92,12 @@ class CommunicateTest extends TestCase
         // What's in the delivery?
         $expectedTo = [$toUser->email => $toUser->name];
         $this->assertEquals($expectedTo, $delivery->to);
-        $this->assertRegExp("/Inviter User/", $delivery->content);
-        $this->assertRegExp("/\/public\/signup#!\/\?e=" . urlencode($toUser->email) . "/", $delivery->content);
-        $this->assertRegExp("/The Language Forge Team/", $delivery->content);
+        $this->assertMatchesRegularExpression("/Inviter User/", $delivery->content);
+        $this->assertMatchesRegularExpression(
+            "/\/public\/signup#!\/\?e=" . urlencode($toUser->email) . "/",
+            $delivery->content
+        );
+        $this->assertMatchesRegularExpression("/The Language Forge Team/", $delivery->content);
     }
 
     public function testSendNewUserInProject_PropertiesFromToBodyOk()
@@ -112,9 +115,9 @@ class CommunicateTest extends TestCase
         // What's in the delivery?
         $expectedTo = [$toUser->email => $toUser->name];
         $this->assertEquals($expectedTo, $delivery->to);
-        $this->assertRegExp("/To Name/", $delivery->content);
-        $this->assertRegExp("/" . $newUserName . "/", $delivery->content);
-        $this->assertRegExp("/" . $newUserPassword . "/", $delivery->content);
+        $this->assertMatchesRegularExpression("/To Name/", $delivery->content);
+        $this->assertMatchesRegularExpression("/" . $newUserName . "/", $delivery->content);
+        $this->assertMatchesRegularExpression("/" . $newUserPassword . "/", $delivery->content);
     }
 
     public function testSendAddedToProject_PropertiesFromToBodyOk()
@@ -136,7 +139,7 @@ class CommunicateTest extends TestCase
         // What's in the delivery?
         $expectedTo = [$toUser->email => $toUser->name];
         $this->assertEquals($expectedTo, $delivery->to);
-        $this->assertRegExp('/To Name.*\n*Inviter User/', $delivery->content);
+        $this->assertMatchesRegularExpression('/To Name.*\n*Inviter User/', $delivery->content);
     }
 
     public function testSendForgotPasswordVerification_PropertiesFromToBodyOk()
@@ -151,11 +154,11 @@ class CommunicateTest extends TestCase
         // What's in the delivery?
         $expectedTo = [$user->email => $user->name];
         $this->assertEquals($expectedTo, $delivery->to);
-        $this->assertNotRegExp("/<p>/", $delivery->content);
-        $this->assertRegExp("/Name/", $delivery->content);
-        $this->assertRegExp("/" . $user->resetPasswordKey . "/", $delivery->content);
-        $this->assertRegExp("/<p>/", $delivery->htmlContent);
-        $this->assertRegExp("/Name/", $delivery->htmlContent);
-        $this->assertRegExp("/" . $user->resetPasswordKey . "/", $delivery->htmlContent);
+        $this->assertDoesNotMatchRegularExpression("/<p>/", $delivery->content);
+        $this->assertMatchesRegularExpression("/Name/", $delivery->content);
+        $this->assertMatchesRegularExpression("/" . $user->resetPasswordKey . "/", $delivery->content);
+        $this->assertMatchesRegularExpression("/<p>/", $delivery->htmlContent);
+        $this->assertMatchesRegularExpression("/Name/", $delivery->htmlContent);
+        $this->assertMatchesRegularExpression("/" . $user->resetPasswordKey . "/", $delivery->htmlContent);
     }
 }

--- a/test/php/model/languageforge/lexicon/Import/LiftImportTest.php
+++ b/test/php/model/languageforge/lexicon/Import/LiftImportTest.php
@@ -918,7 +918,7 @@ EOD;
         $this->assertEquals("khâaw kài thɔ̂ɔt", $entry1["lexeme"]["th-fonipa"]["value"]); // NFC
         $this->assertEquals("ข้าวไก่ทอด", $entry1["lexeme"]["th"]["value"]);
         $this->assertEquals(true, $report->hasError());
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/processing multitext 'definition', unhandled element 'i', unhandled element 'b', unhandled element 'i', unhandled element 'b'/",
             $reportStr
         );
@@ -1102,7 +1102,10 @@ EOD;
         $this->assertEquals("black bear", $entry1["lexeme"]["qaa-x-qaa"]["value"]);
         $this->assertEquals("This is not a brown bear.", $entry1["note"]["en"]["value"]);
         $this->assertEquals(true, $report->hasError());
-        $this->assertRegExp("/processing multitext 'note', unhandled element 'b', unhandled element 'b'/", $reportStr);
+        $this->assertMatchesRegularExpression(
+            "/processing multitext 'note', unhandled element 'b', unhandled element 'b'/",
+            $reportStr
+        );
     }
 
     // has correct th-fonipa form in each entry
@@ -1242,9 +1245,12 @@ EOD;
             $report->nodeErrors[0]->getSubnodeError(0)->hasError(),
             "should have phony and bogus tag entry errors"
         );
-        $this->assertRegExp("/unhandled element 'bogus'/", $reportStr);
-        $this->assertRegExp("/processing multitext 'lexical-unit', unhandled element 'phony'/", $reportStr);
-        $this->assertNotRegExp("/unhandled element 'translation'/", $reportStr);
+        $this->assertMatchesRegularExpression("/unhandled element 'bogus'/", $reportStr);
+        $this->assertMatchesRegularExpression(
+            "/processing multitext 'lexical-unit', unhandled element 'phony'/",
+            $reportStr
+        );
+        $this->assertDoesNotMatchRegularExpression("/unhandled element 'translation'/", $reportStr);
         $this->assertTrue(
             $report->nodeErrors[0]
                 ->getSubnodeError(0)
@@ -1253,7 +1259,7 @@ EOD;
                 ->hasError(),
             "should have rubbish tag example error"
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/unhandled element 'rubbish'/",
             $report->nodeErrors[0]
                 ->getSubnodeError(0)
@@ -1261,7 +1267,7 @@ EOD;
                 ->currentSubnodeError()
                 ->toString()
         );
-        $this->assertRegExp("/unhandled element 'rubbish'/", $reportStr);
+        $this->assertMatchesRegularExpression("/unhandled element 'rubbish'/", $reportStr);
         $this->assertTrue(
             $report->nodeErrors[0]
                 ->getSubnodeError(1)
@@ -1270,7 +1276,7 @@ EOD;
                 ->hasError(),
             "should have fake tag example error"
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/unhandled element 'fake'/",
             $report->nodeErrors[0]
                 ->getSubnodeError(1)
@@ -1278,7 +1284,7 @@ EOD;
                 ->currentSubnodeError()
                 ->toString()
         );
-        $this->assertRegExp("/unhandled element 'fake'/", $reportStr);
+        $this->assertMatchesRegularExpression("/unhandled element 'fake'/", $reportStr);
     }
 
     // lift with ranges referencing lift-ranges file
@@ -1454,7 +1460,10 @@ EOD;
         $report = $importer->getReport();
         $reportStr = $report->toString();
         $this->assertEquals(true, $report->hasError());
-        $this->assertRegExp("/the lift range 'anthro-code' was not found in the current file/", $reportStr);
+        $this->assertMatchesRegularExpression(
+            "/the lift range 'anthro-code' was not found in the current file/",
+            $reportStr
+        );
         $this->assertEquals(1, $importer->stats->newEntries);
 
         $optionList = new LexOptionListModel($project);
@@ -1605,7 +1614,10 @@ EOD;
         $report = $importer->getReport();
         $reportStr = $report->toString();
         $this->assertEquals(true, $report->hasError());
-        $this->assertRegExp("/the lift range 'dialect' was not found in the current file/", $reportStr);
+        $this->assertMatchesRegularExpression(
+            "/the lift range 'dialect' was not found in the current file/",
+            $reportStr
+        );
     }
 
     public function testLiftImportMerge_NoLiftRanges_Error()
@@ -1620,11 +1632,14 @@ EOD;
         $report = $importer->getReport();
         $reportStr = $report->toString();
         $this->assertEquals(true, $report->hasError());
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/range file 'TestLangProj.lift-ranges' was not found alongside the 'LiftWithRangesV0_13.lift' file/",
             $reportStr
         );
-        $this->assertNotRegExp("/the lift range 'anthro-code' was not found in the current file/", $reportStr);
+        $this->assertDoesNotMatchRegularExpression(
+            "/the lift range 'anthro-code' was not found in the current file/",
+            $reportStr
+        );
     }
 
     public function testLiftImportMerge_NoExistingDataFrenchInputSystem_OnlyImportedInputSystems()

--- a/test/php/model/languageforge/lexicon/Import/LiftImportZipTest.php
+++ b/test/php/model/languageforge/lexicon/Import/LiftImportZipTest.php
@@ -65,7 +65,7 @@ class LiftImportZipTest extends TestCase
         $this->assertEquals("ข้าวไก่ทอด", $entry1["lexeme"]["th"]["value"]);
         $this->assertArrayHasKey("th-fonipa", $project->inputSystems);
         $this->assertEquals(1, $importer->getReport()->hasError());
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/range file 'TestProj.lift-ranges' was not found/",
             $importer->getReport()->toFormattedString()
         );
@@ -150,8 +150,8 @@ class LiftImportZipTest extends TestCase
         $reportStr = $report->toString();
 
         $this->assertEquals(true, $report->hasError(), "should have NodeError");
-        $this->assertRegExp("/unhandled LIFT file/", $reportStr);
-        $this->assertRegExp("/unhandled subfolder 'OddFolder'/", $reportStr);
+        $this->assertMatchesRegularExpression("/unhandled LIFT file/", $reportStr);
+        $this->assertMatchesRegularExpression("/unhandled subfolder 'OddFolder'/", $reportStr);
     }
 
     // the following EOD must retain the embedded tabs. IJH 2015-02
@@ -203,6 +203,6 @@ EOD;
         //         echo $report->toFormattedString();
         //         echo "</pre>";
 
-        $this->assertRegExp("/" . self::zipImportReport . "/", $report->toFormattedString());
+        $this->assertMatchesRegularExpression("/" . self::zipImportReport . "/", $report->toFormattedString());
     }
 }

--- a/test/php/model/languageforge/lexicon/LexProjectModelTest.php
+++ b/test/php/model/languageforge/lexicon/LexProjectModelTest.php
@@ -135,8 +135,8 @@ class LexProjectModelTest extends TestCase
 
         // Verify
         $this->assertNoException();
-        $this->assertFileNotExists($projectStatePath);
-        $this->assertDirectoryNotExists($projectWorkPath);
+        $this->assertFileDoesNotExist($projectStatePath);
+        $this->assertDirectoryDoesNotExist($projectWorkPath);
         FileUtilities::removeFolderAndAllContents($baseDirForSendReceive);
     }
 
@@ -160,9 +160,9 @@ class LexProjectModelTest extends TestCase
 
         // Verify
         $this->assertNoException();
-        $this->assertFileNotExists($projectStatePath);
-        $this->assertDirectoryNotExists($projectWorkPath);
-        $this->assertFileNotExists($projectWorkPath);
+        $this->assertFileDoesNotExist($projectStatePath);
+        $this->assertDirectoryDoesNotExist($projectWorkPath);
+        $this->assertFileDoesNotExist($projectWorkPath);
         FileUtilities::removeFolderAndAllContents($baseDirForSendReceive);
     }
 }

--- a/test/php/model/languageforge/lexicon/command/LexUploadCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexUploadCommandsTest.php
@@ -41,12 +41,12 @@ class LexUploadCommandsTest extends TestCase
         $projectSlug = $project->databaseName();
 
         $this->assertTrue($response->result, "Upload should succeed");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/lexicon\/$projectSlug\/audio/",
             $response->data->path,
             "Uploaded audio file path should be in the right location"
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/$fileName/",
             $response->data->fileName,
             "Uploaded audio fileName should contain the original fileName"
@@ -67,12 +67,12 @@ class LexUploadCommandsTest extends TestCase
         $filePath = $folderPath . DIRECTORY_SEPARATOR . $response->data->fileName;
 
         $this->assertTrue($response->result, "Upload should succeed");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/$fileName/",
             $response->data->fileName,
             "Uploaded audio fileName should contain the original fileName"
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/(?<!\d)\d{14}(?!\d)/",
             $response->data->fileName,
             "Uploaded audio fileName should have a timestamp fileName prefix"
@@ -94,12 +94,12 @@ class LexUploadCommandsTest extends TestCase
         $projectSlug = $project->databaseName();
 
         $this->assertTrue($response->result, "Upload should succeed");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/lexicon\/$projectSlug\/audio/",
             $response->data->path,
             "Uploaded audio file path should be in the right location"
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/$fileName/",
             $response->data->fileName,
             "Uploaded audio fileName should contain the original fileName"
@@ -117,7 +117,7 @@ class LexUploadCommandsTest extends TestCase
 
         $this->assertFalse($response->result, "Upload should fail");
         $this->assertEquals("UserMessage", $response->data->errorType, "Error response should be a user message");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/not an allowed audio file/",
             $response->data->errorMessage,
             "Error message should match the error"
@@ -129,7 +129,7 @@ class LexUploadCommandsTest extends TestCase
 
         $this->assertFalse($response->result, "Upload should fail");
         $this->assertEquals("UserMessage", $response->data->errorType, "Error response should be a user message");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/not an allowed audio file/",
             $response->data->errorMessage,
             "Error message should match the error"
@@ -158,12 +158,12 @@ class LexUploadCommandsTest extends TestCase
         $previousFilePath = $folderPath . DIRECTORY_SEPARATOR . $_POST["previousFilename"];
 
         $this->assertTrue($response->result, "Upload should succeed");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/lexicon\/$projectSlug\/audio/",
             $response->data->path,
             "Uploaded audio file path should be in the right location"
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/$fileName/",
             $response->data->fileName,
             "Uploaded audio fileName should contain the original fileName"
@@ -186,12 +186,12 @@ class LexUploadCommandsTest extends TestCase
         $projectSlug = $project->databaseName();
 
         $this->assertTrue($response->result, "Upload should succeed");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/lexicon\/$projectSlug\/pictures/",
             $response->data->path,
             "Uploaded image file path should be in the right location"
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/$fileName/",
             $response->data->fileName,
             "Uploaded image fileName should contain the original fileName"
@@ -212,12 +212,12 @@ class LexUploadCommandsTest extends TestCase
         $filePath = $folderPath . DIRECTORY_SEPARATOR . $response->data->fileName;
 
         $this->assertTrue($response->result, "Upload should succeed");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/$fileName/",
             $response->data->fileName,
             "Uploaded image fileName should contain the original fileName"
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/(?<!\d)\d{14}(?!\d)/",
             $response->data->fileName,
             "Uploaded image fileName should have a timestamp fileName prefix"
@@ -235,7 +235,7 @@ class LexUploadCommandsTest extends TestCase
 
         $this->assertFalse($response->result, "Upload should fail");
         $this->assertEquals("UserMessage", $response->data->errorType, "Error response should be a user message");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/not an allowed image file/",
             $response->data->errorMessage,
             "Error message should match the error"
@@ -247,7 +247,7 @@ class LexUploadCommandsTest extends TestCase
 
         $this->assertFalse($response->result, "Upload should fail");
         $this->assertEquals("UserMessage", $response->data->errorType, "Error response should be a user message");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/not an allowed image file/",
             $response->data->errorMessage,
             "Error message should match the error"
@@ -330,7 +330,7 @@ class LexUploadCommandsTest extends TestCase
         $projectSlug = $project->databaseName();
 
         $this->assertTrue($response->result, "Import should succeed");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/lexicon\/$projectSlug/",
             $response->data->path,
             "Uploaded zip file path should be in the right location"
@@ -405,7 +405,7 @@ class LexUploadCommandsTest extends TestCase
 
         // stats OK?
         $this->assertTrue($response->result, "Import should succeed");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/lexicon\/$projectSlug/",
             $response->data->path,
             "Uploaded zip file path should be in the right location"
@@ -518,7 +518,7 @@ class LexUploadCommandsTest extends TestCase
 
         $this->assertFalse($response->result, "Import should fail");
         $this->assertEquals("UserMessage", $response->data->errorType, "Error response should be a user message");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/not an allowed compressed file/",
             $response->data->errorMessage,
             "Error message should match the error"
@@ -530,7 +530,7 @@ class LexUploadCommandsTest extends TestCase
 
         $this->assertFalse($response->result, "Import should fail");
         $this->assertEquals("UserMessage", $response->data->errorType, "Error response should be a user message");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/not an allowed compressed file/",
             $response->data->errorMessage,
             "Error message should match the error"
@@ -575,12 +575,12 @@ EOD;
         $projectSlug = $project->databaseName();
 
         $this->assertTrue($response->result, "Import should succeed");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/lexicon\/$projectSlug/",
             $response->data->path,
             "Uploaded zip file path should be in the right location"
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/$fileName/",
             $response->data->fileName,
             "Imported LIFT fileName should contain the original fileName"
@@ -604,8 +604,8 @@ EOD;
         $tmpFilePath = self::$environ->uploadLiftFile(self::liftOneEntryV0_13, $fileName, LiftMergeRule::IMPORT_LOSES);
         $response = LexUploadCommands::importLiftFile($projectId, $tmpFilePath);
         $this->assertTrue($response->result, "Import should succeed");
-        $this->assertRegExp("/lexicon\/$projectSlug/", $response->data->path);
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression("/lexicon\/$projectSlug/", $response->data->path);
+        $this->assertMatchesRegularExpression(
             "/$fileName/",
             $response->data->fileName,
             "Imported LIFT fileName should contain the original fileName"
@@ -686,7 +686,7 @@ EOD;
 
         $this->assertFalse($response->result, "Import should fail");
         $this->assertEquals("UserMessage", $response->data->errorType, "Error response should be a user message");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/not an allowed LIFT file/",
             $response->data->errorMessage,
             "Error message should match the error"
@@ -698,7 +698,7 @@ EOD;
 
         $this->assertFalse($response->result, "Import should fail");
         $this->assertEquals("UserMessage", $response->data->errorType, "Error response should be a user message");
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/not an allowed LIFT file/",
             $response->data->errorMessage,
             "Error message should match the error"

--- a/test/php/model/languageforge/lexicon/command/SendReceiveCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/SendReceiveCommandsTest.php
@@ -192,7 +192,7 @@ class SendReceiveCommandsTest extends TestCase
         $filename = SendReceiveCommands::queueProjectForEdit($projectId, $mockEditQueuePath);
 
         $queueFileNames = scandir($mockEditQueuePath);
-        $this->assertRegExp("/" . $project->projectCode . "/", $filename);
+        $this->assertMatchesRegularExpression("/" . $project->projectCode . "/", $filename);
         $this->assertCount(3, $queueFileNames);
         FileUtilities::removeFolderAndAllContents($mockEditQueuePath);
     }

--- a/test/php/model/shared/commands/UserCommandsTest.php
+++ b/test/php/model/shared/commands/UserCommandsTest.php
@@ -602,8 +602,8 @@ class UserCommandsTest extends TestCase
         $senderEmail = "no-reply@" . UrlHelper::getHostname();
         $expectedTo = [$toUser->emailPending => $toUser->name];
         $this->assertEquals($expectedTo, $delivery->to);
-        $this->assertRegExp("/Inviting Name/", $delivery->content);
-        $this->assertRegExp("/Test Project/", $delivery->content);
+        $this->assertMatchesRegularExpression("/Inviting Name/", $delivery->content);
+        $this->assertMatchesRegularExpression("/Test Project/", $delivery->content);
     }
 
     /** @throws Exception */
@@ -625,8 +625,8 @@ class UserCommandsTest extends TestCase
         $expectedTo = [$toUser->email => $toUser->name];
         $this->assertEquals($someoneUserId, $toUserId);
         $this->assertEquals($expectedTo, $delivery->to);
-        $this->assertRegExp("/Inviting Name/", $delivery->content);
-        $this->assertRegExp("/Test Project/", $delivery->content);
+        $this->assertMatchesRegularExpression("/Inviting Name/", $delivery->content);
+        $this->assertMatchesRegularExpression("/Test Project/", $delivery->content);
     }
 
     /** @throws Exception */
@@ -650,9 +650,12 @@ class UserCommandsTest extends TestCase
         $expectedTo = [$toUser->emailPending => $toUser->name];
         $this->assertEquals($toUser1Id, $toUser2Id);
         $this->assertEquals($expectedTo, $delivery->to);
-        $this->assertRegExp("/Inviting Name/", $delivery->content);
-        $this->assertRegExp("/Test Project/", $delivery->content);
-        $this->assertRegExp("/public\/signup#!\/\?e=" . urlencode($toUser->emailPending) . "/", $delivery->content);
+        $this->assertMatchesRegularExpression("/Inviting Name/", $delivery->content);
+        $this->assertMatchesRegularExpression("/Test Project/", $delivery->content);
+        $this->assertMatchesRegularExpression(
+            "/public\/signup#!\/\?e=" . urlencode($toUser->emailPending) . "/",
+            $delivery->content
+        );
     }
 
     /** @throws Exception */

--- a/test/php/phpunit.xml
+++ b/test/php/phpunit.xml
@@ -1,47 +1,26 @@
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
-    backupGlobals="true"
-    backupStaticAttributes="false"
-    bootstrap="TestConfig.php"
-    cacheTokens="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    forceCoversAnnotation="false"
-    processIsolation="false"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
-    stopOnRisky="false"
-    timeoutForSmallTests="1"
-    timeoutForMediumTests="10"
-    timeoutForLargeTests="60"
-    verbose="true"
->
-    <php>
-        <ini name="xdebug.show_exception_trace" value="0"/>
-    </php>
-    <testsuites>
-        <testsuite name="xForge all PHP unit tests">
-            <directory>./</directory>
-            <exclude>./library/shared/LanguageDataTest.php</exclude>
-        </testsuite>
-    </testsuites>
-    <groups>
-        <exclude>
-            <group>explicit</group>
-        </exclude>
-    </groups>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">../../src/Api</directory>
-            <exclude>
-                <directory>../../src/Api/Library/Shared/Script</directory>
-                <directory>../../src/Api/Library/Shared/CLI</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="true" backupStaticAttributes="false" bootstrap="TestConfig.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" forceCoversAnnotation="false" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" stopOnRisky="false" timeoutForSmallTests="1" timeoutForMediumTests="10" timeoutForLargeTests="60" verbose="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">../../src/Api</directory>
+    </include>
+    <exclude>
+      <directory>../../src/Api/Library/Shared/Script</directory>
+      <directory>../../src/Api/Library/Shared/CLI</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <ini name="xdebug.show_exception_trace" value="0"/>
+  </php>
+  <testsuites>
+    <testsuite name="xForge all PHP unit tests">
+      <directory>./</directory>
+      <exclude>./library/shared/LanguageDataTest.php</exclude>
+    </testsuite>
+  </testsuites>
+  <groups>
+    <exclude>
+      <group>explicit</group>
+    </exclude>
+  </groups>
 </phpunit>


### PR DESCRIPTION
## Description

- Upgrade PHPUnit to v9.5
- prefix composer-dev image name with `lf-`
- fix PHPUnit method names that have been deprecated
- migrated PHPUnit config file to latest schema

### Type of Change

- PHP dependency upgrade

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## How to test

This is considered tested when PHP unit tests are passing