### PR TITLE
Fix broken fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ build:
 	npm install
 
     # ensure we start with a clean ui-dist volume for every build
-	docker volume rm web-languageforge_lf-ui-dist 2>/dev/null
+	-docker volume rm web-languageforge_lf-ui-dist 2>/dev/null
 
 	docker compose build mail app lfmerge ld-api next-proxy next-app
 

--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -79,6 +79,7 @@ class LexEntryModel extends MapperModel
                 "cvPattern",
                 "tone",
                 "summaryDefinition",
+                "entryImportResidue",
             ],
             false
         );
@@ -175,6 +176,9 @@ class LexEntryModel extends MapperModel
     /** @var LexMultiText */
     public $summaryDefinition;
 
+    /** @var LexMultiText */
+    public $entryImportResidue;
+
     public static function mapper($databaseName)
     {
         /** @var LexEntryMongoMapper $instance */
@@ -210,6 +214,7 @@ class LexEntryModel extends MapperModel
             case "literalMeaning":
             case "note": // TODO Notes need to be an array, and more capable than a multi-text. Notes have types. CP 2014-10
             case "summaryDefinition":
+            case "entryImportResidue":
                 return "LexMultiText";
             case "environments":
                 return "LexMultiValue";
@@ -461,6 +466,7 @@ class LexEntryModel extends MapperModel
             "cvPattern",
             "tone",
             "summaryDefinition",
+            "entryImportResidue",
         ];
         $result = [];
         foreach ($properties as $property) {

--- a/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexEntryModel.php
@@ -79,7 +79,6 @@ class LexEntryModel extends MapperModel
                 "cvPattern",
                 "tone",
                 "summaryDefinition",
-                "entryImportResidue",
             ],
             false
         );
@@ -176,9 +175,6 @@ class LexEntryModel extends MapperModel
     /** @var LexMultiText */
     public $summaryDefinition;
 
-    /** @var LexMultiText */
-    public $entryImportResidue;
-
     public static function mapper($databaseName)
     {
         /** @var LexEntryMongoMapper $instance */
@@ -214,7 +210,6 @@ class LexEntryModel extends MapperModel
             case "literalMeaning":
             case "note": // TODO Notes need to be an array, and more capable than a multi-text. Notes have types. CP 2014-10
             case "summaryDefinition":
-            case "entryImportResidue":
                 return "LexMultiText";
             case "environments":
                 return "LexMultiValue";
@@ -466,7 +461,6 @@ class LexEntryModel extends MapperModel
             "cvPattern",
             "tone",
             "summaryDefinition",
-            "entryImportResidue",
         ];
         $result = [];
         foreach ($properties as $property) {

--- a/src/Api/Model/Languageforge/Lexicon/LexSense.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexSense.php
@@ -112,7 +112,7 @@ class LexSense extends ObjectForEncoding
             case "anthropologyCategories":
                 return "LexMultiValue";
             case "status":
-                return "LexMultiValue";
+                return "LexValue";
             default:
                 return "string";
         }
@@ -544,6 +544,6 @@ class LexSense extends ObjectForEncoding
     /** @var LexMultiText */
     public $senseImportResidue;
 
-    /** @var LexMultiValue */
+    /** @var LexValue */
     public $status;
 }

--- a/test/php/model/languageforge/lexicon/Import/LiftImportFlexTest.php
+++ b/test/php/model/languageforge/lexicon/Import/LiftImportFlexTest.php
@@ -264,7 +264,7 @@ EOD;
         $this->assertEquals(LexMultiValue::createFromArray(["901"]), $sense00->anthropologyCategories);
         $this->assertEquals(LexMultiValue::createFromArray(["applied linguistics"]), $sense00->academicDomains);
         $this->assertEquals(new LexValue("primary"), $sense00->senseType);
-        $this->assertEquals(LexMultiValue::createFromArray(["Tentative"]), $sense00->status);
+        $this->assertEquals(new LexValue("Tentative"), $sense00->status);
         $this->assertEquals(LexMultiValue::createFromArray(["colloquial"]), $sense00->usages);
 
         $expected = new LexPicture("Desert.jpg", $sense00->pictures[0]->guid);

--- a/test/php/model/languageforge/lexicon/LexSenseModelTest.php
+++ b/test/php/model/languageforge/lexicon/LexSenseModelTest.php
@@ -40,6 +40,6 @@ class LexSenseModelTest extends TestCase
         $this->assertInstanceOf(LexValue::class, $sense->senseType);
         $this->assertInstanceOf(LexMultiValue::class, $sense->academicDomains);
         $this->assertInstanceOf(LexMultiValue::class, $sense->anthropologyCategories);
-        $this->assertInstanceOf(LexMultiValue::class, $sense->status);
+        $this->assertInstanceOf(LexValue::class, $sense->status);
     }
 }


### PR DESCRIPTION
### Fixes #1717

## Description

The **LexEntryModel->entryImportResidue** and **LexSense->status** fields throw exceptions when they're updated, because they're not configured correctly in PHP.

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- ~I have commented my code, particularly in hard-to-understand areas~
- ~I have added tests that prove my fix is effective or that my feature works~
- [ ] I have enabled auto-merge (optional)

## QA testing

Testers, use the following instructions on [qa.languageforge.org](https://qa.languageforge.org). Post your findings as a comment and include any meaningful screenshots, etc.

- Update the mentioned fields
- Wait 5s and confirm no error is displayed
