### PR TITLE
Fix OAuth by adding missing return type

### DIFF
--- a/src/Site/OAuth/SelectAccountAuthorizationParametersTrait.php
+++ b/src/Site/OAuth/SelectAccountAuthorizationParametersTrait.php
@@ -7,7 +7,7 @@ namespace Site\OAuth;
  */
 trait SelectAccountAuthorizationParametersTrait
 {
-    protected function getAuthorizationParameters(array $options)
+    protected function getAuthorizationParameters(array $options): array
     {
         // Default provider adds "approval_prompt=auto", but using both "prompt" and "approval_prompt" together is not allowed
         $params = parent::getAuthorizationParameters($options);


### PR DESCRIPTION
### Fixes #1709

## Description

OAuth was broken, because our implementation didn't match [the signature of our dependency](https://github.com/thephpleague/oauth2-google/search?q=getAuthorizationParameters). So, (based on my limited knowledge of PHP, I guess this was due to the [upgrade to PHP 7.4](https://github.com/sillsdev/web-languageforge/pull/1696), rather than the [upgrade of our OAuth lib](https://github.com/sillsdev/web-languageforge/pull/1707).

## Screenshots

With this change I get the expected error locally:
![image](https://user-images.githubusercontent.com/12587509/214096558-fd210fb4-8a35-4b4d-a3fa-7766a3fbeb40.png)


## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- ~I have commented my code, particularly in hard-to-understand areas~
- ~I have added tests that prove my fix is effective or that my feature works~ I want to do this, but I'll do it in a follow up PR. It's acting a bit goofy
- [x] I have enabled auto-merge (optional)

## QA testing

Testers, use the following instructions on [qa.languageforge.org](https://qa.languageforge.org). Post your findings as a comment and include any meaningful screenshots, etc.

- Verify that signing in with OAuth works again