### PR TITLE
Use release version of LfMerge

### DIFF
--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.139-alpha.43
+FROM ghcr.io/sillsdev/lfmerge:2.0.139
 # Do not add anything to this Dockerfile, it should stay empty


### PR DESCRIPTION
The release version is identical to the alpha version that was being used previously, except for the version number marking it as tested.

No issue number since this is a trivial one-line change that makes no changes to actual behavior (LfMerge release 2.0.139 is built from the same Git commit as 2.0.139-alpha.43, so it's almost literally no change).