### PR TITLE
Fix one failing E2E test on Firefox, skip the other one

### DIFF
--- a/test/e2e/tests/editor/editor.entries.spec.ts
+++ b/test/e2e/tests/editor/editor.entries.spec.ts
@@ -204,7 +204,8 @@ test.describe('Editor entries', () => {
       .toHaveValue(entries.multipleMeaningEntry.senses[0].definition.en.value);
   });
 
-  test('Create new word, modify new word, autosaves changes, new word visible in editor and list', async () => {
+  test('Create new word, modify new word, autosaves changes, new word visible in editor and list', async ({browserName}) => {
+    test.skip(browserName === 'firefox', 'locator.fill() has a bug on Firefox that is causing a false-positive test failure as of 2024-04');
     await editorPageManager.goto({ entryId: entryIds()[2] });
 
     const startEntryCount = await editorPageManager.compactEntryListItem.count();
@@ -231,7 +232,7 @@ test.describe('Editor entries', () => {
 
     const alreadyThere: string = await editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th').inputValue();
     await (editorPageManager.getTextarea(editorPageManager.entryCard, 'Word', 'th'))
-      .fill(alreadyThere + 'a');
+      .fill(alreadyThere + 'a'); // Failing on Firefox due to Playwright bug; remove test.skip() above once the Playwright bug is resolved
     await editorPageManager.page.reload();
     await expect((editorPageManager.getTextarea(
       editorPageManager.entryCard, 'Word', 'th')))

--- a/test/e2e/tests/editor/editor.pictures.spec.ts
+++ b/test/e2e/tests/editor/editor.pictures.spec.ts
@@ -51,6 +51,7 @@ test.describe('Editor pictures', () => {
   });
 
   test('Showing and hiding captions', async ({ managerTab, browserName }) => {
+    test.slow(browserName === 'firefox');
     const configurationPage = new ConfigurationPageFieldsTab(managerTab, project());
 
     await test.step('Hide empty captions', async () => {

--- a/test/e2e/tests/editor/editor.pictures.spec.ts
+++ b/test/e2e/tests/editor/editor.pictures.spec.ts
@@ -7,7 +7,7 @@ import { Project } from '../../utils';
 
 test.describe('Editor pictures', () => {
 
-  const { project } = defaultProject();
+  const { project, entryIds } = defaultProject();
   const newProject = projectPerTest(true);
 
   let editorPageManager: EditorPage;
@@ -51,8 +51,6 @@ test.describe('Editor pictures', () => {
   });
 
   test('Showing and hiding captions', async ({ managerTab, browserName }) => {
-    test.slow(browserName === 'firefox');
-
     const configurationPage = new ConfigurationPageFieldsTab(managerTab, project());
 
     await test.step('Hide empty captions', async () => {
@@ -64,7 +62,7 @@ test.describe('Editor pictures', () => {
     });
 
     const caption = await test.step('Non-empty caption is visible', async () => {
-      await editorPageManager.goto();
+      await editorPageManager.goto({ entryId: entryIds()[0] });
       await editorPageManager.showExtraFields(false);
       const picture = editorPageManager.picture(entries.entry1.senses[0].pictures[0].fileName);
       const caption = editorPageManager.caption(picture);
@@ -76,7 +74,11 @@ test.describe('Editor pictures', () => {
       await expect(caption).toBeVisible(); // it disappears immediately which could be annoying
       await caption.fill('');
       await expect(caption).not.toBeVisible(); // it disappears immediately which could be annoying
+      // Navigate away to force changes to be saved
+      await editorPageManager.goto({ entryId: entryIds()[1] });
+      // Reload page then navigate back to this entry to verify changes took effect
       await editorPageManager.reload();
+      await editorPageManager.goto({ entryId: entryIds()[0] });
       await expect(caption).not.toBeVisible();
     });
 
@@ -89,7 +91,7 @@ test.describe('Editor pictures', () => {
     });
 
     await test.step('Empty caption is visible', async () => {
-      await editorPageManager.goto();
+      await editorPageManager.goto({ entryId: entryIds()[0] });
       await editorPageManager.showExtraFields(false);
       const picture = editorPageManager.picture(entries.entry1.senses[0].pictures[0].fileName);
       const caption = editorPageManager.caption(picture);


### PR DESCRIPTION
### Fixes #1801

## Description

We currently have two E2E tests that fail on Firefox while they pass on Chrome.

One of them appears to be caused by `reload()` not triggering our page autosave when it happens immediately after a `locator.fill()`. I suspect that the `reload()` isn't triggering the `blur` event which would allow our autosave to trigger, but only on Firefox (for reasons that would take so long to determine that I figure it's not worth spending the time). I solved this one by clicking on another entry before running the `reload()`, which forces the just-entered data to autosave and thus the rest of the test passes as it should.

The other test appears to be running into [a Playwright bug with `locator.fill()` on Firefox](https://www.github.com/microsoft/playwright/issues/29614), where the locator thinks the input field (or textarea in this case) is not editable. This happens even if you put `expect(...).toBeEditable()` immediately before the `.fill()`. The `expect` passes, but then the locator waits forever (or rather, until the test times out) for the text area to be editable, for some reason not realizing that it is editable. Since this appears to be caused by a Playwright and/or Firefox bug rather than by our code, and the test passes in Chromium, I decided to simply have this test skipped on Firefox until such time as the `locator.fill()` bug gets resolved.

## Checklist

- [X] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [X] I have performed a self-review of my own code
- [X] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

- Run `npm run test-e2e`; all E2E tests should now pass.
