### PR TITLE
Use chg in LfMerge, only in local dev LF for now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - WAIT_HOSTS=db:27017
       - ENVIRONMENT=development
       - DATABASE=scriptureforge
+      - CHORUS_HG_EXE=chg
       - MONGODB_CONN=mongodb://db:27017
       - MONGODB_AUTHSOURCE=admin
       - LANGUAGE_DEPOT_API_TOKEN=bogus-development-token

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -10,6 +10,8 @@ WORKDIR /data
 # Copy in files needed for compilation, located in the repo root
 COPY package.json pnpm-lock.yaml ./
 
+# Install latest corepack version to work around a bug with signatures
+RUN npm install -g corepack@latest
 RUN corepack enable
 RUN pnpm install
 

--- a/docker/lfmerge/Dockerfile
+++ b/docker/lfmerge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/sillsdev/lfmerge:2.0.140
+FROM ghcr.io/sillsdev/lfmerge:2.0.141
 # Do not add anything to this Dockerfile, it should stay empty

--- a/docker/next-app/Dockerfile.next-app
+++ b/docker/next-app/Dockerfile.next-app
@@ -7,6 +7,8 @@ COPY tsconfig.json pnpm-lock.yaml package.json postcss.config.cjs svelte.config.
 COPY src /app/src
 COPY static /app/static
 
+# Install latest corepack version to work around a bug with signatures
+RUN npm install -g corepack@latest
 RUN corepack enable
 RUN pnpm install
 RUN pnpm run build

--- a/docker/next-app/dev/Dockerfile
+++ b/docker/next-app/dev/Dockerfile
@@ -6,6 +6,8 @@ COPY tsconfig.json pnpm-lock.yaml package.json postcss.config.cjs svelte.config.
 COPY src /app/src
 COPY static /app/static
 
+# Install latest corepack version to work around a bug with signatures
+RUN npm install -g corepack@latest
 RUN corepack enable
 RUN pnpm install
 

--- a/docker/ui-builder/Dockerfile
+++ b/docker/ui-builder/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /data
 
 COPY package.json pnpm-lock.yaml ./
 
+# Install latest corepack version to work around a bug with signatures
+RUN npm install -g corepack@latest
 RUN corepack enable
 RUN pnpm install
 


### PR DESCRIPTION
### Fixes #1841

## Description

We'll start using `chg` for LfMerge in local LF development; once we know that it works, we'll add the relevant environment variable to the k8s deployment so that staging and then prod also start getting the same Send/Receive speedups.

## Checklist

- [X] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [X] I have performed a self-review of my own code
- [X] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have enabled auto-merge (optional)

## Testing

- Run some Send/Receives on local LF and make sure everything still works.
