### PR TITLE
Add E2E tests for OAuth pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,6 +259,10 @@ services:
       - REMEMBER_ME_SECRET=bogus-development-key
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
       - XDEBUG_MODE=develop,debug
+      - GOOGLE_CLIENT_ID=bogus-development-token
+      - GOOGLE_CLIENT_SECRET=bogus-development-token
+      - FACEBOOK_CLIENT_ID=bogus-development-token
+      - FACEBOOK_CLIENT_SECRET=bogus-development-token
     command: sh -c "/wait && apache2-foreground"
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/src/Site/OAuth/SelectAccountAuthorizationParametersTrait.php
+++ b/src/Site/OAuth/SelectAccountAuthorizationParametersTrait.php
@@ -7,7 +7,7 @@ namespace Site\OAuth;
  */
 trait SelectAccountAuthorizationParametersTrait
 {
-    protected function getAuthorizationParameters(array $options)
+    protected function getAuthorizationParameters(array $options): array
     {
         // Default provider adds "approval_prompt=auto", but using both "prompt" and "approval_prompt" together is not allowed
         $params = parent::getAuthorizationParameters($options);

--- a/test/e2e/pages/base-page.ts
+++ b/test/e2e/pages/base-page.ts
@@ -28,7 +28,7 @@ export abstract class BasePage
     return this.page.url().startsWith(appUrl) && !!this.page.url().match(this.urlPattern);
   }
 
-  private readonly locators: Locator[];
+  protected readonly locators: Locator[];
   private readonly urlPattern = this.url.includes('#') ?
     new RegExp(`${this.url}`) : new RegExp(`${this.url}/?(#|$)`);
 

--- a/test/e2e/pages/editor.page.ts
+++ b/test/e2e/pages/editor.page.ts
@@ -109,7 +109,7 @@ export class EditorPage extends BasePage {
     super(page, `/app/lexicon/${project.id}`, page.locator('.words-container-title:visible, .no-entries:visible'));
   }
 
-  async goto(options?: EditorGotoOptions): Promise<this> {
+  override async goto(options?: EditorGotoOptions): Promise<this> {
     await super.goto(options);
     if (options?.entryId) {
       // Navigating from one entry to another via URL/goto doesn't cause angular to load the new entry
@@ -120,7 +120,7 @@ export class EditorPage extends BasePage {
     return this;
   }
 
-  async waitFor(): Promise<this> {
+  override async waitFor(): Promise<this> {
     await super.waitFor();
     if (await this.page.isVisible('[id^=entryId_]')) {
       await this.locator('.entry-card').waitFor();

--- a/test/e2e/pages/index.ts
+++ b/test/e2e/pages/index.ts
@@ -15,3 +15,5 @@ export * from './site-admin.page';
 export * from './user-profile.page';
 export * from './home.page';
 export * from './terms-and-conditions.page';
+export * from './oauth-google.page';
+export * from './oauth-facebook.page';

--- a/test/e2e/pages/oauth-facebook.page.ts
+++ b/test/e2e/pages/oauth-facebook.page.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base-page';
+
+export class OAuthFacebookPage extends BasePage {
+
+  override get isCurrentPage(): boolean {
+    return this.page.url().startsWith('https://www.facebook.com/');
+  }
+
+  constructor(page: Page) {
+    super(page, '/oauthcallback/facebook', page.locator('#facebook'));
+  }
+
+}

--- a/test/e2e/pages/oauth-google.page.ts
+++ b/test/e2e/pages/oauth-google.page.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base-page';
+
+export class OAuthGooglePage extends BasePage {
+
+  override get isCurrentPage(): boolean {
+    return this.page.url().startsWith('https://accounts.google.com/');
+  }
+
+  constructor(page: Page) {
+    super(page, '/oauthcallback/google', page.locator(':text("Google will share your name"), :text("The OAuth client was not found.")'));
+  }
+
+}

--- a/test/e2e/pages/project-settings.page.ts
+++ b/test/e2e/pages/project-settings.page.ts
@@ -27,7 +27,7 @@ export class ProjectSettingsPage extends BasePage {
   }
 
   // navigate to project without UI
-  async goto(): Promise<this> {
+  override async goto(): Promise<this> {
     await super.goto();
     await this.page.getByLabel('Project Name').waitFor();
     return this;

--- a/test/e2e/pages/projects.page.ts
+++ b/test/e2e/pages/projects.page.ts
@@ -35,7 +35,7 @@ export class ProjectsPage extends BasePage {
     super(page, '/app/projects', page.locator('button:has-text("Start or Join a New Project")'));
   }
 
-  async goto(): Promise<this> {
+  override async goto(): Promise<this> {
     await super.goto();
     if (await this.projectsPerPageDropdown.isVisible()) {
       await this.projectsPerPageDropdown.selectOption('100');

--- a/test/e2e/pages/signup.page.ts
+++ b/test/e2e/pages/signup.page.ts
@@ -54,7 +54,7 @@ export class SignupPage extends BasePage {
     super(page, '/public/signup', page.locator('#email'));
   }
 
-  async goto(options?: SignupGotoOptions): Promise<this> {
+  override async goto(options?: SignupGotoOptions): Promise<this> {
     if (options?.email) {
       await this.page.goto(this.url + '#!/?e=' + encodeURIComponent(options?.email));
       await Promise.all([

--- a/test/e2e/pages/tabbed-page.ts
+++ b/test/e2e/pages/tabbed-page.ts
@@ -11,7 +11,7 @@ export abstract class TabbedBasePage extends BasePage {
    */
   protected abstract get tabLink(): Locator;
 
-  async goto(options?: GotoOptions): Promise<this> {
+  override async goto(options?: GotoOptions): Promise<this> {
     await this.page.goto(this.url);
     await Promise.all([
       this.tabLink.click(),

--- a/test/e2e/tests/oauth.spec.ts
+++ b/test/e2e/tests/oauth.spec.ts
@@ -1,0 +1,14 @@
+import { test } from '../fixtures';
+import { OAuthFacebookPage, OAuthGooglePage } from '../pages';
+
+test.describe('OAuth', () => {
+
+  test('Google OAuth page loads', async ({ tab }) => {
+    await new OAuthGooglePage(tab).goto();
+  });
+
+  test('Facebook OAuth page loads', async ({ tab }) => {
+    await new OAuthFacebookPage(tab).goto();
+  });
+
+});


### PR DESCRIPTION
### Extends fix for #1709

## Description

Adds tests that make sure OAuth pages for Google and Facebook load without an exception.

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have enabled auto-merge (optional)

## QA testing

Let 'em rip 🔥 
