### PR TITLE
Revert "Update field names to be consistent with FLEx (#1731)"

### DIFF
--- a/src/Api/Model/Languageforge/Lexicon/Config/LexConfig.php
+++ b/src/Api/Model/Languageforge/Lexicon/Config/LexConfig.php
@@ -127,14 +127,14 @@ class LexConfig extends ObjectForEncoding
      * @var array
      */
     private static $flexOptionlistNames = [
-        "grammatical-info" => "Grammatical Category",
+        "grammatical-info" => "Part of Speech",
         "semantic-domain-ddp4" => "Semantic Domain",
         "domain-type" => "Academic Domains",
         self::ENVIRONMENTS => "Environments",
         "location" => "Location",
         "usage-type" => "Usages",
         "reversal-type" => "Reversal Entries",
-        "sense-type" => "Sense Type",
+        "sense-type" => "Type",
         "anthro-code" => "Anthropology Categories",
         "do-not-publish-in" => "Publish In",
         "status" => "Status",
@@ -145,7 +145,7 @@ class LexConfig extends ObjectForEncoding
         "paradigm" => "Paradigm",
         "users" => "Users",
         "translation-type" => "Translation Type",
-        "from-part-of-speech" => "From Grammatical Category",
+        "from-part-of-speech" => "From Part of Speech",
         "morph-type" => "Morph Type",
         "noun-slot" => "Noun Slot",
         "verb-slot" => "Verb Slot",

--- a/src/Api/Model/Languageforge/Lexicon/Config/LexConfiguration.php
+++ b/src/Api/Model/Languageforge/Lexicon/Config/LexConfiguration.php
@@ -89,11 +89,11 @@ class LexConfiguration
         $this->entry->fieldOrder[] = LexConfig::SENSES_LIST;
 
         $this->entry->fields[LexConfig::LEXEME] = new LexConfigMultiText();
-        $this->entry->fields[LexConfig::LEXEME]->label = "Lexeme Form";
+        $this->entry->fields[LexConfig::LEXEME]->label = "Word";
         $this->entry->fields[LexConfig::LEXEME]->inputSystems[] = "th";
 
         $this->entry->fields[LexConfig::SENSES_LIST] = new LexConfigFieldList();
-        $this->entry->fields[LexConfig::SENSES_LIST]->label = "Sense";
+        $this->entry->fields[LexConfig::SENSES_LIST]->label = "Meaning";
         $this->entry->fields[LexConfig::SENSES_LIST]->fieldOrder[] = LexConfig::GLOSS;
         $this->entry->fields[LexConfig::SENSES_LIST]->fieldOrder[] = LexConfig::DEFINITION;
         $this->entry->fields[LexConfig::SENSES_LIST]->fieldOrder[] = LexConfig::PICTURES;

--- a/src/Api/Model/Languageforge/Lexicon/Import/LiftDecoder.php
+++ b/src/Api/Model/Languageforge/Lexicon/Import/LiftDecoder.php
@@ -264,7 +264,7 @@ class LiftDecoder
                     );
                     break;
                 case "grammatical-info":
-                    // Grammatical Category
+                    // Part Of Speech
                     $sense->partOfSpeech->value = \Normalizer::normalize((string) $element["value"]);
                     break;
                 case "illustration":

--- a/src/Api/Model/Languageforge/Lexicon/Import/LiftImport.php
+++ b/src/Api/Model/Languageforge/Lexicon/Import/LiftImport.php
@@ -279,7 +279,7 @@ class LiftImport
 
     /**
      * Convert a LIFT range to an option list of the right code
-     * Usage example: rangeToOptionList($projectModel, 'grammatical-info', 'Grammatical Category', $liftRanges['grammatical-info'])
+     * Usage example: rangeToOptionList($projectModel, 'grammatical-info', 'Part of Speech', $liftRanges['grammatical-info'])
      * @param LexProjectModel $projectModel
      * @param string $optionListCode
      * @param string $optionListName

--- a/src/Api/Model/Languageforge/Lexicon/LexCommentFieldReference.php
+++ b/src/Api/Model/Languageforge/Lexicon/LexCommentFieldReference.php
@@ -6,10 +6,10 @@ use Api\Model\Shared\Mapper\ObjectForEncoding;
 
 class LexCommentFieldReference extends ObjectForEncoding
 {
-    /** @var string */
+    /** @var string - the field name e.g. "lexeme" */
     public $field;
 
-    /** @var string */
+    /** @var string - the field name for display e.g. "Word" */
     public $fieldNameForDisplay;
 
     /** @var string */
@@ -21,9 +21,11 @@ class LexCommentFieldReference extends ObjectForEncoding
     /** @var string */
     public $inputSystemAbbreviation;
 
-    /** @var string */
+    // The EntryContext and SenseContext are strings storing the value of the effective "word" (the entry context) and "meaning" (the sense context) at the time the comment was made
+
+    /** @var string - the "Word" value of the entry at comment time */
     public $word;
 
-    /** @var string */
+    /** @var string - the "Meaning" value of the entry at comment time */
     public $meaning;
 }

--- a/src/angular-app/bellows/apps/activity/activity-container.component.ts
+++ b/src/angular-app/bellows/apps/activity/activity-container.component.ts
@@ -93,7 +93,7 @@ class Activity {
             if (index.includes('#examples')) {
               label = 'Example - ' + label;
             } else if (index.indexOf('#examples')) {
-              label = 'Sense - ' + label;
+              label = 'Meaning - ' + label;
             }
             return label;
           }
@@ -109,7 +109,7 @@ class Activity {
       label = 'Example ' + fieldLabel.example + (label !== 'examples' ? ' ' + label : '');
     }
     if (fieldLabel.sense) {
-      label = 'Sense ' + fieldLabel.sense + (label !== 'senses' ? ' ' + label : '');
+      label = 'Meaning ' + fieldLabel.sense + (label !== 'senses' ? ' ' + label : '');
     }
     return label;
   }

--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -56,7 +56,7 @@ class EntryListModifiers {
   filterText = () => this.filterBy && this.filterBy.text || '';
   filterByLabel = () => this.filterBy && this.filterBy.option && this.filterBy.option.label || '';
   filterActive = () => !!(this.filterText() || this.filterBy && this.filterBy.option);
-  sortOptionLabel = (s: string) => s === 'Default' ? `Default (${this.filterText() ? 'Relevance' : 'Lexeme Form'})` : s;
+  sortOptionLabel = (s: string) => s === 'Default' ? `Default (${this.filterText() ? 'Relevance' : 'Word'})` : s;
 }
 
 const entriesIncrement = 50;

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.html
@@ -17,9 +17,9 @@
             <dc-fieldrepeat config="$ctrl.config" model="$ctrl.model" control="$ctrl.control" parent-context-guid="$ctrl.contextGuid"></dc-fieldrepeat>
         </div>
     </div>
