### PR TITLE
add tech support role to allowed roles when sending an invite

### DIFF
--- a/src/Api/Model/Shared/Command/UserCommands.php
+++ b/src/Api/Model/Shared/Command/UserCommands.php
@@ -566,7 +566,7 @@ class UserCommands
         // Verify authority of $invitingUser to invite someone of this role
         $userIsAuthorized = false;
         $invitingUserRole = $project->users[$invitingUserId]->role;
-        $authorizedRoles = [ProjectRoles::MANAGER];
+        $authorizedRoles = [ProjectRoles::MANAGER, ProjectRoles::TECH_SUPPORT];
         if ($roleKey == ProjectRoles::MANAGER) {
             $userIsAuthorized = in_array($invitingUserRole, $authorizedRoles);
         }


### PR DESCRIPTION
This fixes a bug where a tech support user cannot add/invite another user

### Fixes #1834 

## Description

Looks like the tech support role was left off the list of allowed roles to send an invite.

## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

Verify that the repro steps in the bug report show no error message