### PR TITLE
Use new LfMerge version with 10MB file size limit

### DIFF
--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.131
+FROM ghcr.io/sillsdev/lfmerge:2.0.132
 # Do not add anything to this Dockerfile, it should stay empty

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-audio.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-audio.component.ts
@@ -115,8 +115,9 @@ export class FieldAudioController implements angular.IController {
             this.dcFilename = response.data.data.fileName;
             this.showAudioUpload = false;
             this.notice.push(this.notice.SUCCESS, 'File uploaded successfully.');
-            if(response.data.data.fileSize > 1000000){ //1 MB file size limit 2022-10
-              this.notice.push(this.notice.WARN, 'WARNING: Because the audio file - ' + response.data.data.fileName + ' - is larger than 1 MB, it will not be synced with FLEx.');
+            if (response.data.data.fileSize > 10000000) {
+              // `MaximumFileSize` in https://github.com/sillsdev/chorus/blob/master/src/LibChorus/FileTypeHandlers/audio/AudioFileTypeHandler.cs
+              this.notice.push(this.notice.WARN, 'WARNING: Because the audio file - ' + response.data.data.fileName + ' - is larger than 10 MB, it will not be synced with FLEx.');
             }
           } else {
             this.notice.push(this.notice.ERROR, response.data.data.errorMessage);

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-picture.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-picture.component.ts
@@ -113,8 +113,9 @@ export class FieldPictureController implements angular.IController {
           if (isUploadSuccess) {
             this.upload.progress = 100.0;
             this.addPicture(response.data.data.fileName);
-            if(response.data.data.fileSize > 1000000){ //1 MB file size limit 2022-10
-              this.notice.push(this.notice.WARN, 'WARNING: Because the image file - ' + response.data.data.fileName + ' - is larger than 1 MB, it will not be synced with FLEx.');
+            if (response.data.data.fileSize > 10000000) {
+              // `MaximumFileSize` in https://github.com/sillsdev/chorus/blob/master/src/LibChorus/FileTypeHandlers/image/ImageFileTypeHandler.cs
+              this.notice.push(this.notice.WARN, 'WARNING: Because the image file - ' + response.data.data.fileName + ' - is larger than 10 MB, it will not be synced with FLEx.');
             }
             this.upload.showAddPicture = false;
           } else {


### PR DESCRIPTION
Fixes #1679

## Description

Makes use of the new 10MB file size limit in LfMerge/Chorus.
Adapts the file-szie warnings accordingly.

### Type of Change

- New feature

## Screenshots

Updated warning:
![image](https://user-images.githubusercontent.com/12587509/212046815-48aa2726-199b-4c1d-a8b2-536bf8f167a6.png)

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have enabled auto-merge (optional)

## How to test

1)
Add these images:
- [5 MB](https://user-images.githubusercontent.com/12587509/212048566-544053bf-5f2f-47fd-b13e-79caa8564597.jpg)
- [8.7 MB](https://user-images.githubusercontent.com/12587509/212048963-3ac31cf3-fa5e-493c-85e9-afca1e193053.jpg)
- [10+ MB](https://sample-videos.com/img/Sample-jpg-image-10mb.jpg)

And this audio file (just if you're curious, it's an mp3, but GitHub doesn't like that file extension):
- [5 MB](https://user-images.githubusercontent.com/12587509/212052285-68d596b7-d79f-4d78-9348-73c09f12fedb.webm)

...to an entry.

2) Sync the project with LD

3) Sync the same project in FLEx OR (I think this is legit 🤔) delete the project in LF and then add it again

4) Verify that all the files except the 10+MB image are in FLEx or the new LF project

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
