### PR TITLE
Add env var for pointing app at lexbox

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 # https://docs.docker.com/compose/compose-file
 # https://github.com/compose-spec/compose-spec/blob/master/spec.md
 version: '3.5'
+
+# networks:
+#   lexbox:
+#     name: lexbox_default
+#     external: true
+#   default:
+
 services:
   ui-builder:
     build:
@@ -37,14 +44,20 @@ services:
       - mail
       - ld-api
       - lfmerge
+    # networks:
+    #   - default
+    #   - lexbox
     environment:
-      - WAIT_HOSTS=db:27017, mail:25
+      - WAIT_HOSTS=lf-db:27017, mail:25
       - XDEBUG_MODE=develop,debug
       - LDAPI_BASE_URL=http://ld-api:3000/api/v2/
+      # Uncomment this to test getting the LD project list from LexBox
+      # To use LexBox locally (in docker) you'll also need to uncomment the networks here and at the top of the file
+      #- LEX_BOX_HOST=https://staging.languagedepot.org #lexbox-api:5158
       - ENVIRONMENT=development
       - WEBSITE=localhost
       - DATABASE=scriptureforge
-      - MONGODB_CONN=mongodb://db:27017
+      - MONGODB_CONN=mongodb://lf-db:27017
       - MAIL_HOST=mail
       - GOOGLE_CLIENT_ID=bogus-development-token
       - GOOGLE_CLIENT_SECRET=bogus-development-token

--- a/docker/deployment/app-deployment.yaml
+++ b/docker/deployment/app-deployment.yaml
@@ -138,6 +138,11 @@ spec:
               secretKeyRef:
                 key: LANGUAGE_DEPOT_API_TOKEN
                 name: ld-api
+          - name: LEX_BOX_HOST
+            valueFrom:
+              secretKeyRef:
+                key: LEX_BOX_HOST
+                name: ld-api
           - name: FACEBOOK_CLIENT_ID
             valueFrom:
               secretKeyRef:

--- a/docker/deployment/secrets.yaml
+++ b/docker/deployment/secrets.yaml
@@ -18,6 +18,7 @@ metadata:
 data:
   LANGUAGE_DEPOT_API_TOKEN: ''
   LDAPI_BASE_URL: ''
+  LEX_BOX_HOST: ''
 
 ---
 

--- a/src/Api/Model/Languageforge/Lexicon/Command/SendReceiveCommands.php
+++ b/src/Api/Model/Languageforge/Lexicon/Command/SendReceiveCommands.php
@@ -88,9 +88,12 @@ class SendReceiveCommands
         }
         $client = new Client(["handler" => $handler]);
 
-        $url = "https://admin.languagedepot.org/api/user/" . $username . "/projects";
+        $host = getenv("LEX_BOX_HOST") ?: "https://admin.languagedepot.org";
+        $url = $host . "/api/user/" . $username . "/projects";
         $postData = [
             "json" => ["password" => $password],
+            // Also supported:
+            // "form_params" => ["password" => $password],
             "headers" => ["Authorization" => "Bearer " . LANGUAGE_DEPOT_API_TOKEN],
         ];
 


### PR DESCRIPTION
Fixes #1767

## Description

We want LexBox to get as much "real" use as possible, so we plan to point the staging environment at it for fetching the list of LD projects.

As is obvious in the change set, I tested this against lexbox locally and in staging. Referencing `db` as `lf-db` was necessary, because both docker networks had a `db`.

This won't work (at the time of writing), because the LexBox API only supports form-data, which is what Chorus sends. It might be safe to just change lf-classic to do the same, but it feels a bit better supporting both, because 🤷 there might be another service sending json.

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have enabled auto-merge (optional)

## Testing

We'll turn this on in staging, once LexBox supports JSON.