### PR TITLE
Prevent UI updates when there is an unresolved recording in progress

### DIFF
--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -34,6 +34,7 @@ import { LexOptionList } from '../shared/model/option-list.model';
 import { FieldControl } from './field/field-control.model';
 import { OfflineCacheUtilsService } from '../../../bellows/core/offline/offline-cache-utils.service';
 import { IDeferred } from 'angular';
+import { RecordingStateService } from './recording-state.service';
 
 class Show {
   more: () => void;
@@ -94,6 +95,7 @@ export class LexiconEditorController implements angular.IController {
     'lexRightsService',
     'lexSendReceive',
     'offlineCacheUtils',
+    'recordingStateService',
   ];
 
   constructor(private readonly $filter: angular.IFilterService,
@@ -115,6 +117,7 @@ export class LexiconEditorController implements angular.IController {
     private readonly rightsService: LexiconRightsService,
     private readonly sendReceive: LexiconSendReceiveService,
     private readonly offlineCacheUtils: OfflineCacheUtilsService,
+    private readonly recordingStateService: RecordingStateService,
   ) { }
 
   $onInit(): void {
@@ -232,8 +235,8 @@ export class LexiconEditorController implements angular.IController {
     this.$state.go('importExport');
   }
 
-  returnToList(): void {
-    this.saveCurrentEntry();
+  async returnToList(): Promise<void> {
+    await this.saveCurrentEntry();
     this.setCurrentEntry();
     this.hideRightPanelWithoutAnimation();
     this.$state.go('editor.list', {
@@ -359,7 +362,7 @@ export class LexiconEditorController implements angular.IController {
     failCallback: (reason?: any) => void = () => { }) => {
     const isNewEntry = LexiconEditorController.entryIsNew(this.currentEntry);
     if (isNewEntry) {
-      // We have to wait for the initial save to complete so that we have
+      // We have to wait for the initial save to complete so that we save with the same entry ID
       await this.saving$.promise;
     }
 
@@ -368,6 +371,10 @@ export class LexiconEditorController implements angular.IController {
     // `doSetEntry` is mainly used for when the save button is pressed, that is when the user is saving the current
     // entry and is NOT going to a different entry (as is the case with editing another entry.
     let newEntryTempId: string;
+
+    // We might be saving, because the user is navigating away from this entry,
+    // in which case we don't want to lose the upload.
+    await this.recordingStateService.uploading$();
 
     if (this.hasUnsavedChanges() && this.lecRights.canEditEntry()) {
       this.cancelAutoSaveTimer();
@@ -1125,7 +1132,15 @@ export class LexiconEditorController implements angular.IController {
     return this.lecConfig.inputSystems[inputSystemTag].abbreviation;
   }
 
-  private setCurrentEntry(entry: LexEntry = new LexEntry()): void {
+  private setCurrentEntry(entry: LexEntry = new LexEntry()): Promise<void> {
+    if (entry.id === this.currentEntry.id && this.recordingStateService.hasUnsavedChanges()) {
+      // If it's the same entry, then we're just making sure the UI is as up to date
+      // as possible. If the user is recording or has audio to save, then we can't touch
+      // the UI, because the audio will get lost.
+      // If it's a different entry, we assume the user is intentionally discarding the audio.
+      return;
+    }
+
     // align custom fields into model
     entry = this.alignCustomFieldsInData(entry);
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.module.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.module.ts
@@ -10,6 +10,7 @@ import {LexiconCoreModule} from '../core/lexicon-core.module';
 import {EditorCommentsModule} from './comment/comment.module';
 import {LexiconEditorComponent, LexiconEditorEntryController, LexiconEditorListController} from './editor.component';
 import {EditorFieldModule} from './field/field.module';
+import { RecordingStateService } from './recording-state.service';
 
 export const LexiconEditorModule = angular
   .module('lexiconEditorModule', [
@@ -27,6 +28,7 @@ export const LexiconEditorModule = angular
   .component('lexiconEditor', LexiconEditorComponent)
   .controller('EditorListCtrl', LexiconEditorListController)
   .controller('EditorEntryCtrl', LexiconEditorEntryController)
+  .service('recordingStateService', RecordingStateService)
   .config(['$stateProvider', ($stateProvider: angular.ui.IStateProvider) => {
 
     // State machine from ui.router

--- a/src/angular-app/languageforge/lexicon/editor/recording-state.service.ts
+++ b/src/angular-app/languageforge/lexicon/editor/recording-state.service.ts
@@ -1,0 +1,39 @@
+import * as angular from 'angular';
+
+export class RecordingStateService {
+  static $inject: string[] = ['$q'];
+
+  private hasUnresolvedRecording = false;
+  private uploads$: angular.IPromise<unknown>[] = [];
+
+  constructor(private readonly $q: angular.IQService) {
+  }
+
+  startRecording(): boolean {
+    if (this.hasUnresolvedRecording) {
+      return false;
+    } else {
+      this.hasUnresolvedRecording = true;
+      return true;
+    }
+  }
+
+  resolveRecording(): void {
+    this.hasUnresolvedRecording = false;
+  }
+
+  startUploading(upload: angular.IPromise<unknown>): void {
+    this.uploads$.push(upload);
+    upload.finally(() =>
+      this.uploads$ = this.uploads$.filter(_upload => _upload !== upload)
+    );
+  }
+
+  uploading$(): angular.IPromise<unknown> {
+    return this.$q.all(this.uploads$);
+  }
+
+  hasUnsavedChanges(): boolean {
+    return this.hasUnresolvedRecording || this.uploads$.length > 0;
+  }
+}


### PR DESCRIPTION
### Fixes #1762 

## Description

See #1762 

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

1) Make various changes to entries while recording, while uploading or anywhere in between and make sure the recording never gets lost.