### PR TITLE
Add reset cache button to advanced project configuration tab

### DIFF
--- a/src/angular-app/bellows/core/offline/comments-offline-cache.service.ts
+++ b/src/angular-app/bellows/core/offline/comments-offline-cache.service.ts
@@ -13,6 +13,10 @@ export class CommentsOfflineCacheService {
     return this.offlineCache.deleteObjectInStore('comments', id);
   }
 
+  deleteAllComments(): angular.IPromise<any> {
+    return this.offlineCache.clearEntireStore('comments');
+  }
+
   getAllComments(): angular.IPromise<any> {
     return this.offlineCache.getAllFromStore('comments', this.sessionService.projectId());
   }

--- a/src/angular-app/bellows/core/offline/editor-offline-cache.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-offline-cache.service.ts
@@ -15,6 +15,10 @@ export class EditorOfflineCacheService {
     return this.offlineCache.deleteObjectInStore('entries', id);
   }
 
+  deleteAllEntries(): angular.IPromise<any> {
+    return this.offlineCache.clearEntireStore('entries');
+  }
+
   getAllEntries(): angular.IPromise<any> {
     return this.offlineCache.getAllFromStore('entries', this.sessionService.projectId());
   }

--- a/src/angular-app/bellows/core/offline/offline-cache.service.ts
+++ b/src/angular-app/bellows/core/offline/offline-cache.service.ts
@@ -20,6 +20,10 @@ export class OfflineCacheService {
     return this.$q.when(this.getStore(storeName).removeItem(key));
   }
 
+  clearEntireStore(storeName: string): angular.IPromise<any> {
+    return this.$q.when(this.getStore(storeName).clear());
+  }
+
   getAllFromStore(storeName: string, projectId?: string): angular.IPromise<any> {
     const results: any[] = [];
     return this.$q.when(this.getStore(storeName).iterate<any, any>(value => {

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.html
@@ -4,5 +4,15 @@
         <p>Please do not change these settings unless asked to by tech support.</p>
         <label for="updateIntervalSeconds">Update interval (in seconds)</label>
         <input type="number" ng-model="$ctrl.accPollUpdateTimerSecondsDirty">
+        <br>
+        <p>If something went wrong with downloading the dictionary and it only loaded a partial copy (i.e. some dictionary entries are missing), the button below can let you reset the browser storage, removing the partial copy of the dictionary stored in your browser so that you can download it again.</p>
+        <p><strong>CAUTION:</strong> Make sure you are online before doing this, otherwise you won't be able to redownload the dictionary and you'll see an empty project until you can go online again.</p>
+        <button
+            class="btn btn-danger"
+            type="button"
+            data-ng-click="$ctrl.resetLocalStorage()"
+            >
+            Reset browser storage
+        </button>
     </div>
 </div>

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.html
@@ -7,12 +7,12 @@
         <br>
         <p>If something went wrong with downloading the dictionary and it only loaded a partial copy (i.e. some dictionary entries are missing), the button below can let you reset the browser storage, removing the partial copy of the dictionary stored in your browser so that you can download it again.</p>
         <p><strong>CAUTION:</strong> Make sure you are online before doing this, otherwise you won't be able to redownload the dictionary and you'll see an empty project until you can go online again.</p>
-        <button
+        <a href="#"
             class="btn btn-danger"
             type="button"
             data-ng-click="$ctrl.resetLocalStorage()"
             >
             Reset browser storage
-        </button>
+        </a>
     </div>
 </div>

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.html
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.html
@@ -7,12 +7,13 @@
         <br>
         <p>If something went wrong with downloading the dictionary and it only loaded a partial copy (i.e. some dictionary entries are missing), the button below can let you reset the browser storage, removing the partial copy of the dictionary stored in your browser so that you can download it again.</p>
         <p><strong>CAUTION:</strong> Make sure you are online before doing this, otherwise you won't be able to redownload the dictionary and you'll see an empty project until you can go online again.</p>
-        <a href="#"
+        <button
             class="btn btn-danger"
+            style="cursor: pointer"
             type="button"
             data-ng-click="$ctrl.resetLocalStorage()"
             >
             Reset browser storage
-        </a>
+    </button>
     </div>
 </div>

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.ts
@@ -27,7 +27,8 @@ export class AdvancedOptionsConfigurationController implements angular.IControll
   async resetLocalStorage() {
     await this.editorOfflineCache.deleteAllEntries();
     await this.commentsOfflineCache.deleteAllComments();
-    alert('Browser storage has been reset. Please refresh the page to redownload dictionary entries.');
+    window.location.hash = '#!/';
+    window.location.reload(); // To force the redownload
   }
 
   $onChanges(changes: any) {

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.ts
@@ -27,6 +27,7 @@ export class AdvancedOptionsConfigurationController implements angular.IControll
   async resetLocalStorage() {
     await this.editorOfflineCache.deleteAllEntries();
     await this.commentsOfflineCache.deleteAllComments();
+    window.location.reload();
   }
 
   $onChanges(changes: any) {

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.ts
@@ -27,7 +27,7 @@ export class AdvancedOptionsConfigurationController implements angular.IControll
   async resetLocalStorage() {
     await this.editorOfflineCache.deleteAllEntries();
     await this.commentsOfflineCache.deleteAllComments();
-    window.location.reload();
+    alert('Browser storage has been reset. Please refresh the page to redownload dictionary entries.');
   }
 
   $onChanges(changes: any) {

--- a/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.ts
+++ b/src/angular-app/languageforge/lexicon/settings/configuration/configuration-advanced-options.component.ts
@@ -1,12 +1,18 @@
 import * as angular from 'angular';
 import {LexiconConfig} from '../../shared/model/lexicon-config.model';
+import {CommentsOfflineCacheService} from '../../../../bellows/core/offline/comments-offline-cache.service';
+import {EditorOfflineCacheService} from '../../../../bellows/core/offline/editor-offline-cache.service';
 
 export class AdvancedOptionsConfigurationController implements angular.IController {
   accPollUpdateTimerSecondsDirty: number;
   accOnUpdate: (params: { $event: { pollUpdateTimerSecondsDirty: number } }) => void;
 
-  static $inject: string[] = ['$scope'];
-  constructor(private $scope: angular.IScope) {
+  static $inject: string[] = ['$scope', 'editorOfflineCache', 'commentsOfflineCache',];
+  constructor(
+    private $scope: angular.IScope,
+    private editorOfflineCache: EditorOfflineCacheService,
+    private commentsOfflineCache: CommentsOfflineCacheService,
+    ) {
     $scope.$watch(
       () => this.accPollUpdateTimerSecondsDirty,
       (newVal: number, oldVal: number) => {
@@ -16,6 +22,11 @@ export class AdvancedOptionsConfigurationController implements angular.IControll
       },
       true
     );
+  }
+
+  async resetLocalStorage() {
+    await this.editorOfflineCache.deleteAllEntries();
+    await this.commentsOfflineCache.deleteAllComments();
   }
 
   $onChanges(changes: any) {


### PR DESCRIPTION
### Fixes #1774

## Description

Add a button to reset the browser storage cache, in case users need to (e.g., an interrupted download of the project dictionary).

## Screenshots

![image](https://github.com/sillsdev/web-languageforge/assets/90762/b2c61aae-8049-4625-99b4-1aa9428faa8d)

## Checklist

- [X] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [X] I have performed a self-review of my own code
- [X] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

- Go to a project's Configuration options
- Go to the advanced configuration tab
- Open Developer Tools, look at Local Storage in Application tab
- Verify there are entries and comments
- Click the red "Reset browser storage" button
- Verify the entries and comments are gone from local storage