### PR TITLE
Require username and password for mongodb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,6 +227,9 @@ services:
     restart: always
     environment:
       - MONGO_INITDB_DATABASE=scriptureforge
+      # Uncomment the next two lines to require authentication (without these, the MongoDB server will be started in permit-all mode)
+      # - MONGO_INITDB_ROOT_USERNAME=admin
+      # - MONGO_INITDB_ROOT_PASSWORD=pass
 
   ld-db:
     image: mariadb:10.10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,9 @@ services:
       - ENVIRONMENT=development
       - WEBSITE=localhost
       - DATABASE=scriptureforge
-      - MONGODB_CONN=mongodb://lf-db:27017
+      - MONGODB_CONN=mongodb://lf-db:27017&authSource=admin
+      - MONGODB_USER=admin
+      - MONGODB_PASS=pass
       - MAIL_HOST=mail
       - GOOGLE_CLIENT_ID=bogus-development-token
       - GOOGLE_CLIENT_SECRET=bogus-development-token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -229,9 +229,8 @@ services:
     restart: always
     environment:
       - MONGO_INITDB_DATABASE=scriptureforge
-      # Uncomment the next two lines to require authentication (without these, the MongoDB server will be started in permit-all mode)
-      # - MONGO_INITDB_ROOT_USERNAME=admin
-      # - MONGO_INITDB_ROOT_PASSWORD=pass
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=pass
 
   ld-db:
     image: mariadb:10.10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,8 @@ services:
       - ENVIRONMENT=development
       - WEBSITE=localhost
       - DATABASE=scriptureforge
-      - MONGODB_CONN=mongodb://lf-db:27017&authSource=admin
+      - MONGODB_CONN=mongodb://lf-db:27017
+      - MONGODB_AUTHSOURCE=admin
       - MONGODB_USER=admin
       - MONGODB_PASS=pass
       - MAIL_HOST=mail
@@ -105,7 +106,8 @@ services:
       - WAIT_HOSTS=db:27017
       - ENVIRONMENT=development
       - DATABASE=scriptureforge
-      - MONGODB_CONN=mongodb://db:27017&authSource=admin
+      - MONGODB_CONN=mongodb://db:27017
+      - MONGODB_AUTHSOURCE=admin
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
       - LANGUAGE_DEPOT_HG_USERNAME=admin
       - LANGUAGE_DEPOT_TRUST_TOKEN=pass
@@ -284,7 +286,8 @@ services:
       - ENVIRONMENT=development
       - WEBSITE=localhost
       - DATABASE=e2e_test
-      - MONGODB_CONN=mongodb://db:27017&authSource=admin
+      - MONGODB_CONN=mongodb://db:27017
+      - MONGODB_AUTHSOURCE=admin
       - MONGODB_USER=admin
       - MONGODB_PASS=pass
       - MAIL_HOST=mail
@@ -320,7 +323,8 @@ services:
       - ENVIRONMENT=development
       - WEBSITE=localhost.languageforge.org
       - DATABASE=scriptureforge_test
-      - MONGODB_CONN=mongodb://db:27017&authSource=admin
+      - MONGODB_CONN=mongodb://db:27017
+      - MONGODB_AUTHSOURCE=admin
       - MONGODB_USER=admin
       - MONGODB_PASS=pass
       - MAIL_HOST=mail

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       - WAIT_HOSTS=db:27017
       - ENVIRONMENT=development
       - DATABASE=scriptureforge
-      - MONGODB_CONN=mongodb://db:27017
+      - MONGODB_CONN=mongodb://db:27017&authSource=admin
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
       - LANGUAGE_DEPOT_HG_USERNAME=admin
       - LANGUAGE_DEPOT_TRUST_TOKEN=pass
@@ -117,6 +117,9 @@ services:
       - LFMERGE_TEMPLATES_DIR=Templates
       - LFMERGE_MONGO_HOSTNAME=db
       - LFMERGE_MONGO_PORT=27017
+      - LFMERGE_MONGO_AUTHSOURCE=admin
+      - LFMERGE_MONGO_USER=admin
+      - LFMERGE_MONGO_PASS=pass
       - LFMERGE_MONGO_MAIN_DB_NAME=scriptureforge
       - LFMERGE_MONGO_DB_NAME_PREFIX=sf_
       - LFMERGE_VERBOSE_PROGRESS=true
@@ -278,7 +281,9 @@ services:
       - ENVIRONMENT=development
       - WEBSITE=localhost
       - DATABASE=e2e_test
-      - MONGODB_CONN=mongodb://db:27017
+      - MONGODB_CONN=mongodb://db:27017&authSource=admin
+      - MONGODB_USER=admin
+      - MONGODB_PASS=pass
       - MAIL_HOST=mail
       - REMEMBER_ME_SECRET=bogus-development-key
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
@@ -312,7 +317,9 @@ services:
       - ENVIRONMENT=development
       - WEBSITE=localhost.languageforge.org
       - DATABASE=scriptureforge_test
