### PR TITLE
Boost SR limit to 10MB for audio conversion settings

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -101,7 +101,8 @@ class LexUploadCommands
 
                 if (
                     strcmp($project->whenToConvertAudio, "always") == 0 ||
-                    (strcmp($project->whenToConvertAudio, "sr") == 0 && // restrictions on send/receive files 01-2023
+                    (strcmp($project->whenToConvertAudio, "sr") == 0 &&
+                        // `MaximumFileSize` in https://github.com/sillsdev/chorus/blob/master/src/LibChorus/FileTypeHandlers/audio/AudioFileTypeHandler.cs
                         (filesize($filePath) > 10000000 ||
                             (strcmp(strtolower($fileExt), ".mp3") !== 0 &&
                                 strcmp(strtolower($fileExt), ".wav") !== 0 &&

--- a/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/LexUploadCommands.php
@@ -101,8 +101,8 @@ class LexUploadCommands
 
                 if (
                     strcmp($project->whenToConvertAudio, "always") == 0 ||
-                    (strcmp($project->whenToConvertAudio, "sr") == 0 && // restrictions on send/receive files 12-2022
-                        (filesize($filePath) > 1000000 ||
+                    (strcmp($project->whenToConvertAudio, "sr") == 0 && // restrictions on send/receive files 01-2023
+                        (filesize($filePath) > 10000000 ||
                             (strcmp(strtolower($fileExt), ".mp3") !== 0 &&
                                 strcmp(strtolower($fileExt), ".wav") !== 0 &&
                                 strcmp(strtolower($fileExt), ".webm") !== 0)))


### PR DESCRIPTION
### Fixes #1702 
Fixes #1679  

## Description

Now that Language Forge allows for Send/Receiving files up to 10 MB in size, we can base our audio conversion settings on the 10 MB limit rather than the old 1 MB limit.

## Screenshots

This PR affects this setting: Settings > Project Settings > Convert Uploaded Audio to OPUS/WEBM...
![Screenshot (15)](https://user-images.githubusercontent.com/56163492/213387754-4ff98451-7e6e-49c0-8aed-3f856cc6b428.png)

For Send/Receive, we can now just convert audio files that are larger than 10 MB (and/or don't have MP3, WAV, or WEBM file extensions, like before).

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have enabled auto-merge (optional)

## QA testing

Testers, use the following instructions on [qa.languageforge.org](https://qa.languageforge.org). Post your findings as a comment and include any meaningful screenshots, etc.

Here are two test files, zipped up to accommodate the file extensions: 
[Two audio test files.zip](https://github.com/sillsdev/web-languageforge/files/10455258/Two.audio.test.files.zip)

1. In Project Settings, select "Convert Uploaded Audio to OPUS/WEBM..." -> "Only when necessary for Send/Receive"
2. Upload '5 MB_WAV.wav' in Language Forge. Click the three dots next to the soundplayer and confirm that the file extension is still **.wav**, and not .webm. Send/Receive. Verify that the file made it into FLEx.
3. Upload '10 MB_MP3.mp3' in Language Forge (this is a 10.2 MB file). Click the three dots next to the soundplayer and confirm that the file extension is now **.webm**. The file should have been converted to WEBM on upload. Send/Receive. Verify that the file made it into FLEx.
4. Change the Project Settings for "Convert Uploaded Audio to OPUS/WEBM..." to "Never". Upload '10 MB MP3.mp3' in Language Forge. Click the three dots next to the soundplayer and confirm that the file extension is still **.mp3**. The file should not have been converted. You should get a warning that the file is larger than 10 MB and won't be synced with FLEx.