### PR TITLE
Update outdated GHA workflow versions

### DIFF
--- a/.github/workflows/build-and-publish-base-php.yml
+++ b/.github/workflows/build-and-publish-base-php.yml
@@ -13,16 +13,16 @@ jobs:
       IMAGE: sillsdev/web-languageforge:base-php
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-qemu-action@v3
 
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/amd64
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         uses: pnpm/action-setup@v4
       -
@@ -26,7 +26,7 @@ jobs:
       -
         name: Upload Playwright test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.browser }}-${{ matrix.shard }}
           path: test/e2e/test-results

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         run: |
           docker --version

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,13 +20,13 @@ jobs:
     outputs:
       status: ${{ steps.check-labels.outputs.status }}
     steps:
-      - uses: mheap/github-action-required-labels@v3
+      - uses: mheap/github-action-required-labels@5847eef68201219cf0a4643ea7be61e77837bbce # v5.4.1
         id: check-labels
         with:
           mode: exactly
           count: 1
           labels: "bug, feature, engineering, security fix, testing"
-      - uses: mheap/github-action-required-labels@v3
+      - uses: mheap/github-action-required-labels@5847eef68201219cf0a4643ea7be61e77837bbce # v5.4.1
         with:
           mode: exactly
           count: 0
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Unit Tests
         run: make unit-tests-ci
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         uses: pnpm/action-setup@v4
       -

--- a/.github/workflows/set-backlog-fields.yml
+++ b/.github/workflows/set-backlog-fields.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1.7
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.LFPROJECTBOARDAUTOMATION_APP_ID }}
           private_key: ${{ secrets.LFPROJECTBOARDAUTOMATION_PRIVATE_KEY }}


### PR DESCRIPTION
### Fixes #1819

## Description

This updates outdated workflow versions to ones that use Node 20, silencing the warnings from GHA about workflows using Node 16. Also, the actions/checkout@v3 workflows are deprecated and must be moved to v4 by the end of 2024.

Finally, in the case of a couple of small third-party workflows, I switched to SHA references as recommended in GHA workflow best practices.
