### PR TITLE
Bug: remove new lines from multitext

### DIFF
--- a/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
+++ b/src/angular-app/bellows/shared/audio-recorder/audio-recorder.component.ts
@@ -88,8 +88,12 @@ export class AudioRecorderController implements angular.IController {
         //Stopping the media stream tracks releases the red recording indicator from browser tabs
         this.mediaRecorder.addEventListener("stop",
           () => {
-            stream.getTracks().forEach(function(track) {
-              track.stop();
+            stream.getTracks().forEach(function (track) {
+              try {
+                console.log('Sample rate', track.getSettings().sampleRate);
+              } finally {
+                track.stop();
+              }
             });
           }
         );

--- a/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/field/dc-text.component.ts
@@ -29,7 +29,7 @@ export class FieldTextController implements angular.IController {
   fteMultiline: boolean;
   fteDir: string;
   fteFieldName: string;
-  
+
   fte: any = {};
   textFieldValue: string = '';
   autocapitalize: string
@@ -72,7 +72,11 @@ export class FieldTextController implements angular.IController {
   }
 
   inputChanged(): void {
-    this.fteModel = FieldTextController.escapeHTML(this.textFieldValue);
+    this.fteModel = FieldTextController
+      .escapeHTML(this.textFieldValue);
+    if (!this.fteMultiline) {
+      this.fteModel = this.fteModel.replace(/\n/g, ' ');
+    }
   }
 
   private static unescapeHTML(str: string): string {


### PR DESCRIPTION
## Description

Multi-texts were changed to `textarea` elements at some point, in order to support line wrapping. However, that also allows them to support line-breaks. There seemed to be some logic for values that are supposed to be single-line, but line breaks were not being removed, so this fixes that.

Additionally, I've added a simple log to see what the sample rate is for recordings on my phone. For some reason, I can't record audio when I access the app on my laptop from my phone, but I can when I access it on languageforge.org 🤷.