### PR TITLE
Upgrade to PHP 7.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
       - SMTP_USERNAME=username
       - SMTP_PASSWORD=password
       - SERVER_HOSTNAME=nobody.localhost
-    command: sh -c "postconf -e 'default_transport = retry:no outbound email allowed' && /run.sh"
+    command: sh -c "postconf -e 'default_transport = discard' && /run.sh"
 
   db:
     image: mongo:6

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -38,7 +38,7 @@ RUN npm run build:${NPM_BUILD_SUFFIX}
 # COMPOSER-BUILDER
 # download composer app dependencies
 # git - needed for composer install
-FROM sillsdev/web-languageforge:base-php AS composer-builder
+FROM sillsdev/web-languageforge:base-php-7.4 AS composer-builder
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
     && install-php-extensions @composer
@@ -47,7 +47,7 @@ COPY src/composer.json src/composer.lock /composer/
 RUN composer install
 
 # PRODUCTION IMAGE
-FROM sillsdev/web-languageforge:base-php AS production-app
+FROM sillsdev/web-languageforge:base-php-7.4 AS production-app
 RUN rm /usr/local/bin/install-php-extensions
 RUN apt-get remove -y gnupg2
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
@@ -55,7 +55,7 @@ RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait
 
 # DEVELOPMENT IMAGE
-FROM sillsdev/web-languageforge:base-php AS development-app
+FROM sillsdev/web-languageforge:base-php-7.4 AS development-app
 RUN install-php-extensions xdebug-^3.1
 COPY docker/app/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d
 RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini

--- a/docker/test-php/Dockerfile
+++ b/docker/test-php/Dockerfile
@@ -1,4 +1,4 @@
-FROM sillsdev/web-languageforge:base-php
+FROM sillsdev/web-languageforge:base-php-7.4
 
 
 # ----- LINES BELOW COPIED FROM APP DOCKERFILE ----------

