### PR TITLE
Redirect to projects and clear session project on project exceptions

### DIFF
--- a/src/Api/Model/Shared/UserModel.php
+++ b/src/Api/Model/Shared/UserModel.php
@@ -246,9 +246,10 @@ class UserModel extends MapperModel
      */
     public function removeProject($projectId)
     {
-        //$projectModel = new ProjectModel($projectId);
         $this->projects->_removeRef($projectId);
-        //$projectModel->users->_removeRef($this->id);
+        if ($projectId == $this->lastUsedProjectId) {
+            $this->lastUsedProjectId = "";
+        }
     }
 
     public function listProjects()

--- a/src/Site/Controller/App.php
+++ b/src/Site/Controller/App.php
@@ -51,13 +51,14 @@ class App extends Base
             $this->setupAngularAppVariables($model);
         } catch (UserUnauthorizedException $e) {
             if (SilexSessionHelper::getUserId($app)) {
-                return $app->redirect("/app/projects");
+                return $this->redirectToProjects($app);
             }
             return $app->redirect("/auth/logout");
         } catch (\Exception $e) {
             // setupBaseVariables() had a catch block for exceptions of unspecified type and it has been refactored here
             // Investigations into exception type were unsuccessful
-            return $app->redirect("/auth/logout");
+            // We'll assume it's project specific and go to the list
+            return $this->redirectToProjects($app);
         }
         return $this->renderPage($app, "angular-app");
     }
@@ -120,6 +121,14 @@ class App extends Base
         $this->addCssFiles($model->appFolder, ["node_modules"]);
 
         $this->addSemanticDomainFile($model);
+    }
+
+    protected function redirectToProjects(Application $app)
+    {
+        $this->_user->lastUsedProjectId = "";
+        $this->_user->write();
+        $app["session"]->set("projectId", "");
+        return $app->redirect("/app/projects");
     }
 
     /**

--- a/src/Site/Controller/Redirect.php
+++ b/src/Site/Controller/Redirect.php
@@ -29,7 +29,7 @@ class Redirect extends App
         } catch (\Exception $e) {
             // Don't know what went wrong, so go to logout route to clear the session
             // This will then redirect to the login page
-            return $app->redirect("/auth/logout");
+            return $this->redirectToProjects($app);
         }
         try {
             // Get most recent project ID, either from PHP session or from user's lastUsedProjectID in MongoDB
@@ -38,13 +38,13 @@ class Redirect extends App
             if (SilexSessionHelper::getUserId($app)) {
                 // User tried to access project they're not a member of, so show them projects view so they can pick a different one
                 // This can happen if the user was removed from the project by a manager between their last login and now
-                return $app->redirect("/app/projects");
+                return $this->redirectToProjects($app);
             }
             // Session somehow persisted despite user being logged out, so go to logout route to clear the session
             return $app->redirect("/auth/logout");
         } catch (\Exception $e) {
-            // Don't know what went wrong, so go to logout route to clear the session
-            return $app->redirect("/auth/logout");
+            // Don't know what went wrong, so we'll assume it's project specific and go to the list
+            return $this->redirectToProjects($app);
         }
         if ($projectId) {
             try {
@@ -55,7 +55,7 @@ class Redirect extends App
                 }
             } catch (\Exception $e) {
                 // Project ID no longer valid, probably because it was deleted. Let user pick a different one
-                return $app->redirect("/app/projects");
+                return $this->redirectToProjects($app);
             }
         }
         // No recently-used project on record, so check if the user has only one project, or none
@@ -75,7 +75,7 @@ class Redirect extends App
                     }
                 } catch (\Exception $e) {
                     // Don't know what went wrong, so default to /app/projects as the most flexible choice
-                    return $app->redirect("/app/projects");
+                    return $this->redirectToProjects($app);
                 }
             } elseif (count($this->_user->projects->refs) == 0) {
                 // User is not a member of any projects, so let them join one or start a new one
@@ -83,6 +83,6 @@ class Redirect extends App
             }
         }
         // If we get here, user had 2 or more projects and didn't have a most recent one, so let them choose their next project
-        return $app->redirect("/app/projects");
+        return $this->redirectToProjects($app);
     }
 }


### PR DESCRIPTION
### Fixes #1726 (hopefully all of it 🤷), Fixes #1708

## Description

Ensure that deleted projects are removed from users entirely (including `lastProjectUsed`. Also change many redirects from `/logout` to `/projects`. Ultimately this is a bit overkill, but will hopefully minimize similar hassles in the future. Invalid project-IDs in URLs now land on the projects page.

We commonly redirect to /logout when an unexpected Exception occurs. The thinking is presumably: we'll clear the session and maybe it will work next time. But, I think it often makes just as much sense to assume that the problem is project-specific, so going to the projects page removes the hassle of having to log in again. The user is authenticated, so there's no security issue to worry about. Worst case is that the projects page doesn't work and the user lands in an infinite redirect loop. 🤷

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

1) Create 2 users
2) User 1 creates a project and invites user 2
3) User 2 joins project and logs out (or not 🤷)
4) User 1 delete project
5) User 3 can still log in and lands on the project list page