### PR TITLE
No 'Profile updated successfully' notice on delete

### DIFF
--- a/src/angular-app/bellows/apps/userprofile/user-profile-app.component.html
+++ b/src/angular-app/bellows/apps/userprofile/user-profile-app.component.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col-sm-12">
             <sil-notices></sil-notices>
-            <form data-ng-submit="$ctrl.submit()" id="userprofileForm" name="userprofileForm">
+            <form id="userprofileForm" name="userprofileForm">
                 <uib-tabset>
                     <uib-tab heading="My Account" id="myAccountTab">
                         <div class="form-group row">
@@ -71,7 +71,7 @@
                         <label><a href="/app/changepassword">Change Password</a></label>
                         <div class="row">
                             <div class="col-sm-6">
-                                <button type="submit" data-ng-disabled="userprofileForm.$invalid||$ctrl.emailExists||$ctrl.usernameExists" class="btn btn-primary " id="saveMyAccountBtn"><i class="fa fa-check" aria-hidden="true"></i> Save</button>
+                                <button type="submit" ng-click="$ctrl.submit()" data-ng-disabled="userprofileForm.$invalid||$ctrl.emailExists||$ctrl.usernameExists" class="btn btn-primary " id="saveMyAccountBtn"><i class="fa fa-check" aria-hidden="true"></i> Save</button>
                             </div>
                         </div>
                     </uib-tab>
@@ -112,7 +112,7 @@
                         </div>
                         <div class="row">
                             <div class="col-sm-6">
-                                <button type="submit" data-ng-disabled="userprofileForm.$invalid||$ctrl.emailExists||$ctrl.usernameExists" class="btn btn-primary " id="saveAboutMeBtn"><i class="fa fa-check" aria-hidden="true"></i> Save</button>
+                                <button type="submit" ng-click="$ctrl.submit()" data-ng-disabled="userprofileForm.$invalid||$ctrl.emailExists||$ctrl.usernameExists" class="btn btn-primary " id="saveAboutMeBtn"><i class="fa fa-check" aria-hidden="true"></i> Save</button>
                             </div>
                         </div>
                     </uib-tab>
@@ -206,7 +206,7 @@
                         </div>
                         <div class="row">
                             <div class="col-sm-6">
-                                <button type="submit" data-ng-disabled="userprofileForm.$invalid||$ctrl.emailExists||$ctrl.usernameExists" class="btn btn-primary " id="saveProjectBtn"><i class="fa fa-check" aria-hidden="true"></i> Save</button>
+                                <button type="submit" ng-click="$ctrl.submit()" data-ng-disabled="userprofileForm.$invalid||$ctrl.emailExists||$ctrl.usernameExists" class="btn btn-primary " id="saveProjectBtn"><i class="fa fa-check" aria-hidden="true"></i> Save</button>
                             </div>
                         </div>
                     </uib-tab>


### PR DESCRIPTION
### Fixes #1697 

## Description

Previously, any modifications in the user profile component would generate a notice: 'Profile updated successfully.' But now, for account deletion, we only display 'Your account was permanently deleted' and not the 'Profile updated successfully' notice that other modifications generate.

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/56163492/213070354-2e74c7d5-8176-44ae-bc44-d6007eb2df11.png)

After:
![image](https://user-images.githubusercontent.com/56163492/213070383-d3aae282-8cc2-409b-b10b-4bbc7e818b58.png)
![Screenshot (12)](https://user-images.githubusercontent.com/56163492/213070401-a83055d1-989c-4f15-81d7-71c5a7aae201.png)


## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have enabled auto-merge (optional)

## QA testing

Testers, use the following instructions on [qa.languageforge.org](https://qa.languageforge.org). Post your findings as a comment and include any meaningful screenshots, etc.

- Under 'My Profile' > 'My Account', make changes to your avatar (color, animal). Click 'Save'. Verify that the 'Profile updated successfully' notice is given.
- Under 'My Profile' > 'About Me', make changes to your personal information. Click 'Save'. Verify that the 'Profile updated successfully' notice is given.
- Under 'My Profile' > 'Delete My Account', delete your account. Verify that the 'Profile updated successfully' notice is not given.