--- a/src/Api/Library/Shared/Communicate/Email.php
+++ b/src/Api/Library/Shared/Communicate/Email.php
@@ -16,13 +16,13 @@ class Email
     public static function send($from, $to, $subject, $content, $htmlContent = "")
     {
         // Create the Transport
-        $transport = \Swift_SmtpTransport::newInstance(Env::requireEnv("MAIL_HOST"));
+        $transport = new \Swift_SmtpTransport(Env::requireEnv("MAIL_HOST"));
 
         // Create the Mailer using your created Transport
-        $mailer = \Swift_Mailer::newInstance($transport);
+        $mailer = new \Swift_Mailer($transport);
 
         // Create a message
-        $message = \Swift_Message::newInstance($subject);
+        $message = new \Swift_Message($subject);
         $message->setFrom($from);
         $message->setTo($to);
         $message->setBody($content);

--- a/src/Api/Library/Shared/LanguageData.php
+++ b/src/Api/Library/Shared/LanguageData.php
@@ -55,7 +55,7 @@ class LanguageData extends MapOf
         $unlisted = new Language("Unlisted Language", "qaa");
         $unlisted->country[] = "?";
         $unlistedCode = $unlisted->code->three;
-        if (!array_key_exists($unlistedCode, $this)) {
+        if (!$this->offsetExists($unlistedCode)) {
             $this[$unlistedCode] = $unlisted;
         }
     }

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexEntryCommands.php
@@ -49,7 +49,7 @@ class LexEntryCommands
         foreach ($parts as $part) {
             // Strip away anything after a @ character
             $fieldName = explode("@", $part, 2)[0];
-            if (array_key_exists($fieldName, $currentList->fields)) {
+            if ($currentList->fields->offsetExists($fieldName)) {
                 /** @var LexConfig $fieldConfig */
                 $fieldConfig = $currentList->fields[$fieldName];
                 $result = $fieldConfig->label;
@@ -198,7 +198,7 @@ class LexEntryCommands
         $entry = new LexEntryModel($project, $entryId);
         $inputSystems = $project->config->entry->fields[LexConfig::LEXEME]->inputSystems;
         foreach ($inputSystems as $inputSystem) {
-            if (array_key_exists($inputSystem, $entry->lexeme) && !empty($entry->lexeme[$inputSystem])) {
+            if ($entry->lexeme->offsetExists($inputSystem) && !empty($entry->lexeme[$inputSystem])) {
                 return $entry->lexeme[$inputSystem]->value;
             }
         }

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexEntryDecoder.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexEntryDecoder.php
@@ -13,13 +13,13 @@ class LexEntryDecoder extends JsonDecoder
      * @param array $values A mixed array of JSON (like) data.
      * @param string $id
      */
-    public static function decode($model, $values, $id = "")
+    public static function decode($model, array $values, $id = "")
     {
         $decoder = new LexEntryDecoder();
         $decoder->_decode($model, $values, $id);
     }
 
-    protected function _decode($model, $values, $id)
+    protected function _decode($model, array $values, string $id)
     {
         switch (get_class($model)) {
             case "Api\Model\Languageforge\Lexicon\LexMultiParagraph":

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexProjectCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexProjectCommands.php
@@ -120,7 +120,7 @@ class LexProjectCommands
     public static function createNewCustomFieldViews($customFieldName, $customFieldType, &$config)
     {
         foreach ($config->roleViews as $role => $roleView) {
-            if (!array_key_exists($customFieldName, $roleView->fields)) {
+            if (!$roleView->fields->offsetExists($customFieldName)) {
                 if ($customFieldType == "MultiUnicode" || $customFieldType == "MultiString") {
                     $roleView->fields[$customFieldName] = new LexViewMultiTextFieldConfig();
                 } else {
@@ -133,7 +133,7 @@ class LexProjectCommands
         }
 
         foreach ($config->userViews as $userId => $userView) {
-            if (!array_key_exists($customFieldName, $userView->fields)) {
+            if (!$userView->fields->offsetExists($customFieldName)) {
                 if ($customFieldType == "MultiUnicode" || $customFieldType == "MultiString") {
                     $userView->fields[$customFieldName] = new LexViewMultiTextFieldConfig();
                 } else {
@@ -181,7 +181,7 @@ class LexProjectCommands
         }
 
         foreach ($customFieldNamesToRemove as $customFieldName) {
-            if (array_key_exists($customFieldName, $view->fields)) {
+            if ($view->fields->offsetExists($customFieldName)) {
                 unset($view->fields[$customFieldName]);
             }
         }

--- a/src/Api/Model/Languageforge/Lexicon/Config/LexConfig.php
+++ b/src/Api/Model/Languageforge/Lexicon/Config/LexConfig.php
@@ -93,7 +93,7 @@ class LexConfig extends ObjectForEncoding
      *
      * @var array
      */
-    private static $flexOptionlistCodes = [
+    private static array $flexOptionlistCodes = [
         self::POS => "grammatical-info",
         self::SEMDOM => "semantic-domain-ddp4",
         self::ENVIRONMENTS => self::ENVIRONMENTS,

--- a/src/Api/Model/Languageforge/Lexicon/Config/LexRoleViewConfig.php
+++ b/src/Api/Model/Languageforge/Lexicon/Config/LexRoleViewConfig.php
@@ -10,7 +10,7 @@ class LexRoleViewConfig
     public function __construct()
     {
         $this->inputSystems = new ArrayOf();
-        $this->fields = new MapOf(function ($data) {
+        $this->fields = new MapOf(function (array $data) {
             if (array_key_exists("overrideInputSystems", $data)) {
                 return new LexViewMultiTextFieldConfig();
             } else {

--- a/src/Api/Model/Languageforge/Lexicon/Dto/LexDbeDto.php
+++ b/src/Api/Model/Languageforge/Lexicon/Dto/LexDbeDto.php
@@ -72,9 +72,10 @@ class LexDbeDto
             }, $deletedCommentsModel->entries);
         }
 
+        // @type ArrayOf
         $lexemeInputSystems = $project->config->entry->fields[LexConfig::LEXEME]->inputSystems;
 
-        usort($entries, function ($a, $b) use ($lexemeInputSystems) {
+        usort($entries, function (array $a, array $b) use ($lexemeInputSystems) {
             $lexeme1Value = "";
             if (array_key_exists(LexConfig::LEXEME, $a)) {
                 $lexeme1 = $a[LexConfig::LEXEME];

--- a/src/Api/Model/Languageforge/Lexicon/Import/LiftDecoder.php
+++ b/src/Api/Model/Languageforge/Lexicon/Import/LiftDecoder.php
@@ -572,7 +572,7 @@ class LiftDecoder
      * @param string $nodeId
      * @return boolean
      */
-    public function isExampleCustomField($nodeId)
+    public function isExampleCustomField(string $nodeId)
     {
         return $this->isCustomField($nodeId, "LexExampleSentence");
     }
@@ -584,7 +584,7 @@ class LiftDecoder
      * @param string $levelClass
      * @return boolean
      */
-    private function isCustomField($nodeId, $levelClass)
+    private function isCustomField(string $nodeId, string $levelClass)
     {
         $fieldType = FileUtilities::replaceSpecialCharacters($nodeId);
         $customFieldSpecs = $this->getCustomFieldSpecs($fieldType);

--- a/src/Api/Model/Languageforge/Lexicon/Import/LiftDecoder.php
+++ b/src/Api/Model/Languageforge/Lexicon/Import/LiftDecoder.php
@@ -690,7 +690,7 @@ class LiftDecoder
             $item->customFields[$customFieldName] = new LexValue();
             $item->customFields[$customFieldName]->value((string) $sxeNode["value"]);
         } elseif ($customFieldSpecs["Type"] == "ReferenceCollection") {
-            if (!array_key_exists($customFieldName, $item->customFields)) {
+            if (!$item->customFields->offsetExists($customFieldName)) {
                 $item->customFields[$customFieldName] = new LexMultiValue();
             }
             $item->customFields[$customFieldName]->value((string) $sxeNode["value"]);
@@ -717,7 +717,7 @@ class LiftDecoder
     {
         $customFieldName = $customFieldNamePrefix . str_replace(" ", "_", $fieldType);
         $levelConfig->fieldOrder->ensureValueExists($customFieldName);
-        if (!array_key_exists($customFieldName, $levelConfig->fields)) {
+        if (!$levelConfig->fields->offsetExists($customFieldName)) {
             if ($customFieldSpecs["Type"] == "ReferenceAtom") {
                 $levelConfig->fields[$customFieldName] = new LexConfigOptionList();
                 $levelConfig->fields[$customFieldName]->listCode = $customFieldSpecs["range"];

--- a/src/Api/Model/Languageforge/Lexicon/Import/LiftImport.php
+++ b/src/Api/Model/Languageforge/Lexicon/Import/LiftImport.php
@@ -303,7 +303,7 @@ class LiftImport
         $optionList->items->exchangeArray([]);
 
         foreach ($liftRange->rangeElements as $id => $elem) {
-            if ($elem->label && array_key_exists($interfaceLang, $elem->label)) {
+            if ($elem->label && $elem->label->offsetExists($interfaceLang)) {
                 $label = $elem->label[$interfaceLang]->value;
                 if (isset($elem->abbrev) && isset($elem->abbrev[$interfaceLang])) {
                     $abbrev = $elem->abbrev[$interfaceLang]->value;

--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -19,7 +19,7 @@ function generateSense()
     return new LexSense();
 }
 
-function generateCustomField($data)
+function generateCustomField(array $data)
 {
     CodeGuard::checkTypeAndThrow($data, "array");
     if (array_key_exists("type", $data)) {

--- a/src/Api/Model/Languageforge/Lexicon/LexMultiText.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexMultiText.php
@@ -18,7 +18,7 @@ class LexMultiText extends MapOf
 
     public function form($inputSystem, $value)
     {
-        if (array_key_exists($inputSystem, $this)) {
+        if ($this->offsetExists($inputSystem)) {
             $this[$inputSystem]->value($value);
         } else {
             $this[$inputSystem] = new LexValue($value);
@@ -27,7 +27,7 @@ class LexMultiText extends MapOf
 
     public function appendForm($inputSystem, $value, $separator = "; ")
     {
-        if (array_key_exists($inputSystem, $this)) {
+        if ($this->offsetExists($inputSystem)) {
             $oldValue = $this[$inputSystem]->value;
             $newValue = $oldValue . $separator . $value;
             $this[$inputSystem]->value($newValue);
@@ -42,7 +42,7 @@ class LexMultiText extends MapOf
      */
     public function hasForm($inputSystem)
     {
-        return array_key_exists($inputSystem, $this);
+        return $this->offsetExists($inputSystem);
     }
 
     public function differences(LexMultiText $otherMultiText)

--- a/src/Api/Model/Languageforge/Lexicon/LexProjectModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexProjectModel.php
@@ -71,7 +71,7 @@ class LexProjectModel extends LfProjectModel
     public function addInputSystem($tag, $abbr = "", $name = "")
     {
         static $languages = null;
-        if (!array_key_exists($tag, $this->inputSystems)) {
+        if (!$this->inputSystems->offsetExists($tag)) {
             if (!$abbr) {
                 $abbr = $tag;
             }
@@ -81,7 +81,7 @@ class LexProjectModel extends LfProjectModel
                     $languages = new LanguageData();
                 }
                 $languageCode = LanguageData::getCode($tag);
-                if (array_key_exists($languageCode, $languages)) {
+                if ($languages->offsetExists($languageCode)) {
                     $name = $languages[$languageCode]->name;
                 }
             }

--- a/src/Api/Model/Languageforge/Lexicon/LexSense.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexSense.php
@@ -230,7 +230,7 @@ class LexSense extends ObjectForEncoding
         foreach ($this->examples as $index => $example) {
             if (
                 isset($example->{$propertyName}) &&
-                array_key_exists($tag, $example->{$propertyName}) &&
+                $example->{$propertyName}->offsetExists($tag) &&
                 trim($example->{$propertyName}[$tag]) !== "" &&
                 $example->{$propertyName}[$tag] == $text
             ) {

--- a/src/Api/Model/Shared/Command/SessionCommands.php
+++ b/src/Api/Model/Shared/Command/SessionCommands.php
@@ -47,7 +47,7 @@ class SessionCommands
 
         if ($projectId) {
             $project = ProjectModel::getById($projectId);
-            if (array_key_exists($userId, $project->users)) {
+            if ($project->users->offsetExists($userId)) {
                 $sessionData["project"] = [];
                 $sessionData["project"]["id"] = (string) $projectId;
                 $sessionData["project"]["projectName"] = $project->projectName;

--- a/src/Api/Model/Shared/Dto/ActivityListDto.php
+++ b/src/Api/Model/Shared/Dto/ActivityListDto.php
@@ -367,7 +367,7 @@ class ActivityListDto
                 list($name, $position) = self::splitFieldIdPart($part);
                 $position = $position + 1; // Mongo stores 0-based indices, but DTO wants 1-based
                 // $guid not used in this DTO
-                if (array_key_exists($name, $currentConfig->fields)) {
+                if ($currentConfig->fields->offsetExists($name)) {
                     $mostRecentName = $name;
                     $mostRecentPosition = $position;
                     //                    $fieldNameHierarchy[] = $name;

--- a/src/Api/Model/Shared/Mapper/JsonDecoder.php
+++ b/src/Api/Model/Shared/Mapper/JsonDecoder.php
@@ -23,7 +23,7 @@ class JsonDecoder
      * @param string $id
      * @throws \Exception
      */
-    public static function decode($model, $values, $id = "")
+    public static function decode($model, array $values, $id = "")
     {
         $decoder = new JsonDecoder();
         $decoder->_decode($model, $values, $id);
@@ -36,7 +36,7 @@ class JsonDecoder
      * @param string $id
      * @throws \Exception
      */
-    protected function _decode($model, $values, $id)
+    protected function _decode($model, array $values, string $id)
     {
         CodeGuard::checkTypeAndThrow($values, "array");
         $propertiesToIgnore = $this->getPrivateAndReadOnlyProperties($model);

--- a/src/Api/Model/Shared/Mapper/JsonEncoder.php
+++ b/src/Api/Model/Shared/Mapper/JsonEncoder.php
@@ -28,47 +28,54 @@ class JsonEncoder
     protected function _encode($model)
     {
         $data = [];
-        $properties = get_object_vars($model);
-        $privateProperties = [];
-        if (method_exists($model, "getPrivateProperties")) {
-            $privateProperties = (array) $model->getPrivateProperties();
-        }
 
-        foreach ($properties as $key => $value) {
-            if (in_array($key, $privateProperties)) {
-                continue;
+        if (is_a($model, "Api\Model\Shared\Mapper\ArrayOf")) {
+            $data = $this->encodeArrayOf("", $model);
+        } elseif (is_a($model, "Api\Model\Shared\Mapper\MapOf")) {
+            $data = $this->encodeMapOf("", $model);
+        } else {
+            $properties = get_object_vars($model);
+            $privateProperties = [];
+            if (method_exists($model, "getPrivateProperties")) {
+                $privateProperties = (array) $model->getPrivateProperties();
             }
-            if (is_a($value, "Api\Model\Shared\Mapper\IdReference")) {
-                $data[$key] = $this->encodeIdReference($key, $model->{$key});
-            } elseif (is_a($value, "Api\Model\Shared\Mapper\Id")) {
-                $data[$key] = $this->encodeId($key, $model->{$key});
-            } elseif (is_a($value, "Api\Model\Shared\Mapper\ArrayOf")) {
-                $data[$key] = $this->encodeArrayOf($key, $model->{$key});
-            } elseif (is_a($value, "Api\Model\Shared\Mapper\MapOf")) {
-                $data[$key] = $this->encodeMapOf($key, $model->{$key});
-            } elseif (is_a($value, "DateTime")) {
-                $data[$key] = $this->encodeDateTime($model->{$key});
-            } elseif (is_a($value, "Litipk\Jiffy\UniversalTimestamp")) {
-                $data[$key] = $this->encodeUniversalTimestamp($model->{$key});
-            } elseif (is_a($value, "Api\Model\Shared\Mapper\ReferenceList")) {
-                $data[$key] = $this->encodeReferenceList($key, $model->{$key});
-            } else {
-                // Data type protection
-                if (is_array($value)) {
-                    throw new \Exception("Must not encode array in '" . get_class($model) . "->" . $key . "'");
+
+            foreach ($properties as $key => $value) {
+                if (in_array($key, $privateProperties)) {
+                    continue;
                 }
-                // Special hack to help debugging our app
-                if ($key == "projects" || $key == "users") {
-                    throw new \Exception("Possible bad write of '$key'\n" . var_export($model, true));
-                }
-                if (is_object($value)) {
-                    $data[$key] = $this->_encode($value);
+                if (is_a($value, "Api\Model\Shared\Mapper\IdReference")) {
+                    $data[$key] = $this->encodeIdReference($key, $model->{$key});
+                } elseif (is_a($value, "Api\Model\Shared\Mapper\Id")) {
+                    $data[$key] = $this->encodeId($key, $model->{$key});
+                } elseif (is_a($value, "Api\Model\Shared\Mapper\ArrayOf")) {
+                    $data[$key] = $this->encodeArrayOf($key, $model->{$key});
+                } elseif (is_a($value, "Api\Model\Shared\Mapper\MapOf")) {
+                    $data[$key] = $this->encodeMapOf($key, $model->{$key});
+                } elseif (is_a($value, "DateTime")) {
+                    $data[$key] = $this->encodeDateTime($model->{$key});
+                } elseif (is_a($value, "Litipk\Jiffy\UniversalTimestamp")) {
+                    $data[$key] = $this->encodeUniversalTimestamp($model->{$key});
+                } elseif (is_a($value, "Api\Model\Shared\Mapper\ReferenceList")) {
+                    $data[$key] = $this->encodeReferenceList($key, $model->{$key});
                 } else {
-                    // Default encode
-                    if (is_null($value)) {
-                        $value = "";
+                    // Data type protection
+                    if (is_array($value)) {
+                        throw new \Exception("Must not encode array in '" . get_class($model) . "->" . $key . "'");
                     }
-                    $data[$key] = $value;
+                    // Special hack to help debugging our app
+                    if ($key == "projects" || $key == "users") {
+                        throw new \Exception("Possible bad write of '$key'\n" . var_export($model, true));
+                    }
+                    if (is_object($value)) {
+                        $data[$key] = $this->_encode($value);
+                    } else {
+                        // Default encode
+                        if (is_null($value)) {
+                            $value = "";
+                        }
+                        $data[$key] = $value;
+                    }
                 }
             }
         }

--- a/src/Api/Model/Shared/Mapper/MapOf.php
+++ b/src/Api/Model/Shared/Mapper/MapOf.php
@@ -35,7 +35,6 @@ class MapOf extends \ArrayObject
     public function offsetGet($index)
     {
         CodeGuard::checkTypeAndThrow($index, "string");
-
         return parent::offsetGet($index);
     }
 
@@ -43,5 +42,11 @@ class MapOf extends \ArrayObject
     {
         CodeGuard::checkTypeAndThrow($index, "string");
         parent::offsetSet($index, $newval);
+    }
+
+    public function offsetExists($index)
+    {
+        CodeGuard::checkTypeAndThrow($index, "string");
+        return parent::offsetExists($index);
     }
 }

--- a/src/Api/Model/Shared/Mapper/MongoEncoder.php
+++ b/src/Api/Model/Shared/Mapper/MongoEncoder.php
@@ -26,37 +26,43 @@ class MongoEncoder
      * @return array
      * @throws \Exception
      */
-    protected function _encode($model, $encodeId = false)
+    protected function _encode(object $model, $encodeId = false)
     {
         $data = [];
-        $properties = get_object_vars($model);
-        foreach ($properties as $key => $value) {
-            if (is_a($value, "Api\Model\Shared\Mapper\ArrayOf")) {
-                $data[$key] = $this->encodeArrayOf($model->{$key});
-            } elseif (is_a($value, "Api\Model\Shared\Mapper\MapOf")) {
-                $data[$key] = $this->encodeMapOf($model->{$key});
-            } elseif (is_a($value, "Api\Model\Shared\Mapper\IdReference")) {
-                $data[$key] = $this->encodeIdReference($model->{$key});
-            } elseif (is_a($value, "Api\Model\Shared\Mapper\Id")) {
-                if ($encodeId) {
-                    $data[$key] = $this->encodeId($model->{$key});
-                }
-            } elseif (is_a($value, "DateTime")) {
-                $data[$key] = $this->encodeDateTime($model->{$key});
-            } elseif (is_a($value, "Litipk\Jiffy\UniversalTimestamp")) {
-                $data[$key] = $this->encodeUniversalTimestamp($model->{$key});
-            } elseif (is_a($value, "Api\Model\Shared\Mapper\ReferenceList")) {
-                $data[$key] = $this->encodeReferenceList($model->{$key});
-            } else {
-                // Data type protection
-                if (is_array($value)) {
-                    throw new \Exception("Must not encode array in '" . get_class($model) . "->" . $key . "'");
-                }
-                if (is_object($value)) {
-                    $data[$key] = $this->_encode($value, true);
+        if (is_a($model, "Api\Model\Shared\Mapper\ArrayOf")) {
+            $data = $this->encodeArrayOf($model);
+        } elseif (is_a($model, "Api\Model\Shared\Mapper\MapOf")) {
+            $data = $this->encodeMapOf($model);
+        } else {
+            $properties = get_object_vars($model);
+            foreach ($properties as $key => $value) {
+                if (is_a($value, "Api\Model\Shared\Mapper\ArrayOf")) {
+                    $data[$key] = $this->encodeArrayOf($model->{$key});
+                } elseif (is_a($value, "Api\Model\Shared\Mapper\MapOf")) {
+                    $data[$key] = $this->encodeMapOf($model->{$key});
+                } elseif (is_a($value, "Api\Model\Shared\Mapper\IdReference")) {
+                    $data[$key] = $this->encodeIdReference($model->{$key});
+                } elseif (is_a($value, "Api\Model\Shared\Mapper\Id")) {
+                    if ($encodeId) {
+                        $data[$key] = $this->encodeId($model->{$key});
+                    }
+                } elseif (is_a($value, "DateTime")) {
+                    $data[$key] = $this->encodeDateTime($model->{$key});
+                } elseif (is_a($value, "Litipk\Jiffy\UniversalTimestamp")) {
+                    $data[$key] = $this->encodeUniversalTimestamp($model->{$key});
+                } elseif (is_a($value, "Api\Model\Shared\Mapper\ReferenceList")) {
+                    $data[$key] = $this->encodeReferenceList($model->{$key});
                 } else {
-                    // Default encode
-                    $data[$key] = $value;
+                    // Data type protection
+                    if (is_array($value)) {
+                        throw new \Exception("Must not encode array in '" . get_class($model) . "->" . $key . "'");
+                    }
+                    if (is_object($value)) {
+                        $data[$key] = $this->_encode($value, true);
+                    } else {
+                        // Default encode
+                        $data[$key] = $value;
+                    }
                 }
             }
         }

--- a/src/Api/Model/Shared/ProjectModel.php
+++ b/src/Api/Model/Shared/ProjectModel.php
@@ -178,7 +178,7 @@ class ProjectModel extends MapperModel
      */
     public function removeUser($userId)
     {
-        if (array_key_exists($userId, $this->users)) {
+        if ($this->users->offsetExists($userId)) {
             unset($this->users[$userId]);
         }
     }
@@ -198,7 +198,7 @@ class ProjectModel extends MapperModel
         $userList->read();
         for ($i = 0, $l = count($userList->entries); $i < $l; $i++) {
             $userId = $userList->entries[$i]["id"];
-            if (!array_key_exists($userId, $this->users)) {
+            if (!$this->users->offsetExists($userId)) {
                 continue;
             }
             $userList->entries[$i]["role"] = $this->users[$userId]->role;
@@ -211,7 +211,7 @@ class ProjectModel extends MapperModel
         $invitees = new InviteeListProjectModel($this->id->asString());
         $invitees->read();
         foreach ($invitees->entries as $i => $invitee) {
-            if (array_key_exists($invitee["id"], $this->users)) {
+            if ($this->users->offsetExists($invitee["id"])) {
                 $invitees->entries[$i]["role"] = $this->users[$invitee["id"]]->role;
             }
         }

--- a/src/composer.json
+++ b/src/composer.json
@@ -20,7 +20,7 @@
     "ramsey/uuid": "^4.2",
     "silex/silex": "~1.3.2",
     "sillsdev/web-php-utilities": "dev-master",
-    "swiftmailer/swiftmailer": "^5",
+    "swiftmailer/swiftmailer": "^6",
     "symfony/security": "^2.7",
     "symfony/twig-bridge": "^2.7",
     "twig/twig": "^2",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "d2449b529538a4390358d652937682cb",
+  "content-hash": "c4dddec211fc7e9a767136204cbd99fb",
   "packages": [
     {
       "name": "brick/math",
@@ -63,6 +63,176 @@
         }
       ],
       "time": "2021-08-15T20:50:18+00:00"
+    },
+    {
+      "name": "doctrine/deprecations",
+      "version": "v1.0.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/doctrine/deprecations.git",
+        "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+        "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.1|^8.0"
+      },
+      "require-dev": {
+        "doctrine/coding-standard": "^9",
+        "phpunit/phpunit": "^7.5|^8.5|^9.5",
+        "psr/log": "^1|^2|^3"
+      },
+      "suggest": {
+        "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+      "homepage": "https://www.doctrine-project.org/",
+      "support": {
+        "issues": "https://github.com/doctrine/deprecations/issues",
+        "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+      },
+      "time": "2022-05-02T15:47:09+00:00"
+    },
+    {
+      "name": "doctrine/lexer",
+      "version": "2.1.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/doctrine/lexer.git",
+        "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
+        "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
+        "shasum": ""
+      },
+      "require": {
+        "doctrine/deprecations": "^1.0",
+        "php": "^7.1 || ^8.0"
+      },
+      "require-dev": {
+        "doctrine/coding-standard": "^9 || ^10",
+        "phpstan/phpstan": "^1.3",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+        "psalm/plugin-phpunit": "^0.18.3",
+        "vimeo/psalm": "^4.11 || ^5.0"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Doctrine\\Common\\Lexer\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Guilherme Blanco",
+          "email": "guilhermeblanco@gmail.com"
+        },
+        {
+          "name": "Roman Borschel",
+          "email": "roman@code-factory.org"
+        },
+        {
+          "name": "Johannes Schmitt",
+          "email": "schmittjoh@gmail.com"
+        }
+      ],
+      "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+      "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+      "keywords": ["annotations", "docblock", "lexer", "parser", "php"],
+      "support": {
+        "issues": "https://github.com/doctrine/lexer/issues",
+        "source": "https://github.com/doctrine/lexer/tree/2.1.0"
+      },
+      "funding": [
+        {
+          "url": "https://www.doctrine-project.org/sponsorship.html",
+          "type": "custom"
+        },
+        {
+          "url": "https://www.patreon.com/phpdoctrine",
+          "type": "patreon"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2022-12-14T08:49:07+00:00"
+    },
+    {
+      "name": "egulias/email-validator",
+      "version": "3.2.5",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/egulias/EmailValidator.git",
+        "reference": "b531a2311709443320c786feb4519cfaf94af796"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/b531a2311709443320c786feb4519cfaf94af796",
+        "reference": "b531a2311709443320c786feb4519cfaf94af796",
+        "shasum": ""
+      },
+      "require": {
+        "doctrine/lexer": "^1.2|^2",
+        "php": ">=7.2",
+        "symfony/polyfill-intl-idn": "^1.15"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^8.5.8|^9.3.3",
+        "vimeo/psalm": "^4"
+      },
+      "suggest": {
+        "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "3.0.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Egulias\\EmailValidator\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Eduardo Gulias Davis"
+        }
+      ],
+      "description": "A library for validating emails against several RFCs",
+      "homepage": "https://github.com/egulias/EmailValidator",
+      "keywords": ["email", "emailvalidation", "emailvalidator", "validation", "validator"],
+      "support": {
+        "issues": "https://github.com/egulias/EmailValidator/issues",
+        "source": "https://github.com/egulias/EmailValidator/tree/3.2.5"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/egulias",
+          "type": "github"
+        }
+      ],
+      "time": "2023-01-02T17:26:14+00:00"
     },
     {
       "name": "firebase/php-jwt",
@@ -1404,29 +1574,36 @@
     },
     {
       "name": "swiftmailer/swiftmailer",
-      "version": "v5.4.12",
+      "version": "v6.3.0",
       "source": {
         "type": "git",
         "url": "https://github.com/swiftmailer/swiftmailer.git",
-        "reference": "181b89f18a90f8925ef805f950d47a7190e9b950"
+        "reference": "8a5d5072dca8f48460fce2f4131fcc495eec654c"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/181b89f18a90f8925ef805f950d47a7190e9b950",
-        "reference": "181b89f18a90f8925ef805f950d47a7190e9b950",
+        "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/8a5d5072dca8f48460fce2f4131fcc495eec654c",
+        "reference": "8a5d5072dca8f48460fce2f4131fcc495eec654c",
         "shasum": ""
       },
       "require": {
-        "php": ">=5.3.3"
+        "egulias/email-validator": "^2.0|^3.1",
+        "php": ">=7.0.0",
+        "symfony/polyfill-iconv": "^1.0",
+        "symfony/polyfill-intl-idn": "^1.10",
+        "symfony/polyfill-mbstring": "^1.0"
       },
       "require-dev": {
-        "mockery/mockery": "~0.9.1",
-        "symfony/phpunit-bridge": "~3.2"
+        "mockery/mockery": "^1.0",
+        "symfony/phpunit-bridge": "^4.4|^5.4"
+      },
+      "suggest": {
+        "ext-intl": "Needed to support internationalized email addresses"
       },
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-master": "5.4-dev"
+          "dev-master": "6.2-dev"
         }
       },
       "autoload": {
@@ -1448,10 +1625,20 @@
       "keywords": ["email", "mail", "mailer"],
       "support": {
         "issues": "https://github.com/swiftmailer/swiftmailer/issues",
-        "source": "https://github.com/swiftmailer/swiftmailer/tree/v5.4.12"
+        "source": "https://github.com/swiftmailer/swiftmailer/tree/v6.3.0"
       },
+      "funding": [
+        {
+          "url": "https://github.com/fabpot",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/swiftmailer/swiftmailer",
+          "type": "tidelift"
+        }
+      ],
       "abandoned": "symfony/mailer",
-      "time": "2018-07-31T09:26:32+00:00"
+      "time": "2021-10-18T15:26:12+00:00"
     },
     {
       "name": "symfony/debug",
@@ -1831,6 +2018,226 @@
       "keywords": ["compatibility", "ctype", "polyfill", "portable"],
       "support": {
         "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+      },
+      "funding": [
+        {
+          "url": "https://symfony.com/sponsor",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/fabpot",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2022-11-03T14:55:06+00:00"
+    },
+    {
+      "name": "symfony/polyfill-iconv",
+      "version": "v1.27.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/polyfill-iconv.git",
+        "reference": "927013f3aac555983a5059aada98e1907d842695"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/927013f3aac555983a5059aada98e1907d842695",
+        "reference": "927013f3aac555983a5059aada98e1907d842695",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "provide": {
+        "ext-iconv": "*"
+      },
+      "suggest": {
+        "ext-iconv": "For best performance"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "1.27-dev"
+        },
+        "thanks": {
+          "name": "symfony/polyfill",
+          "url": "https://github.com/symfony/polyfill"
+        }
+      },
+      "autoload": {
+        "files": ["bootstrap.php"],
+        "psr-4": {
+          "Symfony\\Polyfill\\Iconv\\": ""
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Nicolas Grekas",
+          "email": "p@tchwork.com"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Symfony polyfill for the Iconv extension",
+      "homepage": "https://symfony.com",
+      "keywords": ["compatibility", "iconv", "polyfill", "portable", "shim"],
+      "support": {
+        "source": "https://github.com/symfony/polyfill-iconv/tree/v1.27.0"
+      },
+      "funding": [
+        {
+          "url": "https://symfony.com/sponsor",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/fabpot",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2022-11-03T14:55:06+00:00"
+    },
+    {
+      "name": "symfony/polyfill-intl-idn",
+      "version": "v1.27.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/polyfill-intl-idn.git",
+        "reference": "639084e360537a19f9ee352433b84ce831f3d2da"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da",
+        "reference": "639084e360537a19f9ee352433b84ce831f3d2da",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1",
+        "symfony/polyfill-intl-normalizer": "^1.10",
+        "symfony/polyfill-php72": "^1.10"
+      },
+      "suggest": {
+        "ext-intl": "For best performance"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "1.27-dev"
+        },
+        "thanks": {
+          "name": "symfony/polyfill",
+          "url": "https://github.com/symfony/polyfill"
+        }
+      },
+      "autoload": {
+        "files": ["bootstrap.php"],
+        "psr-4": {
+          "Symfony\\Polyfill\\Intl\\Idn\\": ""
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Laurent Bassin",
+          "email": "laurent@bassin.info"
+        },
+        {
+          "name": "Trevor Rowbotham",
+          "email": "trevor.rowbotham@pm.me"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+      "homepage": "https://symfony.com",
+      "keywords": ["compatibility", "idn", "intl", "polyfill", "portable", "shim"],
+      "support": {
+        "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.27.0"
+      },
+      "funding": [
+        {
+          "url": "https://symfony.com/sponsor",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/fabpot",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2022-11-03T14:55:06+00:00"
+    },
+    {
+      "name": "symfony/polyfill-intl-normalizer",
+      "version": "v1.27.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+        "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+        "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "suggest": {
+        "ext-intl": "For best performance"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "1.27-dev"
+        },
+        "thanks": {
+          "name": "symfony/polyfill",
+          "url": "https://github.com/symfony/polyfill"
+        }
+      },
+      "autoload": {
+        "files": ["bootstrap.php"],
+        "psr-4": {
+          "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+        },
+        "classmap": ["Resources/stubs"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Nicolas Grekas",
+          "email": "p@tchwork.com"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Symfony polyfill for intl's Normalizer class and related functions",
+      "homepage": "https://symfony.com",
+      "keywords": ["compatibility", "intl", "normalizer", "polyfill", "portable", "shim"],
+      "support": {
+        "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
       },
       "funding": [
         {
@@ -2988,16 +3395,16 @@
     },
     {
       "name": "nikic/php-parser",
-      "version": "v4.15.2",
+      "version": "v4.15.3",
       "source": {
         "type": "git",
         "url": "https://github.com/nikic/PHP-Parser.git",
-        "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc"
+        "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
-        "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+        "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+        "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
         "shasum": ""
       },
       "require": {
@@ -3031,9 +3438,9 @@
       "keywords": ["parser", "php"],
       "support": {
         "issues": "https://github.com/nikic/PHP-Parser/issues",
-        "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
+        "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
       },
-      "time": "2022-11-12T15:38:23+00:00"
+      "time": "2023-01-16T22:05:37+00:00"
     },
     {
       "name": "phar-io/manifest",
@@ -3425,20 +3832,20 @@
     },
     {
       "name": "phpunit/phpunit",
-      "version": "9.5.27",
+      "version": "9.5.28",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/phpunit.git",
-        "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
+        "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
-        "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
+        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/954ca3113a03bf780d22f07bf055d883ee04b65e",
+        "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e",
         "shasum": ""
       },
       "require": {
-        "doctrine/instantiator": "^1.3.1",
+        "doctrine/instantiator": "^1.3.1 || ^2",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
@@ -3495,7 +3902,7 @@
       "keywords": ["phpunit", "testing", "xunit"],
       "support": {
         "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-        "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.27"
+        "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.28"
       },
       "funding": [
         {
@@ -3511,7 +3918,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2022-12-09T07:31:23+00:00"
+      "time": "2023-01-14T12:32:24+00:00"
     },
     {
       "name": "sebastian/cli-parser",


### PR DESCRIPTION
### Fixes #1588 

## Description

Upgrade our codebase and composer dependencies to run on PHP 7.4

This was a marathon requiring intense concentration to debug errors in our PHP tests and application, especially related to changed behavior from PHP 7.3 -> 7.4 for the `array_key_exists()` and `get_object_vars()` functions.

There is no section in our PR template for HOURS SPENT 😭 

My [commits are fairly well organized](https://github.com/sillsdev/web-languageforge/pull/1696/commits), so here's the summary of what's changed:
<img width="704" alt="image" src="https://user-images.githubusercontent.com/3444521/212908064-2884f6d5-982a-43be-a26d-1bde87399d05.png">




## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have enabled auto-merge (optional)

## QA testing

Unit tests and E2E tests passing are sufficient evidence that this PR is acceptable.