### PR TITLE
Show 'Account deleted' message on login screen

### DIFF
--- a/src/Api/Service/Sf.php
+++ b/src/Api/Service/Sf.php
@@ -18,7 +18,6 @@ use Api\Model\Shared\Command\ProjectCommands;
 use Api\Model\Shared\Command\SessionCommands;
 use Api\Model\Shared\Command\UserCommands;
 use Api\Model\Shared\Command\LdapiCommands;
-use Api\Model\Shared\Communicate\EmailSettings;
 use Api\Model\Shared\Dto\ActivityListDto;
 use Api\Model\Shared\Dto\ProjectInsightsDto;
 use Api\Model\Shared\Dto\ProjectListDto;
@@ -144,7 +143,11 @@ class Sf
      */
     public function user_delete($userIds)
     {
-        return UserCommands::deleteAccounts($userIds, $this->userId);
+        $result = UserCommands::deleteAccounts($userIds, $this->userId);
+        if (in_array($this->userId, $userIds)) {
+            $this->app["session"]->getFlashBag()->add("infoMessage", "Your account was permanently deleted");
+        }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
## Description

Customizes the info message on the login screen after deleting your own account.

@laineyhm This is something small that I figured was sort of missing when I QA'd https://github.com/sillsdev/web-languageforge/issues/1697.

## Screenshots

![image](https://user-images.githubusercontent.com/12587509/213431347-60741d85-d314-4334-8c0b-82288ec4e80d.png)

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have enabled auto-merge (optional)

## QA testing

Testers, use the following instructions on [qa.languageforge.org](https://qa.languageforge.org). Post your findings as a comment and include any meaningful screenshots, etc.

1) Delete own account
2) Observe Message in screenshot above
