### PR TITLE
Prevent sorting by '-audio' citation and lexeme forms

### DIFF
--- a/src/angular-app/bellows/core/offline/editor-data.service.ts
+++ b/src/angular-app/bellows/core/offline/editor-data.service.ts
@@ -352,11 +352,10 @@ export class EditorDataService {
       if (isSpecialMultitext) {
         if ('citationForm' in config.entry.fields) {
           const citationFormField = config.entry.fields.citationForm as LexConfigMultiText;
-          const citationFormInputSystems = citationFormField.inputSystems;
-          if (entry.citationForm && citationFormInputSystems.length > 0 &&
-            citationFormInputSystems[0] in entry.citationForm
-          ) {
-            sortableValue = entry.citationForm[citationFormInputSystems[0]].value;
+          // don't sort by the first citation form if it is an "-audio" writing system
+          const inputSystem = citationFormField.inputSystems.find((system) => !system.includes('-audio'));
+          if (entry.citationForm && inputSystem && inputSystem in entry.citationForm) {
+            sortableValue = entry.citationForm[inputSystem].value;
           }
         }
 

--- a/src/angular-app/languageforge/lexicon/editor/editor.component.ts
+++ b/src/angular-app/languageforge/lexicon/editor/editor.component.ts
@@ -680,10 +680,11 @@ export class LexiconEditorController implements angular.IController {
 
   getFontFamilyForPrimaryListItemForDisplay(entry: LexEntry) {
     if (!this.getSortableValue(this.lecConfig, entry)) return '';
+
     // FIXME this is not always accurate, given the complexity in get EditorDataService#getSortableValue
-    return this.lecConfig.inputSystems[
-      (this.lecConfig.entry.fields.lexeme as LexConfigMultiText).inputSystems[0]
-    ].cssFontFamily;
+    const lexemeField = this.lecConfig.entry.fields.lexeme as LexConfigMultiText;
+    const inputSystem = lexemeField.inputSystems.find(system => !system.includes('-audio'));
+    return this.lecConfig.inputSystems[inputSystem].cssFontFamily;
   }
 
   getSecondaryListItemForDisplay(entry: LexEntry): string {

--- a/test/e2e/utils/project-utils.ts
+++ b/test/e2e/utils/project-utils.ts
@@ -74,8 +74,9 @@ export class ProjectTestService {
   async createDefaultProject(testInfo: TestInfo): Promise<TestProject> {
     const project = await this.initTestProject(testInfo.titlePath[0], undefined, users.manager, [users.member]);
     await this.addUserToProject(project, users.observer, "observer");
-    await this.addWritingSystemToProject(project, 'th-fonipa', 'tipa');
+    // add audio first to make sure editor.entries tests fail if the audio is used for the dictionary citation
     await this.addWritingSystemToProject(project, 'th-Zxxx-x-audio', 'taud');
+    await this.addWritingSystemToProject(project, 'th-fonipa', 'tipa');
     await this.addPictureFileToProject(project, entries.entry1.senses[0].pictures[0].fileName);
     await this.addAudioVisualFileToProject(project, entries.entry1.lexeme['th-Zxxx-x-audio'].value);
     const projectEntries = await Promise.all([


### PR DESCRIPTION
### Fixes issue where words are sorted by audio filenames if the first analysis writing system is an audio one.

## Description

The default sort uses the first lexeme form (if no citation form is present) which is a problem if the first analysis writing system is an audio writing system. Then the entries are sorted by the filename, which results in a meaningless sort. This pr prevents '-audio' citation forms and lexeme forms from being used.

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

_Describe how to verify your changes and provide any necessary test data._

- Test A
