### PR TITLE
Add liveness probe for MongoDB container

### DIFF
--- a/docker/deployment/db-deployment.yaml
+++ b/docker/deployment/db-deployment.yaml
@@ -51,6 +51,18 @@ spec:
       - name: db
         image: mongo:6
         # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers
+        livenessProbe:
+          exec:
+            command:
+              - mongosh
+              - '--quiet'
+              - '--eval'
+              - db.runCommand('ping')
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
         resources:
           requests:
             memory: 260Mi


### PR DESCRIPTION
This will allow k8s to reboot the pod if MongoDB becomes unresponsive.
