### PR TITLE
add privacy policy link to home page

### DIFF
--- a/src/Site/views/languageforge/theme/default/page/home/index.html.twig
+++ b/src/Site/views/languageforge/theme/default/page/home/index.html.twig
@@ -125,7 +125,7 @@
 
         <ul class="copyright">
             <li>Copyright <span class="notranslate">{{ "now"|date("Y") }}</span> <a href="http://www.sil.org">SIL International</a>. Use of this site is
-                governed by our <a href="/terms_and_conditions">terms and conditions</a>.
+                governed by our <a href="/terms_and_conditions">terms and conditions</a> and our <a href="https://software.sil.org/language-software-privacy-policy/">privacy policy</a>.
             </li>
             <li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
         </ul>


### PR DESCRIPTION
### Fixes #1744 

## Description

Add's a privacy policy link to the bottom of the homepage, in order to comply with FB request.

## Screenshots

![image](https://user-images.githubusercontent.com/3444521/228249492-eabcd9db-09b1-4475-9296-458470d53d9d.png)

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [ ] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

_Describe how to verify your changes and provide any necessary test data._

- Test A
