### PR TITLE
Add maintenance mode messages across the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Language Forge
 
-[Language Forge is no longer developed and is in maintenance mode](https://community.software.sil.org/t/language-forge-in-maintenance-mode/10514). We will continue to support existing Language Forge projects and we encourage all users to try [FieldWorks Lite](https://lexbox.org/fw-lite).
+> [!IMPORTANT]  
+> [Language Forge is no longer developed and is in maintenance mode](https://community.software.sil.org/t/language-forge-in-maintenance-mode/10514). We will continue to support existing Language Forge projects and we encourage all users to try [FieldWorks Lite](https://lexbox.org/fw-lite).
 
 [Language Forge](https://languageforge.org) is an online service to collaborate on building a dictionary. Users should head on over to [languageforge.org](https://languageforge.org)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Language Forge
 
+[Language Forge is no longer developed and is in maintenance mode](https://docs.google.com/document/d/1Op0ZEreOd2N1v8Yh85sxW0O5HgSEj8gBdBVITGdiw8k/edit). We will continue to support existing Language Forge projects and we encourage all users to try [FieldWorks Lite](https://lexbox.org/fw-lite).
+
 [Language Forge](https://languageforge.org) is an online service to collaborate on building a dictionary. Users should head on over to [languageforge.org](https://languageforge.org)
 
 ### Reporting Problems with the Language Forge Application

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Language Forge
 
-[Language Forge is no longer developed and is in maintenance mode](https://docs.google.com/document/d/1Op0ZEreOd2N1v8Yh85sxW0O5HgSEj8gBdBVITGdiw8k/edit). We will continue to support existing Language Forge projects and we encourage all users to try [FieldWorks Lite](https://lexbox.org/fw-lite).
+[Language Forge is no longer developed and is in maintenance mode](https://community.software.sil.org/t/language-forge-in-maintenance-mode/10514). We will continue to support existing Language Forge projects and we encourage all users to try [FieldWorks Lite](https://lexbox.org/fw-lite).
 
 [Language Forge](https://languageforge.org) is an online service to collaborate on building a dictionary. Users should head on over to [languageforge.org](https://languageforge.org)
 

--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -12,14 +12,14 @@
             <nav class="navbar navbar-expand navbar-dark align-items-stretch">
                 <span class="navbar-brand d-md-inline-block mr-auto">
                     <img class="navbar-logo" title="v{{ version }}" src="/Site/views/languageforge/theme/default/image/lf_logo_medium.png">
-                    <a class="website-title" href="/">Language Forge</a> <a href="https://lexbox.org/fw-lite">Try FieldWorks Lite!</a>
+                    <a class="website-title" href="/">Language Forge</a> <a style="color: yellow" href="https://community.software.sil.org/t/language-forge-in-maintenance-mode/10514"><i class="fa fa-exclamation-triangle"></i> Maintenance Mode</a>
                 </span>
                 <ul class="nav navbar-nav">
                     <li class="nav-item" uib-dropdown>
                         <a class="nav-link" uib-dropdown-toggle href id="helpDropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-question-circle"></i> <span>About</span></a>
                         <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu aria-labelledby="helpDropdown">
                             <a class="dropdown-item" target="_blank" href="https://lexbox.org/fw-lite"><i class="fa fa-gift"></i> Try FieldWorks Lite</a>
-                            <a class="dropdown-item" target="_blank" href="https://docs.google.com/document/d/1Op0ZEreOd2N1v8Yh85sxW0O5HgSEj8gBdBVITGdiw8k/edit"><i class="fa fa-exclamation-triangle"></i> Maintenance Mode</a>
+                            <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/t/language-forge-in-maintenance-mode/10514"><i class="fa fa-exclamation-triangle"></i> Maintenance Mode</a>
                             <a class="dropdown-item" target="_blank" href="https://www.youtube.com/playlist?list=PLJLUPwIFOI8d8lmQVAcBapyw87jCtmDNA"><i class="fa fa-youtube-play"></i> Videos</a>
                             <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge"><i class="fa fa-users"></i> Community Support</a>
                             <a class="dropdown-item" target="_blank" href="https://github.com/sillsdev/web-languageforge/wiki/Known-Issues-and-Limitations"><i class="fa fa-exclamation-triangle"></i> Known Issues and Limitations</a>

--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -18,7 +18,8 @@
                     <li class="nav-item" uib-dropdown>
                         <a class="nav-link" uib-dropdown-toggle href id="helpDropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-question-circle"></i> <span>About</span></a>
                         <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu aria-labelledby="helpDropdown">
-                            <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/t/w/5454"><i class="fa fa-gift"></i> What's New?</a>
+                            <a class="dropdown-item" target="_blank" href="https://lexbox.org/fw-lite"><i class="fa fa-gift"></i> Try FieldWorks Lite</a>
+                            <a class="dropdown-item" target="_blank" href="https://docs.google.com/document/d/1Op0ZEreOd2N1v8Yh85sxW0O5HgSEj8gBdBVITGdiw8k/edit"><i class="fa fa-exclamation-triangle"></i> Maintenance Mode</a>
                             <a class="dropdown-item" target="_blank" href="https://www.youtube.com/playlist?list=PLJLUPwIFOI8d8lmQVAcBapyw87jCtmDNA"><i class="fa fa-youtube-play"></i> Videos</a>
                             <a class="dropdown-item" target="_blank" href="https://community.software.sil.org/c/language-forge"><i class="fa fa-users"></i> Community Support</a>
                             <a class="dropdown-item" target="_blank" href="https://github.com/sillsdev/web-languageforge/wiki/Known-Issues-and-Limitations"><i class="fa fa-exclamation-triangle"></i> Known Issues and Limitations</a>

--- a/src/Site/views/languageforge/container/languageforge.html.twig
+++ b/src/Site/views/languageforge/container/languageforge.html.twig
@@ -12,7 +12,7 @@
             <nav class="navbar navbar-expand navbar-dark align-items-stretch">
                 <span class="navbar-brand d-md-inline-block mr-auto">
                     <img class="navbar-logo" title="v{{ version }}" src="/Site/views/languageforge/theme/default/image/lf_logo_medium.png">
-                    <a class="website-title" href="/">Language Forge</a>
+                    <a class="website-title" href="/">Language Forge</a> <a href="https://lexbox.org/fw-lite">Try FieldWorks Lite!</a>
                 </span>
                 <ul class="nav navbar-nav">
                     <li class="nav-item" uib-dropdown>

--- a/src/Site/views/languageforge/theme/default/page/home/index.html.twig
+++ b/src/Site/views/languageforge/theme/default/page/home/index.html.twig
@@ -31,6 +31,8 @@
     <section id="banner">
         <h2>Language Forge</h2>
         <p>Collaborative web-based dictionary building that syncs with FieldWorks</p>
+        <p>Language Forge is no longer developed and is in <a href="https://docs.google.com/document/d/1Op0ZEreOd2N1v8Yh85sxW0O5HgSEj8gBdBVITGdiw8k/edit">maintenance mode</a> - we will support existing projects.<br />
+        We encourage all users to try <a href="https://lexbox.org/fw-lite">FieldWorks Lite</a>.</p>
     </section>
 
     <!-- Main -->

--- a/src/Site/views/languageforge/theme/default/page/home/index.html.twig
+++ b/src/Site/views/languageforge/theme/default/page/home/index.html.twig
@@ -31,7 +31,7 @@
     <section id="banner">
         <h2>Language Forge</h2>
         <p>Collaborative web-based dictionary building that syncs with FieldWorks</p>
-        <p>Language Forge is no longer developed and is in <a href="https://docs.google.com/document/d/1Op0ZEreOd2N1v8Yh85sxW0O5HgSEj8gBdBVITGdiw8k/edit">maintenance mode</a> - we will support existing projects.<br />
+        <p><span style="color: yellow"><i class="fa fa-exclamation-triangle"></i> Language Forge is no longer developed and is in <a href="https://community.software.sil.org/t/language-forge-in-maintenance-mode/10514">maintenance mode</a> - we will support existing projects.<br /></span>
         We encourage all users to try <a href="https://lexbox.org/fw-lite">FieldWorks Lite</a>.</p>
     </section>
 

--- a/src/angular-app/languageforge/lexicon/new-project/send-receive/new-project-credentials.component.html
+++ b/src/angular-app/languageforge/lexicon/new-project/send-receive/new-project-credentials.component.html
@@ -2,6 +2,7 @@
     <div class="row justify-content-center">
         <div class="col-12 col-lg-8">
             <h4 class="text-center no-space-break">Get project from LanguageDepot.org</h4>
+            <p>We don't recommend creating new projects anymore.  Language Forge is now in <a href="https://docs.google.com/document/d/1Op0ZEreOd2N1v8Yh85sxW0O5HgSEj8gBdBVITGdiw8k/edit">maintenance mode</a>.  Give <a href="https://lexbox.org/fw-lite">FieldWorks Lite</a> a try instead.</p>
             <form>
                 <div class="card card-default">
                     <div class="card-body">


### PR DESCRIPTION
## Description

Language Forge is now in maintenance mode.  This PR adds appropriate messaging about maintenance mode and promotes FWLite as a viable alternative to LF.

Specific changes:

- Header prominently displays "maintenance mode"
- About menu includes link to FWLite and maintenance mode doc
- New project wizard includes message and discourages users from creating new projects
- Front page includes the maintenance mode message

[Language Forge is no longer developed and is in maintenance mode](https://community.software.sil.org/t/language-forge-in-maintenance-mode/10514).  We will continue to support existing Language Forge projects and we encourage all users to try [FieldWorks Lite](https://lexbox.org/fw-lite).

## Screenshots

<img width="1322" height="1150" alt="image" src="https://github.com/user-attachments/assets/d10cdfb6-9b79-4831-9f0c-dd2aca9732b9" />

<img width="905" height="303" alt="Screenshot 2025-08-12 at 2 05 11 PM" src="https://github.com/user-attachments/assets/24a9915c-3fc5-4ffd-b876-94f9258695cc" />

<img width="500" height="286" alt="Screenshot 2025-08-12 at 2 09 36 PM" src="https://github.com/user-attachments/assets/78682d2f-8ae9-47fc-8797-693c30219de0" />


## Checklist

- [x] I have labeled my PR with: bug, feature, engineering, security fix or testing
- [x] I have performed a self-review of my own code
- [x] I have reviewed the title & description of this PR which I will use as the squashed PR commit message
- [x] I have enabled auto-merge (optional)
