### PR TITLE
After cloning new project, go to project when done

### DIFF
--- a/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.component.ts
+++ b/src/angular-app/languageforge/lexicon/new-project/lexicon-new-project.component.ts
@@ -106,7 +106,6 @@ export class LexiconNewProjectController implements angular.IController {
     this.sendReceive.clearState();
     this.sendReceive.setCloneProjectStatusSuccessCallback(this.gotoEditor);
     this.sendReceive.setCloneProjectStatusFailedCallback(this.cloneFailed);
-    this.$scope.$on('$locationChangeStart', this.sendReceive.cancelCloneStatusTimer);
   }
 
   // ----- Step 2: Send Receive Clone -----


### PR DESCRIPTION
### Fixes #1806
## Description

The "Clone new project" page was setting a locationChange event handler to cancel the clone-status timer. However, since the clone-status page counts as a different locaiton, the event was firing as soon as the user pressed the "Get Started" button, cancelling the clone-status timer too soon so the "cloning new project" page was never detecting that the clone completed.

By simply removing the locationChange event handler, we can let the clone status proceed. It changes from "Getting initial data" to "syncing" pretty soon, but that's fine. Once the status goes to idle, the existing code already cancels the timer and loads the project page, so there's no need for any further changes.

## Checklist

- [X] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [X] I have performed a self-review of my own code
- [X] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

_Describe how to verify your changes and provide any necessary test data._

- Test A
