### PR TITLE
Set up to run LexBox alongside LF in dev mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - LDAPI_BASE_URL=http://ld-api:3000/api/v2/
       # Uncomment this to test getting the LD project list from LexBox
       # To use LexBox locally (in docker) you'll also need to uncomment the networks here and at the top of the file
-      #- LEX_BOX_HOST=https://staging.languagedepot.org #lexbox-api:5158
+      - LEX_BOX_HOST=http://admin.localhost
       - ENVIRONMENT=development
       - WEBSITE=localhost
       - DATABASE=scriptureforge
@@ -68,6 +68,7 @@ services:
     command: ["/run-with-wait.sh"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
+      - "admin.localhost:host-gateway"
     volumes:
       # holds things like audio files or pictures attached to words within a project
       - lf-project-assets:/var/www/src/assets
@@ -105,6 +106,10 @@ services:
       - DATABASE=scriptureforge
       - MONGODB_CONN=mongodb://db:27017
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
+      - LANGUAGE_DEPOT_HG_USERNAME=admin
+      - LANGUAGE_DEPOT_TRUST_TOKEN=pass
+      - LFMERGE_LANGUAGE_DEPOT_HG_PUBLIC_HOSTNAME=hg.localhost
+      - LFMERGE_LANGUAGE_DEPOT_HG_PROTOCOL=http
       - LFMERGE_LOGGING_DEST=syslog
       - LFMERGE_BASE_DIR=/var/lib/languageforge/lexicon/sendreceive
       - LFMERGE_WEBWORK_DIR=webwork
@@ -114,6 +119,9 @@ services:
       - LFMERGE_MONGO_MAIN_DB_NAME=scriptureforge
       - LFMERGE_MONGO_DB_NAME_PREFIX=sf_
       - LFMERGE_VERBOSE_PROGRESS=true
+    extra_hosts:
+      - "hg.localhost:host-gateway"
+      - "admin.localhost:host-gateway"
     volumes:
       # holds things like audio files or pictures attached to words within a project
       - lf-project-assets:/var/www/src/assets
@@ -125,7 +133,7 @@ services:
     image: caddy
     container_name: lf-ssl
     ports:
-      - 80:80
+      - 8080:80
       - 443:443
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Language Forge port changed to port 8080 so that port 80 can belong to local LexBox.

### Fixes https://github.com/sillsdev/languageforge-lexbox/issues/708

## Description

Add appropriate environment variables to docker-compose.yml so that Language Forge can be run alongside a locally-installed copy of LexBox.

## Screenshots

![image](https://github.com/sillsdev/web-languageforge/assets/90762/4f57be90-0397-4f5a-b3af-001ee50e0707)

## Checklist

- [X] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [X] I have performed a self-review of my own code
- [X] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

To run:

- Check out [LexBox](https://github.com/sillsdev/languageforge-lexbox/) and run `task up`
- Check out [Language Forge](https://github.com/sillsdev/web-languageforge/) and run `make`

To verify:

- Go to `http://localhost:8080` to run Language Forge
- Click on "Get Project from Language Depot"
- Type in username `manager` and password `pass`
- Note the Sena-3 project is available
- Run `docker logs -f lfmerge` to watch the clone process
- Clone Sena-3
- Go to My Projects and click on Sena-3
- Check that all the entries are there