### PR TITLE
enable xdebug for PHP tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -286,12 +286,10 @@ services:
       - MONGODB_CONN=mongodb://db:27017
       - MAIL_HOST=mail
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
-      # Note: Uncomment to enable XDebug in Unit Tests.  The default mode is "off".
-      # These lines are commented out as this XDebug setup causes CI failures.
-      # XDebug is intended for local development only.  Uncomment the following 3 lines:
-      # - XDEBUG_MODE=develop,debug
-    # extra_hosts:
-      # - "host.docker.internal:host-gateway"
+      - XDEBUG_MODE=develop,debug
+    # used by XDebug
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     command: sh -c "/wait && /run.sh"
     volumes:
       # for developer convenience

--- a/docker/test-php/Dockerfile
+++ b/docker/test-php/Dockerfile
@@ -9,9 +9,8 @@ RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
 COPY src/composer.json src/composer.lock /var/www/html/
 RUN composer install
 
-# uncomment if you want xdebug in your local image
-#RUN install-php-extensions xdebug
-#COPY docker/app/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d
+RUN install-php-extensions xdebug
+COPY docker/app/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d
 
 RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -151,14 +151,6 @@ A [tutorial on YouTube is available showing how to use XDebug and VSCode](https:
 
 To debug the PHP tests, follow these steps:
 
-- uncomment the 3 lines in the docker-compose.yml file related to XDebug under the service section `test-php`:
-
-```
-       - XDEBUG_MODE=develop,debug
-     extra_hosts:
-       - "host.docker.internal:host-gateway
-```
-
 - In VS Code, set a breakpoint on a line of code in one of the PHP tests (in the `test/php` folder)
 - Click on the `Run and Debug` area of VS Code, then click the green play icon next to `XDebug` in the configuration dropdown.
 


### PR DESCRIPTION
## Description

While this might make our tests run slightly slower when we don't want to debug, it simplifies the process for the developer - they always know that they can set a breakpoint and debug PHP tests

### Type of Change

- chore

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have enabled auto-merge (optional)

## How to test

PHP unit tests pass