### PR TITLE
Update LfMerge to use Mercurial 6 and .NET 8

### DIFF
--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.136
+FROM ghcr.io/sillsdev/lfmerge:2.0.138
 # Do not add anything to this Dockerfile, it should stay empty


### PR DESCRIPTION
### Fixes #1788

## Description

LfMerge has been on Mercurial 3 for a long time, and we've had constant trouble with HTTPS certificates because our Mercurial version was too old to support SNI. Moving to Mercurial 6 (and Python 3) will fix that.

## Screenshots

_Demonstrate any UI / behavioral changes with screenshots or animations._

## Checklist

- [X] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [X] I have performed a self-review of my own code
- [X] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

_Describe how to verify your changes and provide any necessary test data._

- Do multiple Send/Receives (a clone, a pull, a push, and at least one merge where the project is edited in FLEx and in Language Forge at the same time), and make sure they all succeed.
