### PR TITLE
Kubernetes deployment now requires Mongo auth

### DIFF
--- a/docker/deployment/base/db-deployment.yaml
+++ b/docker/deployment/base/db-deployment.yaml
@@ -69,6 +69,17 @@ spec:
             cpu: 0.1
           limits:
             memory: 400Mi
+        emv:
+          - name: MONGO_INITDB_ROOT_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: MONGODB_USER
+                name: mongo-auth
+          - name: MONGO_INITDB_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: MONGODB_PASS
+                name: mongo-auth
         volumeMounts:
         - mountPath: /data/db
           name: data


### PR DESCRIPTION
This is a followup to https://github.com/sillsdev/web-languageforge/pull/1813.

The `MONGO_INITDB_ROOT_USERNAME` and `MONGO_INITDB_ROOT_PASSWORD` variables, if they exist when the MongoDB container is started up, will be used to tell MongoDB to start in auth-required mode. If there is an existing database then the value of these env vars doesn't matter and the usernames and passwords from the existing database will be used instead, but if the database is empty then these two env vars are used to set up an initial administrator account that can access and change anything, and the DB setup scripts are then expected to create any other required users. Since we now have authentication defined in Mongo, we can turn this on by default and everything will continue to work.

This has already been done manually (via the Rancher control panel) on staging and production; this PR simply adds the required environment variables to the depoyment file so that if anyone runs `make deploy-staging` or `make deploy-prod` in the future, the deployment will not *remove* those environment variables.