### PR TITLE
Show warning message/bar in QA

### DIFF
--- a/src/Site/views/shared/_global.scss
+++ b/src/Site/views/shared/_global.scss
@@ -328,3 +328,20 @@ pui-tab {
 input::-ms-clear {
   display: none;
 }
+
+body[data-version*="develop"] nav:first-child {
+  background-color: #e95e13 !important;
+
+  &::after {
+    content: "⚠️ This is a testing environment. Data is deleted regularly! ⚠️ \a Are you looking for languageforge.org?";
+    color: #02deff;
+    position: absolute;
+    font-size: 10px;
+    left: 50%;
+    transform: translate(-50%);
+    max-height: 30px;
+    overflow: hidden;
+    white-space: pre;
+    text-align: center;
+  }
+}

--- a/src/Site/views/shared/container/container.html.twig
+++ b/src/Site/views/shared/container/container.html.twig
@@ -53,7 +53,7 @@
 
 </head>
 
-<body>
+<body data-version="{{ version }}">
 
 {# appcache disabled due to being an unfinished feature #}
 {# {% block appcache %}{% endblock %} #}


### PR DESCRIPTION
### Fixes #1721

## Description

Show a warning on QA, so that people realize they're not working in a production environment.

It's not pretty, but it's not supposed to be 🤷.

This is the poor man solution 😉. A clickable link would be nice. I'll let the reviewers decide if it's worth adding HTML (in 2 places: the logged in and not logged in headers) for that.

## Screenshots

![image](https://user-images.githubusercontent.com/12587509/216389515-5ba4f22e-99e7-4d9e-af10-5c23cf07edc1.png)

![image](https://user-images.githubusercontent.com/12587509/216389776-9bc61ac1-409b-4eff-bebb-005ea14c9765.png)


## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- ~I have added tests that prove my fix is effective or that my feature works~
- [ ] I have enabled auto-merge (optional)

## QA testing

Testers, use the following instructions on [qa.languageforge.org](https://qa.languageforge.org). Post your findings as a comment and include any meaningful screenshots, etc.

Make sure the layout isn't broken, nothing is covered up in an unusable way and the message appears on all screens.