### PR TITLE
Bug: Project activity on dashboard sometimes triggers internal error

### DIFF
--- a/next-app/src/lib/forms/Button.svelte
+++ b/next-app/src/lib/forms/Button.svelte
@@ -1,12 +1,13 @@
 <script>
 	export let danger = false
 	export let disabled = false
+	export let loading = false
 	export {clazz as class}
 
 	let clazz = ''
 </script>
 
 <!-- https://daisyui.com/components/button -->
-<button on:click class:btn-error={danger} class:btn-disabled={disabled} class='btn btn-primary { clazz }'>
+<button on:click class:btn-error={danger} class:btn-disabled={disabled} class:loading={loading} class='btn btn-primary { clazz }'>
 	<slot />
 </button>

--- a/next-app/src/routes/projects/[project_code]/+page.svelte
+++ b/next-app/src/routes/projects/[project_code]/+page.svelte
@@ -17,6 +17,7 @@
 	export let data: DashboardData
 
 	let only_showing_subset = true
+    let loading = false;
 
 	$: project = data.project
 	$: activities = data.activities
@@ -53,8 +54,9 @@
 	].filter(({ value }) => value !== undefined)
 
 	async function load_all_activities() {
+        loading = true
 		activities = await GET({url: `/projects/${$page.params.project_code}/activities`})
-
+        loading = false
 		only_showing_subset = false
 	}
 </script>
@@ -80,8 +82,8 @@
 	<Activity { activities } />
 
 	{#if only_showing_subset}
-		<footer class='flex justify-center mt-2'>
-			<Button on:click={ load_all_activities } class='btn-outline btn-xs sm:btn-sm'>
+		<footer class='flex justify-center m-4'>
+			<Button on:click={ load_all_activities } class='btn-outline btn-xs sm:btn-sm' {loading}>
 				show all
 			</Button>
 		</footer>

--- a/next-app/src/routes/projects/[project_code]/Activity.svelte
+++ b/next-app/src/routes/projects/[project_code]/Activity.svelte
@@ -5,6 +5,7 @@
 
 	interface AugmentedActivity extends Activity {
 		date_locale: string,
+		date_time_locale: string,
 		date_iso: string,
 		time: number,
 		field_names: string,
@@ -36,6 +37,7 @@
 			return {
 				...activity,
 				date_locale: date.toLocaleDateString(),
+                date_time_locale: date.toLocaleString(),
 				date_iso: date.toISOString().split('T')[0],
 				time: date.getTime(),
 				field_names: to_names(activity.fields),
@@ -59,7 +61,10 @@
 	const des = (a: string | number, b: string | number) => a < b ? 1 : -1
 
 	function to_names(fields: Field[] = []): string {
-		return fields.map(field => field.name).join(', ')
+        // This is quite rudimentary, but far better than nothing
+		return [...new Set(fields.map(field => field.fieldLabel?.label)
+            .filter(label => !!label))]
+            .join(', ')
 	}
 </script>
 
@@ -69,20 +74,20 @@
 		<thead>
 			<tr>
 				<td>user</td>
-				<th>date</th>
 				<th>action</th>
 				<th>entry</th>
 				<th>fields</th>
+				<th>date</th>
 			</tr>
 		</thead>
 		<tbody>
 			{#each sorted_activities as activity}
 				<tr>
 					<td>{ activity.user.username }</td>
-					<td>{ activity.date_locale }</td>
 					<td>{ action_display[activity.action] || activity.action }</td>
 					<td>{ activity.entry || '—' }</td>
 					<td>{ activity.field_names || '—' }</td>
+					<td>{ activity.date_time_locale }</td>
 				</tr>
 			{:else}
 				<tr><td>No activity</td></tr>

--- a/next-app/src/routes/projects/[project_code]/Activity.svelte
+++ b/next-app/src/routes/projects/[project_code]/Activity.svelte
@@ -44,9 +44,15 @@
 	}
 
 	function byDateThenUser(a: AugmentedActivity, b: AugmentedActivity) {
-		return a.date_iso === b.date_iso ? a.user === b.user ? des(a.time, b.time)
-															 : asc(a.user.username, b.user.username)
-		                                 : des(a.date_iso, b.date_iso)
+        if (a.date_iso !== b.date_iso) {
+            return des(a.date_iso, b.date_iso);
+        }
+
+        if (a.user.username !== b.user.username) {
+            return asc(a.user.username, b.user.username);
+        }
+
+        return des(a.time, b.time);
 	}
 
 	const asc = (a: string | number, b: string | number) => a > b ? 1 : -1

--- a/next-app/src/routes/projects/[project_code]/activities/+server.ts
+++ b/next-app/src/routes/projects/[project_code]/activities/+server.ts
@@ -13,7 +13,7 @@ type LegacyResult = {
 }
 
 export type Field = {
-	name: string,
+  fieldLabel?: { label: string },
 }
 
 type LegacyActivity = {

--- a/src/Api/Model/Shared/Dto/ActivityListDto.php
+++ b/src/Api/Model/Shared/Dto/ActivityListDto.php
@@ -104,7 +104,7 @@ class ActivityListDto
             $unreadItems = array_merge($unreadItems, self::getUnreadActivityForUserInProject($userId, $project["id"]));
         }
         $unreadItems = array_merge($unreadItems, self::getGlobalUnreadActivityForUser($userId));
-        uasort($activity, ["self", "sortActivity"]);
+        usort($activity, ["self", "sortActivity"]);
         $dto = [
             "activity" => $activity,
             "unread" => $unreadItems,
@@ -124,7 +124,7 @@ class ActivityListDto
     {
         $activity = self::getActivityForProject($projectModel, $filterParams);
         $unreadItems = self::getUnreadActivityForUserInProject($userId, $projectModel->id->asString());
-        uasort($activity, ["self", "sortActivity"]);
+        usort($activity, ["self", "sortActivity"]);
         $dto = [
             "activity" => $activity,
             "unread" => $unreadItems,
@@ -146,7 +146,7 @@ class ActivityListDto
         // TODO: handle unread items for this activity log type (single-entry). Perhaps the getUnreadActivity() functions should just take a list of items? 2018-02 RM
         //        $unreadItems = self::getUnreadActivityForUserInProject($userId, $projectModel->id->asString());
         $unreadItems = [];
-        uasort($activity, ["self", "sortActivity"]);
+        usort($activity, ["self", "sortActivity"]);
         $dto = [
             "activity" => $activity,
             "unread" => $unreadItems,


### PR DESCRIPTION
### Fixes #1759

## Description

The culprit of the Internal Error was PHP's `uasort`, which we were using to sort activity _leaving indices in place_. Leaving indices in places potentially makes the array incompatible of being serialized as a JSON array. We don't care about the indices, so they can be tossed using `usort` instead.

Additionally:
- Now display date **and time** and moved it to the far right (because that seemed more intuitive to me)
- Found something meaningful to put in the "Fields" column as it seemed to be broken,
- Fixed the partially broken sorting  (it was comparing user objects (which are never the same) instead of user names)
- Added a loading indicator, because loading all activity can take a while

_Almost_ removed the sorting by username before time functionality, but...maybe it's useful and I made enough changes 🤷.
There are no indications that the list is not truly chronological and a truly chronological sort seems more compatible with real-time collaboration.

Yup, I see now that the original code uses tabs and I used spaces.

## Screenshots

![image](https://github.com/sillsdev/web-languageforge/assets/12587509/a627941c-fe87-431c-b3fa-07617b86088c)

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
~I have added tests that prove my fix is effective or that my feature works~
- [ ] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

1) View project activity
2) Make sure the column content seems reasonable
3) Observe no errors