### PR TITLE
Add docker-compose merge file for production build

### DIFF
--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm install
       -
         name: Build legacy app
-        run: docker compose -f docker-compose.yml -f docker-compose.production.yml build --build-arg ENVIRONMENT=production --build-arg BUILD_VERSION=${{ steps.image.outputs.TAG_APP }} app
+        run: docker compose -f docker-compose.yml -f docker-compose.production.yml build --build-arg BUILD_VERSION=${{ steps.image.outputs.TAG_APP }} app
       -
         name: Verify version stamping
         run: |

--- a/.github/workflows/integrate-and-deploy.yml
+++ b/.github/workflows/integrate-and-deploy.yml
@@ -63,12 +63,8 @@ jobs:
       -
         run: pnpm install
       -
-        name: Prep for production build of legacy app
-        # docker compose build doesn't allow passing a `--target` parameter, so we have to replace the target in docker-compose.yml
-        run: "sed -i 's/target: development/target: production/g' docker-compose.yml"
-      -
         name: Build legacy app
-        run: docker compose build --build-arg ENVIRONMENT=production --build-arg BUILD_VERSION=${{ steps.image.outputs.TAG_APP }} app
+        run: docker compose -f docker-compose.yml -f docker-compose.production.yml build --build-arg ENVIRONMENT=production --build-arg BUILD_VERSION=${{ steps.image.outputs.TAG_APP }} app
       -
         name: Verify version stamping
         run: |

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,27 @@
+services:
+
+  app:
+    build:
+      target: production
+      args:
+        - ENVIRONMENT=production
+    environment:
+      - ENVIRONMENT=production
+
+  lfmerge:
+    build:
+      args:
+        - ENVIRONMENT=production
+    environment:
+      - ENVIRONMENT=production
+
+  e2e-app:
+    build:
+      args:
+        - ENVIRONMENT=production
+    environment:
+      - ENVIRONMENT=production
+
+  test-php:
+    environment:
+      - ENVIRONMENT=production


### PR DESCRIPTION
### Fixes #1821

## Description

This will allow the default docker-compose.yml file to build the development build, but allow passing an extra `-f` flag to docker compose in order to build the production build instead. (This is the Docker Compose equivalent of kustomize, though a little easier to use and understand than kustomize).

## Screenshots

_Demonstrate any UI / behavioral changes with screenshots or animations._

## Checklist

- [X] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [X] I have performed a self-review of my own code
- [X] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

Testers, use the following instructions against our staging environment. Post your findings as a comment and include any meaningful screenshots, etc.

_Describe how to verify your changes and provide any necessary test data._

- Check PR, make sure tests still pass
- Edit your Makefile and change the `docker compose build` steps to include `-f docker-compose.yml -f docker-compose.production.yml` and make sure running various `make` commands still works.
