### PR TITLE
Bug/share with others dialog opening when it shouldnt

### DIFF
--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -73,7 +73,8 @@
                             {% verbatim %}
                             <div data-ng-repeat="setting in $ctrl.header.settings">
                                 <div class="dropdown-divider" data-ng-show="setting.divider"></div>
-                                <a id="{{ setting.id }}" class="dropdown-item" data-ng-href="{{ setting.href }}" ng-click="$ctrl.openShareWithOthersModal()">{{ setting.label }}</a>
+                                <a ng-if="setting.id === 'userManagementLink'" id="{{ setting.id }}" class="dropdown-item" data-ng-href="{{ setting.href }}" ng-click="$ctrl.openShareWithOthersModal()">{{ setting.label }}</a>
+                                <a ng-if="setting.id !== 'userManagementLink'" id="{{ setting.id }}" class="dropdown-item" data-ng-href="{{ setting.href }}">{{ setting.label }}</a>
                             </div>
                             {% endverbatim %}
                         </div>

--- a/src/angular-app/languageforge/lexicon/core/lexicon-project.service.ts
+++ b/src/angular-app/languageforge/lexicon/core/lexicon-project.service.ts
@@ -54,7 +54,7 @@ export class LexiconProjectService {
         settings.push(new HeaderSetting(
           'userManagementLink',
           'Share With Others',
-          '#',
+          '',
           false
         ));
         settings.push(new HeaderSetting(

--- a/test/e2e/pages/home.page.ts
+++ b/test/e2e/pages/home.page.ts
@@ -4,6 +4,7 @@ import { BasePage } from './base-page';
 export class HomePage extends BasePage {
   readonly signupButton = this.locator('a:text("Sign Up"):visible');
   readonly loginButton = this.locator('a:text("Login"):visible');
+  readonly termsAndConditionsLink = this.locator('a:text("terms and conditions"):visible');
   readonly additionalResourceLinkContainer = this.locator('section:has-text("Additional Resources") .actions li');
   readonly videoIFrame = this.locator('div.videoWrapper iframe');
 

--- a/test/e2e/pages/index.ts
+++ b/test/e2e/pages/index.ts
@@ -14,3 +14,4 @@ export * from './signup.page';
 export * from './site-admin.page';
 export * from './user-profile.page';
 export * from './home.page';
+export * from './terms-and-conditions.page';

--- a/test/e2e/pages/terms-and-conditions.page.ts
+++ b/test/e2e/pages/terms-and-conditions.page.ts
@@ -1,0 +1,9 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base-page';
+
+export class TermsAndConditionsPage extends BasePage {
+
+  constructor(page: Page) {
+    super(page, '/terms_and_conditions', page.locator(':text("Website Terms of Use")'));
+  }
+}

--- a/test/e2e/pages/user-profile.page.ts
+++ b/test/e2e/pages/user-profile.page.ts
@@ -27,6 +27,8 @@ export class UserProfilePage extends BasePage {
     saveChangesBtn: this.locator('.modal-dialog button:has-text("Save changes")'),
   };
 
+  private readonly successNotice = this.noticeList.success('Profile updated successfully');
+
   constructor(page: Page) {
     super(page, '/app/userprofile', page.locator('.page-name >> text=\'s User Profile'));
   }
@@ -34,11 +36,11 @@ export class UserProfilePage extends BasePage {
   async save(): Promise<void> {
     await this.saveBtn.click();
 
-    if (await this.modal.saveChangesBtn.isVisible()) {
-      // Some changes require confirmation and log the user out
-      await this.modal.saveChangesBtn.click();
-    } else {
-      await this.noticeList.success('Profile updated successfully').waitFor();
-    }
+    await Promise.race([
+      // Some changes require confirmation and then log the user out (e.g. username)
+      this.modal.saveChangesBtn.click(),
+      // others just show a success message
+      this.successNotice.waitFor(),
+    ]);
   }
 }

--- a/test/e2e/tests/homepage.spec.ts
+++ b/test/e2e/tests/homepage.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { test } from '../fixtures';
-import { HomePage, LoginPage, SignupPage } from '../pages';
+import { HomePage, LoginPage, SignupPage, TermsAndConditionsPage } from '../pages';
 
 test.describe('Homepage', () => {
 
@@ -8,6 +8,11 @@ test.describe('Homepage', () => {
     const homePage = await HomePage.goto(tab);
     await expect(homePage.additionalResourceLinkContainer.first()).not.toBeEmpty();
     await expect(homePage.videoIFrame).toBeVisible();
+
+    await Promise.all([
+      homePage.termsAndConditionsLink.click(),
+      TermsAndConditionsPage.waitFor(tab),
+    ]);
   });
 
   test('Signup and login buttons', async ({ tab }) => {

--- a/test/e2e/tests/terms-and-conditions.spec.ts
+++ b/test/e2e/tests/terms-and-conditions.spec.ts
@@ -1,0 +1,11 @@
+import { expect } from '@playwright/test';
+import { test } from '../fixtures';
+import { TermsAndConditionsPage } from '../pages';
+
+test.describe('Terms and conditions', () => {
+
+  test('Content', async ({ tab }) => {
+    const termsPage = await TermsAndConditionsPage.goto(tab);
+    await expect(termsPage.locator(':text("PLEASE REVIEW BEFORE USING THIS WEBSITE")')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Fixes #1687

## Description

- Stop "Share with Others" dialog from opening when any Settings link is clicked.
- Stop "Share wtih Others" link from redirecting to editor
- Bonus: Fix flaky E2E test and add tests for terms and conditions

I messed up the "Share with Others" dialog quite a while ago. Fortunately, it didn't break any workflows, but it could be pretty annoying.

## Screenshots

https://user-images.githubusercontent.com/12587509/212072044-e1605059-4435-4c6c-b707-af77cd87c494.mp4

## Type of Change

- Bug fix

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have enabled auto-merge (optional)

## How to test

- Click on Settings > Configuration: The "Share with Others" dialog should not open
- On Configuration page click on Settings > Share with Others: The Share with others dialog should open and the user should stay on the Configuration page

## qa.languageforge.org testing

Testers should add his/her findings to end of the PR in a comment and include screenshots, files, etc that are beneficial.