-      - MONGODB_CONN=mongodb://db:27017
+      - MONGODB_CONN=mongodb://db:27017&authSource=admin
+      - MONGODB_USER=admin
+      - MONGODB_PASS=pass
       - MAIL_HOST=mail
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token
       - XDEBUG_MODE=develop,debug

--- a/docker/deployment/base/app-deployment.yaml
+++ b/docker/deployment/base/app-deployment.yaml
@@ -97,6 +97,21 @@ spec:
               secretKeyRef:
                 key: MONGODB_CONN
                 name: app
+          - name: MONGODB_AUTHSOURCE
+            valueFrom:
+              secretKeyRef:
+                key: MONGODB_AUTHSOURCE
+                name: mongo-auth
+          - name: MONGODB_USER
+            valueFrom:
+              secretKeyRef:
+                key: MONGODB_USER
+                name: mongo-auth
+          - name: MONGODB_PASS
+            valueFrom:
+              secretKeyRef:
+                key: MONGODB_PASS
+                name: mongo-auth
           - name: REMEMBER_ME_SECRET
             valueFrom:
               secretKeyRef:

--- a/docker/deployment/base/lfmerge-deployment.yaml
+++ b/docker/deployment/base/lfmerge-deployment.yaml
@@ -99,6 +99,21 @@ spec:
             value: "27017"
           - name: LFMERGE_MONGO_MAIN_DB_NAME
             value: scriptureforge
+          - name: LFMERGE_MONGO_AUTHSOURCE
+            valueFrom:
+              secretKeyRef:
+                key: MONGODB_AUTHSOURCE
+                name: mongo-auth
+          - name: LFMERGE_MONGO_USER
+            valueFrom:
+              secretKeyRef:
+                key: MONGODB_USER
+                name: mongo-auth
+          - name: LFMERGE_MONGO_PASS
+            valueFrom:
+              secretKeyRef:
+                key: MONGODB_PASS
+                name: mongo-auth
           - name: LFMERGE_MONGO_DB_NAME_PREFIX
             value: sf_
           - name: LFMERGE_VERBOSE_PROGRESS

--- a/docker/deployment/base/secrets.yaml
+++ b/docker/deployment/base/secrets.yaml
@@ -13,6 +13,18 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: mongo-auth
+  namespace: languageforge
+data:
+  MONGODB_AUTHSOURCE: ''
+  MONGODB_USER: ''
+  MONGODB_PASS: ''
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
   name: ld-api
   namespace: languageforge
 data:

--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.138
+FROM ghcr.io/sillsdev/lfmerge:2.0.139-alpha.43
 # Do not add anything to this Dockerfile, it should stay empty

--- a/scripts/scriptsConfig.php
+++ b/scripts/scriptsConfig.php
@@ -10,6 +10,7 @@ require_once APPPATH . "vendor/autoload.php";
 
 define("DATABASE", Env::requireEnv("DATABASE"));
 define("MONGODB_CONN", Env::requireEnv("MONGODB_CONN"));
+define("MONGODB_AUTHSOURCE", Env::get("MONGODB_AUTHSOURCE"));
 define("MONGODB_USER", Env::get("MONGODB_USER"));
 define("MONGODB_PASS", Env::get("MONGODB_PASS"));
 define("BCRYPT_COST", 7);

--- a/scripts/scriptsConfig.php
+++ b/scripts/scriptsConfig.php
@@ -10,4 +10,6 @@ require_once APPPATH . "vendor/autoload.php";
 
 define("DATABASE", Env::requireEnv("DATABASE"));
 define("MONGODB_CONN", Env::requireEnv("MONGODB_CONN"));
+define("MONGODB_USER", Env::get("MONGODB_USER"));
+define("MONGODB_PASS", Env::get("MONGODB_PASS"));
 define("BCRYPT_COST", 7);

--- a/src/Api/Model/Shared/Mapper/MongoStore.php
+++ b/src/Api/Model/Shared/Mapper/MongoStore.php
@@ -24,6 +24,10 @@ class MongoStore
                     $options = [ 'username' => MONGODB_USER, 'password' => MONGODB_PASS ];
                 }
             }