-
-	<div data-ng-if="$ctrl.control.rights.canEditEntry() && isAtEditorEntry()" class="addItem topAddMeaning">
-        <a class="btn btn-sm btn-std" data-ng-click="$ctrl.addSense(0)"><i class="fa fa-plus"></i> Add Sense</a>
+    <!-- Place links to "Add Meaning" at the top and bottom of the senses so users can easily find them -->
+    <div data-ng-if="$ctrl.control.rights.canEditEntry() && isAtEditorEntry()" class="addItem topAddMeaning">
+        <a class="btn btn-sm btn-std" data-ng-click="$ctrl.addSense(0)"><i class="fa fa-plus"></i> Add Meaning</a>
     </div>
     <div data-ng-if="$ctrl.config.fields.senses.fieldOrder.length > 0">
         <!--suppress JSUnusedLocalSymbols -->
@@ -30,6 +30,6 @@
         </div>
     </div>
     <div data-ng-if="$ctrl.control.rights.canEditEntry() && $ctrl.isAtEditorEntry()" class="addItem">
-        <a class="btn btn-sm btn-std" data-ng-click="$ctrl.addSense()"><i class="fa fa-plus"></i> Add Sense</a>
+        <a class="btn btn-sm btn-std" data-ng-click="$ctrl.addSense()"><i class="fa fa-plus"></i> Add Meaning</a>
     </div>
 </div>

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-entry.component.ts
@@ -52,10 +52,10 @@ export class FieldEntryController implements angular.IController {
   }
 
   deleteSense = (index: number): void => {
-    const deletemsg = 'Are you sure you want to delete the sense <b>\'' +
+    const deletemsg = 'Are you sure you want to delete the meaning <b>\'' +
       LexiconUtilityService.getMeaning(this.control.config, this.config.fields.senses as LexConfigFieldList,
         this.model.senses[index]) + '\'</b>?';
-    this.modal.showModalSimple('Delete Sense', deletemsg, 'Cancel', 'Delete Sense')
+    this.modal.showModalSimple('Delete Meaning', deletemsg, 'Cancel', 'Delete Meaning')
       .then(() => {
         // Adding or removing senses makes for a non-delta update, so save a possible delta update first
         this.control.saveCurrentEntry(false, () => {

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.html
@@ -1,7 +1,7 @@
 <div class="dc-sense card">
     <div class="meaning-label card-header">
         <div data-ng-if="$ctrl.control.rights.canEditEntry() && $ctrl.isAtEditorEntry()" class="d-flex align-items-center">
-            Sense <span class="notranslate pl-1">{{$ctrl.index+1}}</span>
+            Meaning <span class="notranslate pl-1">{{$ctrl.index+1}}</span>
 
 			<span class="flex-grow"></span>
 

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-sense.component.ts
@@ -30,10 +30,10 @@ export class FieldSenseController implements angular.IController {
         const field = this.config.fields[fieldName];
         if (field.senseLabel == null) {
           field.senseLabel = [];
-          field.senseLabel[-1] = 'Sense';
+          field.senseLabel[-1] = 'Meaning';
         }
 
-        field.senseLabel[this.index] = 'Sense ' + (this.index + 1);
+        field.senseLabel[this.index] = 'Meaning ' + (this.index + 1);
       }
     }
   }

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-fields.component.html
@@ -305,7 +305,7 @@
             </tr>
             <tr class="table-secondary">
                 <td></td>
-                <th class="text-center align-middle">Sense Fields</th>
+                <th class="text-center align-middle">Meaning Fields</th>
                 <td></td>
                 <th class="text-center align-middle">Select All</th>
                 <td class="text-center align-middle">

--- a/test/e2e/tests/editor/editor.audio.spec.ts
+++ b/test/e2e/tests/editor/editor.audio.spec.ts
@@ -10,9 +10,9 @@ test.describe('Editor audio', () => {
 
   test.beforeAll(async ({ managerTab }) => {
     const configurationPage = await new ConfigurationPageFieldsTab(managerTab, project()).goto();
-    await configurationPage.toggleFieldExpanded('Entry Fields', 'Lexeme Form');
-    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', 'ภาษาไทย (IPA)')).check();
-    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', 'ภาษาไทย (Voice)')).check();
+    await configurationPage.toggleFieldExpanded('Entry Fields', 'Word');
+    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', 'ภาษาไทย (IPA)')).check();
+    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', 'ภาษาไทย (Voice)')).check();
     await configurationPage.applyButton.click();
   });
 
@@ -25,7 +25,7 @@ test.describe('Editor audio', () => {
 
     test('Audio input system is present, playable and has "more" control (member)', async () => {
       await editorPageMember.goto();
-      const audio = editorPageMember.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageMember.getAudioPlayer('Word', 'taud');
       await expect(audio.playIcon).toBeVisible();
       await expect(audio.togglePlaybackAnchor).toBeEnabled();
 
@@ -36,9 +36,9 @@ test.describe('Editor audio', () => {
       await expect(audio.downloadButton).not.toBeVisible();
     });
 
-    test('Lexeme 2 (without audio): audio input system is not playable but has "upload" button (member)', async () => {
+    test('Word 2 (without audio): audio input system is not playable but has "upload" button (member)', async () => {
       await editorPageMember.goto({ entryId: entryIds()[1] });
-      const audio = editorPageMember.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageMember.getAudioPlayer('Word', 'taud');
       await expect(audio.togglePlaybackAnchor).not.toBeVisible();
       await expect(audio.dropdownToggle).toBeEnabled();
       await expect(audio.uploadButton).toBeVisible();
@@ -56,7 +56,7 @@ test.describe('Editor audio', () => {
 
     test('Audio Input System is playable but does not have "more" control (observer)', async () => {
       await editorPageObserver.goto();
-      const audio = editorPageObserver.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageObserver.getAudioPlayer('Word', 'taud');
       await expect(audio.playIcon).toBeVisible();
       await expect(audio.togglePlaybackAnchor).toBeVisible();
       await expect(audio.togglePlaybackAnchor).toBeEnabled();
@@ -65,9 +65,9 @@ test.describe('Editor audio', () => {
       await expect(audio.downloadButton).toBeVisible();
     });
 
-    test('Lexeme 2 (without audio): audio input system is not playable and does not have "upload" button (observer)', async () => {
+    test('Word 2 (without audio): audio input system is not playable and does not have "upload" button (observer)', async () => {
       await editorPageObserver.goto({ entryId: entryIds()[1] });
-      const audio = editorPageObserver.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageObserver.getAudioPlayer('Word', 'taud');
       await expect(audio.togglePlaybackAnchor).not.toBeVisible();
       await expect(audio.dropdownToggle).not.toBeVisible();
       await expect(audio.uploadButton).not.toBeVisible();
@@ -85,7 +85,7 @@ test.describe('Editor audio', () => {
 
     test('Audio input system is present, playable and has "more" control (manager)', async () => {
       await editorPageManager.goto();
-      const audio = editorPageManager.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageManager.getAudioPlayer('Word', 'taud');
       await expect(audio.playIcon).toBeVisible();
       await expect(audio.togglePlaybackAnchor).toBeEnabled();
       await expect(audio.dropdownToggle).toBeVisible();
@@ -97,7 +97,7 @@ test.describe('Editor audio', () => {
 
     test('Slider is present and updates with seeking', async () => {
       await editorPageManager.goto();
-      const audio = editorPageManager.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageManager.getAudioPlayer('Word', 'taud');
       await expect(audio.slider).toBeVisible();
       const bounds = await audio.slider.boundingBox();
       const yMiddle = bounds.y + bounds.height / 2;
@@ -113,7 +113,7 @@ test.describe('Editor audio', () => {
       const cancelAddingAudio = editorPageManager.getCancelDropboxButton(editorPageManager.entryCard, 'Audio');
       await expect(cancelAddingAudio).not.toBeVisible();
 
-      const audio = editorPageManager.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageManager.getAudioPlayer('Word', 'taud');
       await audio.dropdownToggle.click();
       await audio.dropdownMenu.uploadReplacementButton.click();
       await expect(audio.dropdownToggle).not.toBeVisible();
@@ -126,9 +126,9 @@ test.describe('Editor audio', () => {
       await expect(cancelAddingAudio).not.toBeVisible();
     });
 
-    test('Lexeme 2 (without audio): audio input system is not playable but has "upload" button (manager)', async () => {
+    test('Word 2 (without audio): audio input system is not playable but has "upload" button (manager)', async () => {
       await editorPageManager.goto({ entryId: entryIds()[1] });
-      const audio = editorPageManager.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageManager.getAudioPlayer('Word', 'taud');
       await expect(audio.playIcon).not.toBeVisible();
 
       await expect(audio.dropdownToggle).not.toBeVisible();
@@ -139,7 +139,7 @@ test.describe('Editor audio', () => {
 
     test('Can delete audio input system (manager)', async () => {
       await editorPageManager.goto();
-      const audio = editorPageManager.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageManager.getAudioPlayer('Word', 'taud');
       await audio.dropdownToggle.click();
       await audio.dropdownMenu.deleteAudioButton.click();
       const confirmModal = new ConfirmModal(editorPageManager.page);
@@ -154,7 +154,7 @@ test.describe('Editor audio', () => {
       await expect(noticeElement.notices).toHaveCount(0);
 
       // Can't upload a non-audio file
-      const audio = editorPageManager.getAudioPlayer('Lexeme Form', 'taud');
+      const audio = editorPageManager.getAudioPlayer('Word', 'taud');
       await audio.uploadButton.click();
 
       // Note that Promise.all prevents a race condition between clicking and waiting for the file chooser.

--- a/test/e2e/tests/editor/editor.comments.spec.ts
+++ b/test/e2e/tests/editor/editor.comments.spec.ts
@@ -11,16 +11,17 @@ test.describe('Lexicon Editor Comments', () => {
 
     await test.step('And input systems and entries', async () => {
       const configurationPage = await new ConfigurationPageFieldsTab(managerTab, project()).goto();
-      await configurationPage.toggleFieldExpanded('Entry Fields', 'Lexeme Form');
-      await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', 'English')).check();
-      await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', 'ภาษาไทย (Voice)')).check();
+      await configurationPage.toggleFieldExpanded('Entry Fields', 'Word');
+      await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', 'English')).check();
+      await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', 'ภาษาไทย (Voice)')).check();
       await configurationPage.applyButton.click();
     });
 
     const editorPage = await test.step('Create comments and replies', async () => {
       const editorPage = await new EditorPage(managerTab, project()).goto();
 
-      await editorPage.commentBubble('Lexeme Form', 'th').click();
+      // Create comments on "Word" "th"
+      await editorPage.commentBubble('Word', 'th').click();
 
       const comment1 = await editorPage.postComment('Test comment 1');
       await comment1.toggleReplies();
@@ -32,13 +33,15 @@ test.describe('Lexicon Editor Comments', () => {
       await comment2.postReply('Test reply 2.1');
       await comment2.postReply('Test reply 2.2');
 
-      await editorPage.commentBubble('Lexeme Form', 'en').click();
+      // Create comments on "Word" "en"
+      await editorPage.commentBubble('Word', 'en').click();
 
       const comment3 = await editorPage.postComment('Test comment 3');
       await comment3.toggleReplies();
       await comment3.postReply('Test reply 3.1');
 
-      await editorPage.commentBubble('Grammatical Category').click();
+      // Create comments on "Part of Speech"
+      await editorPage.commentBubble('Part of Speech').click();
 
       const comment4 = await editorPage.postComment('Test comment 4');
       await comment4.toggleReplies();
@@ -50,8 +53,8 @@ test.describe('Lexicon Editor Comments', () => {
     await test.step('Verify comments and replies', async () => {
       await editorPage.reload();
 
-      await expect(editorPage.commentCount('Lexeme Form', 'th')).toHaveText('2');
-      await editorPage.commentBubble('Lexeme Form', 'th').click();
+      await expect(editorPage.commentCount('Word', 'th')).toHaveText('2');
+      await editorPage.commentBubble('Word', 'th').click();
       await expect(editorPage.comments).toHaveCount(2);
       const comment1 = editorPage.getComment(1);
       await expect(comment1.content).toContainText('Test comment 1');
@@ -67,10 +70,10 @@ test.describe('Lexicon Editor Comments', () => {
       await expect(comment2.getReply(1).content).toContainText('Test reply 2.1');
       await expect(comment2.getReply(2).content).toContainText('Test reply 2.2');
 
-      await expect(editorPage.commentCount('Lexeme Form', 'en')).toHaveText('1');
+      await expect(editorPage.commentCount('Word', 'en')).toHaveText('1');
 
-      await expect(editorPage.commentCount('Grammatical Category')).toHaveText('1');
-      await editorPage.commentBubble('Grammatical Category').click();
+      await expect(editorPage.commentCount('Part of Speech')).toHaveText('1');
+      await editorPage.commentBubble('Part of Speech').click();
       await expect(editorPage.comments).toHaveCount(1);
       const comment4 = editorPage.getComment(1);
       await expect(comment4.content).toContainText('Test comment 4');
@@ -80,7 +83,7 @@ test.describe('Lexicon Editor Comments', () => {
     });
 
     await test.step('Like and change state', async () => {
-      await editorPage.commentBubble('Lexeme Form', 'th').click();
+      await editorPage.commentBubble('Word', 'th').click();
       let comment2 = editorPage.getComment(2);
 
       // Likes
@@ -103,7 +106,7 @@ test.describe('Lexicon Editor Comments', () => {
 
       // Verify it stuck
       await editorPage.reload();
-      await editorPage.commentBubble('Lexeme Form', 'th').click();
+      await editorPage.commentBubble('Word', 'th').click();
       comment2 = editorPage.getComment(2);
       await expect(comment2.likes).toContainText('1 Like');
       await expect(comment2.stateButton.markToDo).not.toBeVisible();
@@ -125,7 +128,7 @@ test.describe('Lexicon Editor Comments', () => {
       await expect(editorPage.comments).toHaveCount(4);
 
       // open for field
-      await editorPage.toggleComments('Lexeme Form', 'th');
+      await editorPage.toggleComments('Word', 'th');
       await expect(editorPage.comments).toHaveCount(2);
 
       // open all
@@ -133,19 +136,19 @@ test.describe('Lexicon Editor Comments', () => {
       await expect(editorPage.comments).toHaveCount(4);
 
       // open for field
-      await editorPage.toggleComments('Lexeme Form', 'th');
+      await editorPage.toggleComments('Word', 'th');
       await expect(editorPage.comments).toHaveCount(2);
 
       // close field
-      await editorPage.toggleComments('Lexeme Form', 'th');
+      await editorPage.toggleComments('Word', 'th');
       await expect(editorPage.comments).toHaveCount(0);
 
       // open for field
-      await editorPage.toggleComments('Lexeme Form', 'en');
+      await editorPage.toggleComments('Word', 'en');
       await expect(editorPage.comments).toHaveCount(1);
 
       // open for different field
-      await editorPage.toggleComments('Lexeme Form', 'th');
+      await editorPage.toggleComments('Word', 'th');
       await expect(editorPage.comments).toHaveCount(2);
     });
   });

--- a/test/e2e/tests/editor/editor.configuration.spec.ts
+++ b/test/e2e/tests/editor/editor.configuration.spec.ts
@@ -9,9 +9,9 @@ test.describe('Editor configuration', async () => {
   test.beforeAll(async ({ managerTab }) => {
     const configurationPage = new ConfigurationPageFieldsTab(managerTab, project());
     await configurationPage.goto();
-    await configurationPage.toggleFieldExpanded('Entry Fields', 'Lexeme Form');
-    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', 'ภาษาไทย (IPA)')).check();
-    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', 'ภาษาไทย (Voice)')).check();
+    await configurationPage.toggleFieldExpanded('Entry Fields', 'Word');
+    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', 'ภาษาไทย (IPA)')).check();
+    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', 'ภาษาไทย (Voice)')).check();
     await configurationPage.applyButton.click();
   });
 
@@ -24,42 +24,42 @@ test.describe('Editor configuration', async () => {
   test('Can change configuration to make a writing system visible or invisible', async ({ managerTab }) => {
     await editorPageManager.goto();
     // word has only "th", "tipa" and "taud" visible
-    await expect(editorPageManager.label('Lexeme Form', editorPageManager.entryCard)).toHaveCount(3);
-    await expect(editorPageManager.label('Lexeme Form', editorPageManager.entryCard)).toHaveCount(3);
-    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'th')).toBeVisible();
-    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'tipa')).toBeVisible();
-    await expect(editorPageManager.audioPlayer('Lexeme Form', 'taud')).toBeVisible();
+    await expect(editorPageManager.label('Word', editorPageManager.entryCard)).toHaveCount(3);
+    await expect(editorPageManager.label('Word', editorPageManager.entryCard)).toHaveCount(3);
+    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th')).toBeVisible();
+    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'tipa')).toBeVisible();
+    await expect(editorPageManager.audioPlayer('Word', 'taud')).toBeVisible();
 
-    // make "en" input system visible for "Lexeme" field
+    // make "en" input system visible for "Word" field
     const configurationPage = await new ConfigurationPageFieldsTab(managerTab, project()).goto();
-    await configurationPage.toggleFieldExpanded('Entry Fields', 'Lexeme Form');
-    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', 'English')).check();
+    await configurationPage.toggleFieldExpanded('Entry Fields', 'Word');
+    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', 'English')).check();
     await configurationPage.applyButton.click();
 
     // check if "en" is visible
     await editorPageManager.goto();
-    await expect(editorPageManager.label('Lexeme Form', editorPageManager.entryCard)).toHaveCount(4);
-    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'en')).toBeVisible();
+    await expect(editorPageManager.label('Word', editorPageManager.entryCard)).toHaveCount(4);
+    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'en')).toBeVisible();
 
-    // make "en" input system invisible for "Lexeme" field
+    // make "en" input system invisible for "Word" field
     await configurationPage.goto();
-    await configurationPage.toggleFieldExpanded('Entry Fields', 'Lexeme Form');
-    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', 'English')).uncheck();
+    await configurationPage.toggleFieldExpanded('Entry Fields', 'Word');
+    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', 'English')).uncheck();
     await configurationPage.applyButton.click();
 
     // check if "en" is invisible
     await editorPageManager.goto();
-    await expect(editorPageManager.label('Lexeme Form', editorPageManager.entryCard)).toHaveCount(3);
-    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'en')).not.toBeVisible();
+    await expect(editorPageManager.label('Word', editorPageManager.entryCard)).toHaveCount(3);
+    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'en')).not.toBeVisible();
   });
 
-  test('Make "taud" input system invisible for "Lexeme" field and "tipa" invisible for manager role, then ensure it worked and change it back', async ({ managerTab, memberTab }) => {
+  test('Make "taud" input system invisible for "Word" field and "tipa" invisible for manager role, then ensure it worked and change it back', async ({ managerTab, memberTab }) => {
     test.slow();
 
     const configurationPage = await new ConfigurationPageFieldsTab(managerTab, project()).goto();
-    await configurationPage.toggleFieldExpanded('Entry Fields', 'Lexeme Form');
-    // Make "taud" input system invisible for "Lexeme" field....
-    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', '(Voice)')).uncheck();
+    await configurationPage.toggleFieldExpanded('Entry Fields', 'Word');
+    // Make "taud" input system invisible for "Word" field....
+    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', '(Voice)')).uncheck();
     // ....and "tipa" invisible for manager role
     await (await configurationPage.getCheckbox('Input Systems', 'IPA', 'Manager')).uncheck();
     await configurationPage.applyButton.click();
@@ -67,36 +67,36 @@ test.describe('Editor configuration', async () => {
     // verify that contributor can still see "tipa"
     const editorPageMember = new EditorPage(memberTab, project());
     await editorPageMember.goto();
-    await expect(editorPageMember.label('Lexeme Form', editorPageMember.entryCard)).toHaveCount(2);
-    await expect(editorPageMember.getTextarea(editorPageMember.entryCard, 'Lexeme Form', 'th')).toBeVisible();
-    await expect(editorPageMember.getTextarea(editorPageMember.entryCard, 'Lexeme Form', 'tipa')).toBeVisible();
+    await expect(editorPageMember.label('Word', editorPageMember.entryCard)).toHaveCount(2);
+    await expect(editorPageMember.getTextarea(editorPageMember.entryCard, 'Word', 'th')).toBeVisible();
+    await expect(editorPageMember.getTextarea(editorPageMember.entryCard, 'Word', 'tipa')).toBeVisible();
 
-    // Lexeme then only has "th" visible for manager role
+    // Word then only has "th" visible for manager role
     await editorPageManager.goto();
-    await expect(editorPageManager.label('Lexeme Form', editorPageManager.entryCard)).toHaveCount(1);
-    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'th')).toBeVisible();
+    await expect(editorPageManager.label('Word', editorPageManager.entryCard)).toHaveCount(1);
+    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th')).toBeVisible();
 
-    // restore visibility of "taud" for "Lexeme" field
+    // restore visibility of "taud" for "Word" field
     await configurationPage.goto();
-    await configurationPage.toggleFieldExpanded('Entry Fields', 'Lexeme Form');
-    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', '(Voice)')).check();
+    await configurationPage.toggleFieldExpanded('Entry Fields', 'Word');
+    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', '(Voice)')).check();
     await configurationPage.applyButton.click();
 
-    // Lexeme has only "th" and "taud" visible for manager role
+    // Word has only "th" and "taud" visible for manager role
     await editorPageManager.goto();
-    await expect(editorPageManager.label('Lexeme Form', editorPageManager.entryCard)).toHaveCount(2);
-    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'th')).toBeVisible();
-    await expect(editorPageManager.audioPlayer('Lexeme Form', 'taud')).toBeVisible();
+    await expect(editorPageManager.label('Word', editorPageManager.entryCard)).toHaveCount(2);
+    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th')).toBeVisible();
+    await expect(editorPageManager.audioPlayer('Word', 'taud')).toBeVisible();
 
     // restore visibility of "tipa" input system for manager role
     await configurationPage.goto();
     await (await configurationPage.getCheckbox('Input Systems', 'IPA', 'Manager')).check();
     await configurationPage.applyButton.click();
 
-    // Lexeme has "th", "tipa" and "taud" visible again for manager role
+    // Word has "th", "tipa" and "taud" visible again for manager role
     await editorPageManager.goto();
-    await expect(editorPageManager.label('Lexeme Form', editorPageManager.entryCard)).toHaveCount(3);
-    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'tipa')).toBeVisible();
+    await expect(editorPageManager.label('Word', editorPageManager.entryCard)).toHaveCount(3);
+    await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'tipa')).toBeVisible();
   });
 
 });

--- a/test/e2e/tests/editor/editor.entries.spec.ts
+++ b/test/e2e/tests/editor/editor.entries.spec.ts
@@ -41,12 +41,12 @@ test.describe('Editor entries', () => {
     expect(editorPageManager.page.url()).not.toContain(entryIds()[0]);
   });
 
-  test('Entry 1: edit page has correct definition, grammatical category', async () => {
+  test('Entry 1: edit page has correct definition, part of speech', async () => {
     await editorPageManager.goto();
     await expect(editorPageManager.getTextarea(
       editorPageManager.senseCard, 'Definition', 'en'))
       .toHaveValue(entries.entry1.senses[0].definition.en.value);
-    expect(await editorPageManager.getSelectedValueFromSelectDropdown(editorPageManager.senseCard, 'Grammatical Category'))
+    expect(await editorPageManager.getSelectedValueFromSelectDropdown(editorPageManager.senseCard, 'Part of Speech'))
       .toEqual(entries.entry1.senses[0].partOfSpeech.displayName);
   });
 
@@ -61,8 +61,8 @@ test.describe('Editor entries', () => {
 
   test('Citation form field overrides lexeme form in dictionary citation view', async ({ managerTab }) => {
     const configurationPage = await new ConfigurationPageFieldsTab(managerTab, project()).goto();
-    await configurationPage.toggleFieldExpanded('Entry Fields', 'Lexeme Form');
-    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Lexeme Form', 'ภาษาไทย (IPA)')).check();
+    await configurationPage.toggleFieldExpanded('Entry Fields', 'Word');
+    await (await configurationPage.getFieldCheckbox('Entry Fields', 'Word', 'ภาษาไทย (IPA)')).check();
     await configurationPage.applyButton.click();
 
     await editorPageManager.goto();
@@ -96,13 +96,13 @@ test.describe('Editor entries', () => {
       editorPageManager.senseCard.first(), 'Definition', 'en')).toHaveValue(entries.multipleMeaningEntry.senses[0].definition.en.value);
   });
 
-  test('Lexeme 2: edit page has correct definition, grammatical category', async () => {
+  test('Word 2: edit page has correct definition, part of speech', async () => {
     await editorPageManager.goto({ entryId: entryIds()[1] });
     await expect(editorPageManager.getTextarea(
       editorPageManager.senseCard, 'Definition', 'en'))
       .toHaveValue(entries.entry2.senses[0].definition.en.value);
 
-    expect(await editorPageManager.getSelectedValueFromSelectDropdown(editorPageManager.senseCard, 'Grammatical Category'))
+    expect(await editorPageManager.getSelectedValueFromSelectDropdown(editorPageManager.senseCard, 'Part of Speech'))
       .toEqual(entries.entry2.senses[0].partOfSpeech.displayName);
   });
 
@@ -119,7 +119,7 @@ test.describe('Editor entries', () => {
     await expect(editorPageManager.renderedDivs).toContainText([entries.multipleMeaningEntry.senses[1].examples[1].translation.en.value, entries.multipleMeaningEntry.senses[1].examples[1].translation.en.value]);
   });
 
-  test('Lexeme with multiple definitions: edit page has correct definitions, parts of speech', async () => {
+  test('Word with multiple definitions: edit page has correct definitions, parts of speech', async () => {
     await editorPageManager.goto({ entryId: entryIds()[2] });
     await expect(editorPageManager.getTextarea(
       editorPageManager.senseCard.first(), 'Definition', 'en'))
@@ -128,13 +128,13 @@ test.describe('Editor entries', () => {
       editorPageManager.senseCard.nth(1), 'Definition', 'en'))
       .toHaveValue(entries.multipleMeaningEntry.senses[1].definition.en.value);
 
-    expect(await editorPageManager.getSelectedValueFromSelectDropdown(editorPageManager.senseCard.nth(0), 'Grammatical Category'))
+    expect(await editorPageManager.getSelectedValueFromSelectDropdown(editorPageManager.senseCard.nth(0), 'Part of Speech'))
       .toEqual(entries.multipleMeaningEntry.senses[0].partOfSpeech.displayName);
-    expect(await editorPageManager.getSelectedValueFromSelectDropdown(editorPageManager.senseCard.nth(1), 'Grammatical Category'))
+    expect(await editorPageManager.getSelectedValueFromSelectDropdown(editorPageManager.senseCard.nth(1), 'Part of Speech'))
       .toEqual(entries.multipleMeaningEntry.senses[1].partOfSpeech.displayName);
   });
 
-  test('Lexeme with multiple meanings: edit page has correct example sentences, translations', async () => {
+  test('Word with multiple meanings: edit page has correct example sentences, translations', async () => {
     await editorPageManager.goto({ entryId: entryIds()[2] });
 
     await expect(editorPageManager.getTextarea(
@@ -176,7 +176,7 @@ test.describe('Editor entries', () => {
       editorPageManager.senseCard.nth(0), 'General Note', 'en')).toBeVisible();
   });
 
-  test('Lexeme with multiple meanings: edit page has correct general notes, sources', async () => {
+  test('Word with multiple meanings: edit page has correct general notes, sources', async () => {
     await editorPageManager.goto({ entryId: entryIds()[2] });
     await expect(editorPageManager.getTextarea(
       editorPageManager.senseCard.nth(0), 'General Note', 'en'))
@@ -215,12 +215,12 @@ test.describe('Editor entries', () => {
     await expect(editorPageManager.compactEntryListItem).toHaveCount(newEntryCount);
 
     // go back to editor
-    await (editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'th'))
+    await (editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th'))
       .fill(entries.entry3.lexeme.th.value);
     await (editorPageManager.getTextarea(editorPageManager.senseCard, 'Definition', 'en'))
       .fill(entries.entry3.senses[0].definition.en.value);
 
-    const partOfSpeedDropdown = editorPageManager.getDropdown(editorPageManager.senseCard, 'Grammatical Category');
+    const partOfSpeedDropdown = editorPageManager.getDropdown(editorPageManager.senseCard, 'Part of Speech');
     partOfSpeedDropdown.selectOption({ label: 'Noun (n)' });
 
     // Autosaves changes
@@ -229,14 +229,14 @@ test.describe('Editor entries', () => {
 
     await expect(partOfSpeedDropdown).toHaveSelectedOption({ label: 'Noun (n)' });
 
-    const alreadyThere: string = await editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'th').inputValue();
-    await (editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'th'))
+    const alreadyThere: string = await editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th').inputValue();
+    await (editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th'))
       .fill(alreadyThere + 'a');
     await editorPageManager.page.reload();
     await expect((editorPageManager.getTextarea(
-      editorPageManager.entryCard, 'Lexeme Form', 'th')))
+      editorPageManager.entryCard, 'Word', 'th')))
       .toHaveValue(entries.entry3.lexeme.th.value + 'a');
-    await (editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'th'))
+    await (editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th'))
       .fill(entries.entry3.lexeme.th.value);
 
     // New word is visible in list
@@ -253,7 +253,7 @@ test.describe('Editor entries', () => {
 
     // previous entry is selected after delete
     await expect(editorPageManager.getTextarea(
-      editorPageManager.entryCard, 'Lexeme Form', 'th'))
+      editorPageManager.entryCard, 'Word', 'th'))
       .toHaveValue(entries.entry1.lexeme.th.value);
   });
 });

--- a/test/e2e/tests/editor/editor.pictures.spec.ts
+++ b/test/e2e/tests/editor/editor.pictures.spec.ts
@@ -58,8 +58,8 @@ test.describe('Editor pictures', () => {
     await test.step('Hide empty captions', async () => {
       await configurationPage.goto();
       await configurationPage.tabLinks.fields.click();
-      await configurationPage.toggleFieldExpanded('Sense Fields', 'Pictures');
-      await (await configurationPage.getFieldCheckbox('Sense Fields', 'Pictures', 'Hide Caption If Empty')).check();
+      await configurationPage.toggleFieldExpanded('Meaning Fields', 'Pictures');
+      await (await configurationPage.getFieldCheckbox('Meaning Fields', 'Pictures', 'Hide Caption If Empty')).check();
       await configurationPage.applyButton.click();
     });
 
@@ -83,8 +83,8 @@ test.describe('Editor pictures', () => {
     await test.step('Show empty captions', async () => {
       await configurationPage.goto();
       await configurationPage.tabLinks.fields.click();
-      await configurationPage.toggleFieldExpanded('Sense Fields', 'Pictures');
-      await (await configurationPage.getFieldCheckbox('Sense Fields', 'Pictures', 'Hide Caption If Empty')).uncheck();
+      await configurationPage.toggleFieldExpanded('Meaning Fields', 'Pictures');
+      await (await configurationPage.getFieldCheckbox('Meaning Fields', 'Pictures', 'Hide Caption If Empty')).uncheck();
       await configurationPage.applyButton.click();
     });
 
@@ -113,9 +113,9 @@ test.describe('Editor pictures', () => {
 
     const configurationPage = await new ConfigurationPageFieldsTab(editorPageManager.page, testProject).goto();
     await configurationPage.tabLinks.fields.click();
-    await (await configurationPage.getCheckbox('Sense Fields', 'Pictures', 'Hidden if Empty')).check();
-    await configurationPage.toggleFieldExpanded('Sense Fields', 'Pictures');
-    await (await configurationPage.getFieldCheckbox('Sense Fields', 'Pictures', 'Hide Caption If Empty')).uncheck();
+    await (await configurationPage.getCheckbox('Meaning Fields', 'Pictures', 'Hidden if Empty')).check();
+    await configurationPage.toggleFieldExpanded('Meaning Fields', 'Pictures');
+    await (await configurationPage.getFieldCheckbox('Meaning Fields', 'Pictures', 'Hide Caption If Empty')).uncheck();
     await configurationPage.applyButton.click();
 
     // can change config to hide pictures and hide captions

--- a/test/e2e/tests/entry-list.spec.ts
+++ b/test/e2e/tests/entry-list.spec.ts
@@ -35,7 +35,7 @@ test.describe('Entries List', () => {
         entryListPageManager.entry(entries.entry1.lexeme.th.value).click(),
         new EditorPage(entryListPageManager.page, project()).waitFor(),
       ])
-      await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Lexeme Form', 'th')).toHaveValue(entries.entry1.lexeme.th.value);
+      await expect(editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th')).toHaveValue(entries.entry1.lexeme.th.value);
     });
 
     test('Add word buttons works and redirects to editor', async () => {

--- a/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexEntryCommandsTest.php
@@ -207,11 +207,7 @@ class LexEntryCommandsTest extends TestCase
         $this->assertEquals(["oldValue.lexeme.th" => "apple", "newValue.lexeme.th" => "first edit"], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
         $this->assertEquals(
-            [
-                "oldValue.lexeme.th" => "apple",
-                "newValue.lexeme.th" => "first edit",
-                "fieldLabel.lexeme.th" => "Lexeme Form",
-            ],
+            ["oldValue.lexeme.th" => "apple", "newValue.lexeme.th" => "first edit", "fieldLabel.lexeme.th" => "Word"],
             $withLabels
         );
 
@@ -229,7 +225,7 @@ class LexEntryCommandsTest extends TestCase
             [
                 "oldValue.lexeme.th" => "first edit",
                 "newValue.lexeme.th" => "second edit",
-                "fieldLabel.lexeme.th" => "Lexeme Form",
+                "fieldLabel.lexeme.th" => "Word",
             ],
             $withLabels
         );
@@ -256,7 +252,7 @@ class LexEntryCommandsTest extends TestCase
         $this->assertEquals(["oldValue.lexeme.th" => "apple", "newValue.lexeme.th" => ""], $differences);
         $withLabels = LexEntryCommands::addFieldLabelsToDifferences($project->config, $differences);
         $this->assertEquals(
-            ["oldValue.lexeme.th" => "apple", "newValue.lexeme.th" => "", "fieldLabel.lexeme.th" => "Lexeme Form"],
+            ["oldValue.lexeme.th" => "apple", "newValue.lexeme.th" => "", "fieldLabel.lexeme.th" => "Word"],
             $withLabels
         );
     }
@@ -296,7 +292,7 @@ class LexEntryCommandsTest extends TestCase
                 "deleted.senses@0#" . $sense->guid => "apple",
                 "oldValue.senses@0#" . $sense->guid . ".definition.en" => "apple",
                 "newValue.senses@0#" . $sense->guid . ".definition.en" => "",
-                "fieldLabel.senses@0#" . $sense->guid => "Sense",
+                "fieldLabel.senses@0#" . $sense->guid => "Meaning",
                 "fieldLabel.senses@0#" . $sense->guid . ".definition.en" => "Definition",
             ],
             $withLabels
@@ -344,12 +340,12 @@ class LexEntryCommandsTest extends TestCase
                 "deleted.senses@0#" . $sense1->guid => "apple",
                 "oldValue.senses@0#" . $sense1->guid . ".definition.en" => "apple",
                 "newValue.senses@0#" . $sense1->guid . ".definition.en" => "",
-                "fieldLabel.senses@0#" . $sense1->guid => "Sense",
+                "fieldLabel.senses@0#" . $sense1->guid => "Meaning",
                 "fieldLabel.senses@0#" . $sense1->guid . ".definition.en" => "Definition",
                 "deleted.senses@1#" . $sense2->guid => "also an apple",
                 "oldValue.senses@1#" . $sense2->guid . ".definition.en" => "also an apple",
                 "newValue.senses@1#" . $sense2->guid . ".definition.en" => "",
-                "fieldLabel.senses@1#" . $sense2->guid => "Sense",
+                "fieldLabel.senses@1#" . $sense2->guid => "Meaning",
                 "fieldLabel.senses@1#" . $sense2->guid . ".definition.en" => "Definition",
             ],
             $withLabels
@@ -393,8 +389,8 @@ class LexEntryCommandsTest extends TestCase
             [
                 "moved.senses@0#" . $sense1->guid => "1",
                 "moved.senses@1#" . $sense2->guid => "0",
-                "fieldLabel.senses@0#" . $sense1->guid => "Sense",
-                "fieldLabel.senses@1#" . $sense2->guid => "Sense",
+                "fieldLabel.senses@0#" . $sense1->guid => "Meaning",
+                "fieldLabel.senses@1#" . $sense2->guid => "Meaning",
             ],
             $withLabels
         );
@@ -439,10 +435,10 @@ class LexEntryCommandsTest extends TestCase
                 "deleted.senses@0#" . $sense1->guid => "apple",
                 "oldValue.senses@0#" . $sense1->guid . ".definition.en" => "apple",
                 "newValue.senses@0#" . $sense1->guid . ".definition.en" => "",
-                "fieldLabel.senses@0#" . $sense1->guid => "Sense",
+                "fieldLabel.senses@0#" . $sense1->guid => "Meaning",
                 "fieldLabel.senses@0#" . $sense1->guid . ".definition.en" => "Definition",
                 "moved.senses@1#" . $sense2->guid => 0,
-                "fieldLabel.senses@1#" . $sense2->guid => "Sense",
+                "fieldLabel.senses@1#" . $sense2->guid => "Meaning",
             ],
             $withLabels
         );
@@ -486,7 +482,7 @@ class LexEntryCommandsTest extends TestCase
                 "deleted.senses@1#" . $sense2->guid => "also an apple",
                 "oldValue.senses@1#" . $sense2->guid . ".definition.en" => "also an apple",
                 "newValue.senses@1#" . $sense2->guid . ".definition.en" => "",
-                "fieldLabel.senses@1#" . $sense2->guid => "Sense",
+                "fieldLabel.senses@1#" . $sense2->guid => "Meaning",
                 "fieldLabel.senses@1#" . $sense2->guid . ".definition.en" => "Definition",
             ],
             $withLabels
@@ -545,7 +541,7 @@ class LexEntryCommandsTest extends TestCase
                 "newValue.senses@1#" . $sense2Guid . ".definition.fr" => "une pomme",
                 "oldValue.senses@1#" . $sense2Guid . ".generalNote.en" => "",
                 "newValue.senses@1#" . $sense2Guid . ".generalNote.en" => "note about the apple",
-                "fieldLabel.senses@1#" . $sense2Guid => "Sense",
+                "fieldLabel.senses@1#" . $sense2Guid => "Meaning",
                 "fieldLabel.senses@1#" . $sense2Guid . ".definition.en" => "Definition",
                 "fieldLabel.senses@1#" . $sense2Guid . ".definition.fr" => "Definition",
                 "fieldLabel.senses@1#" . $sense2Guid . ".generalNote.en" => "General Note",
@@ -602,7 +598,7 @@ class LexEntryCommandsTest extends TestCase
         $this->assertEquals(
             [
                 "moved.senses@0#" . $sense2->guid => 1,
-                "fieldLabel.senses@0#" . $sense2->guid => "Sense",
+                "fieldLabel.senses@0#" . $sense2->guid => "Meaning",
                 "added.senses@0#" . $newSenseGuid => "also an apple",
                 "oldValue.senses@0#" . $newSenseGuid . ".definition.en" => "",
                 "newValue.senses@0#" . $newSenseGuid . ".definition.en" => "also an apple",
@@ -610,7 +606,7 @@ class LexEntryCommandsTest extends TestCase
                 "newValue.senses@0#" . $newSenseGuid . ".definition.fr" => "une pomme",
                 "oldValue.senses@0#" . $newSenseGuid . ".generalNote.en" => "",
                 "newValue.senses@0#" . $newSenseGuid . ".generalNote.en" => "note about the apple",
-                "fieldLabel.senses@0#" . $newSenseGuid => "Sense",
+                "fieldLabel.senses@0#" . $newSenseGuid => "Meaning",
                 "fieldLabel.senses@0#" . $newSenseGuid . ".definition.en" => "Definition",
                 "fieldLabel.senses@0#" . $newSenseGuid . ".definition.fr" => "Definition",
                 "fieldLabel.senses@0#" . $newSenseGuid . ".generalNote.en" => "General Note",
@@ -695,12 +691,12 @@ class LexEntryCommandsTest extends TestCase
                 "newValue.senses@1#" . $senseB->guid . ".definition.en" => "",
                 "oldValue.senses@2#" . $senseC->guid . ".definition.en" => "C",
                 "newValue.senses@2#" . $senseC->guid . ".definition.en" => "C2",
-                "fieldLabel.senses@0#" . $senseA->guid => "Sense",
-                "fieldLabel.senses@1#" . $senseB->guid => "Sense",
+                "fieldLabel.senses@0#" . $senseA->guid => "Meaning",
+                "fieldLabel.senses@1#" . $senseB->guid => "Meaning",
                 "fieldLabel.senses@1#" . $senseB->guid . ".definition.en" => "Definition",
-                "fieldLabel.senses@2#" . $senseC->guid => "Sense",
+                "fieldLabel.senses@2#" . $senseC->guid => "Meaning",
                 "fieldLabel.senses@2#" . $senseC->guid . ".definition.en" => "Definition",
-                "fieldLabel.senses@0#" . $newSenseGuid => "Sense",
+                "fieldLabel.senses@0#" . $newSenseGuid => "Meaning",
                 "fieldLabel.senses@0#" . $newSenseGuid . ".definition.en" => "Definition",
             ],
             $withLabels
@@ -1030,10 +1026,10 @@ class LexEntryCommandsTest extends TestCase
                 "newValue.senses@1#" . $senseD->guid . ".examples@0#" . $exampleD1->guid . ".sentence.en" => "D1",
 
                 // All added, deleted, moved, oldValue and newValue entries also have corresponding fieldLabel entries
-                "fieldLabel.senses@0#" . $senseA->guid => "Sense",
-                "fieldLabel.senses@1#" . $senseB->guid => "Sense",
-                "fieldLabel.senses@2#" . $senseC->guid => "Sense",
-                "fieldLabel.senses@1#" . $senseD->guid => "Sense",
+                "fieldLabel.senses@0#" . $senseA->guid => "Meaning",
+                "fieldLabel.senses@1#" . $senseB->guid => "Meaning",
+                "fieldLabel.senses@2#" . $senseC->guid => "Meaning",
+                "fieldLabel.senses@1#" . $senseD->guid => "Meaning",
 
                 "fieldLabel.senses@1#" . $senseB->guid . ".definition.en" => "Definition",
                 "fieldLabel.senses@2#" . $senseC->guid . ".definition.en" => "Definition",

--- a/test/php/model/languageforge/lexicon/command/LexOptionListCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexOptionListCommandsTest.php
@@ -18,7 +18,7 @@ class LexOptionListCommandsTest extends TestCase
         // Initial project has no optionlists populated
         $this->assertEquals(0, $optionLists->count);
 
-        // Initialized project has grammatical category optionlist defined
+        // Initialized project has part of speech optionlist defined
         $project->initializeNewProject();
         $optionLists->read();
         $this->assertEquals(1, $optionLists->count);
@@ -36,7 +36,7 @@ class LexOptionListCommandsTest extends TestCase
         $newValue = $optionLists->entries[0]["items"][0]["value"];
         $this->assertEquals("Verb (v)", $newValue);
 
-        // Create grammatical category list for fruits
+        // Create part of speech list for fruits
         $fruits = [
             ["key" => "a", "value" => "apple"],
             ["key" => "b", "value" => "berry"],

--- a/test/php/model/languageforge/lexicon/command/LexProjectCommandsTest.php
+++ b/test/php/model/languageforge/lexicon/command/LexProjectCommandsTest.php
@@ -53,7 +53,7 @@ class LexProjectCommandsTest extends TestCase
         // test for a few default values
         $this->assertEquals("en", $project2->inputSystems["en"]->tag);
         $this->assertTrue($project2->config->tasks["dbe"]->visible);
-        $this->assertEquals("Lexeme Form", $project2->config->entry->fields["lexeme"]->label);
+        $this->assertEquals("Word", $project2->config->entry->fields["lexeme"]->label);
         $this->assertCount(0, $project2->config->roleViews["observer"]->fields["lexeme"]->inputSystems);
         $this->assertCount(0, $project2->config->roleViews["observer_with_comment"]->fields["lexeme"]->inputSystems);
 

--- a/test/php/model/languageforge/lexicon/dto/LexBaseViewDtoTest.php
+++ b/test/php/model/languageforge/lexicon/dto/LexBaseViewDtoTest.php
@@ -32,10 +32,10 @@ class LexBaseViewDtoTest extends TestCase
         $this->assertEquals("en", $dto["config"]["inputSystems"]["en"]["tag"]);
         $this->assertTrue($dto["config"]["tasks"]["dbe"]["visible"]);
         $this->assertEquals("fields", $dto["config"]["entry"]["type"], "dto config is not valid");
-        $this->assertEquals("Lexeme Form", $dto["config"]["entry"]["fields"]["lexeme"]["label"]);
-        $this->assertEquals("Lexeme Form", $dto["config"]["entry"]["fields"]["lexeme"]["label"]);
+        $this->assertEquals("Word", $dto["config"]["entry"]["fields"]["lexeme"]["label"]);
+        $this->assertEquals("Word", $dto["config"]["entry"]["fields"]["lexeme"]["label"]);
         $this->assertEquals(
-            "Grammatical Category",
+            "Part of Speech",
             $dto["config"]["entry"]["fields"]["senses"]["fields"]["partOfSpeech"]["label"]
         );
         $this->assertTrue($dto["config"]["roleViews"]["contributor"]["fields"]["lexeme"]["show"]);


### PR DESCRIPTION
This reverts commit 3927735a1779516f65c003d8f7d8f2f72c42f344.

## Description

We came to a realization about the significance of the field names and the fact that some were stored in the database that led us to need to back this change out until a later time.

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

CI tests should be sufficient.