### PR TITLE
Migrate staging to traefik

### DIFF
--- a/docker/deployment/base/next-proxy-deployment.yaml
+++ b/docker/deployment/base/next-proxy-deployment.yaml
@@ -4,16 +4,15 @@ kind: Ingress
 metadata:
   name: languageforge-app
   annotations:
-    # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size
-    # Added this to allow large file uploads, this setting should match the php custom config, i.e., upload_max_filesize, found in the app's customizations.php.ini
-    nginx.ingress.kubernetes.io/proxy-body-size: 60M
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
+  ingressClassName: traefik
   rules:
   - host: localhost
     http:
       paths:
       - path: /
-        pathType: ImplementationSpecific
+        pathType: Prefix
         backend:
           service:
             name: next-proxy

--- a/docker/deployment/prod/ingress-class-revert-patch.yaml
+++ b/docker/deployment/prod/ingress-class-revert-patch.yaml
@@ -1,0 +1,17 @@
+# Temporary patch: prod still runs on the (retired) community ingress-nginx
+# controller. The base manifest has been flipped to Traefik for the staging
+# cutover; this patch keeps prod on nginx until its own DNS cutover is
+# scheduled with LTOps. Delete this patch (and the kustomization entry that
+# references it) when prod migrates to Traefik.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: languageforge-app
+  annotations:
+    # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size
+    # Added this to allow large file uploads, this setting should match the php custom config, i.e., upload_max_filesize, found in the app's customizations.php.ini
+    nginx.ingress.kubernetes.io/proxy-body-size: 60M
+    # Strip the Traefik router annotation inherited from base; prod is still on nginx.
+    traefik.ingress.kubernetes.io/router.tls: null
+spec:
+  ingressClassName: nginx

--- a/docker/deployment/prod/ingress-config-patch.yaml
+++ b/docker/deployment/prod/ingress-config-patch.yaml
@@ -7,3 +7,9 @@
   path: /spec/tls/0/hosts
   value:
     - languageforge.org
+# Revert base's pathType change until prod migrates from ingress-nginx to Traefik.
+# This apparently isn't necessary, but I'm being conservative.
+# Remove this op when prod migrates.
+- op: replace
+  path: /spec/rules/0/http/paths/0/pathType
+  value: ImplementationSpecific

--- a/docker/deployment/prod/kustomization.yaml
+++ b/docker/deployment/prod/kustomization.yaml
@@ -28,3 +28,6 @@ patches:
       kind: Ingress
       name: languageforge-app
       namespace: languageforge
+  # Keep prod on the community ingress-nginx controller until its DNS cutover
+  # to Traefik is scheduled. Remove this once prod migrates.
+  - path: ingress-class-revert-patch.yaml


### PR DESCRIPTION
Migrates the default Ingres config from nginx-ingress to Traefik.
The prod environment uses a patch to patch "back" to nginx-ingress.