+            $options['authSource'] = 'admin';
+            if (defined('MONGODB_AUTHSOURCE') && MONGODB_AUTHSOURCE != null) {
+                $options['authSource'] = MONGODB_AUTHSOURCE;
+            }
             static::$_mongoClient = new Client(
                 MONGODB_CONN,
                 $options,

--- a/src/Api/Model/Shared/Mapper/MongoStore.php
+++ b/src/Api/Model/Shared/Mapper/MongoStore.php
@@ -18,9 +18,15 @@ class MongoStore
         if (static::$_mongoClient == null) {
             // MongoDB Client that will unserialize everything as PHP Arrays consistent with the legacy driver (which our code was built on)
             // see http://mongodb.github.io/mongo-php-library/classes/client/#example
+            $options = [];
+            if (defined(MONGODB_USER) && defined(MONGODB_PASS)) {
+                if (MONGODB_USER != null && MONGODB_PASS != null) {
+                    $options = [ 'username' => MONGODB_USER, 'password' => MONGODB_PASS ];
+                }
+            }
             static::$_mongoClient = new Client(
                 MONGODB_CONN,
-                [],
+                $options,
                 ["typeMap" => ["root" => "array", "document" => "array", "array" => "array"]]
             );
         }

--- a/src/Api/Model/Shared/Mapper/MongoStore.php
+++ b/src/Api/Model/Shared/Mapper/MongoStore.php
@@ -19,7 +19,7 @@ class MongoStore
             // MongoDB Client that will unserialize everything as PHP Arrays consistent with the legacy driver (which our code was built on)
             // see http://mongodb.github.io/mongo-php-library/classes/client/#example
             $options = [];
-            if (defined(MONGODB_USER) && defined(MONGODB_PASS)) {
+            if (defined('MONGODB_USER') && defined('MONGODB_PASS')) {
                 if (MONGODB_USER != null && MONGODB_PASS != null) {
                     $options = [ 'username' => MONGODB_USER, 'password' => MONGODB_PASS ];
                 }

--- a/src/config.php
+++ b/src/config.php
@@ -5,6 +5,7 @@ use Sil\PhpEnv\Env; // https://github.com/silinternational/php-env#class-env-sum
 define("ENVIRONMENT", Env::requireEnv("ENVIRONMENT"));
 define("DATABASE", Env::requireEnv("DATABASE"));
 define("MONGODB_CONN", Env::requireEnv("MONGODB_CONN"));
+define("MONGODB_AUTHSOURCE", Env::get("MONGODB_AUTHSOURCE"));
 define("MONGODB_USER", Env::get("MONGODB_USER"));
 define("MONGODB_PASS", Env::get("MONGODB_PASS"));
 define("LANGUAGE_DEPOT_API_TOKEN", Env::requireEnv("LANGUAGE_DEPOT_API_TOKEN"));

--- a/src/config.php
+++ b/src/config.php
@@ -5,6 +5,8 @@ use Sil\PhpEnv\Env; // https://github.com/silinternational/php-env#class-env-sum
 define("ENVIRONMENT", Env::requireEnv("ENVIRONMENT"));
 define("DATABASE", Env::requireEnv("DATABASE"));
 define("MONGODB_CONN", Env::requireEnv("MONGODB_CONN"));
+define("MONGODB_USER", Env::get("MONGODB_USER"));
+define("MONGODB_PASS", Env::get("MONGODB_PASS"));
 define("LANGUAGE_DEPOT_API_TOKEN", Env::requireEnv("LANGUAGE_DEPOT_API_TOKEN"));
 
 define("BCRYPT_COST", 7);

--- a/test/php/TestConfig.php
+++ b/test/php/TestConfig.php
@@ -19,6 +19,7 @@ define("SourcePath", $rootPath . "src/");
 
 define("DATABASE", Env::requireEnv("DATABASE"));
 define("MONGODB_CONN", Env::requireEnv("MONGODB_CONN"));
+define("MONGODB_AUTHSOURCE", Env::get("MONGODB_AUTHSOURCE"));
 define("MONGODB_USER", Env::get("MONGODB_USER"));
 define("MONGODB_PASS", Env::get("MONGODB_PASS"));
 define("SF_TESTPROJECT", "Test Project");

--- a/test/php/TestConfig.php
+++ b/test/php/TestConfig.php
@@ -19,6 +19,8 @@ define("SourcePath", $rootPath . "src/");
 
 define("DATABASE", Env::requireEnv("DATABASE"));
 define("MONGODB_CONN", Env::requireEnv("MONGODB_CONN"));
+define("MONGODB_USER", Env::get("MONGODB_USER"));
+define("MONGODB_PASS", Env::get("MONGODB_PASS"));
 define("SF_TESTPROJECT", "Test Project");
 define("SF_TESTPROJECTCODE", "testcode1");
 define("SF_TESTPROJECT2", "Test Project2");


### PR DESCRIPTION
### Fixes #1787

## Description

Add env vars `MONGODB_USER` and `MONGODB_PASS` to optionally specify authentication when connecting to MongoDB. Some manual setup on the MongoDB server(s) should be done before this is deployed; see https://github.com/sillsdev/web-languageforge/issues/1787#issuecomment-2119674540 for details. Once the appropriate admin user has been created and Kubernetes secrets set, this PR can then be deployed to staging and production.

Note that https://github.com/sillsdev/LfMerge/pull/336 will need to be merged first, and a new LfMerge version built. The version number in `lfmerge/Dockerfile` can then be bumped as part of this PR.

## Screenshots

None

## Checklist

- [X] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

- Log in
- Send/Receive a test project if you already have one
- Delete the test project if it exists
- Clone it afresh from Language Depot

If those all continue to pass, then the necessary setup steps (creating an admin user and giving it a password, and creating Kubernetes secrets for that username and password) were correctly completed.
