### PR TITLE
add basic permissive robots.txt

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
### Fixes #1776 

## Description

It appears that one of the reasons languageforge.org does not show up in google search results is the absence of a robots.txt file (who knew?)

## Screenshots

From google search console:
<img width="973" alt="image" src="https://github.com/sillsdev/web-languageforge/assets/3444521/99503555-e4ba-409a-8f6b-47404b508dd5">


## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have enabled auto-merge (optional)

## Testing

This PR needs to be merged and testing can really only be done once the robots.txt has shipped to production.
