### PR TITLE
enable webkit e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, firefox]
+        browser: [chromium, firefox, webkit]
         shard: [1, 2, 3, 4, 5, 6]
         shards: [6]
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ e2e-tests-ci:
 e2e-tests: ui-builder
 	npm install
 	$(MAKE) e2e-app
-	npx playwright install chromium firefox
+	npx playwright install chromium firefox webkit
 	npx playwright test -c ./test/e2e/playwright.config.ts $(params)
 
 .PHONY: e2e-app

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -78,12 +78,12 @@ const config: PlaywrightTestConfig = {
       },
     },
 
-    // {
-    //   name: 'webkit',
-    //   use: {
-    //     ...devices['Desktop Safari'],
-    //   },
-    // },
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
   ],
 
   /**


### PR DESCRIPTION
Fixes #1681 

## Description

This is a draft PR for enabling webkit E2E tests.  There are currently 4 failing tests.

### Type of Change

- E2E testing

## Checklist

- [ ] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have enabled auto-merge (optional)

## How to test

All E2E tests should be passing