### PR TITLE
Base php 7.4

### DIFF
--- a/.github/workflows/build-and-publish-base-php.yml
+++ b/.github/workflows/build-and-publish-base-php.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
@@ -28,4 +28,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Build, tag and push image
-        run: docker buildx build --push --platform linux/amd64,linux/arm64 -t ${{ env.IMAGE }} -f docker/base-php/Dockerfile .
+        run: docker buildx build --push --platform linux/amd64 -t ${{ env.IMAGE }} -f docker/base-php/Dockerfile .

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -38,7 +38,7 @@ RUN npm run build:${NPM_BUILD_SUFFIX}
 # COMPOSER-BUILDER
 # download composer app dependencies
 # git - needed for composer install
-FROM sillsdev/web-languageforge:base-php-7.4 AS composer-builder
+FROM sillsdev/web-languageforge:base-php AS composer-builder
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
     && install-php-extensions @composer
@@ -47,7 +47,7 @@ COPY src/composer.json src/composer.lock /composer/
 RUN composer install
 
 # PRODUCTION IMAGE
-FROM sillsdev/web-languageforge:base-php-7.4 AS production-app
+FROM sillsdev/web-languageforge:base-php AS production-app
 RUN rm /usr/local/bin/install-php-extensions
 RUN apt-get remove -y gnupg2
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
@@ -55,7 +55,7 @@ RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait
 
 # DEVELOPMENT IMAGE
-FROM sillsdev/web-languageforge:base-php-7.4 AS development-app
+FROM sillsdev/web-languageforge:base-php AS development-app
 RUN install-php-extensions xdebug-^3.1
 COPY docker/app/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d
 RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -40,8 +40,6 @@ RUN npm run build:${NPM_BUILD_SUFFIX}
 # git - needed for composer install
 FROM sillsdev/web-languageforge:base-php AS composer-builder
 ENV COMPOSER_ALLOW_SUPERUSER=1
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
-    && install-php-extensions @composer
 WORKDIR /composer
 COPY src/composer.json src/composer.lock /composer/
 RUN composer install
@@ -49,7 +47,8 @@ RUN composer install
 # PRODUCTION IMAGE
 FROM sillsdev/web-languageforge:base-php AS production-app
 RUN rm /usr/local/bin/install-php-extensions
-RUN apt-get remove -y gnupg2
+RUN apt-get remove -y gnupg2 git
+# TODO: remove composer - how do we do this?
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 # had to add /wait into prod image so the prod image could be run through E2E tests.
 COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -46,9 +46,8 @@ RUN composer install
 
 # PRODUCTION IMAGE
 FROM sillsdev/web-languageforge:base-php AS production-app
-RUN rm /usr/local/bin/install-php-extensions
+RUN rm /usr/local/bin/install-php-extensions /usr/local/bin/composer
 RUN apt-get remove -y gnupg2 git
-# TODO: remove composer - how do we do this?
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 # had to add /wait into prod image so the prod image could be run through E2E tests.
 COPY --from=sillsdev/web-languageforge:wait-latest /wait /wait

--- a/docker/base-php/Dockerfile
+++ b/docker/base-php/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get -y install gnupg git p7zip-full unzip curl tini ff
 # mongodb-org-tools - contains mongoimport/mongoexport used by LF backup/restore project commands
 # mongodb-mongosh - contains mongosh which is useful for querying the db from the app container
 RUN curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg --dearmor
-RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 RUN apt-get update && apt-get -y install mongodb-org-tools mongodb-mongosh && rm -rf /var/lib/apt/lists/*
 
 # see https://github.com/mlocati/docker-php-extension-installer

--- a/docker/base-php/Dockerfile
+++ b/docker/base-php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3.28-apache
+FROM php:7.4-apache
 
 # install apt packages
 # p7zip-full - used by LF application for unzipping lexicon uploads

--- a/docker/base-php/Dockerfile
+++ b/docker/base-php/Dockerfile
@@ -2,29 +2,26 @@
 # https://hub.docker.com/layers/library/php/7.4-apache/images/sha256-c44681664d111addef2a2b6598901609990d45047b874c87d7d40fc7ce269195
 FROM php:7.4-apache
 
-# Update package list and install necessary tools
-RUN apt-get update \
-    && apt-get install -y gnupg
-
-# Add MongoDB's GPG key
-RUN curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg --dearmor
-
-# Add MongoDB to the list of apt repositories
-RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list
-
 # install apt packages
+# gnupg - for installing Mongo GPG key below
+# git - for use by composer to install dependencies
 # p7zip-full - used by LF application for unzipping lexicon uploads
 # unzip - used by LF application for unzipping lexicon uploads
 # curl - used by LF application
 # ffmpeg - used by LF audio upload method
+RUN apt-get update && apt-get -y install gnupg git p7zip-full unzip curl tini ffmpeg
+
+# Install MongoDB shell and tools (must be done after gnupg is installed)
 # mongodb-org-tools - contains mongoimport/mongoexport used by LF backup/restore project commands
 # mongodb-mongosh - contains mongosh which is useful for querying the db from the app container
-RUN apt-get update && apt-get -y install p7zip-full mongodb-org-tools mongodb-mongosh unzip curl tini ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg --dearmor
+RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+RUN apt-get update && apt-get -y install mongodb-org-tools mongodb-mongosh && rm -rf /var/lib/apt/lists/*
 
 # see https://github.com/mlocati/docker-php-extension-installer
 # PHP extensions required by the LF application
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-RUN install-php-extensions mongodb intl
+RUN install-php-extensions mongodb intl @composer
 
 # php customizations
 COPY docker/base-php/customizations.php.ini $PHP_INI_DIR/conf.d/

--- a/docker/base-php/Dockerfile
+++ b/docker/base-php/Dockerfile
@@ -1,11 +1,25 @@
+# This image is based on debian 11 bullseye
+# https://hub.docker.com/layers/library/php/7.4-apache/images/sha256-c44681664d111addef2a2b6598901609990d45047b874c87d7d40fc7ce269195
 FROM php:7.4-apache
+
+# Update package list and install necessary tools
+RUN apt-get update \
+    && apt-get install -y gnupg
+
+# Add MongoDB's GPG key
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg --dearmor
+
+# Add MongoDB to the list of apt repositories
+RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 
 # install apt packages
 # p7zip-full - used by LF application for unzipping lexicon uploads
 # unzip - used by LF application for unzipping lexicon uploads
 # curl - used by LF application
 # ffmpeg - used by LF audio upload method
-RUN apt-get update && apt-get -y install p7zip-full unzip curl tini ffmpeg && rm -rf /var/lib/apt/lists/*
+# mongodb-org-tools - contains mongoimport/mongoexport used by LF backup/restore project commands
+# mongodb-mongosh - contains mongosh which is useful for querying the db from the app container
+RUN apt-get update && apt-get -y install p7zip-full mongodb-org-tools mongodb-mongosh unzip curl tini ffmpeg && rm -rf /var/lib/apt/lists/*
 
 # see https://github.com/mlocati/docker-php-extension-installer
 # PHP extensions required by the LF application

--- a/docker/composer-dev/Dockerfile
+++ b/docker/composer-dev/Dockerfile
@@ -3,8 +3,6 @@ FROM sillsdev/web-languageforge:base-php
 
 WORKDIR /work
 ENV COMPOSER_ALLOW_SUPERUSER=1
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
-    && install-php-extensions @composer
 COPY src/composer.json src/composer.lock /work/
 
 CMD ["bash"]

--- a/docker/test-php/Dockerfile
+++ b/docker/test-php/Dockerfile
@@ -4,12 +4,10 @@ FROM sillsdev/web-languageforge:base-php
 # ----- LINES BELOW COPIED FROM APP DOCKERFILE ----------
 WORKDIR /var/www/html
 ENV COMPOSER_ALLOW_SUPERUSER=1
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
-    && install-php-extensions @composer
 COPY src/composer.json src/composer.lock /var/www/html/
 RUN composer install
 
-RUN install-php-extensions xdebug
+RUN install-php-extensions xdebug-^3.1
 COPY docker/app/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d
 
 RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini

--- a/docker/test-php/Dockerfile
+++ b/docker/test-php/Dockerfile
@@ -1,4 +1,4 @@
-FROM sillsdev/web-languageforge:base-php-7.4
+FROM sillsdev/web-languageforge:base-php
 
 
 # ----- LINES BELOW COPIED FROM APP DOCKERFILE ----------


### PR DESCRIPTION
This is a PR to update the base-php image to 7.4.  We will not update to future PHP versions, so it makes sense to just name this base-php

We also add the mongodb-org-tools apt package to the base-php image for use in the backup/restore planned task.

Once this is merged, I can manually create a new base-php image via GHA.

TODO:

- [x] - figure out what debian package has mongoexport in it - which version of debian are we running?
- [x] - `make build-base-php` locally
- [x] - `make` locally
- [x] - run PHP tests locally
- [x] - confirm that `mongoexport` is available in the running app container

PHP tests complete successfully on my local machine, but will fail in this PR build since base-php hasn't been built properly until this is merged.
![image](https://github.com/sillsdev/web-languageforge/assets/3444521/99035565-87de-4699-8ce9-733da120bfb2)
