### PR TITLE
Update LfMerge version to 2.0.140

### DIFF
--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.139
+FROM ghcr.io/sillsdev/lfmerge:2.0.140
 # Do not add anything to this Dockerfile, it should stay empty


### PR DESCRIPTION
This pulls in the bugfix for the CommentConversionError class from https://github.com/sillsdev/LfMerge/pull/350.
